### PR TITLE
Add more uses of canPseudoScrew

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -3893,11 +3893,7 @@
                     }},
                     {"or": [
                       "ScrewAttack",
-                      "Charge",
-                      "Ice",
-                      "Wave",
-                      "Spazer",
-                      "Plasma"
+                      "h_hasBeamUpgrade"
                     ]},
                     {"refill": ["Energy", "Missile"]}
                   ]

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -2776,26 +2776,41 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Base",
+                  "name": "Space Jump",
                   "notable": false,
                   "requires": [
                     "Gravity",
+                    "SpaceJump",
                     {"or": [
-                      "canConsecutiveWalljump",
-                      "SpaceJump"
-                    ]},
-                    {"or": [
+                      "ScrewAttack",
+                      "canPseudoScrew",
                       {"enemyDamage": {
                         "enemy": "Menu",
                         "type": "contact",
                         "hits": 1
-                      }},
-                      "ScrewAttack",
-                      "canStaggeredWalljump",
-                      "Charge"
+                      }}
                     ]}
                   ],
-                  "note": "The swarm of Menus will attack Samus at the top of the room.",
+                  "note": "The swarm of Menus will attack Samus at the top of the room. Tank them or kill them with Screw or Pseudo Screw."
+                },
+                {
+                  "name": "Wall Jump",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
+                    "canConsecutiveWalljump",
+                    {"or": [
+                      "ScrewAttack",
+                      "canStaggeredWalljump",
+                      "canWalljumpWithCharge",
+                      {"enemyDamage": {
+                        "enemy": "Menu",
+                        "type": "contact",
+                        "hits": 1
+                      }}
+                    ]}
+                  ],
+                  "note": "The swarm of Menus will attack Samus at the top of the room. Tank them, carefully dodge them, or kill them with Screw or Pseudo Screw.",
                   "devNote": "The Menus prevent a reliable IBJ."
                 },
                 {
@@ -2819,7 +2834,7 @@
                       }},
                       "ScrewAttack",
                       "canStaggeredWalljump",
-                      "Charge"
+                      "canPseudoScrew"
                     ]}
                   ],
                   "note": [

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -4815,7 +4815,7 @@
                         }}
                       ]},
                       {"and": [
-                        "Charge",
+                        "canPseudoScrew",
                         { "enemyDamage": { "enemy": "Pink Space Pirate (standing)", "type": "contact", "hits": 1 } }
                       ]}
                     ]}


### PR DESCRIPTION
I went through all the notes for `pseudo` and went through all the uses of `"Charge"` to look for missing uses of `canPseudoScrew`. I think it can be used as a full tech instead of a minor tech.