### PR TITLE
Update strats.md and schema

### DIFF
--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -118,19 +118,6 @@
             }
           }
         },
-        "stratProperties": {
-          "$id": "#/definitions/strat/properties/stratProperties",
-          "type": "array",
-          "title": "Strat Properties",
-          "description": "A list of strat properties this strat has, which may impact what is doable once the strat's destination is reached.",
-          "examples": ["spinjump"],
-          "items": {
-            "$id": "#/definitions/strat/properties/stratProperties/items",
-            "type": "string",
-            "title": "Strat Property",
-            "description": "An individual property of the strat."
-          }
-        },
         "note": {
           "$ref" : "m3-note.schema.json#/definitions/note",
           "$id": "#/definitions/strat/properties/note"

--- a/strats.md
+++ b/strats.md
@@ -3,6 +3,28 @@ Strats are a concept that encompasses performing a series of maneuvers in a room
 
 Strats are usually presented within an array of strats, where all individual strats are a way to attain roughly the same goal.
 
+## Structure
+
+A `strat` can have the following properties:
+  * _name:_ The name of the strat.
+  * _notable:_ Indicates whether the strat is notable.
+  * _requires:_ The [logical requirements](logicalRequirements.md) that must be fulfilled to execute that strat.
+  * _clearsObstacles:_ An array containing the ID of obstacles that will be cleared by executing this strat (if they are not already cleared).
+  * _reusableRoomwideNotable:_ The name of the reusable roomwide notable strat. This must share an identical name with an entry in the `reusableRoomwideNotable` array and the other strats that are connected to this one. This is only applicable for strats where `notable` is `true`.
+
+These properties are described below in more detail.
+### Example
+
+Here's a simple example of a strat:
+
+```json
+{
+  "name": "Base",
+  "notable": false,
+  "requires": ["Morph"]
+}
+```
+
 ## Notable Strats
 
 Some strats are flagged as "notable". this means a few things:
@@ -14,65 +36,12 @@ Some strats are flagged as "notable". this means a few things:
 
 ## Logical Requirements
 
-A strat has [logical requirements](logicalRequirements.md) which must be fulfilled in order to execute it. Those will always be specified, although they may be explicitly set to null if there are no requirements.
+A strat has [logical requirements](logicalRequirements.md) which must be fulfilled in order to execute it. These must always be specified, although they may be explicitly set to an empty array if there are no requirements.
 
-## Obstacles
+## Clears Obstacles
 
-Execution of a strat may also require an [obstacle](region/region-readme.md#obstacles) (or more) in the room to be handled in some way. Possible ways to handle an obstacle:
- * Having destroyed the obstacle previously, during the execution of a previous strat. This only works so long as Samus hasn't reset the room since.
- * Destroying the obstacle while executing the current strat, by fulfilling specific [logical requirements](logicalRequirements.md).
- * Bypassing the obstacle without destroying it, by fulfilling specific [logical requirements](logicalRequirements.md).
+Execution of a strat may have an effect of clearing one or more [obstacles](region/region-readme.md#obstacles) in the room. This can represent, for example, that certain enemies or special blocks are destroyed by executing this strat. This allows later performing strats in the room that have an [`obstaclesCleared`](logicalRequirements.md#obstaclescleared) logical requirement on the same obstacle.
 
 ## Reusable Roomwide Notable Strats
 
-Some notable strats may be very similar to each other. If similar notable strats exist in different rooms, a tech might be made for them. Otherwise, if similar notable strats exist in the same room, a [reusable notable strat](region/region-readme.md#reusable) can exist to connect them with a common name and description. This is often only the case for symmetric links with strats of notable difficulty. 
-
-## Structure
-
-A `strat` can have the following properties:
-  * _name:_ The name of the strat.
-  * _notable:_ Indicates whether the strat is notable.
-  * _requires:_ The [logical requirements](logicalRequirements.md) that must be fulfilled to execute that strat.
-  * _clearsObstacles:_ An array containing the ID of obstacles that will be cleared by executing this strat (if they are not already cleared).
-  * _obstacles_ An array of objects, each representing an [obstacle](region/region-readme.md#obstacles) that must be destroyed (or bypassed) to execute the strat, either by fulfilling requirements or by having destroyed it previously (without exiting the room). It is preferred to
-  use the `clearsObstacles` property (along with `obstaclesCleared` logical requirements) instead of this property. Each object under `obstacles` has the following properties:
-    * _id:_ The in-room id of the obstacle
-    * _requires:_ The [logical requirements](logicalRequirements.md) that must be fulfilled to destroy the obstacle, if it isn't already destroyed. These requirements are in addition to any requirements already tied to the `obstacle`'s definition within the room.
-    * _bypass:_ Some [logical requirements](logicalRequirements.md) that can be fulfilled to bypass the obstacle, if it isn't already destroyed. Voids both the `requires` property and the requirements tied to the `obstacle`'s definition within the room. Naturally, this does not destroy the obstacle.
-    * _additionalObstacles:_ An array containing the ID of additional obstacles that may not need to be destroyed to execute the strat, but that will be destroyed by destroying the containing `obstacle` via this `strat`. Additional obstacles are _not_ destroyed when bypassing the main obstacle.
-  * _stratProperties:_ An array of keywords, which can be used as a requirement for strats in the destination node. These properties can be used to describe miscellaneous details (such as being in a spinjump) that will impact whether it's possible to follow-up with another specific strat.
-  * _reusableRoomwideNotable:_ The name of the reusable roomwide notable strat. This must share an identical name with an entry in the `reusableRoomwideNotable` array and the other strats that are connected to this one. This is only applicable for strats where `notable` is `true`.
-
-### Example
-
-Here's an example of a strat:
-
-```json
-{
-  "name": "Base",
-  "notable": false,
-  "requires": ["Morph"],
-  "obstacles": [
-    {
-      "id": "F",
-      "requires": [
-        "Super",
-        {"ammo": {
-          "type": "Super",
-          "count": 1
-        }},
-        {"or":[
-          "Bombs",
-          {"and": [
-            "PowerBomb",
-            {"ammo": {
-              "type": "PowerBomb",
-              "count": 1
-            }}
-          ]}
-        ]}
-      ]
-    }
-  ]
-}
-```
+Some notable strats may be very similar to each other. If similar notable strats exist in different rooms, a tech might be made for them. Otherwise, if similar notable strats exist in the same room, a [reusable notable strat](region/region-readme.md#reusable) can exist to connect them with a common name and description. A typical example is for symmetric links with strats of notable difficulty, with one notable strat for each of two directions the room can be traversed in, and the two strats being connected by sharing the same reusable notable.


### PR DESCRIPTION
- Remove the obsolete description of `obstacles` strat property and its occurrence in the example.
- Remove the `stratProperties` strat property from the docs and schema. There were never very many occurrences of this in the data, and by now they have all been removed as we've settled on using abstract nodes or obstacles to handle such scenarios.
- In the strat docs, move the "Structure" section to the top. We will soon be adding more strat properties, and it can be helpful to have the overview at the beginning rather than the end of the page.