### PR TITLE
Add requirements for WRITG top pirate

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -2052,10 +2052,40 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [
+                    "h_heatProof"
+                  ]
+                },
+                {
+                  "name": "Kill the Pirate",
+                  "notable": false,
+                  "requires": [
                     "h_canNavigateHeatRooms",
+                    {"or": [
+                      "ScrewAttack",
+                      {"and": [
+                        {"heatFrames": 60},
+                        {"enemyKill": {
+                          "enemies": [["Yellow Space Pirate (standing)"]],
+                          "explicitWeapons": [
+                            "Missile",
+                            "Super",
+                            "Charge+Plasma"
+                          ]
+                        }}
+                      ]}
+                    ]},
+                    {"heatFrames": 300}
+                  ]
+                },
+                {
+                  "name": "Avoid the Top Pirate",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canCarefulJump",
                     {"heatFrames": 210}
                   ],
-                  "note": "The shot blocks can be safely cleared from the door."
+                  "note": "Safely clear the shot blocks from the door without drawing fire from the space pirate."
                 }
               ]
             },
@@ -2070,7 +2100,7 @@
                     {"or": [
                       {"and": [
                         {"or": [
-                          "canCarefulJump",
+                          "canTrickyJump",
                           {"enemyKill": {
                             "enemies": [["Yellow Space Pirate (standing)"]],
                             "explicitWeapons": ["ScrewAttack"]


### PR DESCRIPTION
I think heat frame scaling gets around the intended strat being not obvious.  Since you are just taking longer to do the same thing.

Fixes #1005 