### PR TITLE
Remove All Previous Node Objects

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -527,25 +527,6 @@ __Example:__
 {"obstaclesNotCleared": ["A"]}
 ```
 
-### Room Pathing Objects
-This section contains logical elements that are affected by Samus' pathing within a room.
-
-#### previousNode object
-A `previousNode` object represents the need for Samus to have arrived to the node directly from a given node. This usually has to do with quick-respawn blocks not being back yet.
-
-__Example:__
-```json
-{"previousNode": 1}
-```
-
-#### previousStratProperty object
-A `previousStratProperty` object represents the need for Samus to have arrived to the node via a strat that has a given stratProperty. This usually has to do with quick-respawn blocks not being back yet, or spinjump conservation. In those cases, arriving via other strats doesn't allow reproducing those conditions.
-
-__Example:__
-```json
-{"previousStratProperty": "spinjump"}
-```
-
 __Additional considerations__
 Entering a room does not count as executing a strat, so this logical element cannot be fulfilled instantly upon entering a room.
 

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -1553,6 +1553,13 @@
           "nodeSubType": "junction"
         }
       ],
+      "obstacles": [
+        {
+          "id": "A",
+          "name": "Gates Have Closed",
+          "obstacleType": "inanimate"
+        }
+      ],
       "enemies": [
         {
           "id": "e1",
@@ -1613,28 +1620,23 @@
                   "name": "Speed Through",
                   "notable": false,
                   "requires": [
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
+                    {"obstaclesNotCleared": ["A"]},
                     "SpeedBooster"
-                  ]
+                  ],
+                  "clearsObstacles": ["A"]
                 },
                 {
                   "name": "Early Supers Mockball",
                   "notable": true,
                   "requires": [
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
+                    {"obstaclesNotCleared": ["A"]},
                     "canMockball"
                   ],
+                  "clearsObstacles": ["A"],
                   "failures": [
                     {
                       "name": "Crumble Fall",
                       "leadsToNode": 3,
-                      "clearsPreviousNode": true,
                       "note": "Falls down into node 3 with no possiblity of quick crumble escape."
                     }
                   ],
@@ -1644,21 +1646,18 @@
                   "name": "Early Supers Crouch Gate Clip Jump",
                   "notable": false,
                   "requires": [
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
+                    {"obstaclesNotCleared": ["A"]},
                     "canCrouchGateClip",
                     {"or": [
                       "canXRayTurnaround",
                       "canMoonwalk"
                     ]}
                   ],
+                  "clearsObstacles": ["A"],
                   "failures": [
                     {
                       "name": "Crumble Fall",
                       "leadsToNode": 3,
-                      "clearsPreviousNode": true,
                       "note": "Falls down into node 3 with no possiblity of quick crumble escape."
                     }
                   ],
@@ -1673,10 +1672,7 @@
                   "name": "Early Supers Crouch Gate Clip Damage Boost",
                   "notable": true,
                   "requires": [
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
+                    {"obstaclesNotCleared": ["A"]},
                     "canCrouchGateClip",
                     "canCameraManip",
                     "canHorizontalDamageBoost",
@@ -1686,11 +1682,11 @@
                       "type": "contact"
                     }}
                   ],
+                  "clearsObstacles": ["A"],
                   "failures": [
                     {
                       "name": "Crumble Fall",
                       "leadsToNode": 3,
-                      "clearsPreviousNode": true,
                       "note": "Falls down into node 3 with no possiblity of quick crumble escape."
                     }
                   ],
@@ -1709,7 +1705,8 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [],
-                  "note": "This has no requirements, but getting back out does!"
+                  "clearsObstacles": ["A"],
+                  "note": "This has no requirements, but getting back out does."
                 }
               ]
             },
@@ -1720,24 +1717,11 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
+                    {"obstaclesNotCleared": ["A"]},
                     "SpeedBooster"
-                  ]
-                },
-                {
-                  "name": "Mockball",
-                  "notable": false,
-                  "requires": [
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
-                    "canMockball"
                   ],
-                  "note" : "Not considered a notable strat because executing this has no real value."
+                  "clearsObstacles": ["A"],
+                  "devNote": "There are other ways to get here, but there is no reason to go there, so they are omitted."
                 }
               ]
             }
@@ -1754,20 +1738,19 @@
                   "notable": false,
                   "requires": [
                     {"or": [
+                      "canWalljump",
                       "HiJump",
-                      "h_canFly"
+                      "h_canFly",
+                      "canSpringBallJumpMidAir"
                     ]}
-                  ]
-                },
-                {
-                  "name": "Wall Jump",
-                  "notable": false,
-                  "requires": [ "canWalljump" ]
+                  ],
+                  "clearsObstacles": ["A"]
                 },
                 {
                   "name": "Crouch Jump Down Grab",
                   "notable": false,
-                  "requires": [ "h_canCrouchJumpDownGrab" ]
+                  "requires": [ "h_canCrouchJumpDownGrab" ],
+                  "clearsObstacles": ["A"]
                 }
               ]
             }
@@ -1785,69 +1768,18 @@
                   "requires": [ "h_canBombThings" ]
                 },
                 {
-                  "name": "Early Supers Quick Crumble Escape (Dual Quick Crumble)",
+                  "name": "Early Supers Quick Crumble Escape",
                   "notable": false,
-                  "requires": [
-                    "canQuickCrumbleEscape",
-                    {"previousNode": 1}
-                  ],
+                  "requires": [ "canQuickCrumbleEscape" ],
                   "failures": [
                     {
                       "name": "Crumble Failure",
-                      "clearsPreviousNode": true,
                       "note": "Failure leaves you in node 3 with solid crumble blocks above your head."
                     }
                   ],
-                  "note": "This one involves doing a second quick crumble escape on the way out as a means to avoid doing a crumble jump."
-                },
-                {
-                  "name": "Early Supers Quick Crumble Escape (Space)",
-                  "notable": false,
-                  "requires": [
-                    "canQuickCrumbleEscape",
-                    "SpaceJump",
-                    {"previousNode": 1}
-                  ],
-                  "failures": [
-                    {
-                      "name": "Crumble Failure",
-                      "clearsPreviousNode": true,
-                      "note": "Failure leaves you in node 3 with solid crumble blocks above your head."
-                    }
-                  ],
-                  "note": "Space Jump is here as an alternative to performing a crumble jump on the way out."
-                },
-                {
-                  "name": "Early Supers Quick Crumble Escape (SpringBall)",
-                  "notable": false,
-                  "requires": [
-                    "canQuickCrumbleEscape",
-                    "h_canUseSpringBall",
-                    {"previousNode": 1}
-                  ],
-                  "failures": [
-                    {
-                      "name": "Crumble Failure",
-                      "clearsPreviousNode": true,
-                      "note": "Failure leaves you in node 3 with solid crumble blocks above your head."
-                    }
-                  ],
-                  "note": "Spring Ball is here as an alternative to performing a crumble jump on the way out."
-                },
-                {
-                  "name": "Early Supers Quick Crumble Escape (Crumble Jump)",
-                  "notable": false,
-                  "requires": [
-                    "canQuickCrumbleEscape",
-                    "canCrumbleJump",
-                    {"previousNode": 1}
-                  ],
-                  "failures": [
-                    {
-                      "name": "Crumble Failure",
-                      "clearsPreviousNode": true,
-                      "note": "Failure leaves you in node 3 with solid crumble blocks above your head."
-                    }
+                  "note": [
+                    "It is possible to do a quick crumble escape twice, requiring no other items or tech.",
+                    "It is easier to escape by doing a quick crumble escape, followed by a crumble block jump or using spring ball or space jump."
                   ]
                 }
               ]

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1797,6 +1797,11 @@
           "id": "A",
           "name": "Sidehoppers",
           "obstacleType": "enemies"
+        },
+        {
+          "id": "B",
+          "name": "Mission Impossible: Return through the Crumble Block",
+          "obstacleType": "abstract"
         }
       ],
       "enemies": [
@@ -2019,13 +2024,11 @@
                   "requires": [
                     "canQuickCrumbleEscape",
                     "HiJump",
-                    {"obstaclesCleared": ["A"]},
-                    {"previousNode": 4}
+                    {"obstaclesCleared": ["A","B"]}
                   ],
                   "failures": [
                     {
                       "name": "Crumble Failure",
-                      "clearsPreviousNode": true,
                       "note": "Failure leaves you at 3 with a solid crumble block above."
                     }
                   ],
@@ -2058,7 +2061,8 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ {"ammo": { "type": "Super", "count": 1 }} ]
+                  "requires": [ {"ammo": { "type": "Super", "count": 1 }} ],
+                  "clearsObstacles": ["B"]
                 }
               ]
             }

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -5359,7 +5359,6 @@
                     {
                       "name": "Crumble Fall",
                       "leadsToNode": 5,
-                      "clearsPreviousNode": true,
                       "note": "Falls down into node 5 with no possiblity of quick crumble escape."
                     }
                   ],

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2354,6 +2354,18 @@
                   "note": "Shoot the shot block, then crumble jump on the middle platform."
                 },
                 {
+                  "name": "Crumble Shaft Top Item Crumble Spin Jump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canCrumbleJump",
+                    "canTrickyJump",
+                    {"heatFrames": 150}
+                  ],
+                  "clearsObstacles": ["A"],
+                  "note": "Shoot the shot block, then crumble spin jump on the middle platform."
+                },
+                {
                   "name": "Space Jump",
                   "notable": false,
                   "requires": [
@@ -2612,7 +2624,10 @@
                   "notable": false,
                   "requires": [
                     "h_heatProof",
-                    "canCrumbleJump",
+                    {"or": [
+                      "canCrumbleJump",
+                      "h_canUseSpringBall"
+                    ]},
                     {"resetRoom": {
                       "nodes": [1, 2],
                       "mustStayPut": false
@@ -2632,8 +2647,7 @@
                     "h_canNavigateHeatRooms",
                     "canConsecutiveWalljump",
                     {"heatFrames": 550}
-                  ],
-                  "clearsObstacles": ["A"]
+                  ]
                 },
                 {
                   "name": "Crumble Shaft IBJ (Left)",

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2306,6 +2306,13 @@
           "nodeAddress": "0x78B46"
         }
       ],
+      "obstacles": [
+        {
+          "id": "A",
+          "name": "Obtain the Item while in a Spin Jump State",
+          "obstacleType": "abstract"
+        }
+      ],
       "enemies": [
         {
           "id": "e1",
@@ -2354,7 +2361,7 @@
                     "SpaceJump",
                     {"heatFrames": 150}
                   ],
-                  "stratProperties": ["spinjump"]
+                  "clearsObstacles": ["A"]
                 },
                 {
                   "name": "Shinespark",
@@ -2378,7 +2385,7 @@
                     "canCameraManip",
                     {"heatFrames": 300}
                   ],
-                  "stratProperties": ["spinjump"],
+                  "clearsObstacles": ["A"],
                   "note": [
                     "Jump and aim down to lower the camera so the middle platform Sova starts moving.",
                     "Then shoot the shot block and walljump off the left side of the middle platform to reach the item."
@@ -2393,7 +2400,7 @@
                     "canCameraManip",
                     {"heatFrames": 350}
                   ],
-                  "stratProperties": ["spinjump"],
+                  "clearsObstacles": ["A"],
                   "note": [
                     "Jump and aim down to lower the camera so the middle platform Sova starts moving.",
                     "Then freeze it by aiming down, shoot the shot block, and use the Sova as a stable platform."
@@ -2625,7 +2632,8 @@
                     "h_canNavigateHeatRooms",
                     "canConsecutiveWalljump",
                     {"heatFrames": 550}
-                  ]
+                  ],
+                  "clearsObstacles": ["A"]
                 },
                 {
                   "name": "Crumble Shaft IBJ (Left)",
@@ -2708,7 +2716,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "SpaceJump",
-                    {"previousStratProperty": "spinjump"},
+                    {"obstaclesCleared": ["A"]},
                     {"heatFrames": 175}
                   ],
                   "note": "Must have grabbed the item with a spinjump still active."

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -163,12 +163,6 @@
                 "title": "Softlock",
                 "description": "Indicates whether this failure causes a softlock. If missing, this should be viewed as false."
               },
-              "clearsPreviousNode": {
-                "$id": "#/definitions/strat/properties/failures/items/properties/clearsPreviousNode",
-                "type": "boolean",
-                "title": "Clears Previous Node",
-                "description": "Indicates whether this failure causes the previous node to be overwritten (and set to current node). If the failure leads to a node, Samus lands at that node and that node is also set to the previous node If missing, this should be viewed as false."
-              },
               "note": {
                 "$ref" : "m3-note.schema.json#/definitions/note",
                 "$id": "#/definitions/strat/properties/failures/items/properties/note"

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -626,18 +626,6 @@
               }
             }
           },
-          "previousNode": {
-            "$id": "#/definitions/logicalRequirement/items/properties/previousNode",
-            "type": "integer",
-            "title": "Previous Node",
-            "description": "Fulfilled if the player arrived to the current node directly from the node with the provided in-room ID."
-          },
-          "previousStratProperty": {
-            "$id": "#/definitions/logicalRequirement/items/properties/previousStratProperty",
-            "type": "string",
-            "title": "Previous Strat Property",
-            "description": "Fulfilled if the player arrived to the current node via a strat that had a given stratProperty."
-          },
           "resetRoom": {
             "$id": "#/definitions/logicalRequirement/items/properties/resetRoom",
             "type": "object",


### PR DESCRIPTION
Previous nodes are not really practical to use when interpreting the data, as the number of nodes and links is too large. Fortunately these are no longer required due to the new encoding methods we have developed. 

Removed: `previousNode`, `clearsPreviousNode`, and `previousStratProperty`