### PR TITLE
Sand halls Update

### DIFF
--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -1211,7 +1211,30 @@
                   ],
                   "note": [
                     "Freeze the Evir quickly before it descends and use it to get to the platforms.",
-                    "Getting a good jump while on the right side of the floating block can get Samus to the rightmost block.",
+                    "Getting a good jump while on the right side of the floating block can get Samus to the leftmost block.",
+                    "With a clean jump off of the sand, Samus can then get onto the final vertical pillar."
+                  ]
+                },
+                {
+                  "name": "West Sand Hall Suitless Damage Boost (Center to Left)",
+                  "notable": true,
+                  "requires": [
+                    "canSuitlessMaridia",
+                    "canPlayInSand",
+                    "canTrickyJump",
+                    "canCrouchJump",
+                    "canNeutralDamageBoost",
+                    {"enemyDamage": {
+                      "enemy": "Evir",
+                      "type": "particle",
+                      "hits": 1
+                    }}
+                  ],
+                  "note": [
+                    "Use the projectile from a fully submerged Evir to boost Samus into the sandfall, providing just enough height to make the first and hardest jump.",
+                    "Time the projectile to hit Samus when at the maximum height from a jump.",
+                    "The hit must be on the right side of Samus and with no inputs held, but also hold forward during the damage knockback to move through the sandfall.",
+                    "Getting a good jump while on the right side of the next floating block can get Samus to the leftmost block.",
                     "With a clean jump off of the sand, Samus can then get onto the final vertical pillar."
                   ]
                 }

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -1005,6 +1005,7 @@
                   "requires": [
                     "Gravity",
                     {"or": [
+                      "ScrewAttack",
                       "canCarefulJump",
                       {"enemyDamage": {
                         "enemy": "Evir",
@@ -1251,6 +1252,10 @@
                       "canCarefulJump"
                     ]},
                     {"or": [
+                      {"and": [
+                        "ScrewAttack",
+                        "canCarefulJump"
+                      ]},
                       "canTrickyJump",
                       {"enemyDamage": {
                         "enemy": "Evir",
@@ -2811,8 +2816,7 @@
                     "Gravity",
                     "Grapple",
                     "SpringBall",
-                    "canJumpIntoIBJ",
-                    "h_canIBJ"
+                    "h_canJumpIntoIBJ"
                   ],
                   "note": "Springball can keep Samus out of the sand.  Place the first bomb right after Samus begins falling back towards the sand."
                 },

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -1019,16 +1019,26 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [
+                    {"enemyDamage": {
+                      "enemy": "Evir",
+                      "type": "particle",
+                      "hits": 1
+                    }}
+                  ]
+                },
+                {
+                  "name": "Evir Dodge",
+                  "notable": false,
+                  "requires": [
+                    "canPrepareForNextRoom",
+                    "canPlayInSand",
                     {"or": [
-                      "canPrepareForNextRoom",
-                      {"enemyDamage": {
-                        "enemy": "Evir",
-                        "type": "particle",
-                        "hits": 1
-                      }}
+                      "Gravity",
+                      "HiJump",
+                      "canSandfallBounce"
                     ]}
                   ],
-                  "note": "Evirs will shoot Samus upon entering the room.  It can be avoided by starting on the right side of the entrance and moving left."
+                  "note": "Enter on the right side of the transition and move left to avoid damage."
                 }
               ]
             }
@@ -1986,16 +1996,26 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [
+                    {"enemyDamage": {
+                      "enemy": "Evir",
+                      "type": "particle",
+                      "hits": 1
+                    }}
+                  ]
+                },
+                {
+                  "name": "Evir Dodge",
+                  "notable": false,
+                  "requires": [
+                    "canPrepareForNextRoom",
+                    "canPlayInSand",
                     {"or": [
-                      "canPrepareForNextRoom",
-                      {"enemyDamage": {
-                        "enemy": "Evir",
-                        "type": "particle",
-                        "hits": 1
-                      }}
+                      "Gravity",
+                      "HiJump",
+                      "canSandfallBounce"
                     ]}
                   ],
-                  "note": "Enter on the right side of the transition to avoid damage."
+                  "note": "Enter on the right side of the transition to prevent the Evirs from firing."
                 }
               ]
             }

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -821,7 +821,7 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "HiJump",
-                    "canSpringBallJumpMidAir",
+                    "canTrickySpringBallJump",
                     "canPlayInSand"
                   ]
                 },
@@ -1172,8 +1172,24 @@
                     "canPlayInSand",
                     "canTrickyJump",
                     "canCrouchJump",
-                    "canSpringBallJumpMidAir",
-                    "canStationaryLateralMidAirMorph"
+                    "canTrickySpringBallJump",
+                    "canStationaryLateralMidAirMorph",
+                    {"or": [
+                      {"enemyKill": {
+                        "enemies": [["Evir"]],
+                        "explicitWeapons": [
+                          "Super",
+                          "Missile",
+                          "PowerBombPeriphery",
+                          "Plasma"
+                        ]
+                      }},
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
+                    ]}
                   ],
                   "reusableRoomwideNotable": "West Sand Hall Suitless Bootless Spring Ball",
                   "note": [
@@ -1194,7 +1210,7 @@
                   "note": [
                     "From the sand fall, quickly get onto the left platform to prevent the right side Evir from lowering too far.",
                     "Freeze the right Evir, then jump on the sand to the right while shooting ice over the first Evir to also freeze the second.",
-                    "After crossing with both Evirs frozen and high, let them lower just enough to use them as platforms to jump through to the right door.",
+                    "Freezing the first Evir very high up would also work.",
                     "As a backup, it may be possible to make them rise again by hitting them with a PB - place the PB in the air to avoid double hitting and killing them."
                   ]
                 },
@@ -1269,8 +1285,24 @@
                     "canPlayInSand",
                     "canTrickyJump",
                     "canCrouchJump",
-                    "canSpringBallJumpMidAir",
-                    "canStationaryLateralMidAirMorph"
+                    "canTrickySpringBallJump",
+                    "canStationaryLateralMidAirMorph",
+                    {"or": [
+                      {"enemyKill": {
+                        "enemies": [["Evir"]],
+                        "explicitWeapons": [
+                          "Super",
+                          "Missile",
+                          "PowerBombPeriphery",
+                          "Plasma"
+                        ]
+                      }},
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
+                    ]}
                   ],
                   "reusableRoomwideNotable": "West Sand Hall Suitless Bootless Spring Ball",
                   "note": [
@@ -1417,7 +1449,7 @@
                     "canPlayInSand",
                     "canTrickyJump",
                     "canCrouchJump",
-                    "canSpringBallJumpMidAir",
+                    "canTrickySpringBallJump",
                     "canStationaryLateralMidAirMorph"
                   ],
                   "reusableRoomwideNotable": "West Sand Hall Suitless Bootless Spring Ball",

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -805,7 +805,7 @@
                   ]
                 }
               ],
-              "devNote": "This link is only for sparking and GMode. All other strats should go 1 -> 5 -> 4 -> 2."
+              "devNote": "This link is only for sparking and G-Mode. All other strats should go 1 -> 5 -> 4 -> 2."
             },
             {
               "id": 5,
@@ -986,7 +986,7 @@
                   ]
                 }
               ],
-              "devNote": "This link is only for sparking and GMode. All other strats should go 2 -> 4 -> 5 -> 1."
+              "devNote": "This link is only for sparking and G-Mode. All other strats should go 2 -> 4 -> 5 -> 1."
             },
             {
               "id": 4,
@@ -1790,7 +1790,7 @@
                   ]
                 }
               ],
-              "devNote": "This link is only for sparking. All other strats should go 1 -> 4 -> 2."
+              "devNote": "This link is only for sparking and G-Mode. All other strats should go 1 -> 4 -> 2."
             },
             {
               "id": 4,
@@ -2035,7 +2035,7 @@
                   "devNote": "Only the last jump needs any items."
                 }
               ],
-              "devNote": "This link is only for sparking. All other strats should go 2 -> 4 -> 1."
+              "devNote": "This link is only for sparking and G-Mode. All other strats should go 2 -> 4 -> 1."
             },
             {
               "id": 4,
@@ -2120,6 +2120,7 @@
                   "requires": [
                     "canPrepareForNextRoom",
                     "canPlayInSand",
+                    "canTrickyJump",
                     {"or": [
                       "Gravity",
                       "HiJump",
@@ -2157,7 +2158,7 @@
                       "h_canUseSpringBall"
                      ]},
                     {"or": [
-                      "canCarefulJump",
+                      "canTrickyJump",
                       {"enemyDamage": {
                         "enemy": "Evir",
                         "type": "particle",
@@ -2181,7 +2182,7 @@
                     "HiJump",
                     "canPlayInSand",
                     {"or": [
-                      "canCarefulJump",
+                      "canTrickyJump",
                       {"enemyDamage": {
                         "enemy": "Evir",
                         "type": "particle",
@@ -2209,7 +2210,8 @@
                     {"enemyDamage": { "enemy": "Evir", "type": "particle", "hits": 1 }}
                   ],
                   "note": [
-                    "From the left pillar, jump and place a PB to make the Evirs rise again, while being careful not to kill the close Evir. Freeze the first Evir such that its bottom is only slightly lower than the top of the pillar.",
+                    "From the left pillar, jump and place a PB to make the Evirs rise again, while being careful not to kill the close Evir.",
+                    "Freeze the first Evir such that its bottom is only slightly lower than the top of the pillar.",
                     "Crouch jump onto the Evir, then freeze the second about 1.5 to 2.5 tiles lower. Jump off of the sand to get to the left door."
                   ]
                 },

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -775,7 +775,7 @@
                       "shinesparkFrames": 98
                     }}
                   ],
-                  "note": "Frame cost assumes no Gravity"
+                  "devNote": "Frame cost assumes no Gravity"
                 },
                 {
                   "name": "G-Mode",
@@ -797,7 +797,7 @@
                   ]
                 }
               ],
-              "note": "This link is only for sparking. All other strats should go 1 -> 5 -> 4 -> 2."
+              "devNote": "This link is only for sparking and GMode. All other strats should go 1 -> 5 -> 4 -> 2."
             },
             {
               "id": 5,
@@ -823,19 +823,20 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "canTrickyJump",
-                    "canBombJumpOnSand",
                     "canSandfallBounce",
-                    {"or":[
+                    {"or": [
                       "canSandIBJ",
                       {"and": [
                         "HiJump",
-                        "canMidAirMorph"
+                        "can3HighMidAirMorph",
+                        "h_canUseMorphBombs"
                       ]}
                     ]}
                   ],
                   "note": [
                     "Time a bomb to hit Samus when she is morphed, 1 pixel into the sand, inside a sandfall, and moving horizontally.",
-                    "There is a setup using a sand IBJ to get the right timing, and another setup using a very fast jump morph with HiJump."
+                    "There is a setup using a Sand IBJ to rise up the sandfall from the floor and Sandfall Bounce with the correct timing.",
+                    "An alternate setup places the bomb before entering the sand and jumps into it with a very fast jump morph, using HiJump."
                   ]
                 },
                 {
@@ -2687,9 +2688,7 @@
                   "requires": [
                     "Gravity",
                     "Grapple",
-                    "canPlayInSand",
-                    "h_canJumpIntoIBJ",
-                    "canTrickyJump"
+                    "canSandIBJ"
                   ],
                   "note": "Wait for a good jump out of the sand to begin the IBJ with.  A stationary spinjump can help."
                 },
@@ -2700,6 +2699,7 @@
                     "Gravity",
                     "Grapple",
                     "SpringBall",
+                    "canJumpIntoIBJ",
                     "h_canIBJ"
                   ],
                   "note": "Springball can keep Samus out of the sand.  Place the first bomb right after Samus begins falling back towards the sand."

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -793,6 +793,14 @@
                       "HiJump",
                       "Gravity",
                       "canSpringBallJumpMidAir"
+                    ]},
+                    {"or": [
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
                     ]}
                   ]
                 }
@@ -808,7 +816,7 @@
                   "requires": [ "Gravity" ]
                 },
                 {
-                  "name": "Suitless",
+                  "name": "Suitless SpringBall Jump",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
@@ -824,12 +832,12 @@
                     "canSuitlessMaridia",
                     "canTrickyJump",
                     "canSandfallBounce",
+                    "h_canUseMorphBombs",
                     {"or": [
                       "canSandIBJ",
                       {"and": [
                         "HiJump",
-                        "can3HighMidAirMorph",
-                        "h_canUseMorphBombs"
+                        "can3HighMidAirMorph"
                       ]}
                     ]}
                   ],
@@ -962,7 +970,7 @@
                       "shinesparkFrames": 98
                     }}
                   ],
-                  "note": "Frame cost assumes no Gravity"
+                  "devNote": "Frame cost assumes no Gravity"
                 },
                 {
                   "name": "G-Mode",
@@ -973,11 +981,12 @@
                       "mode": "any",
                       "artificialMorph": false
                     }},
-                    "h_canNavigateUnderwater"
+                    "h_canNavigateUnderwater",
+                    "canCarefulJump"
                   ]
                 }
               ],
-              "note": "This link is only for sparking. All other strats should go 2 -> 4 -> 5 -> 1."
+              "devNote": "This link is only for sparking and GMode. All other strats should go 2 -> 4 -> 5 -> 1."
             },
             {
               "id": 4,
@@ -985,19 +994,45 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    "SpaceJump"
+                  ]
                 },
                 {
-                  "name": "Suitless HiJump",
+                  "name": "Gravity Platforming (Right to Center)",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
+                    {"or": [
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Suitless HiJump (Right to Center)",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
                     "HiJump",
-                    "canPlayInSand"
+                    "canPlayInSand",
+                    {"or": [
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
+                    ]}
                   ]
                 },
                 {
-                  "name": "Suitless",
+                  "name": "Suitless Itemless (Right to Center)",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
@@ -1033,6 +1068,7 @@
                   "requires": [
                     "canPrepareForNextRoom",
                     "canPlayInSand",
+                    "canTrickyJump",
                     {"or": [
                       "Gravity",
                       "HiJump",
@@ -1067,6 +1103,14 @@
                       "HiJump",
                       "Gravity",
                       "canSpringBallJumpMidAir"
+                    ]},
+                    {"or": [
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
                     ]}
                   ]
                 }
@@ -1080,22 +1124,44 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    {"or": [
-                      "SpaceJump",
-                      "canPlayInSand",
-                      "canUseFrozenEnemies",
-                      "canTrickyJump"
-                    ]}
-                  ],
-                  "devNote": "Tricky for avoiding damage while platforming."
+                    "SpaceJump"
+                  ]
                 },
                 {
-                  "name": "Suitless",
+                  "name": "Gravity Platforming (Center to Right)",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
+                    {"or": [
+                      "canPlayInSand",
+                      "canUseFrozenEnemies",
+                      "canCarefulJump"
+                    ]},
+                    {"or": [
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Suitless Platforming (Center to Right)",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
                     "canPlayInSand",
-                    "HiJump"
+                    "HiJump",
+                    {"or": [
+                      "canCarefulJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
+                    ]}
                   ]
                 },
                 {
@@ -1158,7 +1224,7 @@
                   ]
                 },
                 {
-                  "name": "Gravity platforming",
+                  "name": "Gravity Platforming (Center to Left)",
                   "notable": false,
                   "requires": [
                     "Gravity",
@@ -1169,13 +1235,7 @@
                       "canCarefulJump"
                     ]},
                     {"or": [
-                      "canCarefulJump",
-                      "ScrewAttack",
-                      "Ice",
-                      {"enemyKill": {
-                        "enemies": [["Evir"]],
-                        "explicitWeapons": [ "Plasma", "Super", "PowerBombPeriphery" ]
-                      }},
+                      "canTrickyJump",
                       {"enemyDamage": {
                         "enemy": "Evir",
                         "type": "particle",
@@ -1185,12 +1245,20 @@
                   ]
                 },
                 {
-                  "name": "Suitless",
+                  "name": "Suitless Platforming (Center to Left)",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
                     "HiJump",
-                    "canPlayInSand"
+                    "canPlayInSand",
+                    {"or": [
+                      "canTrickyJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
+                    ]}
                   ]
                 },
                 {
@@ -1297,16 +1365,31 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
+                    "SpaceJump"
+                  ]
+                },
+                {
+                  "name": "Gravity Platforming (Left to Center)",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
                     {"or": [
-                      "SpaceJump",
                       "HiJump",
                       "canPreciseWalljump",
                       "canPlayInSand"
+                    ]},
+                    {"or": [
+                      "canTrickyJump",
+                      {"enemyDamage": {
+                        "enemy": "Evir",
+                        "type": "particle",
+                        "hits": 1
+                      }}
                     ]}
                   ]
                 },
                 {
-                  "name": "Suitless",
+                  "name": "Suitless Platforming (Left to Center)",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
@@ -1317,12 +1400,7 @@
                       "canSpringBallJumpMidAir"
                     ]},
                     {"or": [
-                      "canCarefulJump",
-                      "Ice",
-                      {"enemyKill": {
-                        "enemies": [["Evir"]],
-                        "explicitWeapons": [ "Plasma", "Super", "PowerBombPeriphery" ]
-                      }},
+                      "canTrickyJump",
                       {"enemyDamage": {
                         "enemy": "Evir",
                         "type": "particle",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -5287,7 +5287,6 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canPlayInSand",
                     "canSandIBJ"
                   ]
                 },
@@ -8503,10 +8502,7 @@
                       "canGravityJump",
                       "HiJump",
                       "canSpringBallJumpMidAir",
-                      {"and": [
-                        "canBombJumpOnSand",
-                        "h_canJumpIntoIBJ"
-                      ]},
+                      "canSandIBJ",
                       {"and": [
                         "h_canUseSpringBall",
                         "h_canJumpIntoIBJ"

--- a/tech.json
+++ b/tech.json
@@ -698,8 +698,19 @@
             },
             {
               "name": "canSandIBJ",
-              "requires": [ "h_canJumpIntoIBJ" ],
-              "note": "The ability to start an IBJ off a jump on sand. It requires precise rapid inputs and can be pretty obnoxious to execute."
+              "requires": [ 
+                "h_canJumpIntoIBJ",
+                "canPlayInSand"
+              ],
+              "note": [
+                "The ability to start an IBJ from sand.",
+                "Jumping from the top of sand into an IBJ takes more precision than a standard jump into IBJ.",
+                "Escaping a shallow sand fall does not require this tech, but there is a section of Maridia's West Sand Hall which would use a Sand IBJ."
+              ],
+              "devNote": [
+                "Escaping a shallow sandfall with bombs falls under canPlayInSand.",
+                "The Sandfall IBJ in West Sandhall for the bounce is specific to one section of one room because the sand depth is different there."
+              ]
             },
             {
               "name": "canDoubleBombJump",
@@ -729,18 +740,6 @@
           ],
           "note": "From a submerged platform, setting up a single bomb jump above the water line to propel Samus up and out of the water.",
           "devNote": "It's recommended to apply a number of tries as leniency here for the PBs version."
-        },
-        {
-          "name": "canBombJumpOnSand",
-          "requires": [ 
-            "canPlayInSand", 
-            "h_canBombThings"
-          ],
-          "note": [
-            "The ability to bomb jump while dealing with the sinking effect of sand physics.",
-            "This is done by placing the bomb on or above the top of the sand line and then jumping again to land on the bomb explosion,",
-            "or by rising out of the sand using Bombs inside of a sandfall to then land on the bomb that is at the sand line."
-          ]
         }
       ]
     },


### PR DESCRIPTION
Removed canBombJumpOnSand.  It and canSandIBJ were the same thing.  Their approach to west sand hall insane bomb jump was different, but that was specific to that one strat.

I wanted to expect more enemy hits when crossing the sand halls.  West sand hall has some tricky platforming and its sort of written where crossing the room in Basic takes two hits, careful jump reduces it to one hit, and at VeryHard you can expect to dodge.  Then east sandhall already had most of that logic already there.  
In East the enemies were more exposed so I was more ok using weapons to kill them.  In West it felt like you needed to know enemy spawns to kill them and that would be VeryHard level knowledge.

Writing the sandjump room entry, in the center of the room, didn't work out since it depends on the room above having walkable sand tiles.  Entering in the right place still works.