### PR TITLE
Speed ball revisit

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -251,7 +251,7 @@
                   "name": "Room Entry Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "shinesparkFrames": 0,
@@ -690,7 +690,7 @@
                       "shinesparkFrames": 0,
                       "openEnd": 1
                     }},
-                    "canMockball"
+                    "canSpeedball"
                   ],
                   "clearsObstacles": ["A"],
                   "note": [
@@ -768,7 +768,7 @@
                   "name": "Morph Ball Room Speedball (Left to Right)",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"obstaclesCleared": ["C"]},
                     {"canShineCharge": {
                       "usedTiles": 18,

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -1576,7 +1576,7 @@
                   "name": "Brinstar Reserve Temporary Blue",
                   "notable": true,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "canTrickyJump",
                     {"or": [
                       "canTemporaryBlue",
@@ -1603,6 +1603,10 @@
                   "note": [
                     "Speedball through the morphtunnel and use it to break the bomb blocks in front of the hidden Missile location.",
                     "This can be done using springball, or by unmorphing and using Temporary Blue to bounce through the bomb blocks."
+                  ],
+                  "devNote": [
+                    "Speedballing through a door into a pit like this must limit run speed a little bit.",
+                    "UnusableTiles doesn't help, but with canTrickyJump and Notable, we can make some assumptions about shortcharge ability."
                   ]
                 }
               ]
@@ -1705,15 +1709,23 @@
                     "Morph",
                     {"or": [
                       "h_canBombThings",
-                      {"obstaclesCleared": ["A"]}
+                      {"obstaclesCleared": ["A"]},
+                      {"and": [
+                        "canSlowShortCharge",
+                        "canSpeedball",
+                        {"canShineCharge": {
+                          "usedTiles": 14,
+                          "shinesparkFrames": 0,
+                          "openEnd": 1
+                        }}
+                      ]}
                     ]}
                   ],
                   "clearsObstacles": ["A"],
                   "note": [
                     "Both sides of the room must be accessed to reach all enemies and unlock the door.",
                     "Beyond that, the enemies can be killed with Power Beam."
-                  ],
-                  "devNote": "A speedball would require a room reset to set up."
+                  ]
                 }
               ],
               "yields": [ "f_ZebesAwake" ]
@@ -1808,16 +1820,26 @@
                   "clearsObstacles": ["A"]
                 },
                 {
-                  "name": "SpeedBall",
+                  "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
-                    {"canComeInCharged": {
-                      "framesRemaining": 180,
-                      "fromNode": 2,
-                      "shinesparkFrames": 0,
-                      "unusableTiles": 3
-                    }}
+                    "canSpeedball",
+                    {"or": [
+                      {"canComeInCharged": {
+                        "framesRemaining": 180,
+                        "fromNode": 2,
+                        "shinesparkFrames": 0,
+                        "unusableTiles": 3
+                      }},
+                      {"and": [
+                        "canSlowShortCharge",
+                        {"canShineCharge": {
+                          "usedTiles": 14,
+                          "shinesparkFrames": 0,
+                          "openEnd": 1
+                        }}
+                      ]}
+                    ]}
                   ],
                   "clearsObstacles": ["A"]
                 }

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -561,22 +561,22 @@
                   "name": "Through Door Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"or": [
                       {"and": [
                         "canSlowShortCharge",
                         {"canComeInCharged": {
-                            "framesRemaining": 180,
-                            "fromNode": 2,
-                            "shinesparkFrames": 0,
-                            "unusableTiles": 4
-                          }}
+                          "framesRemaining": 180,
+                          "fromNode": 2,
+                          "shinesparkFrames": 0,
+                          "unusableTiles": 5
+                        }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
                         "fromNode": 2,
                         "shinesparkFrames": 0,
-                        "unusableTiles": 11
+                        "unusableTiles": 14
                       }}
                     ]}
                   ]
@@ -1324,27 +1324,17 @@
                   ]
                 },
                 {
-                  "name": "SpeedBall",
+                  "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
-                    {"or": [
-                      {"and": [
-                        "canSlowShortCharge",
-                        {"canComeInCharged": {
-                          "framesRemaining": 180,
-                          "fromNode": 3,
-                          "shinesparkFrames": 0,
-                          "unusableTiles": 1
-                        }}
-                      ]},
-                      {"canComeInCharged": {
-                        "framesRemaining": 180,
-                        "fromNode": 3,
-                        "shinesparkFrames": 0,
-                        "unusableTiles": 9
-                      }}
-                    ]}
+                    "canSpeedball",
+                    "canSlowShortCharge",
+                    {"canComeInCharged": {
+                      "framesRemaining": 180,
+                      "fromNode": 3,
+                      "shinesparkFrames": 0,
+                      "unusableTiles": 1
+                    }}
                   ],
                   "clearsObstacles": ["B","C"],
                   "note": "The Kihunters can be killed by retreating to the morph tunnel if needed."
@@ -1459,7 +1449,7 @@
                     {"or": [
                       {"and": [
                         "canSlowShortCharge",
-                        "canMockball",
+                        "canSpeedball",
                         {"canShineCharge": {
                           "usedTiles": 17,
                           "shinesparkFrames": 0,

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -808,7 +808,7 @@
       ],
       "reusableRoomwideNotable": [
         {
-          "name": "Big Pink SpeedBall into Raised Bomb Blocks",
+          "name": "Big Pink Speedball into Raised Bomb Blocks",
           "note": [
             "Break the \"Spore Spawn Skip\" bomb blocks (from the left) using only speed.",
             "Either by jump morphing into them, or by falling and bouncing through them with Temporary Blue."
@@ -835,10 +835,10 @@
                   "clearsObstacles": ["A"]
                 },
                 {
-                  "name": "SpeedBall",
+                  "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"or": [
                       {"and": [
                         "canSlowShortCharge",
@@ -853,7 +853,7 @@
                         "framesRemaining": 180,
                         "fromNode": 1,
                         "shinesparkFrames": 0,
-                        "unusableTiles": 10
+                        "unusableTiles": 14
                       }}
                     ]}
                   ]
@@ -1022,7 +1022,7 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "canTrickyJump",
                     "canSlowShortCharge",
                     {"canComeInCharged": {
@@ -1302,7 +1302,7 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"or": [
                       {"canComeInCharged": {
                         "fromNode": 2,
@@ -1436,9 +1436,10 @@
                   "note": "Crystal Flash in the morph tunnel to force a standup, making it possible to shoot the super block from the left while it's on-screen."
                 },
                 {
-                  "name": "Big Pink SpeedBall Jump into Raised Bomb Blocks",
+                  "name": "Big Pink Speedball Jump into Raised Bomb Blocks",
                   "notable": true,
                   "requires": [
+                    "canSpeedball",
                     "canLateralMidAirMorph",
                     "canSlowShortCharge",
                     "canTrickyJump",
@@ -1450,7 +1451,7 @@
                     "canOffScreenSuperShot"
                   ],
                   "clearsObstacles": ["F"],
-                  "reusableRoomwideNotable": "Big Pink SpeedBall into Raised Bomb Blocks",
+                  "reusableRoomwideNotable": "Big Pink Speedball into Raised Bomb Blocks",
                   "note": "Break the bomb blocks by jumping into them with speed. These is more easily done at low run speed."
                 },
                 {
@@ -1468,7 +1469,7 @@
                     "canOffScreenSuperShot"
                   ],
                   "clearsObstacles": ["F"],
-                  "reusableRoomwideNotable": "Big Pink SpeedBall into Raised Bomb Blocks",
+                  "reusableRoomwideNotable": "Big Pink Speedball into Raised Bomb Blocks",
                   "note": "Stop with Temporary Blue in front of the bomb blocks then jump and bounce into the morph tunnel to clear them."
                 }
               ]
@@ -2955,7 +2956,7 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "shinesparkFrames": 0,
@@ -2965,7 +2966,7 @@
                   ],
                   "note": [
                     "Roll through the whole room breaking the speedblocks.",
-                    "The fish enemies will die but some puyos will remain, to be killed with power beam shots."
+                    "The fish enemies will die but some puyos will remain."
                   ]
                 }
               ]

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1745,7 +1745,7 @@
                   "notable": false,
                   "requires": [
                     "Spazer",
-                    "canMockball",
+                    "canSpeedball",
                     "canCarefulJump",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
@@ -1760,7 +1760,7 @@
                   "name": "Below Spazer Jump Shot Speedball",
                   "notable": true,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "canTrickyJump",
                     {"canComeInCharged": {
                       "framesRemaining": 180,

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2918,10 +2918,10 @@
                   "requires": [ "h_canBombThings" ]
                 },
                 {
-                  "name": "SpeedBall",
+                  "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "h_canUseSpringBall",
                     "canSlowShortCharge",
                     {"canComeInCharged": {
@@ -4554,7 +4554,7 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"or": [
                       {"and": [
                         "canSlowShortCharge",
@@ -4562,14 +4562,14 @@
                           "framesRemaining": 180,
                           "shinesparkFrames": 0,
                           "fromNode": 2,
-                          "unusableTiles": 4
+                          "unusableTiles": 5
                         }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
                         "shinesparkFrames": 0,
                         "fromNode": 2,
-                        "unusableTiles": 11
+                        "unusableTiles": 14
                       }}
                     ]}
                   ]
@@ -5561,13 +5561,13 @@
                   "name": "SpaceJump Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "canBlueSpaceJump",
                     {"canComeInCharged": {
-                       "fromNode": 1,
-                       "framesRemaining": 180,
-                       "shinesparkFrames": 0
-                     }}
+                      "fromNode": 1,
+                      "framesRemaining": 180,
+                      "shinesparkFrames": 0
+                    }}
                   ]
                 }
               ]

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -2279,7 +2279,7 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "canCarefulJump",
                     "canSlowShortCharge",
                     {"canComeInCharged": {

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -10059,8 +10059,8 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "h_canUseSpringBall",
+                    "canSpeedball",
                     "canLateralMidAirMorph",
-                    "canCarefulJump",
                     {"canShineCharge": {
                       "usedTiles": 26,
                       "gentleDownTiles": 2,
@@ -10073,7 +10073,7 @@
                   "note": "Jump and Morph with a speedball to enter the morph tunnel and then use SpringBall to break the bomb blocks."
                 }
               ],
-              "devNote": "This one-way link represents only the Hotarubi Special. Anything else should go 6-> 4-> 5."
+              "devNote": "This one-way link represents only the Maze Air Speedball. Anything else should go 6-> 4-> 5."
             },
             {
               "id": 7,

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1159,7 +1159,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canMockball",
+                    "canSpeedball",
                     "canSlowShortCharge",
                     {"canComeInCharged": {
                       "framesRemaining": 180,

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -3088,7 +3088,6 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "SpeedBooster",
-                    {"heatFrames": 700},
                     {"or": [
                       {"canComeInCharged":{
                         "fromNode": 3,
@@ -3111,7 +3110,8 @@
                         "shinesparkFrames": 94,
                         "excessShinesparkFrames": 45
                       }}
-                    ]}
+                    ]},
+                    {"heatFrames": 700}
                   ],
                   "clearsObstacles": ["A"],
                   "note": "Spark left through the speed blocks through Croc Speedway. Then run to the right and back to get speed to go through the rest.",
@@ -3122,9 +3122,7 @@
                   "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canMockball",
-                    "canCarefulJump",
-                    "SpeedBooster",
+                    "canSpeedball",
                     {"heatFrames": 570},
                     {"canComeInCharged": {
                       "fromNode": 4,

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -614,16 +614,16 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"or": [
                       {"and": [
                         "canSlowShortCharge",
                         {"canComeInCharged": {
-                            "framesRemaining": 180,
-                            "shinesparkFrames": 0,
-                            "fromNode": 6,
-                            "unusableTiles": 5
-                          }}
+                          "framesRemaining": 180,
+                          "shinesparkFrames": 0,
+                          "fromNode": 6,
+                          "unusableTiles": 5
+                        }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
@@ -830,7 +830,7 @@
                   "requires": [
                     {"not": "f_DefeatedPhantoon"},
                     "canRiskPermanentLossOfAccess",
-                    "canMockball",
+                    "canSpeedball",
                     {"canShineCharge": {
                       "usedTiles": 14,
                       "openEnd": 0,
@@ -924,14 +924,27 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
-                    {"canComeInCharged": {
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0,
-                      "fromNode": 3,
-                      "inRoomPath": [3,9],
-                      "unusableTiles": 10
-                    }}
+                    "canSpeedball",
+                    {"or": [
+                      {"and": [
+                        "canSlowShortCharge",
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "shinesparkFrames": 0,
+                          "fromNode": 3,
+                          "inRoomPath": [3,9],
+                          "unusableTiles": 5
+                        }}
+                      ]},
+                      {"canComeInCharged": {
+                        "framesRemaining": 180,
+                        "shinesparkFrames": 0,
+                        "fromNode": 3,
+                        "inRoomPath": [3,9],
+                        "unusableTiles": 14
+                      }}
+                    ]}
+                    
                   ],
                   "clearsObstacles": ["A"]
                 },
@@ -1362,7 +1375,7 @@
                   "name": "Basement Speedball (Phantoon Dead)",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "f_DefeatedPhantoon",
                     {"canShineCharge": {
                       "usedTiles": 33,
@@ -1379,9 +1392,9 @@
                   "name": "Basement Speedball (Phantoon Alive)",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     {"canShineCharge": {
-                      "usedTiles": 25,
+                      "usedTiles": 22,
                       "shinesparkFrames": 0,
                       "openEnd": 0
                     }}
@@ -1420,7 +1433,7 @@
                   "name": "Speedball",
                   "notable": false,
                   "requires": [
-                    "canMockball",
+                    "canSpeedball",
                     "canCarefulJump",
                     "canSlowShortCharge",
                     {"canComeInCharged": {

--- a/tech.json
+++ b/tech.json
@@ -307,7 +307,7 @@
               ],
               "note": [
                 "Maintain the SpeedBooster effect while rolling as a Morph Ball in order to destroy bomb blocks in Morph tunnels.",
-                "A Speedball involved performing a Mockball at faster speeds and, as a consequence, it will help to be able to perform short jumps when attempting the Mockball.",
+                "A Speedball involves performing a Mockball at faster speeds and additionally it will help to be able to perform short jumps to reduce the amount of space needed.",
                 "A Speedball can also be used with SpringBall as a way to jump with temporary blue state while maintaining Samus' momentum."
               ]
             }

--- a/tech.json
+++ b/tech.json
@@ -296,6 +296,21 @@
           "note": [
             "Maintaining running speed while morphed, by holding jump and down (to crouch) during a lateral jump, then morphing as Samus hits the ground while holding jump and transition from holding down to holding forward.",
             "Sometimes referred to as a Machball."
+          ],
+          "extensionTechs": [
+            {
+              "name": "canSpeedball",
+              "requires": [
+                "canMockball",
+                "SpeedBooster",
+                "canCarefulJump"
+              ],
+              "note": [
+                "Maintain the SpeedBooster effect while rolling as a Morph Ball in order to destroy bomb blocks in Morph tunnels.",
+                "A Speedball involved performing a Mockball at faster speeds and, as a consequence, it will help to be able to perform short jumps when attempting the Mockball.",
+                "A Speedball can also be used with SpringBall as a way to jump with temporary blue state while maintaining Samus' momentum."
+              ]
+            }
           ]
         },
         {


### PR DESCRIPTION
It was hard to decide if `canSpeedball` was different from `canMockball`+SpeedBooster.  But its a named maneuver and I want a slight requirement to jump height and run speed control.

Fixes #939 
It was hard to test the `fast` through door speedballs before, but after testing 14 unused tiles feels like a better number.