### PR TITLE
G-Mode: Pink Brinstar part 2

### DIFF
--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -568,6 +568,18 @@
                 }
               ]
             }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": [],
+                  "note": "Carefully lure a Zeb from the pipe."
+                }
+              ]
+            }
           ]
         },
         {
@@ -612,6 +624,18 @@
               ]
             }
           ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": [],
+                  "note": "Lure a Zeb from the pipe."
+                }
+              ]
+            }
+          ],
           "locks": [
             {
               "name": "Big Pink Top Right Red Lock (to Kihunters)",
@@ -645,6 +669,21 @@
                 }
               ],
               "openEnd": 1
+            }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": [ "canTrickyUseFrozenEnemies" ],
+                  "note": [
+                    "Carefully lure a Zeb from the pipe below while freezing it.",
+                    "Samus must start to the left of the pipe in order for the Zeb to move left at the end."
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -690,6 +729,37 @@
                     {"obstaclesCleared": ["C"]}
                   ],
                   "note": "Use the morph tunnel that used to have crumble blocks as a faster path to the Mission Impossible transition."
+                }
+              ]
+            }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": [
+                    "canTrickyUseFrozenEnemies",
+                    {"or": [
+                      "h_canUsePowerBombs",
+                      {"obstaclesCleared": ["B"]},
+                      {"and": [
+                        "Morph",
+                        {"obstaclesCleared": ["C"]},
+                      ]}
+                    ]},
+                    {"or": [
+                      "canWalljump",
+                      "HiJump",
+                      "SpaceJump",
+                      "canSpringBallJumpMidAir"
+                    ]}
+                  ],
+                  "note": [
+                    "Carefully lure a Zeb from the pipe below while freezing it.",
+                    "Samus must start to the left of the pipe in order for the Zeb to move left at the end."
+                  ]
                 }
               ]
             }
@@ -750,6 +820,18 @@
                   "name": "Base",
                   "notable": false,
                   "requires": []
+                }
+              ]
+            }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": [],
+                  "note": "Carefully lure a Zeb from the pipe below."
                 }
               ]
             }

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -746,7 +746,7 @@
                       {"obstaclesCleared": ["B"]},
                       {"and": [
                         "Morph",
-                        {"obstaclesCleared": ["C"]},
+                        {"obstaclesCleared": ["C"]}
                       ]}
                     ]},
                     {"or": [

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -575,7 +575,12 @@
                 {
                   "name": "Get Hit By Zeb",
                   "notable": false,
-                  "requires": [],
+                  "requires": [
+                    {"or": [
+                      "h_canBombThings",
+                      {"obstaclesCleared": ["A"]}
+                    ]}
+                  ],
                   "note": "Carefully lure a Zeb from the pipe."
                 }
               ]
@@ -3404,7 +3409,7 @@
                   "name": "Get Hit By Zero",
                   "notable": false,
                   "requires": [],
-                  "note": "The timing to get hit by these guys is a bit tighter, since they are so slow."
+                  "note": "The timing to get hit by these guys is a bit tighter, since they are so slow. Buffering their movement with x-ray can help."
                 }
               ]
             }

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -2885,6 +2885,17 @@
               ],
               "openEnd": 0
             }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": []
+                }
+              ]
+            }
           ]
         },
         {
@@ -2982,6 +2993,26 @@
                     "canBeVeryPatient"
                   ],
                   "note": "Climb up 8 screens."
+                },
+                {
+                  "name": "G-Mode Overload PLMS with Camera Scroll Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }},
+                    {"or": [
+                      "canConsecutiveWalljump",
+                      "SpaceJump"
+                    ]}
+                  ],
+                  "note": "Climb the shaft and overload PLMs with the camera scroll blocks which are against the crumble blocks.",
+                  "devNote": [
+                    "This is mostly an alternative to the canBeVeryPatient X-Ray climb.",
+                    "This is possible with an IBJ, but it's still about 3 minutes, and you can't remotely acquire the item because it's in a Chozo Ball."
+                  ]
                 }
               ]
             },

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -3092,6 +3092,17 @@
               ]
             }
           ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": []
+                }
+              ]
+            }
+          ],
           "locks": [
             {
               "name": "Spore Spawn Farming Room Green Lock (to Big Pink)",
@@ -3126,6 +3137,17 @@
                 }
               ],
               "openEnd": 0
+            }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zeb",
+                  "notable": false,
+                  "requires": []
+                }
+              ]
             }
           ]
         }
@@ -3291,6 +3313,18 @@
                 }
               ],
               "note": "Charge a spark going left, then build speed and jump far to the right before sparking."
+            }
+          ],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Zero",
+                  "notable": false,
+                  "requires": [],
+                  "note": "The timing to get hit by these guys is a bit tighter, since they are so slow."
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
Adds several g-mode strats in Pink Brinstar. The remaining strats that are not included in this PR:
- Big Pink uses
- Big Pink leave with g-mode from door 4
- Pink Hoppers: Left to Right