### PR TITLE
East Ocean Springball Hops + Spacejump strat

### DIFF
--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -2559,8 +2559,7 @@
                   "note": [
                     "Build up run speed and then use controlled springball bounces to cross the ocean to the far right ledge, and then use SpaceJump to reach the door.",
                     "Mockball down the submerged ramp and begin SpringBall bouncing under water using the platforms.",
-                    "Disable SpringBall after the final jump once Samus starts falling again as a way to gain extra speed.",
-                    "It is not necessary to enter the water to kill the right side submerged Choot."
+                    "Disable SpringBall after the final jump once Samus starts falling again as a way to gain extra speed."
                   ]
                 },
                 {

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -2544,6 +2544,26 @@
                   ]
                 },
                 {
+                  "name": "East Ocean Springball Bounce to the Door with SpaceJump",
+                  "notable": true,
+                  "requires": [
+                    "canTrickyJump",
+                    "canSpaceJumpWaterBounce",
+                    "canSpringBallBounce",
+                    "canMockball",
+                    {"or": [
+                      "canDownGrab",
+                      "canWalljump"
+                    ]}
+                  ],
+                  "note": [
+                    "Build up run speed and then use controlled springball bounces to cross the ocean to the far right ledge, and then use SpaceJump to reach the door.",
+                    "Mockball down the submerged ramp and begin SpringBall bouncing under water using the platforms.",
+                    "Disable SpringBall after the final jump once Samus starts falling again as a way to gain extra speed.",
+                    "It is not necessary to enter the water to kill the right side submerged Choot."
+                  ]
+                },
+                {
                   "name": "East Ocean Speedy Springball Bounce to the Door",
                   "notable": true,
                   "requires": [


### PR DESCRIPTION
I found an easier way to do the remaining east ocean strat -- 1) fully in room 2)no Choot damage 3)Turning off springball at the end makes it much easier.

It is equivalently difficult to the `walljump + frame perfect spacejumpwaterbounce` strat.  But you can probably get this more consistent.