### PR TITLE
Wrap-up obstacles clean-up

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2704,8 +2704,7 @@
         {
           "id": "A",
           "name": "Bottom Bomb Blocks",
-          "obstacleType": "inanimate",
-          "requires": []
+          "obstacleType": "inanimate"
         }
       ],
       "enemies": [

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -5154,8 +5154,7 @@
         {
           "id": "A",
           "name": "Metal Pirates",
-          "obstacleType": "enemies",
-          "requires": []
+          "obstacleType": "enemies"
         }
       ],
       "enemies": [

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -257,10 +257,7 @@ A room can have an array of obstacles. Obstacles are barriers that can be destro
 * To allow proper ammo requirements when passing somewhere multiple times but only needing to break the obstacle once
 * To represent things that can be opened only from one direction, but then can be freely passed once opened (e.g. crumble blocks, green and blue gates)
 
-Clearing an obstacle is done by executing a [strat](../strats.md) that includes the obstacle in its `clearsObstacles` property. An
-`obstaclesCleared` requirement is used to represent that an obstacle must be already cleared in order to execute a strat. The requirements to destroy an obstacle can also be found in a couple other places which are deprecated (and will likely be removed in the future):
-* Some requirements can be placed on the obstacle definition. Those are needed to destroy an obstacle in _all_ situations where the obstacle must be cleared. For the most part, this will be left null unless the requirements are complicated enough that their duplication becomes undesirable.
-* Requirements can be placed on [a strat's obstacles property](../strats.md#obstacles). These represent requirements on the strat for an obstacle to be cleared while executing the strat; if the obstacle is already cleared, then these requirements are not applicable.
+Clearing an obstacle is done by executing a [strat](../strats.md) that includes the obstacle in its `clearsObstacles` property. An `obstaclesCleared` [logical requirement](../logicalRequirements.md) is used to represent that an obstacle must be already cleared in order to execute a strat.
 
 __Additional considerations__ 
 

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -1317,12 +1317,6 @@
                 "devNote": {
                   "$ref" : "m3-note.schema.json#/definitions/devNote",
                   "$id": "#/properties/rooms/items/properties/obstacles/items/properties/devNote"
-                },
-                "requires": {
-                  "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
-                  "$id": "#/properties/rooms/items/properties/obstacles/items/properties/requires",
-                  "title": "Absolute Obstacle Requirements",
-                  "description": "Equipment, tech, and flag requirements that are always needed to break this obstacle. Those are applied on top of any requirements specified on an `obstacle` logical element that references this obstacle."
                 }
               }
             }

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -67,62 +67,6 @@
             "pattern": "^(.*)$"
           }
         },
-        "obstacles": {
-          "$id": "#/definitions/strat/properties/obstacles",
-          "type": "array",
-          "title": "Strat obstacles",
-          "description": "DEPRECATED: An array of obstacles that must be destroyed (during the strat or previously) for the strat to be successfully executed. Going forward, 'obstaclesCleared' requirements and 'clearsObstacles' strat property should be used in favor of this 'obstacles' property.",
-          "items": {
-            "$id": "#/definitions/strat/properties/obstacles/items",
-            "type": "object",
-            "required": [
-              "id",
-              "requires"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "id": {
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/id",
-                "type": "string",
-                "title": "Obstacle ID",
-                "description": "The ID of the obstacle that must be destroyed.",
-                "default": "",
-                "examples": ["A", "B"],
-                "pattern": "^(.*)$"
-              },
-              "requires": {
-                "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/requires",
-                "title": "Obstacle Requirements",
-                "description": "Equipment, tech, and flag requirements to destroy this obstacle, on top of requirements defined on the obstacle itself (does not apply if obstacle already destroyed since entering the room)."
-              },
-              "bypass": {
-                "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/bypass",
-                "title": "Obstacle Bypass Requirements",
-                "description": "Equipment, tech, and flag requirements to bypass this obstacle instead of destroying it."
-              },
-              "additionalObstacles": {
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/additionalObstacles",
-                "type": "array",
-                "title": "Additional obstacles",
-                "description": "The IDs of obstacles that are simultaneously destroyed if the containing obstacle is destroyed via this strat.",
-                "items": {
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                }
-              },
-              "note": {
-                "$ref" : "m3-note.schema.json#/definitions/note",
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/note"
-              },
-              "devNote": {
-                "$ref" : "m3-note.schema.json#/definitions/devNote",
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/devNote"
-              }
-            }
-          }
-        },
         "failures": {
           "$id": "#/definitions/strat/properties/failures",
           "type": "array",

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -268,31 +268,6 @@ def process_strats(src, paramData):
                     messages["counts"]["reds"] += 1
                 else:
                     # valid strat
-                    # if it's got obstacles
-                    if "obstacles" in strat:
-                        for obstacle in strat["obstacles"]:
-                            # make sure the obstacle exists in the room
-                            if obstacle["id"] not in roomData["obstacles"]["ids"]:
-                                msg = f"🔴ERROR: Invalid Obstacle ID:{stratRef}:{obstacle['id']}"
-                                messages["reds"].append(msg)
-                                messages["counts"]["reds"] += 1
-                            # check additionalObstacles too
-                            if "additionalObstacles" in obstacle:
-                                for addtlObstacle in obstacle["additionalObstacles"]:
-                                    # make sure it exists in the room
-                                    if addtlObstacle not in roomData["obstacles"]["ids"]:
-                                        msg = f"🔴ERROR: Invalid Additional Obstacle ID:{stratRef}:{obstacle['id']}:{addtlObstacle}"
-                                        messages["reds"].append(msg)
-                                        messages["counts"]["reds"] += 1
-                    # check cleared obstacles too
-                    if "clearedObstacles" in strat:
-                        for obstacle in strat["clearedObstacles"]:
-                            # make sure it exists in the room
-                            if obstacle not in roomData["obstacles"]["ids"]:
-                                msg = f"🔴ERROR: Invalid Cleared Obstacle ID:{stratRef}:{obstacle}"
-                                messages["reds"].append(msg)
-                                messages["counts"]["reds"] += 1
-
                     if showArea:
                         msg = ""
                         area = roomData["area"]


### PR DESCRIPTION
- Remove deprecated strat property "obstacles" from schema (All occurrences were previously removed).
- Remove deprecated property "requires" on obstacles from the schema and from the last two places where they occurred.
- Clean up the docs to remove references to the now-removed properties.
- Remove the tests corresponding to the now-removed properties (and also to a strat property "clearedObstacles" which doesn't exist). I checked that the remaining tests do cover the strat property "clearsObstacles" and logical requirements "obstaclesCleared" and "obstaclesNotCleared".