### PR TITLE
Update Thread The Needle Room

### DIFF
--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -3597,8 +3597,15 @@
                   "name": "Choot and Puyo Farm",
                   "notable": false,
                   "requires": [
+                    {"or": [
+                      "h_hasBeamUpgrade",
+                      "canDodgeWhileShooting",
+                      {"resourceCapacity": [
+                        {"type": "Missile", "count": 1}
+                      ]}
+                    ]},
                     {"resetRoom": {
-                      "nodes": [1, 2],
+                      "nodes": [1],
                       "mustStayPut": false
                     }},
                     {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
@@ -3612,7 +3619,29 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"or": [
+                      "h_hasBeamUpgrade",
+                      "canDodgeWhileShooting",
+                      {"resourceCapacity": [
+                        {"type": "Missile", "count": 1}
+                      ]},
+                      {"enemyDamage": {
+                        "enemy": "Puyo",
+                        "type": "contact",
+                        "hits": 2
+                      }},
+                      {"and": [
+                        "Moprh",
+                        {"enemyDamage": {
+                          "enemy": "Puyo",
+                          "type": "contact",
+                          "hits": 1
+                        }}
+                      ]},
+                      "h_canUsePowerBombs"
+                    ]}
+                  ]
                 }
               ]
             }
@@ -3622,12 +3651,57 @@
           "from": 2,
           "to": [
             {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Choot and Puyo Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "h_hasBeamUpgrade",
+                      "canDodgeWhileShooting",
+                      {"resourceCapacity": [
+                        {"type": "Missile", "count": 1}
+                      ]}
+                    ]},
+                    {"resetRoom": {
+                      "nodes": [2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 1,
               "strats": [
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"or": [
+                      "h_hasBeamUpgrade",
+                      "canDodgeWhileShooting",
+                      {"resourceCapacity": [
+                        {"type": "Missile", "count": 1}
+                      ]},
+                      {"enemyDamage": {
+                        "enemy": "Puyo",
+                        "type": "contact",
+                        "hits": 2
+                      }},
+                      {"and": [
+                        "Moprh",
+                        {"enemyDamage": {
+                          "enemy": "Puyo",
+                          "type": "contact",
+                          "hits": 1
+                        }}
+                      ]},
+                      "h_canUsePowerBombs"
+                    ]}
+                  ]
                 }
               ]
             }

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -3671,14 +3671,26 @@
                   "name": "Morph Dodge",
                   "notable": false,
                   "requires": [
+                    "h_canNavigateUnderwater",
                     "Morph",
                     {"enemyDamage": {
                       "enemy": "Puyo",
                       "type": "contact",
                       "hits": 1
-                    }}
+                    }},
+                    {"or":[
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Puyo",
+                        "type": "contact",
+                        "hits": 1
+                      }}
+                    ]}
                   ],
-                  "note": "Roll through the bottom of the room when it is safe. Expects one Puyo hit when crossing the middle of the room."
+                  "note": [
+                    "Safely kill the first Choot, then roll through the bottom of the room after passing the two Puyos.",
+                    "Expects one to two Puyo hits while crossing the room."
+                  ]
                 },
                 {
                   "name": "Lenient Dodge",
@@ -3688,9 +3700,17 @@
                       "enemy": "Puyo",
                       "type": "contact",
                       "hits": 2
-                    }}
+                    }},
+                    {"or":[
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Puyo",
+                        "type": "contact",
+                        "hits": 1
+                      }}
+                    ]}
                   ],
-                  "note": "Dodge and kill the enemies. Expects two Puyo hits."
+                  "note": "Dodge the Puyos and kill the Choots. Expects two to three Puyo hits."
                 }
               ]
             }
@@ -3780,14 +3800,26 @@
                   "name": "Morph Dodge",
                   "notable": false,
                   "requires": [
+                    "h_canNavigateUnderwater",
                     "Morph",
                     {"enemyDamage": {
                       "enemy": "Puyo",
                       "type": "contact",
                       "hits": 1
-                    }}
+                    }},
+                    {"or":[
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Puyo",
+                        "type": "contact",
+                        "hits": 1
+                      }}
+                    ]}
                   ],
-                  "note": "Roll through the bottom of the room when it is safe. Expects one Puyo hit when crossing the middle of the room."
+                  "note": [
+                    "Safely kill the first Choot, then roll through the bottom of the room after passing the two Puyos.",
+                    "Expects one to two Puyo hits while crossing the room."
+                  ]
                 },
                 {
                   "name": "Lenient Dodge",
@@ -3797,9 +3829,17 @@
                       "enemy": "Puyo",
                       "type": "contact",
                       "hits": 2
-                    }}
+                    }},
+                    {"or":[
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Puyo",
+                        "type": "contact",
+                        "hits": 1
+                      }}
+                    ]}
                   ],
-                  "note": "Dodge and kill the enemies. Expects two Puyo hits."
+                  "note": "Dodge the Puyos and kill the Choots. Expects two to three Puyo hits."
                 }
               ]
             }

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -3594,21 +3594,55 @@
               "id": 1,
               "strats": [
                 {
-                  "name": "Choot and Puyo Farm",
+                  "name": "Basic Choot and Puyo Farm",
                   "notable": false,
                   "requires": [
                     {"or": [
                       "h_hasBeamUpgrade",
                       "canDodgeWhileShooting",
-                      {"resourceCapacity": [
-                        {"type": "Missile", "count": 1}
-                      ]}
+                      "Grapple",
+                      "ScrewAttack"
                     ]},
                     {"resetRoom": {
-                      "nodes": [1],
+                      "nodes": [2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile"]}
+                  ]
+                },
+                {
+                  "name": "Choot and Puyo Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "Wave",
+                      "Spazer",
+                      "Plasma",
+                      "Grapple",
+                      "ScrewAttack"
+                    ]},
+                    {"resetRoom": {
+                      "nodes": [2],
                       "mustStayPut": false
                     }},
                     {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
+                  ]
+                },
+                {
+                  "name": "Patient Choot and Puyo Farm",
+                  "notable": false,
+                  "requires": [
+                    "canBePatient",
+                    {"or": [
+                      "canDodgeWhileShooting",
+                      "Charge",
+                      "Ice",
+                    ]},
+                    {"resetRoom": {
+                      "nodes": [2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Super", "PowerBomb"]}
                   ]
                 }
               ]
@@ -3617,31 +3651,46 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Base",
+                  "name": "Kill the Enemies",
                   "notable": false,
                   "requires": [
                     {"or": [
                       "h_hasBeamUpgrade",
                       "canDodgeWhileShooting",
+                      "Grapple",
+                      "ScrewAttack",
+                      "canBePatient",
                       {"resourceCapacity": [
                         {"type": "Missile", "count": 1}
-                      ]},
-                      {"enemyDamage": {
-                        "enemy": "Puyo",
-                        "type": "contact",
-                        "hits": 2
-                      }},
-                      {"and": [
-                        "Morph",
-                        {"enemyDamage": {
-                          "enemy": "Puyo",
-                          "type": "contact",
-                          "hits": 1
-                        }}
                       ]},
                       "h_canUsePowerBombs"
                     ]}
                   ]
+                },
+                {
+                  "name": "Morph Dodge",
+                  "notable": false,
+                  "requires": [
+                    "Morph",
+                    {"enemyDamage": {
+                      "enemy": "Puyo",
+                      "type": "contact",
+                      "hits": 1
+                    }}
+                  ],
+                  "note": "Roll through the bottom of the room when it is safe. Expects one Puyo hit when crossing the middle of the room."
+                },
+                {
+                  "name": "Lenient Dodge",
+                  "notable": false,
+                  "requires": [
+                    {"enemyDamage": {
+                      "enemy": "Puyo",
+                      "type": "contact",
+                      "hits": 2
+                    }}
+                  ],
+                  "note": "Dodge and kill the enemies. Expects two Puyo hits."
                 }
               ]
             }
@@ -3654,21 +3703,55 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Choot and Puyo Farm",
+                  "name": "Basic Choot and Puyo Farm",
                   "notable": false,
                   "requires": [
                     {"or": [
                       "h_hasBeamUpgrade",
                       "canDodgeWhileShooting",
-                      {"resourceCapacity": [
-                        {"type": "Missile", "count": 1}
-                      ]}
+                      "Grapple",
+                      "ScrewAttack"
+                    ]},
+                    {"resetRoom": {
+                      "nodes": [2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile"]}
+                  ]
+                },
+                {
+                  "name": "Choot and Puyo Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "Wave",
+                      "Spazer",
+                      "Plasma",
+                      "Grapple",
+                      "ScrewAttack"
                     ]},
                     {"resetRoom": {
                       "nodes": [2],
                       "mustStayPut": false
                     }},
                     {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
+                  ]
+                },
+                {
+                  "name": "Patient Choot and Puyo Farm",
+                  "notable": false,
+                  "requires": [
+                    "canBePatient",
+                    {"or": [
+                      "canDodgeWhileShooting",
+                      "Charge",
+                      "Ice",
+                    ]},
+                    {"resetRoom": {
+                      "nodes": [2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Super", "PowerBomb"]}
                   ]
                 }
               ]
@@ -3677,31 +3760,46 @@
               "id": 1,
               "strats": [
                 {
-                  "name": "Base",
+                  "name": "Kill the Enemies",
                   "notable": false,
                   "requires": [
                     {"or": [
                       "h_hasBeamUpgrade",
                       "canDodgeWhileShooting",
+                      "Grapple",
+                      "ScrewAttack",
+                      "canBePatient",
                       {"resourceCapacity": [
                         {"type": "Missile", "count": 1}
-                      ]},
-                      {"enemyDamage": {
-                        "enemy": "Puyo",
-                        "type": "contact",
-                        "hits": 2
-                      }},
-                      {"and": [
-                        "Morph",
-                        {"enemyDamage": {
-                          "enemy": "Puyo",
-                          "type": "contact",
-                          "hits": 1
-                        }}
                       ]},
                       "h_canUsePowerBombs"
                     ]}
                   ]
+                },
+                {
+                  "name": "Morph Dodge",
+                  "notable": false,
+                  "requires": [
+                    "Morph",
+                    {"enemyDamage": {
+                      "enemy": "Puyo",
+                      "type": "contact",
+                      "hits": 1
+                    }}
+                  ],
+                  "note": "Roll through the bottom of the room when it is safe. Expects one Puyo hit when crossing the middle of the room."
+                },
+                {
+                  "name": "Lenient Dodge",
+                  "notable": false,
+                  "requires": [
+                    {"enemyDamage": {
+                      "enemy": "Puyo",
+                      "type": "contact",
+                      "hits": 2
+                    }}
+                  ],
+                  "note": "Dodge and kill the enemies. Expects two Puyo hits."
                 }
               ]
             }

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -3636,7 +3636,7 @@
                     {"or": [
                       "canDodgeWhileShooting",
                       "Charge",
-                      "Ice",
+                      "Ice"
                     ]},
                     {"resetRoom": {
                       "nodes": [2],
@@ -3745,7 +3745,7 @@
                     {"or": [
                       "canDodgeWhileShooting",
                       "Charge",
-                      "Ice",
+                      "Ice"
                     ]},
                     {"resetRoom": {
                       "nodes": [2],

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -3632,7 +3632,7 @@
                         "hits": 2
                       }},
                       {"and": [
-                        "Moprh",
+                        "Morph",
                         {"enemyDamage": {
                           "enemy": "Puyo",
                           "type": "contact",
@@ -3692,7 +3692,7 @@
                         "hits": 2
                       }},
                       {"and": [
-                        "Moprh",
+                        "Morph",
                         {"enemyDamage": {
                           "enemy": "Puyo",
                           "type": "contact",


### PR DESCRIPTION
Make it a little more lenient for lower difficulties by adding `canDodgeWhileShooting`, or other ways to dodge or kill the enemies. 

It's assumed that some of the enemies can be killed easily (mostly the Choots) and can be used to refill missiles enough for the trickier enemies in the middle of the room.