### PR TITLE
Upward G-Mode

### DIFF
--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -482,6 +482,21 @@
               "rightPosition": 2,
               "requires": []
             }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Zeela",
+                  "notable": false,
+                  "requires": [
+                    "canUpwardGModeSetup",
+                    "canTrickyUseFrozenEnemies",
+                    "h_canBombThings"
+                  ]
+                }
+              ]
+            }
           ]
         }
       ],

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -3258,6 +3258,31 @@
               "requires": []
             }
           ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Sciser",
+                  "notable": false,
+                  "requires": [ 
+                    "canUpwardGModeSetup",
+                    "canTrickyUseFrozenEnemies",
+                    "Morph",
+                    "SpringBall",
+                    "canBePatient"
+                  ],
+                  "note": [
+                    "The nearby Global crab can be used to exit on the left side of the door.",
+                    "Exiting on the right will require travelling the Morph maze to find a local crab or two."
+                  ],
+                  "devNote": [
+                    "There is a Morphless way to jump on the crab with aim down but it feels too precise to include.",
+                    "Global Crab (left side) takes 40 seconds, local crab (Right side) is 180.  Finding two left side crabs to use together is faster."
+                  ]
+                }
+              ]
+            }
+          ],
           "gModeImmobile": {
             "requires": [
               {"enemyDamage": {
@@ -3266,11 +3291,7 @@
                 "hits": 1
               }}
             ]
-          },
-          "devNote": [
-            "FIXME Add leaveWithGModeSetup.",
-            "FIXME Requires Samus to be completely against the left or right side of the doorframe. Currently all setups can do this."
-          ]
+          }
         },
         {
           "id": 2,

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -3267,8 +3267,7 @@
                   "requires": [ 
                     "canUpwardGModeSetup",
                     "canTrickyUseFrozenEnemies",
-                    "Morph",
-                    "SpringBall",
+                    "h_canUseSpringBall",
                     "canBePatient"
                   ],
                   "note": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -130,6 +130,35 @@
           "nodeSubType": "blue",
           "nodeAddress": "0x001a4bc",
           "doorEnvironments": [{"physics": "water"}],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Sciser",
+                  "notable": false,
+                  "requires": [
+                    "canUpwardGModeSetup",
+                    "canTrickyUseFrozenEnemies",
+                    {"or": [
+                      {"ammo": {"type": "Super", "count": 1}},
+                      "Gravity",
+                      {"and": [
+                        "canSuitlessMaridia",
+                        {"or": [
+                          "HiJump",
+                          "canBePatient"
+                        ]}
+                      ]}
+                    ]}
+                  ],
+                  "note": [
+                    "The Global crab in the upper section can be knocked off the wall to enter the left side of the above door.",
+                    "Otherwise, there are more crabs in the lower section of the room."
+                  ]
+                }
+              ]
+            }
+          ],
           "gModeImmobile": {
             "requires": [
               {"ammo": { "type": "Super", "count": 1 }},
@@ -773,6 +802,22 @@
           "nodeAddress": "0x001a72c",
           "doorEnvironments": [{"physics": "water"}],
           "spawnAt": 9,
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Snail Platform",
+                  "notable": false,
+                  "requires": [
+                    "canUpwardGModeSetup",
+                    "h_canNavigateUnderwater",
+                    "canTwoTileSqueeze"
+                  ],
+                  "note": "The two snails together can setup G-Mode on either side of the door."
+                }
+              ]
+            }
+          ],
           "gModeImmobile": {
             "requires": [
               {"enemyDamage": {

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -4236,6 +4236,26 @@
                 "Shinespark frames are 0 because those are covered by the Shinespark strat from 9 to 5."
               ]
             }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Sciser",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
+                    "canUpwardGModeSetup",
+                    "SpaceJump",
+                    "canTrickyUseFrozenEnemies",
+                    {"or": [
+                      "Morph",
+                      "canTwoTileSqueeze"
+                    ]}
+                  ]
+                }
+              ]
+            }
           ]
         },
         {

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -982,6 +982,23 @@
               "rightPosition": 3.5,
               "requires": []
             }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Viola",
+                  "notable": false,
+                  "requires": [
+                    "canTrickyUseFrozenEnemies",
+                    {"ammo": {"type": "Super", "count": 1}},
+                    "Morph",
+                    "SpringBall"
+                  ],
+                  "note": "Knock a Viola off of its platform and keep it on camera as it climbs to the top of the room."
+                }
+              ]
+            }
           ]
         }
       ],

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -992,8 +992,7 @@
                   "requires": [
                     "canTrickyUseFrozenEnemies",
                     {"ammo": {"type": "Super", "count": 1}},
-                    "Morph",
-                    "SpringBall"
+                    "h_canUseSpringBall"
                   ],
                   "note": "Knock a Viola off of its platform and keep it on camera as it climbs to the top of the room."
                 }

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -7561,6 +7561,30 @@
               "rightPosition": 7,
               "requires": [{"heatFrames": 120}]
             }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Gammets",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    "canUpwardGModeSetup",
+                    "canTrickyUseFrozenEnemies",
+                    "Morph"
+                  ],
+                  "note": [
+                    "Freeze the stack of Gammets together a few times to try and raise them as high as possible.",
+                    "Run with them to the door and freeze the top two such that Samus can stand on the lower and take damage from the higher Gammet when it unfreezes."
+                  ],
+                  "devNote": [
+                    "Landing on the Gammet with an aim down, or spin, wasn't working.  So require Morph.",
+                    "Would be notable but its a GMode strat."
+                  ]
+                }
+              ]
+            }
           ]
         },
         {

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -137,6 +137,31 @@
               "requires": []
             }
           ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Atomic",
+                  "notable": false,
+                  "requires": [
+                    "canUpwardGModeSetup",
+                    "canTwoTileSqueeze",
+                    "canTrickyUseFrozenEnemies",
+                    "f_DefeatedPhantoon",
+                    {"enemyDamage": {
+                      "enemy": "Atomic",
+                      "type": "contact",
+                      "hits": 1
+                    }}
+                  ],
+                  "note": [
+                    "Bring two atomics to the top of the room.",
+                    "Stand on one frozen Atomic to bring a second Atomic to the correct height to use as a crouch platform."
+                  ]
+                }
+              ]
+            }
+          ],
           "gModeImmobile": {
             "requires": [
               {"enemyDamage": {
@@ -1208,6 +1233,23 @@
                   "name": "Base",
                   "notable": false,
                   "requires": []
+                }
+              ]
+            }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Frozen Atomic",
+                  "notable": false,
+                  "requires": [
+                    "canUpwardGModeSetup",
+                    "canTwoTileSqueeze",
+                    "canTrickyUseFrozenEnemies",
+                    "f_DefeatedPhantoon"
+                  ],
+                  "note": "Stand on one frozen Atomic to bring a second Atomic to the correct height to use as a crouch platform."
                 }
               ]
             }

--- a/tech.json
+++ b/tech.json
@@ -1294,7 +1294,9 @@
               "note": [
                 "Ability to setup an R-mode or G-mode through an upward door.",
                 "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
-                "This is typically done by using an enemy as a platform beneath the door and instantly standing up by pressing forward while crouched."
+                "This is typically done by using an enemy as a platform beneath the door and instantly standing up by pressing forward while crouched.",
+                "Getting Samus into the crouch position can usually be down by spinjumping (beneath the transition tiles) then aiming down to stand on the enemy.",
+                "Unmorphing when on top of the enemy will also put Samus in a crouch."
               ]
             }
           ]

--- a/tech.json
+++ b/tech.json
@@ -1287,6 +1287,15 @@
                 "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
                 "This is typically done using quicksand, clipping into the floor, or using a thawing frozen wall crawler."
               ]
+            },
+            {
+              "name": "canUpwardGModeSetup",
+              "requires": [ "canEnterRMode" ],
+              "note": [
+                "Ability to setup an R-mode or G-mode through an upward door.",
+                "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
+                "This is typically done by using an enemy as a platform beneath the door and instantly standing up by pressing forward while crouched."
+              ]
             }
           ]
         }


### PR DESCRIPTION
PCJR mellas were too chaotic so they were left out.

Touching the transition on the Left side vs Right side was possible from all doors except extra requirements were required in some rooms.
-Crab maze can get left side but needs morph for right side
-Crab shaft can use supers for left side but needs to travel to the bottom to touch right side
-Aqueduct is harder to get left side when itemless but it can be done

So much easier with custom portals.  And all the transitions are in a list for me.