### PR TITLE
update WRITG

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -1736,13 +1736,14 @@
                   ]
                 },
                 {
-                  "name": "Jump Assist and PowerBomb",
-                  "notable": false,
+                  "name": "WRITG with PowerBombs and a Jump Assist",
+                  "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canPreciseWalljump",
                     "canHitbox",
                     "h_canUsePowerBombs",
+                    "canTrickyJump",
                     {"or": [
                       "canSpringwall",
                       "HiJump",
@@ -2191,6 +2192,7 @@
                     "h_canNavigateHeatRooms",
                     "HiJump",
                     "canTrickyJump",
+                    "canMidAirMorph",
                     {"heatFrames": 240}
                   ]
                 },
@@ -2199,9 +2201,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canPreciseWalljump",
-                    "Morph",
+                    "canWallJumpInstantMorph",
                     "canTrickyJump",
+                    "canInsaneWalljump",
                     {"heatFrames": 290}
                   ]
                 },
@@ -2254,6 +2256,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "HiJump",
+                    "canMidAirMorph",
                     "canTrickyJump",
                     {"heatFrames": 160}
                   ]
@@ -2263,8 +2266,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canPreciseWalljump",
-                    "Morph",
+                    "canInsaneWalljump",
+                    "canWallJumpInstantMorph",
                     "canTrickyJump",
                     {"heatFrames": 160}
                   ]


### PR DESCRIPTION
"Jump Assist and PowerBomb" was just as hard as New Route WRITG and is very similar to low% ice, which are both notables.  So this was made notable too.

And HJBless morph over the pirate is around Expert level, but also unreliable.