### PR TITLE
Split (excess)shinesparkFrames into separate requirements

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -120,6 +120,12 @@ When trying to determine the ammo needed to fulfill an `enemyKill` object, it co
 ### Health Management Objects
 This section contains logical elements that are fulfilled by spending health. Encountering enough of those successively without having a chance to refill can impact the number of e-tanks that are needed to get through.
 
+#### shinesparkFrames
+A `shinesparkFrames` object represents the need for Samus to spend energy performing a shinespark for the given number of frames, which equals the amount of energy spent, as shinesparks use 1 energy per frame. This implicitly requires the `canShinespark` tech. It also requires that Samus has at least 29 energy remaining at the end of the spark.
+
+#### excessShinesparkFrames
+An `excessShinesparkFrames` object represents the need for Samus to spend energy performing a shinespark for the given number of frames, or until Samus' energy reaches 29, whichever happens first. This implicitly requires the `canShinespark` tech.
+
 #### acidFrames object
 An `acidFrames` object represents the need for Samus to spend time (measured in frames) in a pool of acid. This is meant to be converted to a flat health value based on item loadout. The vanilla damage for acid is 6 damage every 4 frames, halved by Varia (3 damage every 4 frames), and halved again by Gravity Suit (3 damage every 8 frames).
 
@@ -356,23 +362,19 @@ A `canComeInCharged` object represents the need to charge a shinespark in an adj
 * _fromNode:_ Indicates from what door this logical requirement expects Samus to enter the room
 * _inRoomPath:_ An array that indicates the path of node IDs that the player should travel, up to and including the node where the `adjacentRunway` logical element is, in order to be able to used the adjacent runway. If this is missing, the player is expected to enter the room at the current node and not move from there.
 * _framesRemaining:_ Indicates the minimum number of frames Samus needs to have left, upon entering the room, before the shinespark charge expires. A value of 0 indicates that shinesparking through the door works.
-* _shinesparkFrames:_ Indicates how many frames the shinespark that will be used lasts. This can be 0 in cases where only the blue suit is needed. During a shinespark, Samus is damaged by 1 every frame, and being able to spend that health is part of of being able to fulfill a `canComeInCharged` object.
-* _excessShinesparkFrames:_ Indicates how far beyond a breakable wall or ledge a shinespark will travel, in terms of frames.  This enables shinesparking at a lower health value but will still cost the full `shinesparkFrames` value if that health can be paid.
 * _unusableTiles:_ The number of tiles that are part of the runway but cannot be used for this shinespark.  Meaning the combined runway must be this many tiles longer to fulfill the requirement.  The `unusableTiles` must count from the end of the runway in the current room that is not touching the door.  The number of unusableTiles may be larger than the current room's runway.
 
 __Example:__
 ```json
 {"canComeInCharged": {
   "fromNode": 4,
-  "framesRemaining": 180,
-  "shinesparkFrames": 75
+  "framesRemaining": 180
 }}
 ```
 
 __Additional considerations__
 
 * A `canComeInCharged` object implicitly requires the Speed Booster.
-* A `canComeInCharged` object implicitly requires the `canShinespark` tech if it has more than 0 `shinesparkFrames`.
 * A `canComeInCharged` object is implicitly fulfilled if the runways on the two sides of the door combine into a large enough runway to charge a spark. Combining with the adjacent room's runway is _not_ necessary if the current room's runway by itself is large enough.
 The number of framesRemaining in that case is:
   * 180 if there is a usable runway in the destination room
@@ -380,6 +382,8 @@ The number of framesRemaining in that case is:
 * Please note that unless the adjacent room is not used at all, fulfilling this logical element also causes the room to be reset. This means all obstacles respawn.
 
 Please refer to the section about runways in [the Region documentation](region/region-readme.md) for a more detailed explanation of runways and how to combine them.
+
+Energy requirements for shinesparking (if applicable) are specified separately using `shinesparkFrames` and `excessShinesparkFrames` objects.
 
 #### canShineCharge object
 A `canShineCharge` object represents the need for Samus to be able to charge a shinespark within the current room. It has the following special properties:
@@ -391,8 +395,6 @@ A `canShineCharge` object represents the need for Samus to be able to charge a s
   * _steepDownTiles:_ Indicates how many tiles steeply slope downwards (like in Landing Site).
   * _startingDownTiles:_  Indicates how many tiles slope downwards at the expected start of the running space. A stutter can't be executed on those tiles.
 * _openEnd:_ Any runway that is used to gain momentum has two ends. An open end is when a platform drops off into nothingness, as opposed to ending against a wall. Since those offer a bit more room, this property indicates the number of open ends that are available for charging (between 0 and 2).
-* _shinesparkFrames:_ Indicates how many frames the shinespark that will be used lasts. This can be 0 in cases where only the blue suit is needed. During a shinespark, Samus is damaged by 1 every frame, and being able to spend that health is part of of being able to fulfill a `canShineCharge` object.
-* _excessShinesparkFrames:_ Indicates how far beyond a breakable wall or ledge a shinespark will travel, in terms of frames.  This enables shinesparking at a lower health value but will still cost the full `shinesparkFrames` value if that health can be paid.
 
 __Example:__
 ```json
@@ -400,15 +402,13 @@ __Example:__
   "usedTiles": 25,
   "steepUpTiles": 3,
   "steepDownTiles": 3,
-  "shinesparkFrames": 0,
   "openEnd": 1
 }},
 ```
 
 __Additional considerations__
 
-* A `canShineCharge` object implicitly requires the Speed Booster.
-* A `canShineCharge` object implicitly requires the `canShineCharge` tech if it has more than 0 `shinesparkFrames`.
+* A `canShineCharge` object implicitly requires the Speed Booster. Energy requirements for the shinespark are specified separately using `shinesparkFrames` and `excessShinesparkFrames` objects.
 
 #### comeInWithRMode object
 A `comeInWithRMode` object represents the need to obtain R-mode when entering the room. It has the following properties:

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -361,7 +361,7 @@ Please note that fulfilling this logical element requires interaction with the d
 A `canComeInCharged` object represents the need to charge a shinespark in an adjacent room, or to initiate a shinespark in an adjacent room and into the current room. It has the following properties:
 * _fromNode:_ Indicates from what door this logical requirement expects Samus to enter the room
 * _inRoomPath:_ An array that indicates the path of node IDs that the player should travel, up to and including the node where the `adjacentRunway` logical element is, in order to be able to used the adjacent runway. If this is missing, the player is expected to enter the room at the current node and not move from there.
-* _framesRemaining:_ Indicates the minimum number of frames Samus needs to have left, upon entering the room, before the shinespark charge expires. A value of 0 indicates that shinesparking through the door works.
+* _framesRemaining:_ Indicates the minimum number of frames Samus needs to have left, upon entering the room, before the shinespark charge expires. A value of 0 indicates that shinesparking through the door works. A value of 180 indicate that Samus must be able to obtain blue speed in the current room.
 * _unusableTiles:_ The number of tiles that are part of the runway but cannot be used for this shinespark.  Meaning the combined runway must be this many tiles longer to fulfill the requirement.  The `unusableTiles` must count from the end of the runway in the current room that is not touching the door.  The number of unusableTiles may be larger than the current room's runway.
 
 __Example:__

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -120,11 +120,11 @@ When trying to determine the ammo needed to fulfill an `enemyKill` object, it co
 ### Health Management Objects
 This section contains logical elements that are fulfilled by spending health. Encountering enough of those successively without having a chance to refill can impact the number of e-tanks that are needed to get through.
 
-#### shinesparkFrames
-A `shinesparkFrames` object represents the need for Samus to spend energy performing a shinespark for the given number of frames, which equals the amount of energy spent, as shinesparks use 1 energy per frame. This implicitly requires the `canShinespark` tech. It also requires that Samus has at least 29 energy remaining at the end of the spark.
+#### shinespark
+A `shinespark` object represents the need for Samus to spend energy performing a shinespark for a given number of frames. This implicitly requires the `canShinespark` tech. It has the following properties:
 
-#### excessShinesparkFrames
-An `excessShinesparkFrames` object represents the need for Samus to spend energy performing a shinespark for the given number of frames, or until Samus' energy reaches 29, whichever happens first. This implicitly requires the `canShinespark` tech.
+* _frames_: The duration of the shinespark in frames, assuming the spark is completed without being interrupted by reaching 29 energy. The shinespark frames equals the amount of energy spent, as a shinespark uses 1 energy per frame. 
+* _excessFrames_: The shinespark duration (in frames) that is not required to complete the objective of the shinespark. Subtracting this from the `frames` defines the lower limit of the shinespark energy cost.
 
 #### acidFrames object
 An `acidFrames` object represents the need for Samus to spend time (measured in frames) in a pool of acid. This is meant to be converted to a flat health value based on item loadout. The vanilla damage for acid is 6 damage every 4 frames, halved by Varia (3 damage every 4 frames), and halved again by Gravity Suit (3 damage every 8 frames).
@@ -383,7 +383,7 @@ The number of framesRemaining in that case is:
 
 Please refer to the section about runways in [the Region documentation](region/region-readme.md) for a more detailed explanation of runways and how to combine them.
 
-Energy requirements for shinesparking (if applicable) are specified separately using `shinesparkFrames` and `excessShinesparkFrames` objects.
+Energy requirements for shinesparking (if applicable) are specified separately using a `shinespark` object.
 
 #### canShineCharge object
 A `canShineCharge` object represents the need for Samus to be able to charge a shinespark within the current room. It has the following special properties:
@@ -408,7 +408,7 @@ __Example:__
 
 __Additional considerations__
 
-* A `canShineCharge` object implicitly requires the Speed Booster. Energy requirements for the shinespark are specified separately using `shinesparkFrames` and `excessShinesparkFrames` objects.
+* A `canShineCharge` object implicitly requires the Speed Booster. Energy requirements for the shinespark (if applicable) are specified separately using a `shinespark` object.
 
 #### comeInWithRMode object
 A `comeInWithRMode` object represents the need to obtain R-mode when entering the room. It has the following properties:

--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -440,8 +440,10 @@
                           "fromNode": 1,
                           "framesRemaining": 0
                         }},
-                        {"shinesparkFrames": 31},
-                        {"excessShinesparkFrames": 9}  
+                        {"shinespark": {
+                          "frames": 40,
+                          "excessFrames": 9
+                        }}
                       ]}
                   ]}
                   ],
@@ -1308,7 +1310,7 @@
                       "usedTiles": 33,
                       "openEnd": 2
                     }},
-                    {"shinesparkFrames": 43}
+                    {"shinespark": {"frames": 43 }}
                   ],
                   "note": "Falling down the shaft and breaking the crumble block does not require Morph."
                 },
@@ -1832,7 +1834,7 @@
                       "usedTiles": 33,
                       "openEnd": 2
                     }},
-                    {"shinesparkFrames": 43}
+                    {"shinespark": {"frames": 43}}
                   ],
                   "clearsObstacles": ["A","B","C"],
                   "devNote": "The runway here is 31 tiles before breaking the Power Bomb blocks, but becomes longer after."
@@ -1851,7 +1853,7 @@
                       "usedTiles": 33,
                       "openEnd": 2
                     }},
-                    {"shinesparkFrames": 17}
+                    {"shinespark": {"frames": 17}}
                   ],
                   "clearsObstacles": ["A","B","C"],
                   "note": [

--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -254,7 +254,6 @@
                     "canSpeedball",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 1,
                       "unusableTiles": 1
                     }}
@@ -436,13 +435,15 @@
                           ]
                         }}
                       ]},
-                      {"canComeInCharged": {
-                        "fromNode": 1,
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 40,
-                        "excessShinesparkFrames": 9
-                      }}
-                    ]}
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 1,
+                          "framesRemaining": 0
+                        }},
+                        {"shinesparkFrames": 31},
+                        {"excessShinesparkFrames": 9}  
+                      ]}
+                  ]}
                   ],
                   "clearsObstacles": ["C"],
                   "note": [
@@ -687,7 +688,6 @@
                     {"obstaclesCleared": ["B"]},
                     {"canShineCharge": {
                       "usedTiles": 21,
-                      "shinesparkFrames": 0,
                       "openEnd": 1
                     }},
                     "canSpeedball"
@@ -772,7 +772,6 @@
                     {"obstaclesCleared": ["C"]},
                     {"canShineCharge": {
                       "usedTiles": 18,
-                      "shinesparkFrames": 0,
                       "openEnd": 0
                     }}
                   ],
@@ -1307,9 +1306,9 @@
                     "h_canUsePowerBombs",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 43,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinesparkFrames": 43}
                   ],
                   "note": "Falling down the shaft and breaking the crumble block does not require Morph."
                 },
@@ -1709,7 +1708,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 2,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ],
@@ -1832,9 +1830,9 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 43,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinesparkFrames": 43}
                   ],
                   "clearsObstacles": ["A","B","C"],
                   "devNote": "The runway here is 31 tiles before breaking the Power Bomb blocks, but becomes longer after."
@@ -1851,9 +1849,9 @@
                     "canFastWalljumpClimb",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 17,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinesparkFrames": 17}
                   ],
                   "clearsObstacles": ["A","B","C"],
                   "note": [

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -875,10 +875,12 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 10,
-                      "framesRemaining": 30,
-                      "shinesparkFrames": 75,
-                      "excessShinesparkFrames": 5
-                     }}
+                      "framesRemaining": 30
+                    }},
+                    {"shinespark": {
+                      "frames": 75,
+                      "excessFrames": 5
+                    }}
                   ]
                 },
                 {
@@ -988,9 +990,11 @@
                     {"canComeInCharged": {
                       "fromNode": 10,
                       "framesRemaining": 60,
-                      "shinesparkFrames": 20,
-                      "excessShinesparkFrames": 11
-                     }}
+                    }},
+                    {"shinespark": {
+                      "frames": 20,
+                      "excessFrames": 11
+                    }}
                   ],
                   "note": [
                     "This is specifically a shinespark that doesn't reach the top.",
@@ -2048,14 +2052,12 @@
                         {"canComeInCharged": {
                           "framesRemaining": 180,
                           "fromNode": 1,
-                          "shinesparkFrames": 0,
                           "unusableTiles": 2
                         }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
                         "fromNode": 1,
-                        "shinesparkFrames": 0,
                         "unusableTiles": 10
                       }}
                     ]}
@@ -2215,7 +2217,6 @@
                         "canSpeedball",
                         {"canShineCharge": {
                           "usedTiles": 14,
-                          "shinesparkFrames": 0,
                           "openEnd": 1
                         }}
                       ]}
@@ -2291,7 +2292,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 1,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ],
@@ -2328,14 +2328,12 @@
                       {"canComeInCharged": {
                         "framesRemaining": 180,
                         "fromNode": 2,
-                        "shinesparkFrames": 0,
                         "unusableTiles": 3
                       }},
                       {"and": [
                         "canSlowShortCharge",
                         {"canShineCharge": {
                           "usedTiles": 14,
-                          "shinesparkFrames": 0,
                           "openEnd": 1
                         }}
                       ]}
@@ -2515,7 +2513,6 @@
               "framesRemaining": 0,
               "usedTiles": 33,
               "openEnd": 2,
-              "shinesparkFrames": 45,
               "strats": [
                 {
                   "name": "XMode",
@@ -2527,7 +2524,8 @@
                       "HiJump",
                       "canWalljump",
                       "SpaceJump"
-                    ]}
+                    ]},
+                    {"shinespark": {"frames": 45}}
                   ],
                   "note": "Jump into the large patch of thorns from below."
                 }

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -989,7 +989,7 @@
                     "canShinechargeMovement",
                     {"canComeInCharged": {
                       "fromNode": 10,
-                      "framesRemaining": 60,
+                      "framesRemaining": 60
                     }},
                     {"shinespark": {
                       "frames": 20,

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -1470,7 +1470,7 @@
                         "canLateralMidAirMorph",
                         {"canShineCharge": {
                           "usedTiles": 32,
-                          "openEnd": 1,
+                          "openEnd": 1
                         }}
                       ]}
                     ]}
@@ -1734,7 +1734,7 @@
                     "canCarefulJump",
                     {"canShineCharge": {
                       "usedTiles": 29,
-                      "openEnd": 2,
+                      "openEnd": 2
                     }}
                   ],
                   "clearsObstacles": ["A"],

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -63,8 +63,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 1,
-                      "shinesparkFrames": 0
+                      "fromNode": 1
                     }}
                   ]
                 }
@@ -583,14 +582,12 @@
                         {"canComeInCharged": {
                           "framesRemaining": 180,
                           "fromNode": 2,
-                          "shinesparkFrames": 0,
                           "unusableTiles": 5
                         }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
                         "fromNode": 2,
-                        "shinesparkFrames": 0,
                         "unusableTiles": 14
                       }}
                     ]}
@@ -605,7 +602,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 2,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ]
@@ -992,7 +988,6 @@
               },
               "usedTiles": 25,
               "framesRemaining": 0,
-              "shinesparkFrames": 20,
               "openEnd": 0,
               "strats": [
                 {
@@ -1001,7 +996,8 @@
                   "requires": [
                     "canShinechargeMovementComplex",
                     {"obstaclesCleared": ["C"]},
-                    {"obstaclesNotCleared": ["D"]}
+                    {"obstaclesNotCleared": ["D"]},
+                    {"shinespark": {"frames": 20}}
                   ],
                   "note": "Charge a spark, then break the shot blocks, drop through, and spark out the bottom right door."
                 }
@@ -1044,7 +1040,6 @@
               },
               "usedTiles": 31,
               "framesRemaining": 0,
-              "shinesparkFrames": 15,
               "strats": [
                 {
                   "name": "Warehouse Kihunter Room Tunnel Charge",
@@ -1053,7 +1048,8 @@
                   "requires": [
                     "canShinechargeMovementComplex",
                     {"obstaclesCleared": ["B","C"]},
-                    {"obstaclesNotCleared": ["D"]}
+                    {"obstaclesNotCleared": ["D"]},
+                    {"shinespark": {"frames": 15}}
                   ]
                 }
               ],
@@ -1347,7 +1343,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 3,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ],
@@ -1467,7 +1462,6 @@
                         "canSpeedball",
                         {"canShineCharge": {
                           "usedTiles": 17,
-                          "shinesparkFrames": 0,
                           "openEnd": 0
                         }}
                       ]},
@@ -1477,7 +1471,6 @@
                         {"canShineCharge": {
                           "usedTiles": 32,
                           "openEnd": 1,
-                          "shinesparkFrames": 0
                         }}
                       ]}
                     ]}
@@ -1742,7 +1735,6 @@
                     {"canShineCharge": {
                       "usedTiles": 29,
                       "openEnd": 2,
-                      "shinesparkFrames": 0
                     }}
                   ],
                   "clearsObstacles": ["A"],

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -91,7 +91,7 @@
                           "frames": 110,
                           "excessFrames": 3
                         }}
-                      ]}
+                      ]},
                       {"and": [
                         "SpeedBooster",
                         {"obstaclesCleared": ["A"]}
@@ -358,7 +358,7 @@
                     }},
                     {"shinespark": {
                       "frames": 110,
-                      "excessFrames": 3,
+                      "excessFrames": 3
                     }}
                   ],
                   "note": "Diagonal spark left to save health."

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -82,12 +82,16 @@
                   "requires": [
                     "canBePatient",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 110,
-                        "excessShinesparkFrames": 3,
-                        "openEnd": 2
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 110,
+                          "excessFrames": 3
+                        }}
+                      ]}
                       {"and": [
                         "SpeedBooster",
                         {"obstaclesCleared": ["A"]}
@@ -350,9 +354,11 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 110,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 110,
+                      "excessFrames": 3,
                     }}
                   ],
                   "note": "Diagonal spark left to save health."
@@ -366,9 +372,11 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 85,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 85,
+                      "excessFrames": 3                      
                     }}
                   ],
                   "note": "Diagonal spark left to save health."
@@ -383,9 +391,11 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 67,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 67,
+                      "excessFrames": 3                      
                     }}
                   ]
                 },
@@ -398,9 +408,11 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 73,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 73,
+                      "excessFrames": 3                      
                     }}
                   ],
                   "note": "Quickly wall jump up the right wall and shinespark up to barely get above the speed blocks without any tanks.",
@@ -554,7 +566,6 @@
               "framesRemaining": 0,
               "usedTiles": 17,
               "openEnd": 1,
-              "shinesparkFrames": 10,
               "strats": [
                 {
                   "name": "Big Pink Fast Mockball into Save Room",
@@ -562,7 +573,8 @@
                   "requires": [
                     "canMockball",
                     "canShinechargeMovementComplex",
-                    {"obstaclesCleared": ["A"]}
+                    {"obstaclesCleared": ["A"]},
+                    {"shinespark": {"frames": 10}}
                   ],
                   "note": "Shinecharge towards the top right door.  Then turn around for a fast mockball after jumping the bug pipe."
                 }
@@ -613,7 +625,6 @@
               "framesRemaining": 0,
               "usedTiles": 25,
               "openEnd": 1,
-              "shinesparkFrames": 28,
               "strats": [
                 {
                   "name": "Shinecharge Below and Jump Up",
@@ -621,9 +632,10 @@
                   "requires": [
                     "canShinechargeMovementComplex",
                     {"or": [
-                       "HiJump",
-                       "canWalljump"
-                     ]}
+                      "HiJump",
+                      "canWalljump"
+                    ]},
+                    {"shinespark": {"frames": 28}}
                   ]
                 }
               ]
@@ -1138,14 +1150,12 @@
                         {"canComeInCharged": {
                           "framesRemaining": 180,
                           "fromNode": 1,
-                          "shinesparkFrames": 0,
                           "unusableTiles": 5
                         }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
                         "fromNode": 1,
-                        "shinesparkFrames": 0,
                         "unusableTiles": 14
                       }}
                     ]}
@@ -1160,7 +1170,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 1,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ]
@@ -1320,7 +1329,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 7,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 2
                     }},
                     {"ammo":{"type": "Super","count": 1}}
@@ -1336,8 +1344,7 @@
                     "canSpringBallBounce",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 7,
-                      "shinesparkFrames": 0
+                      "fromNode": 7
                     }},
                     {"ammo":{"type": "Super","count": 1}}
                   ],
@@ -1495,8 +1502,7 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 24,
-                      "openEnd": 1,
-                      "shinesparkFrames": 0
+                      "openEnd": 1
                     }},
                     "canChainTemporaryBlue",
                     "canXRayTurnaround"
@@ -1600,13 +1606,11 @@
                         "fromNode": 2,
                         "inRoomPath": [2,13],
                         "framesRemaining": 180,
-                        "shinesparkFrames": 0, 
                         "unusableTiles": 1
                       }},
                       {"canShineCharge": {
                         "usedTiles": 17,
-                        "openEnd": 0,
-                        "shinesparkFrames": 0
+                        "openEnd": 0
                       }}
                     ]}
                   ],
@@ -1627,14 +1631,12 @@
                         "canXRayTurnaround",
                         {"canShineCharge": {
                           "usedTiles": 25,
-                          "openEnd": 0,
-                          "shinesparkFrames": 0
+                          "openEnd": 0
                         }}
                       ]},
                       {"canShineCharge": {
                         "usedTiles": 21,
-                        "openEnd": 0,
-                        "shinesparkFrames": 0
+                        "openEnd": 0
                       }}
                     ]}
                   ],
@@ -1804,8 +1806,7 @@
                     "canTrickyJump",
                     {"canShineCharge": {
                       "usedTiles": 20,
-                      "openEnd": 2,
-                      "shinesparkFrames": 0
+                      "openEnd": 2
                     }},
                     "canOffScreenSuperShot"
                   ],
@@ -1822,8 +1823,7 @@
                     "canLateralMidAirMorph",
                     {"canShineCharge": {
                       "usedTiles": 22,
-                      "openEnd": 2,
-                      "shinesparkFrames": 0
+                      "openEnd": 2
                     }},
                     "canOffScreenSuperShot"
                   ],
@@ -1856,24 +1856,36 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 16,
-                        "openEnd": 1,
-                        "shinesparkFrames": 24,
-                        "excessShinesparkFrames": 4
-                      }},
-                      {"canComeInCharged": {
-                        "fromNode": 3,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 38,
-                        "excessShinesparkFrames": 7
-                      }},
-                      {"canShineCharge": {
-                        "usedTiles": 24,
-                        "openEnd": 1,
-                        "shinesparkFrames": 38,
-                        "excessShinesparkFrames": 7
-                      }}
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 16,
+                          "openEnd": 1
+                        }},
+                        {"shinespark": {
+                          "frames": 24,
+                          "excessFrames": 4
+                        }}
+                      ]},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 3,
+                          "framesRemaining": 180
+                        }},
+                        {"shinespark": {
+                          "frames": 38,
+                          "excessFrames": 7
+                        }}
+                      ]},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 24,
+                          "openEnd": 1
+                        }},
+                        {"shinespark": {
+                          "frames": 38,
+                          "excessFrames": 7
+                        }}
+                      ]}
                     ]}
                   ]
                 },
@@ -2706,15 +2718,16 @@
                     "canPrepareForNextRoom",
                     {"or":[
                       "ScrewAttack",
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 1,
+                          "framesRemaining": 0
+                        }},
+                        {"shinespark": {"frames": 24}}
+                      ]},
                       {"canComeInCharged": {
                         "fromNode": 1,
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 24
-                      }},
-                      {"canComeInCharged": {
-                        "fromNode": 1,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }}
                     ]}
                   ],
@@ -3168,13 +3181,15 @@
               "usedTiles": 21,
               "steepUpTiles": 2,
               "framesRemaining": 0,
-              "shinesparkFrames": 20,
               "openEnd": 0,
               "strats": [
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "canShinechargeMovement" ]
+                  "requires": [ 
+                    "canShinechargeMovement",
+                    {"shinespark": {"frames": 20}}
+                  ]
                 }
               ]
             }
@@ -3372,13 +3387,15 @@
             {
               "usedTiles": 32,
               "framesRemaining": 0,
-              "shinesparkFrames": 75,
               "openEnd": 1,
               "strats": [
                 {
                   "name": "Midair Shinespark",
                   "notable": false,
-                  "requires": [ "canMidairShinespark" ]
+                  "requires": [
+                    "canMidairShinespark",
+                    {"shinespark": {"frames": 75}}
+                  ]
                 }
               ],
               "note": "Charge a shinespark on the dry platform and spark back out."
@@ -3386,7 +3403,6 @@
             {
               "usedTiles": 32,
               "framesRemaining": 0,
-              "shinesparkFrames": 62,
               "openEnd": 1,
               "strats": [
                 {
@@ -3395,7 +3411,8 @@
                   "requires": [
                     "canMidairShinespark",
                     "canShinechargeMovement",
-                    "canCarefulJump"
+                    "canCarefulJump",
+                    {"shinespark": {"frames": 62}}
                   ]
                 }
               ],
@@ -3487,9 +3504,11 @@
                     "canShinechargeMovement",
                     {"canShineCharge": {
                       "usedTiles": 32,
-                      "shinesparkFrames": 72,
-                      "excessShinesparkFrames": 10,
                       "openEnd": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 72,
+                      "excessFrames": 10
                     }}
                   ],
                   "note": "Doable without a short charge, since there are 32 tiles (plus one open end) to charge it."
@@ -3518,9 +3537,11 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 32,
-                      "shinesparkFrames": 72,
-                      "excessShinesparkFrames": 10,
                       "openEnd": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 72,
+                      "excessFrames": 10
                     }}
                   ],
                   "note": "Doable without a short charge, since there are 32 tiles (plus one open end) to charge it."
@@ -3535,9 +3556,11 @@
                     {"ammo": {"type": "Super","count": 1}},
                     {"canShineCharge": {
                       "usedTiles": 32,
-                      "shinesparkFrames": 72,
-                      "excessShinesparkFrames": 10,
                       "openEnd": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 72,
+                      "excessFrames": 10
                     }}
                   ],
                   "note": [
@@ -3551,9 +3574,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 40,
-                      "shinesparkFrames": 155,
-                      "excessShinesparkFrames": 10
+                      "framesRemaining": 40
+                    }},
+                    {"shinespark": {
+                      "frames": 155,
+                      "excessFrames": 10
                     }}
                   ],
                   "note": "Doable without a wall jump if Samus comes in charged."
@@ -3565,7 +3590,6 @@
                     "canSpeedball",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 1,
                       "unusableTiles": 1
                     }}

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -342,9 +342,11 @@
                     "canHeroShot",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 100,
-                      "shinesparkFrames": 77,
-                      "excessShinesparkFrames": 3
+                      "framesRemaining": 100
+                    }},
+                    {"shinespark": {
+                      "frames": 77,
+                      "excessFrames": 3
                     }},
                     {"ammo": { "type": "Missile", "count": 1 }}
                   ],
@@ -698,18 +700,18 @@
                       {"canComeInCharged": {
                         "fromNode": 4,
                         "inRoomPath": [4, 8],
-                        "framesRemaining": 30,
-                        "shinesparkFrames": 45,
-                        "excessShinesparkFrames": 5
+                        "framesRemaining": 30
                       }},
                       {"canComeInCharged": {
                         "fromNode": 3,
                         "inRoomPath": [3, 8],
-                        "framesRemaining": 40,
-                        "shinesparkFrames": 45,
-                        "excessShinesparkFrames": 5
+                        "framesRemaining": 40
                       }}
-                    ]}
+                    ]},
+                    {"shinespark": {
+                      "frames": 45,
+                      "excessFrames": 5
+                    }}
                   ]
                 }
               ],
@@ -881,7 +883,6 @@
               "usedTiles": 13,
               "openEnd": 0,
               "framesRemaining": 0,
-              "shinesparkFrames": 0,
               "initiateRemotely": {
                 "initiateAt": 2,
                 "mustOpenDoorFirst": true,
@@ -908,7 +909,6 @@
               "usedTiles": 33,
               "openEnd": 2,
               "framesRemaining": 0,
-              "shinesparkFrames": 50,
               "strats": [
                 {
                   "name": "XMode",
@@ -920,7 +920,10 @@
                     {"or": [
                       "SpaceJump",
                       {"spikeHits": 2}
-                    ]}
+                    ]},
+                    {"shinespark": {
+                      "frames": 50
+                    }}
                   ]
                 }
               ]
@@ -953,14 +956,14 @@
               "usedTiles": 13,
               "openEnd": 0,
               "framesRemaining": 0,
-              "shinesparkFrames": 50,
               "strats": [
                 {
                   "name": "Base",
                   "notable": false,
                   "requires": [
                     "canShinechargeMovementComplex",
-                    "canMidairShinespark"
+                    "canMidairShinespark",
+                    {"shinespark": {"frames": 50}}
                   ],
                   "note": "Requires opening the door, then going to pit in the middle of the room to use the really small runway."
                 }
@@ -1044,9 +1047,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 150,
-                      "excessShinesparkFrames": 57
+                      "framesRemaining": 0
+                     }},
+                     {"shinespark": {
+                        "frames": 150,
+                        "excessFrames": 57
                      }}
                   ],
                   "note": "Enter the door high to avoid a frame perfect spike hit.",
@@ -1109,10 +1114,12 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 146,
-                      "excessShinesparkFrames": 6
-                     }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 146,
+                      "excessFrames": 6
+                    }}
                   ]
                 },
                 {
@@ -1123,9 +1130,11 @@
                     "canShinechargeMovementComplex",
                     {"canShineCharge": {
                       "usedTiles": 13,
-                      "openEnd": 0,
-                      "shinesparkFrames": 107,
-                      "excessShinesparkFrames": 6
+                      "openEnd": 0
+                     }},
+                     {"shinespark": {
+                      "frames": 107,
+                      "excessFrames": 6
                      }}
                   ],
                   "note": "Use the really small runway in a pit in the middle of the room."
@@ -1138,9 +1147,11 @@
                     "h_canXMode",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "openEnd": 2,
-                      "shinesparkFrames": 146,
-                      "excessShinesparkFrames": 6
+                      "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 146,
+                      "excessFrames": 6
                     }},
                     {"spikeHits": 1}
                   ],
@@ -1753,7 +1764,6 @@
                     "canCarefulJump",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 3,
                       "unusableTiles": 1
                     }}
@@ -1768,7 +1778,6 @@
                     "canTrickyJump",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 3,
                       "unusableTiles": 1
                     }}
@@ -2085,7 +2094,6 @@
               "framesRemaining": 0,
               "openEnd": 1,
               "usedTiles": 17,
-              "shinesparkFrames": 22,
               "strats": [
                 {
                   "name": "Gate Open",
@@ -2093,7 +2101,8 @@
                   "requires": [
                     "canShinechargeMovementComplex",
                     "Morph",
-                    {"obstaclesCleared": ["A"]}
+                    {"obstaclesCleared": ["A"]},
+                    {"shinespark": {"frames": 22}}
                   ],
                   "note": "Slow rolling or getting a fast mockball work equally well."
 
@@ -2642,8 +2651,7 @@
                         "canCarefulJump",
                         {"canComeInCharged": {
                           "framesRemaining": 180,
-                          "fromNode": 1,
-                          "shinesparkFrames": 0
+                          "fromNode": 1
                         }}
                       ]}
                     ]}

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1048,11 +1048,11 @@
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "framesRemaining": 0
-                     }},
-                     {"shinespark": {
-                        "frames": 150,
-                        "excessFrames": 57
-                     }}
+                    }},
+                    {"shinespark": {
+                      "frames": 150,
+                      "excessFrames": 57
+                    }}
                   ],
                   "note": "Enter the door high to avoid a frame perfect spike hit.",
                   "devNote": [
@@ -1131,11 +1131,11 @@
                     {"canShineCharge": {
                       "usedTiles": 13,
                       "openEnd": 0
-                     }},
-                     {"shinespark": {
+                    }},
+                    {"shinespark": {
                       "frames": 107,
                       "excessFrames": 6
-                     }}
+                    }}
                   ],
                   "note": "Use the really small runway in a pit in the middle of the room."
                 },

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -1326,7 +1326,7 @@
                     {"or":[
                       {"canComeInCharged": {
                         "fromNode": 1,
-                        "framesRemaining": 180,
+                        "framesRemaining": 180
                       }},
                       {"and": [
                         {"canComeInCharged": {

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -46,7 +46,6 @@
               },
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 0,
               "openEnd": 1,
               "strats": [
                 {
@@ -73,7 +72,6 @@
               },
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 0,
               "openEnd": 1,
               "strats": [
                 {
@@ -101,7 +99,6 @@
               },
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 0,
               "openEnd": 2,
               "note": [
                 "It's actually possible to use this without going to 1 to open the door first, with a wraparound shot at 3.",
@@ -340,10 +337,12 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 160,
-                      "excessShinesparkFrames": 107
-                     }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 160,
+                      "excessFrames": 107
+                    }}
                   ],
                   "clearsObstacles": ["A"]
                 },
@@ -459,9 +458,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 125,
-                      "excessShinesparkFrames": 33
+                      "framesRemaining": 180
+                    }},
+                    {"shinespark": {
+                      "frames": 125,
+                      "excessFrames": 33
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -494,7 +495,6 @@
                     "canTrickyDashJump",
                     {"canShineCharge": {
                       "usedTiles": 22,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
                     }}
                   ],
@@ -516,7 +516,6 @@
                     "canLateralMidAirMorph",
                     {"canShineCharge": {
                       "usedTiles": 30,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
                     }}
                   ],
@@ -571,9 +570,11 @@
                       "usedTiles": 19,
                       "steepUpTiles": 2,
                       "steepDownTiles": 1,
-                      "shinesparkFrames": 125,
-                      "excessShinesparkFrames": 33,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 125,
+                      "excessFrames": 33
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -588,9 +589,11 @@
                       "usedTiles": 19,
                       "steepUpTiles": 2,
                       "steepDownTiles": 1,
-                      "shinesparkFrames": 95,
-                      "excessShinesparkFrames": 33,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 95,
+                      "excessFrames": 33
                     }}
                   ],
                   "clearsObstacles": ["A"],
@@ -608,7 +611,6 @@
                       "usedTiles": 19,
                       "steepUpTiles": 2,
                       "steepDownTiles": 1,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
                     }}
                   ],
@@ -623,8 +625,11 @@
                     "HiJump",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 95,
+                      "excessFrames": 33
                     }}
                   ],
                   "clearsObstacles": ["A"],
@@ -642,7 +647,6 @@
                     "HiJump",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
                     }}
                   ],
@@ -670,9 +674,11 @@
                       "usedTiles": 19,
                       "steepUpTiles": 2,
                       "steepDownTiles": 1,
-                      "shinesparkFrames": 45,
-                      "excessShinesparkFrames": 13,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 45,
+                      "excessFrames": 13
                     }}
                   ]
                 },
@@ -705,9 +711,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "shinesparkFrames": 1,
-                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb",
@@ -802,19 +810,25 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 78,
-                        "excessShinesparkFrames": 13,
-                        "openEnd": 2
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 78,
+                          "excessFrames": 13
+                        }}
+                      ]},
                       {"and": [
                         "canShinechargeMovement",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 65,
-                          "excessShinesparkFrames": 13,
                           "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 65,
+                          "excessFrames": 13
                         }}
                       ]}
                     ]}
@@ -984,9 +998,9 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 40,
                       "openEnd": 2
                     }},
+                    {"shinespark": {"frames": 40}},
                     {"or": [
                       "h_canDestroyBombWalls",
                       {"obstaclesCleared": ["A"]}
@@ -1276,13 +1290,14 @@
               "steepUpTiles": 3,
               "steepDownTiles": 3,
               "framesRemaining": 0,
-              "shinesparkFrames": 40,
               "openEnd": 1,
               "strats": [
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"shinespark": {"frames": 40}}
+                  ]
                 }
               ]
             }
@@ -1312,21 +1327,23 @@
                       {"canComeInCharged": {
                         "fromNode": 1,
                         "framesRemaining": 180,
-                        "shinesparkFrames": 0
                       }},
-                      {"canComeInCharged": {
-                        "fromNode": 1,
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 67,
-                        "excessShinesparkFrames": 42
-                       }}
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 1,
+                          "framesRemaining": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 67,
+                          "excessFrames": 42
+                        }}
+                      ]}
                     ]},
                     "canCarefulJump",
                     {"canShineCharge": {
                       "usedTiles": 25,
                       "steepUpTiles": 3,
                       "steepDownTiles": 3,
-                      "shinesparkFrames": 0,
                       "openEnd": 1
                     }}
                   ],
@@ -1523,7 +1540,6 @@
               "gentleDownTiles": 1,
               "gentleUpTiles": 1,
               "framesRemaining": 90,
-              "shinesparkFrames": 0,
               "openEnd": 2,
               "strats": [
                 {
@@ -1538,7 +1554,6 @@
               "steepUpTiles": 3,
               "steepDownTiles": 3,
               "framesRemaining": 30,
-              "shinesparkFrames": 0,
               "openEnd": 1,
               "strats": [
                 {
@@ -1883,10 +1898,12 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 67,
-                      "excessShinesparkFrames": 42
-                     }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 67,
+                      "excessFrames": 42
+                    }}
                   ]
                 },
                 {
@@ -1895,8 +1912,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ]
                 },
@@ -2300,7 +2316,6 @@
                       "usedTiles": 25,
                       "steepUpTiles": 3,
                       "steepDownTiles": 3,
-                      "shinesparkFrames": 0,
                       "openEnd": 1
                     }}
                   ]
@@ -2313,10 +2328,12 @@
                     {"canComeInCharged": {
                       "fromNode": 4,
                       "inRoomPath": [4, 8],
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 68,
-                      "excessShinesparkFrames": 11
-                     }}
+                      "framesRemaining": 180
+                    }},
+                    {"shinespark": {
+                      "frames": 68,
+                      "excessFrames": 11
+                    }}
                   ],
                   "note": "Shinespark at least from just above the left side morph tunnel."
                 },
@@ -2328,8 +2345,7 @@
                     {"canComeInCharged": {
                       "fromNode": 4,
                       "inRoomPath": [4, 8],
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }},
                     {"or": [
                       "canBlueSpaceJump",
@@ -2779,9 +2795,9 @@
                     ]},
                     {"canComeInCharged": {
                       "framesRemaining": 65,
-                      "fromNode": 1,
-                      "shinesparkFrames": 5
-                    }}
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {"frames": 5}}
                   ],
                   "reusableRoomwideNotable": "Climb Behemoth Shinespark",
                   "note": [
@@ -2851,14 +2867,12 @@
                     {"or": [
                       {"canComeInCharged": {
                         "fromNode": 2,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }},
                       {"and": [
                         {"canShineCharge": {
                           "usedTiles": 28,
-                          "openEnd": 0,
-                          "shinesparkFrames": 0
+                          "openEnd": 0
                         }},
                         {"obstaclesCleared": ["A"]}
                       ]}
@@ -2901,14 +2915,12 @@
                     {"or": [
                       {"canComeInCharged": {
                         "fromNode": 2,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }},
                       {"and": [
                         {"canShineCharge": {
                           "usedTiles": 28,
-                          "openEnd": 0,
-                          "shinesparkFrames": 0
+                          "openEnd": 0
                         }},
                         {"obstaclesCleared": ["A"]}
                       ]}
@@ -2931,14 +2943,12 @@
                     {"or": [
                       {"canComeInCharged": {
                         "fromNode": 2,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }},
                       {"and": [
                         {"canShineCharge": {
                           "usedTiles": 19,
-                          "openEnd": 0,
-                          "shinesparkFrames": 0
+                          "openEnd": 0
                         }},
                         {"obstaclesCleared": ["A"]}
                       ]}
@@ -2989,9 +2999,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 43,
-                      "excessShinesparkFrames": 17
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 43,
+                      "excessFrames": 17
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -3002,8 +3014,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -3110,7 +3121,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 3,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 2
                     }}
                   ],
@@ -3283,7 +3293,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 3,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 2
                     }}
                   ],
@@ -3346,8 +3355,7 @@
                     "canBePatient",
                     {"canComeInCharged": {
                       "fromNode": 5,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
@@ -3453,8 +3461,7 @@
                     "canTrickyJump",
                     {"canComeInCharged": {
                       "fromNode": 5,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
@@ -3572,9 +3579,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 5,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 43,
-                      "excessShinesparkFrames": 17
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 43,
+                      "excessFrames": 17
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -3585,8 +3594,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 5,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -3615,9 +3623,9 @@
                     "Morph",
                     {"canShineCharge": {
                       "usedTiles": 28,
-                      "shinesparkFrames": 147,
                       "openEnd": 0
                     }},
+                    {"shinespark": {"frames": 147}},
                     {"obstaclesCleared": ["A"]}
                   ],
                   "reusableRoomwideNotable": "Climb Behemoth Shinespark",
@@ -3632,7 +3640,6 @@
                     "canTrickyJump",
                     {"canShineCharge": {
                       "usedTiles": 27.5,
-                      "shinesparkFrames": 0,
                       "openEnd": 0
                     }},
                     {"obstaclesCleared": ["A"]}
@@ -3658,9 +3665,11 @@
                     "Morph",
                     {"canShineCharge": {
                       "usedTiles": 28,
-                      "shinesparkFrames": 147,
-                      "excessShinesparkFrames": 124,
                       "openEnd": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 147,
+                      "excessFrames": 124
                     }},
                     {"obstaclesCleared": ["A"]}
                   ],
@@ -3689,7 +3698,6 @@
                     "canTrickyJump",
                     {"canShineCharge": {
                       "usedTiles": 27.5,
-                      "shinesparkFrames": 0,
                       "openEnd": 0
                     }},
                     {"obstaclesCleared": ["A"]}
@@ -3960,8 +3968,7 @@
                     "canTemporaryBlue",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 1,
-                      "shinesparkFrames": 0
+                      "fromNode": 1
                     }}
                   ],
                   "clearsObstacles": ["A"],
@@ -4065,7 +4072,6 @@
                     {"canComeInCharged": {
                       "fromNode": 2,
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }},
                     {"or": [
@@ -4865,14 +4871,12 @@
                         "canSlowShortCharge",
                         {"canComeInCharged": {
                           "framesRemaining": 180,
-                          "shinesparkFrames": 0,
                           "fromNode": 2,
                           "unusableTiles": 5
                         }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
-                        "shinesparkFrames": 0,
                         "fromNode": 2,
                         "unusableTiles": 14
                       }}
@@ -4887,7 +4891,6 @@
                     "canSpringBallBounce",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 2,
                       "unusableTiles": 1
                     }}
@@ -5426,9 +5429,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 65
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 65}}
                   ]
                 }
               ]
@@ -5444,8 +5447,7 @@
                     "Morph",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 1,
-                      "shinesparkFrames": 0
+                      "fromNode": 1
                     }},
                     {"spikeHits": 3},
                     {"or": [
@@ -5620,9 +5622,11 @@
                     "canUseFrozenEnemies",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 130,
-                      "excessShinesparkFrames": 6,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 130,
+                      "excessFrames": 6
                     }}
                   ]
                 },
@@ -5635,9 +5639,11 @@
                     "canFastWalljumpClimb",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 98,
-                      "excessShinesparkFrames": 6,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 98,
+                      "excessFrames": 6
                     }}
                   ],
                   "note": [
@@ -5653,9 +5659,11 @@
                     "HiJump",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 108,
-                      "excessShinesparkFrames": 6,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 108,
+                      "excessFrames": 6
                     }}
                   ],
                   "note": [
@@ -5669,9 +5677,11 @@
                     "canShinechargeMovement",
                     {"canShineCharge": {
                       "usedTiles": 25,
-                      "shinesparkFrames": 130,
-                      "excessShinesparkFrames": 6,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 130,
+                      "excessFrames": 6
                     }},
                     {"or": [
                       { "enemyKill": { "enemies": [ [ "Boyon", "Boyon", "Boyon", "Boyon" ] ] } },
@@ -5692,9 +5702,11 @@
                     "canShinechargeMovement",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 130,
-                      "excessShinesparkFrames": 6,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 130,
+                      "excessFrames": 6
                     }}
                   ],
                   "note": "Involves charging a spark running left, then getting blue suit running right to jump through the Boyons."
@@ -5870,8 +5882,7 @@
                     "canBlueSpaceJump",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ]
                 }
@@ -5976,8 +5987,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 1,
-                      "shinesparkFrames": 0
+                      "fromNode": 1
                     }}
                   ]
                 }

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -253,7 +253,7 @@
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "inRoomPath": [1, 3],
-                      "framesRemaining": 0,
+                      "framesRemaining": 0
                     }},
                     {"shinespark": {
                       "frames": 44,
@@ -1330,7 +1330,7 @@
                     {"shinespark": {
                       "frames": 1,
                       "excessFrames": 1
-                    }}
+                    }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
                   ],

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -169,9 +169,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "framesRemaining": 0,
-                      "fromNode": 2,
-                      "shinesparkFrames": 42,
-                      "excessShinesparkFrames": 15
+                      "fromNode": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 42,
+                      "excessFrames": 15
                     }}
                   ],
                   "devNote": "FIXME: This will grab the item and continue the spark to the left door. If this is an E-Tank, Samus will not maintain full Energy after the strat."
@@ -252,8 +254,10 @@
                       "fromNode": 1,
                       "inRoomPath": [1, 3],
                       "framesRemaining": 0,
-                      "shinesparkFrames": 44,
-                      "excessShinesparkFrames": 6
+                    }},
+                    {"shinespark": {
+                      "frames": 44,
+                      "excessFrames": 6
                     }}
                   ]
                 },
@@ -751,14 +755,14 @@
               "framesRemaining": 0,
               "usedTiles": 33,
               "openEnd": 2,
-              "shinesparkFrames": 38,
               "strats": [
                 {
                   "name": "Ocean Floor Shinecharge Left",
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canShinechargeMovementComplex"
+                    "canShinechargeMovementComplex",
+                    {"shinespark": {"frames": 38}}
                   ],
                   "note": "Jump to the Runway connected to the Left side door before sparking."
                 }
@@ -973,7 +977,6 @@
               "framesRemaining": 0,
               "openEnd": 2,
               "usedTiles": 33,
-              "shinesparkFrames": 15,
               "strats": [
                 {
                   "name": "Ocean Floor Precise Walljump Shinecharge Right",
@@ -981,7 +984,8 @@
                   "requires": [
                     "Gravity",
                     "canShinechargeMovementComplex",
-                    "canPreciseWalljump"
+                    "canPreciseWalljump",
+                    {"shinespark": {"frames": 15}}
                   ]
                 }
               ]
@@ -992,12 +996,13 @@
               "usedTiles": 23,
               "steepUpTiles": 6,
               "steepDownTiles": 1,
-              "shinesparkFrames": 131,
               "strats": [
                 {
                   "name": "Over Ocean Spark",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"shinespark": {"frames": 131}}
+                  ]
                 }
               ]
             },
@@ -1007,14 +1012,14 @@
               "usedTiles": 23,
               "steepUpTiles": 6,
               "steepDownTiles": 1,
-              "shinesparkFrames": 106,
               "strats": [
                 {
                   "name": "Over Ocean Midair Spark",
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
-                    "canMidairShinespark"
+                    "canMidairShinespark",
+                    {"shinespark": {"frames": 106}}
                   ]
                 }
               ]
@@ -1061,14 +1066,14 @@
               "framesRemaining": 0,
               "usedTiles": 33,
               "openEnd": 2,
-              "shinesparkFrames": 25,
               "strats": [
                 {
                   "name": "West Ocean Morph Tunnel Rush",
                   "notable": true,
                   "requires": [
                     "canShinechargeMovementComplex",
-                    "h_canUseSpringBall"
+                    "h_canUseSpringBall",
+                    {"shinespark": {"frames": 25}}
                   ],
                   "note": [
                     "Preopen the door and shotblock, then go back and charge a shinespark.",
@@ -1320,10 +1325,12 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "shinesparkFrames": 1,
-                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
+                    }}
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
                   ],
@@ -1432,9 +1439,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 5,
-                      "shinesparkFrames": 1,
-                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb",
@@ -1480,9 +1489,11 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 50,
-                      "excessShinesparkFrames": 10,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 50,
+                      "excessFrames": 10
                     }}
                   ]
                 },
@@ -1495,9 +1506,11 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 35,
-                      "excessShinesparkFrames": 10,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 35,
+                      "excessFrames": 10
                     }}
                   ],
                   "note": "Jump to the submerged platform, then jump again."
@@ -1780,9 +1793,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 6,
-                      "shinesparkFrames": 1,
-                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
@@ -1944,9 +1959,9 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 36,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 36}}
                   ]
                 },
                 {
@@ -2032,26 +2047,36 @@
                   "notable": false,
                   "requires": [
                     {"or":[
-                      {"canComeInCharged": {
-                        "fromNode": 1,
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 146,
-                        "excessShinesparkFrames": 35
-                       }},
-                      {"canComeInCharged": {
-                        "fromNode": 1,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 131,
-                        "excessShinesparkFrames": 35
-                      }},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 1,
+                          "framesRemaining": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 146,
+                          "excessFrames": 35
+                        }}
+                      ]},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 1,
+                          "framesRemaining": 180
+                        }},
+                        {"shinespark": {
+                          "frames": 131,
+                          "excessFrames": 35
+                        }}
+                      ]},
                       {"and": [
                         "canShinechargeMovement",
                         "canMidairShinespark",
                         {"canComeInCharged": {
                           "fromNode": 1,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 106,
-                          "excessShinesparkFrames": 35
+                          "framesRemaining": 180
+                        }},
+                        {"shinespark": {
+                          "frames": 106,
+                          "excessFrames": 35
                         }}
                       ]}
                     ]}
@@ -2064,9 +2089,11 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 17,
-                      "excessShinesparkFrames": 5,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 17,
+                      "excessFrames": 5
                     }}
                   ]
                 }
@@ -2488,7 +2515,6 @@
               "startingDownTiles": 1,
               "steepDownTiles": 4,
               "steepUpTiles": 2,
-              "shinesparkFrames": 23,
               "strats": [
                 {
                   "name": "East Ocean Floor Shinecharge Left",
@@ -2496,7 +2522,8 @@
                   "requires": [
                     "canShinechargeMovementComplex",
                     "canMidairShinespark",
-                    "Gravity"
+                    "Gravity",
+                    {"shinespark": {"frames": 23}}
                   ],
                   "note": "Quickly climb the submerged structures.  Not dashing may make platforming easier."
                 }
@@ -2556,8 +2583,6 @@
               "startingDownTiles": 1,
               "steepDownTiles": 3,
               "steepUpTiles": 3,
-              "shinesparkFrames": 10,
-              
               "strats": [
                 {
                   "name": "East Ocean Floor Walljump Shinecharge Right",
@@ -2565,7 +2590,8 @@
                   "requires": [
                     "canShinechargeMovementComplex",
                     "Gravity",
-                    "canWalljump"
+                    "canWalljump",
+                    {"shinespark": {"frames": 10}}
                   ]
                 }
               ]
@@ -2728,9 +2754,11 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 1,
-                      "shinesparkFrames": 123,
-                      "excessShinesparkFrames": 5,
                       "unusableTiles": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 123,
+                      "excessFrames": 5
                     }},
                     "canSpaceJumpWaterBounce",
                     {"or": [
@@ -2772,9 +2800,11 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 1,
-                      "shinesparkFrames": 14,
-                      "excessShinesparkFrames": 5,
                       "unusableTiles": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 14,
+                      "excessFrames": 5
                     }},
                     "canShinechargeMovementComplex",
                     "SpaceJump",
@@ -2812,9 +2842,11 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 1,
-                      "shinesparkFrames": 14,
-                      "excessShinesparkFrames": 5,
                       "unusableTiles": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 14,
+                      "excessFrames": 5
                     }},
                     "canShinechargeMovementComplex",
                     "SpaceJump",
@@ -2839,9 +2871,11 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 1,
-                      "shinesparkFrames": 14,
-                      "excessShinesparkFrames": 5,
                       "unusableTiles": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 14,
+                      "excessFrames": 5
                     }},
                     "canShinechargeMovementComplex",
                     "canMidairShinespark",
@@ -2896,14 +2930,14 @@
                   "requires": [ "SpaceJump" ]
                 },
                 {
-                  "name": "Shine Spark",
+                  "name": "Shinespark",
                   "notable": false,
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 10,
-                      "shinesparkFrames": 35
-                    }}
+                      "framesRemaining": 10
+                    }},
+                    {"shinespark": {"frames": 35}}
                   ],
                   "note": "Horizontally shinespark from the grassy patch on the ledge near the door, then jump across the platforms."
                 }
@@ -3130,9 +3164,11 @@
                       "usedTiles": 22,
                       "steepUpTiles": 3,
                       "steepDownTiles": 3,
-                      "shinesparkFrames": 25,
-                      "excessShinesparkFrames": 5,
                       "openEnd": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 25,
+                      "excessFrames": 5
                     }}
                   ]
                 },

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -1007,8 +1007,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 1,
-                      "shinesparkFrames": 0
+                      "fromNode": 1
                     }}
                   ]
                 }
@@ -1433,9 +1432,11 @@
                     {"canComeInCharged": {
                       "framesRemaining": 40,
                       "fromNode": 2,
-                      "shinesparkFrames": 21,
-                      "excessShinesparkFrames": 7,
                       "inRoomPath": [2,4]
+                    }},
+                    {"shinespark": {
+                      "frames": 21,
+                      "excessFrames": 7
                     }}
                   ],
                   "note": "Jump to either side and diagonal spark out."
@@ -1506,7 +1507,6 @@
               "startingDownTiles": 0,
               "steepDownTiles": 1,
               "steepUpTiles": 2,
-              "shinesparkFrames": 45,
               "strats": [
                 {
                   "name": "Yapping Maw Alive",
@@ -1514,7 +1514,8 @@
                   "requires": [
                     {"obstaclesCleared": ["A"]},
                     "canMidairShinespark",
-                    "canShinechargeMovement"
+                    "canShinechargeMovement",
+                    {"shinespark": {"frames": 45}}
                   ],
                   "note": [
                     "It is possible to run through the Yapping Maw while it is attacking a different direction.",
@@ -1530,7 +1531,6 @@
               "startingDownTiles": 1,
               "steepDownTiles": 2,
               "steepUpTiles": 2,
-              "shinesparkFrames": 45,
               "strats": [
                 {
                   "name": "Yapping Maw Dead",
@@ -1565,8 +1565,7 @@
                       "h_canDestroyBombWalls",
                       {"canComeInCharged": {
                         "fromNode": 1,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }}
                     ]}
                   ],
@@ -1621,14 +1620,14 @@
               "startingDownTiles": 2,
               "steepDownTiles": 3,
               "steepUpTiles": 1,
-              "shinesparkFrames": 45,
               "strats": [
                 {
                   "name": "Yapping Maw Alive",
                   "notable": false,
                   "requires": [
                     {"obstaclesCleared": ["A"]},
-                    "canMidairShinespark"
+                    "canMidairShinespark",
+                    {"shinespark": {"frames": 45}}
                   ],
                   "devNote": "The yapping maw prevents use of an extra runway tile because it will move to grab Samus"
                 }
@@ -1641,7 +1640,6 @@
               "startingDownTiles": 2,
               "steepDownTiles": 3,
               "steepUpTiles": 2,
-              "shinesparkFrames": 45,
               "strats": [
                 {
                   "name": "Yapping Maw Dead",
@@ -1649,7 +1647,8 @@
                   "requires": [
                     {"obstaclesCleared": ["A"]},
                     "canMidairShinespark",
-                    {"enemyKill": {"enemies": [["Yapping Maw"]]}}
+                    {"enemyKill": {"enemies": [["Yapping Maw"]]}},
+                    {"shinespark": {"frames": 45}}
                   ]
                 },
                 {
@@ -1658,7 +1657,8 @@
                   "requires": [
                     {"obstaclesCleared": ["A"]},
                     "canMidairShinespark",
-                    "canCameraManip"
+                    "canCameraManip",
+                    {"shinespark": {"frames": 45}}
                   ],
                   "note": [
                     "Jump towards the yapping maw before it is on screen so it moves up.",
@@ -1680,8 +1680,7 @@
                       "h_canDestroyBombWalls",
                       {"canComeInCharged": {
                         "fromNode": 2,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }}
                     ]}
                   ],
@@ -1774,9 +1773,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 95,
-                      "excessShinesparkFrames": 20
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 95,
+                      "excessFrames": 20
                     }}
                   ]
                 },
@@ -1788,9 +1789,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 50,
-                      "shinesparkFrames": 85,
-                      "excessShinesparkFrames": 20
+                      "framesRemaining": 50
+                    }},
+                    {"shinespark": {
+                      "frames": 85,
+                      "excessFrames": 20
                     }}
                   ],
                   "note": "Shinespark below the top block or Samus will crash into a solid wall."
@@ -1802,9 +1805,9 @@
                     "canShinechargeMovement",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 37,
-                      "shinesparkFrames": 70
+                      "framesRemaining": 37
                     }},
+                    {"shinespark": {"frames": 70}},
                     {"or": [
                       "Morph",
                       "canTunnelCrawl",
@@ -1828,8 +1831,7 @@
                     "canTrickyJump",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "clearsObstacles": ["A"],
@@ -1877,9 +1879,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 95,
-                      "excessShinesparkFrames": 13
+                      "framesRemaining": 0
+                     }},
+                     {"shinespark": {
+                      "frames": 95,
+                      "excessFrames": 13
                      }}
                   ]
                 },
@@ -1891,10 +1895,12 @@
                     "canShinechargeMovement",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 80,
-                      "excessShinesparkFrames": 13
-                     }}
+                      "framesRemaining": 180
+                    }},
+                    {"shinespark": {
+                      "frames": 80,
+                      "excessFrames": 13
+                    }}
                   ],
                   "note": "Wait for the acid to clear before moving to shinespark on the other side of the bomb blocks."
                 },
@@ -1906,8 +1912,7 @@
                     "canTrickyJump",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "clearsObstacles": ["A"],
@@ -2164,9 +2169,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 90,
-                      "excessShinesparkFrames": 17
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 90,
+                      "excessFrames": 17
                     }}
                   ],
                   "clearsObstacles": ["A","B"],
@@ -2180,9 +2187,11 @@
                     "canShinechargeMovement",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 77,
-                      "excessShinesparkFrames": 17
+                      "framesRemaining": 180
+                    }},
+                    {"shinespark": {
+                      "frames": 77,
+                      "excessFrames": 17
                     }}
                   ],
                   "clearsObstacles": ["A","B"],
@@ -2196,8 +2205,7 @@
                     "canCarefulJump",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "clearsObstacles": ["A","B"]
@@ -2234,8 +2242,7 @@
                       "h_canUsePowerBombs",
                       {"canComeInCharged": {
                         "framesRemaining": 180,
-                        "fromNode": 1,
-                        "shinesparkFrames": 0
+                        "fromNode": 1
                       }},
                       {"obstaclesCleared": ["B"]}
                     ]}
@@ -2294,7 +2301,6 @@
                       "framesRemaining": 180,
                       "fromNode": 2,
                       "inRoomPath": [2,3],
-                      "shinesparkFrames": 0,
                       "unusableTiles": 9
                     }},
                     {"acidFrames": 60}
@@ -2312,7 +2318,6 @@
                           "framesRemaining": 180,
                           "fromNode": 2,
                           "inRoomPath": [2,3],
-                          "shinesparkFrames": 0,
                           "unusableTiles": 5
                         }},
                         {"acidFrames": 200}
@@ -2326,7 +2331,6 @@
                           "framesRemaining": 180,
                           "fromNode": 2,
                           "inRoomPath": [2,3],
-                          "shinesparkFrames": 0,
                           "unusableTiles": 6
                         }}
                       ]},
@@ -2337,7 +2341,6 @@
                           "framesRemaining": 180,
                           "fromNode": 2,
                           "inRoomPath": [2,3],
-                          "shinesparkFrames": 0,
                           "unusableTiles": 1
                         }},
                         {"acidFrames": 27}

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -1880,11 +1880,11 @@
                     {"canComeInCharged": {
                       "fromNode": 2,
                       "framesRemaining": 0
-                     }},
-                     {"shinespark": {
+                    }},
+                    {"shinespark": {
                       "frames": 95,
                       "excessFrames": 13
-                     }}
+                    }}
                   ]
                 },
                 {

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -1538,7 +1538,8 @@
                   "requires": [
                     {"obstaclesCleared": ["A"]},
                     "canMidairShinespark",
-                    {"enemyKill": {"enemies": [["Yapping Maw"]]}}
+                    {"enemyKill": {"enemies": [["Yapping Maw"]]}},
+                    {"shinespark": {"frames": 45}}
                   ]
                 },
                 {
@@ -1547,7 +1548,8 @@
                   "requires": [
                     {"obstaclesCleared": ["A"]},
                     "canMidairShinespark",
-                    "canUseFrozenEnemies"
+                    "canUseFrozenEnemies",
+                    {"shinespark": {"frames": 45}}
                   ],
                   "note": "Freeze the Yapping Maw while it is in the air, extended."
                 }

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -269,8 +269,7 @@
                         "canBlueSpaceJump",
                         {"canShineCharge": {
                           "usedTiles": 23,
-                          "openEnd": 2,
-                          "shinesparkFrames": 0
+                          "openEnd": 2
                         }}
                       ]}
                     ]},
@@ -286,10 +285,12 @@
                     "canShinechargeMovement",
                     {"canShineCharge": {
                       "usedTiles": 24,
-                      "openEnd": 1,
-                      "shinesparkFrames": 75,
-                      "excessShinesparkFrames": 5
-                     }},
+                      "openEnd": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 75,
+                      "excessFrames": 5
+                    }},
                     {"heatFrames": 380}
                   ]
                 },
@@ -754,9 +755,11 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "framesRemaining": 5,
-                      "fromNode": 1,
-                      "shinesparkFrames": 21,
-                      "excessShinesparkFrames": 5
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 21,
+                      "excessFrames": 5
                     }},
                     {"heatFrames": 250}
                   ],
@@ -842,7 +845,6 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "shinesparkFrames": 0,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",
@@ -894,9 +896,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "shinesparkFrames": 1,
-                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb",
@@ -954,18 +958,22 @@
                       "canPreciseWalljump",
                       "canSpringBallJumpMidAir",
                       "SpaceJump",
-                      {"canComeInCharged": {
-                       "framesRemaining": 45,
-                        "fromNode": 2,
-                        "shinesparkFrames": 12,
-                        "inRoomPath": [2,5]
-                      }},
-                      {"canComeInCharged": {
-                        "framesRemaining": 45,
-                        "fromNode": 3,
-                        "shinesparkFrames": 12,
-                        "inRoomPath": [3,5]
-                      }}
+                      {"and": [
+                        {"canComeInCharged": {
+                          "framesRemaining": 45,
+                           "fromNode": 2,
+                           "inRoomPath": [2,5]
+                         }},
+                         {"shinespark": {"frames": 12}}   
+                      ]},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "framesRemaining": 45,
+                          "fromNode": 3,
+                          "inRoomPath": [3,5]
+                        }},
+                        {"shinespark": {"frames": 12}}
+                      ]}
                     ]},
                     {"heatFrames": 400},
                     {"or": [
@@ -1231,9 +1239,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 15,
-                      "shinesparkFrames": 78,
-                      "excessShinesparkFrames": 8
+                      "framesRemaining": 15
+                    }},
+                    {"shinespark": {
+                      "frames": 78,
+                      "excessFrames": 8
                     }},
                     {"heatFrames": 210}
                   ],
@@ -1250,8 +1260,7 @@
                     "canBlueSpaceJump",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }},
                     {"heatFrames": 300}
                   ],
@@ -1374,8 +1383,7 @@
                     "canBlueSpaceJump",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }},
                     {"heatFrames": 300}
                   ],
@@ -1392,9 +1400,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 15,
-                      "shinesparkFrames": 78,
-                      "excessShinesparkFrames": 4
+                      "framesRemaining": 15
+                    }},
+                    {"shinespark": {
+                      "frames": 78,
+                      "excessFrames": 4
                     }},
                     {"heatFrames": 210}
                   ],
@@ -1692,9 +1702,11 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 40,
-                      "excessShinesparkFrames": 3
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {
+                      "frames": 40,
+                      "excessFrames": 3
                     }},
                     {"heatFrames": 240}
                   ],
@@ -2840,7 +2852,6 @@
                         {"canComeInCharged": {
                           "framesRemaining": 180,
                           "fromNode": 2,
-                          "shinesparkFrames": 0,
                           "unusableTiles": 14
                         }}
                       ]}
@@ -2899,9 +2910,9 @@
                     "canSuitlessLavaDive",
                     {"canShineCharge": {
                       "usedTiles": 13,
-                      "openEnd": 1,
-                      "shinesparkFrames": 55
+                      "openEnd": 1
                     }},
+                    {"shinespark": {"frames": 55}},
                     {"acidFrames": 600}
                   ],
                   "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
@@ -5473,9 +5484,9 @@
                     {"heatFrames": 450},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 18,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 18}}
                   ],
                   "clearsObstacles": ["A"]
                 },
@@ -6267,9 +6278,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 15,
-                      "fromNode": 1,
-                      "shinesparkFrames": 57,
-                      "excessShinesparkFrames": 4
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 57,
+                      "excessFrames": 4
                     }},
                     {"heatFrames": 230}
                   ]
@@ -6322,9 +6335,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 15,
-                      "fromNode": 2,
-                      "shinesparkFrames": 59,
-                      "excessShinesparkFrames": 5
+                      "fromNode": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 59,
+                      "excessFrames": 5
                     }},
                     {"heatFrames": 190}
                   ]
@@ -7142,8 +7157,7 @@
                     {"heatFrames": 135},
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }}
                   ],
                   "clearsObstacles": ["C","E","F"]
@@ -7156,9 +7170,9 @@
                     {"heatFrames": 160},
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 80
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 80}}
                   ],
                   "clearsObstacles": ["C","E","F"],
                   "note": "More heat frames than shinespark frames because the shinespark bonk takes some time."
@@ -7221,8 +7235,7 @@
                       }},
                       {"canComeInCharged": {
                         "fromNode": 1,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }}
                     ]}
                   ],
@@ -7294,7 +7307,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 2,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }},
                     {"adjacentRunway": {
@@ -7325,7 +7337,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 2,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }},
                     {"adjacentRunway": {
@@ -7908,7 +7919,6 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 23,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
                     }},
                     {"heatFrames":200}
@@ -8392,8 +8402,7 @@
                     "canHitbox",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "openEnd": 2,
-                      "shinesparkFrames": 0
+                      "openEnd": 2
                     }},
                     {"heatFrames": 145}
                   ],
@@ -9440,7 +9449,6 @@
             {
               "usedTiles": 27,
               "framesRemaining": 0,
-              "shinesparkFrames": 35,
               "strats": [
                 {
                   "name": "Pre Open Door",
@@ -9463,6 +9471,7 @@
                       ]}
                     ]},
                     "canShinechargeMovement",
+                    {"shinespark": {"frames": 35}},
                     {"heatFrames": 1240}
                   ],
                   "note": [
@@ -9490,6 +9499,7 @@
                     "h_canNavigateHeatRooms",
                     "h_canXMode",
                     {"spikeHits": 2},
+                    {"shinespark": {"frames": 35}},
                     {"or": [
                       {"and": [
                         {"enemyKill": {
@@ -9738,7 +9748,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 3,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }},
                     {"heatFrames": 60}
@@ -10068,8 +10077,7 @@
                     {"canShineCharge": {
                       "usedTiles": 26,
                       "gentleDownTiles": 2,
-                      "openEnd": 1,
-                      "shinesparkFrames": 0
+                      "openEnd": 1
                     }},
                     {"heatFrames": 160}
                   ],

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -210,10 +210,12 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                        "framesRemaining": 16,
-                       "fromNode": 1,
-                       "shinesparkFrames": 75,
-                       "excessShinesparkFrames": 10
-                     }},
+                       "fromNode": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 75,
+                      "excessFrames": 10
+                    }},
                     {"heatFrames": 270}
                   ]
                 }

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -202,7 +202,7 @@
                   ]
                 },
                 {
-                  "name": "ShineSpark",
+                  "name": "Shinespark",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -9471,8 +9471,8 @@
                       ]}
                     ]},
                     "canShinechargeMovement",
-                    {"shinespark": {"frames": 35}},
-                    {"heatFrames": 1240}
+                    {"heatFrames": 1240},
+                    {"shinespark": {"frames": 35}}
                   ],
                   "note": [
                     "Open the door to be able to spark out later.",
@@ -9499,7 +9499,6 @@
                     "h_canNavigateHeatRooms",
                     "h_canXMode",
                     {"spikeHits": 2},
-                    {"shinespark": {"frames": 35}},
                     {"or": [
                       {"and": [
                         {"enemyKill": {
@@ -9533,7 +9532,8 @@
                         }},
                         {"heatFrames": 620}
                       ]}
-                    ]}
+                    ]},
+                    {"shinespark": {"frames": 35}}
                   ],
                   "note": "Clear the Alcoon then bounce into the spike patch."
                 }

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -848,6 +848,10 @@
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
+                    }},
                     "canXRayClimb",
                     {"heatFrames": 1600}
                   ],
@@ -9532,8 +9536,7 @@
                         }},
                         {"heatFrames": 620}
                       ]}
-                    ]},
-                    {"shinespark": {"frames": 35}}
+                    ]}
                   ],
                   "note": "Clear the Alcoon then bounce into the spike patch."
                 }

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -169,9 +169,9 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "framesRemaining": 0,
-                      "fromNode": 1,
-                      "shinesparkFrames": 36
+                      "fromNode": 1
                     }},
+                    {"shinespark": {"frames": 36}},
                     {"heatFrames": 125}
                   ]
                 },
@@ -343,9 +343,11 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "framesRemaining": 0,
-                      "fromNode": 2,
-                      "shinesparkFrames": 41,
-                      "excessShinesparkFrames": 6
+                      "fromNode": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 41,
+                      "excessFrames": 6
                     }},
                     {"heatFrames": 125}
                   ]
@@ -1135,10 +1137,12 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 17,
-                      "excessShinesparkFrames": 3
-                     }},
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 17,
+                      "excessFrames": 3
+                    }},
                     {"heatFrames": 150}
                   ]
                 }
@@ -1359,9 +1363,9 @@
                     "canConsecutiveWalljump",
                     {"canShineCharge": {
                       "usedTiles": 28,
-                      "shinesparkFrames": 11,
                       "openEnd": 0
                     }},
+                    {"shinespark": {"frames": 11}},
                     {"heatFrames": 900}
                   ],
                   "reusableRoomwideNotable": "Golden Torizo Supers Double Shinespark",
@@ -1381,9 +1385,9 @@
                     "HiJump",
                     {"canShineCharge": {
                       "usedTiles": 28,
-                      "shinesparkFrames": 11,
                       "openEnd": 0
                     }},
+                    {"shinespark": {"frames": 11}},
                     {"heatFrames": 900}
                   ],
                   "reusableRoomwideNotable": "Golden Torizo Supers Double Shinespark",
@@ -1720,9 +1724,11 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 25,
-                      "shinesparkFrames": 31,
-                      "excessShinesparkFrames": 10
+                      "framesRemaining": 25
+                    }},
+                    {"shinespark": {
+                      "frames": 31,
+                      "excessFrames": 10
                     }},
                     { "heatFrames": 200 }
                   ],
@@ -1760,13 +1766,15 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    { "canComeInCharged": {
+                    {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 50,
-                      "shinesparkFrames": 41,
-                      "excessShinesparkFrames": 4
-                      }},
-                    { "heatFrames": 250 }
+                      "framesRemaining": 50
+                    }},
+                    {"shinespark": {
+                      "frames": 41,
+                      "excessFrames": 4
+                    }},
+                    {"heatFrames": 250}
                   ],
                   "clearsObstacles": ["A","B"]
                 },
@@ -1851,9 +1859,11 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 50,
-                      "shinesparkFrames": 35,
-                      "excessShinesparkFrames": 4
+                      "framesRemaining": 50
+                    }},
+                    {"shinespark": {
+                      "frames": 35,
+                      "excessFrames": 4
                     }},
                     {"heatFrames": 250}
                   ],
@@ -1869,9 +1879,11 @@
                     "canPrepareForNextRoom",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 15,
-                      "shinesparkFrames": 18,
-                      "excessShinesparkFrames": 4
+                      "framesRemaining": 15
+                    }},
+                    {"shinespark": {
+                      "frames": 18,
+                      "excessFrames": 4
                     }},
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -1972,8 +1984,7 @@
                     "canPrepareForNextRoom",
                     {"canComeInCharged": {
                        "framesRemaining": 180,
-                       "fromNode": 2,
-                       "shinesparkFrames": 0
+                       "fromNode": 2
                      }},
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -1994,8 +2005,7 @@
                     "canPrepareForNextRoom",
                     {"canComeInCharged": {
                        "framesRemaining": 180,
-                       "fromNode": 2,
-                       "shinesparkFrames": 0
+                       "fromNode": 2
                      }},
                     {"heatFrames": 75}
                   ],
@@ -2011,8 +2021,7 @@
                     "canShinechargeMovement",
                     {"canComeInCharged": {
                        "framesRemaining": 125,
-                       "fromNode": 2,
-                       "shinesparkFrames": 0
+                       "fromNode": 2
                      }},
                     {"heatFrames": 120}
                   ],
@@ -2142,7 +2151,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 3,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 4
                     }},
                     {"heatFrames": 200}
@@ -2165,7 +2173,6 @@
                         {"canComeInCharged": {
                           "framesRemaining": 180,
                           "fromNode": 3,
-                          "shinesparkFrames": 0,
                           "unusableTiles": 9
                         }},
                         {"heatFrames": 240}
@@ -2174,8 +2181,7 @@
                         "canXRayTurnaround",
                         {"canComeInCharged": {
                           "framesRemaining": 180,
-                          "fromNode": 3,
-                          "shinesparkFrames": 0
+                          "fromNode": 3
                         }},
                         {"heatFrames": 285}
                       ]}
@@ -2192,7 +2198,6 @@
                     {"canComeInCharged": {
                       "framesRemaining": 180,
                       "fromNode": 3,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 9
                     }},
                     {"heatFrames": 130}
@@ -2209,8 +2214,7 @@
                     "canShinechargeMovement",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 3,
-                      "shinesparkFrames": 0
+                      "fromNode": 3
                     }},
                     {"heatFrames": 170}
                   ],
@@ -2289,9 +2293,11 @@
                     {"obstaclesCleared": ["C"]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "openEnd": 2,
-                      "shinesparkFrames": 31,
-                      "excessShinesparkFrames": 10
+                      "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 31,
+                      "excessFrames": 10
                     }},
                     {"heatFrames": 240}
                   ],
@@ -2316,9 +2322,11 @@
                     {"obstaclesCleared": ["C"]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "openEnd": 2,
-                      "shinesparkFrames": 41,
-                      "excessShinesparkFrames": 4
+                      "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 41,
+                      "excessFrames": 4
                     }},
                     {"heatFrames": 270}
                   ],

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -171,8 +171,8 @@
                       "framesRemaining": 0,
                       "fromNode": 1
                     }},
-                    {"shinespark": {"frames": 36}},
-                    {"heatFrames": 125}
+                    {"heatFrames": 125},
+                    {"shinespark": {"frames": 36}}
                   ]
                 },
                 {
@@ -345,11 +345,11 @@
                       "framesRemaining": 0,
                       "fromNode": 2
                     }},
+                    {"heatFrames": 125},
                     {"shinespark": {
                       "frames": 41,
                       "excessFrames": 6
-                    }},
-                    {"heatFrames": 125}
+                    }}
                   ]
                 }
               ]
@@ -1139,11 +1139,11 @@
                       "fromNode": 1,
                       "framesRemaining": 0
                     }},
+                    {"heatFrames": 150},
                     {"shinespark": {
                       "frames": 17,
                       "excessFrames": 3
-                    }},
-                    {"heatFrames": 150}
+                    }}
                   ]
                 }
               ]
@@ -1365,8 +1365,8 @@
                       "usedTiles": 28,
                       "openEnd": 0
                     }},
-                    {"shinespark": {"frames": 11}},
-                    {"heatFrames": 900}
+                    {"heatFrames": 900},
+                    {"shinespark": {"frames": 11}}
                   ],
                   "reusableRoomwideNotable": "Golden Torizo Supers Double Shinespark",
                   "note": [
@@ -1387,8 +1387,8 @@
                       "usedTiles": 28,
                       "openEnd": 0
                     }},
-                    {"shinespark": {"frames": 11}},
-                    {"heatFrames": 900}
+                    {"heatFrames": 900},
+                    {"shinespark": {"frames": 11}}
                   ],
                   "reusableRoomwideNotable": "Golden Torizo Supers Double Shinespark",
                   "note": [
@@ -1726,11 +1726,11 @@
                       "fromNode": 1,
                       "framesRemaining": 25
                     }},
+                    {"heatFrames": 200},
                     {"shinespark": {
                       "frames": 31,
                       "excessFrames": 10
-                    }},
-                    { "heatFrames": 200 }
+                    }}
                   ],
                   "clearsObstacles": ["B"]
                 },
@@ -1770,11 +1770,11 @@
                       "fromNode": 1,
                       "framesRemaining": 50
                     }},
+                    {"heatFrames": 250},
                     {"shinespark": {
                       "frames": 41,
                       "excessFrames": 4
-                    }},
-                    {"heatFrames": 250}
+                    }}
                   ],
                   "clearsObstacles": ["A","B"]
                 },
@@ -1861,11 +1861,11 @@
                       "fromNode": 2,
                       "framesRemaining": 50
                     }},
+                    {"heatFrames": 250},
                     {"shinespark": {
                       "frames": 35,
                       "excessFrames": 4
-                    }},
-                    {"heatFrames": 250}
+                    }}
                   ],
                   "clearsObstacles": ["A"]
                 },
@@ -1881,15 +1881,15 @@
                       "fromNode": 2,
                       "framesRemaining": 15
                     }},
-                    {"shinespark": {
-                      "frames": 18,
-                      "excessFrames": 4
-                    }},
                     {"adjacentRunway": {
                       "fromNode": 2,
                       "usedTiles": 0.5
                     }},
-                    {"heatFrames": 250}
+                    {"heatFrames": 250},
+                    {"shinespark": {
+                      "frames": 18,
+                      "excessFrames": 4
+                    }}
                   ],
                   "clearsObstacles": ["A"],
                   "note": [
@@ -2295,11 +2295,11 @@
                       "usedTiles": 33,
                       "openEnd": 2
                     }},
+                    {"heatFrames": 240},
                     {"shinespark": {
                       "frames": 31,
                       "excessFrames": 10
-                    }},
-                    {"heatFrames": 240}
+                    }}
                   ],
                   "clearsObstacles": ["B"],
                   "reusableRoomwideNotable": "Screw Attack Room Descent and Shinespark Escape",
@@ -2324,11 +2324,11 @@
                       "usedTiles": 33,
                       "openEnd": 2
                     }},
+                    {"heatFrames": 270},
                     {"shinespark": {
                       "frames": 41,
                       "excessFrames": 4
-                    }},
-                    {"heatFrames": 270}
+                    }}
                   ],
                   "clearsObstacles": ["A","B"],
                   "reusableRoomwideNotable": "Screw Attack Room Descent and Shinespark Escape",

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -345,18 +345,18 @@
                       {"canComeInCharged": {
                         "fromNode": 1,
                         "inRoomPath": [1, 5],
-                        "framesRemaining": 30,
-                        "shinesparkFrames": 23,
-                        "excessShinesparkFrames": 10
+                        "framesRemaining": 30
                       }},
                       {"canComeInCharged": {
                         "fromNode": 2,
                         "inRoomPath": [2, 5],
-                        "framesRemaining": 30,
-                        "shinesparkFrames": 23,
-                        "excessShinesparkFrames": 10
+                        "framesRemaining": 30
                       }}
-                    ]}
+                    ]},
+                    {"shinespark": {
+                      "frames": 23,
+                      "excessFrames": 10
+                    }}  
                   ],
                   "note": "The spark takes Samus directly to the top platform.",
                   "devNote": "This does not require canWaterShineCharge, as you can store the shinecharge before entering the room."
@@ -386,9 +386,11 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 23,
-                      "excessShinesparkFrames": 10,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 23,
+                      "excessFrames": 10
                     }}
                   ],
                   "note": "Spark diagonally through the bomb blocks."
@@ -453,16 +455,15 @@
                       {"canComeInCharged": {
                         "fromNode": 1,
                         "inRoomPath": [1, 5],
-                        "framesRemaining": 30,
-                        "shinesparkFrames": 3
+                        "framesRemaining": 30
                       }},
                       {"canComeInCharged": {
                         "fromNode": 2,
                         "inRoomPath": [2, 5],
-                        "framesRemaining": 30,
-                        "shinesparkFrames": 3
+                        "framesRemaining": 30
                       }}
-                    ]}
+                    ]},
+                    {"shinespark": {"frames": 3}}
                   ],
                   "note": "Spark into the bomb blocks. The trick can fail with 50% probability due to collision oscillation.",
                   "devNote": "This does not require canWaterShineCharge, as you can store the shinecharge before entering the room."
@@ -492,9 +493,9 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 3,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 3}}
                   ],
                   "note": "Spark into the bomb blocks. The trick can fail with 50% probability due to collision oscillation."
                 },
@@ -771,9 +772,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 98
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 98}}
                   ],
                   "devNote": "Frame cost assumes no Gravity"
                 },
@@ -966,9 +967,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 98
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 98}}
                   ],
                   "devNote": "Frame cost assumes no Gravity"
                 },
@@ -1750,9 +1751,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 15,
-                      "fromNode": 1,
-                      "shinesparkFrames": 58,
-                      "excessShinesparkFrames": 4
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 58,
+                      "excessFrames": 4
                     }}
                   ],
                   "devNote": "Needs to activate the spark in-room because Samus will bonk if sparking through too low."
@@ -1764,10 +1767,12 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 71,
-                      "excessShinesparkFrames": 4
-                     }}
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {
+                      "frames": 71,
+                      "excessFrames": 4
+                    }}
                   ],
                   "devNote": "Needs to activate the spark in-room because Samus will bonk if sparking through too low."
                 },
@@ -1999,9 +2004,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 15,
-                      "fromNode": 2,
-                      "shinesparkFrames": 61,
-                      "excessShinesparkFrames": 4
+                      "fromNode": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 61,
+                      "excessFrames": 4
                     }}
                   ],
                   "devNote": "Needs to activate the spark in-room because Samus will bonk if sparking through too low."
@@ -2013,9 +2020,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 71,
-                      "excessShinesparkFrames": 4
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {
+                      "frames": 71,
+                      "excessFrames": 4
                     }}
                   ],
                   "devNote": "Needs to activate the spark in-room because Samus will bonk if sparking through too low."
@@ -2670,16 +2679,15 @@
                       {"canComeInCharged": {
                         "fromNode": 1,
                         "inRoomPath": [1, 4],
-                        "framesRemaining": 150,
-                        "shinesparkFrames": 65
+                        "framesRemaining": 150
                       }},
                       {"canComeInCharged": {
                         "fromNode": 3,
                         "inRoomPath": [3, 4],
-                        "framesRemaining": 150,
-                        "shinesparkFrames": 65
+                        "framesRemaining": 150
                       }}
                     ]},
+                    {"shinespark": {"frames": 65}},
                     {"enemyDamage": {
                       "enemy": "Menu",
                       "type": "contact",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -3318,11 +3318,7 @@
                           "useFrames": 80
                         }}
                       ]}
-                    ]},
-                    {"canShineCharge": {
-                      "usedTiles": 33,
-                      "openEnd": 2
-                    }}
+                    ]}
                   ],
                   "clearsObstacles": ["A"]
                 },
@@ -3476,10 +3472,6 @@
                         }}
                       ]}
                     ]},
-                    {"canShineCharge": {
-                      "usedTiles": 33,
-                      "openEnd": 2
-                    }},
                     {"shinespark": {"frames": 8}}
                   ],
                   "note": "Shinespark diagonally over the zoa pit or run through the speed blocks and shinespark after turning around."
@@ -4404,10 +4396,6 @@
                         }}
                       ]}
                     ]},
-                    {"canShineCharge": {
-                      "usedTiles": 33,
-                      "openEnd": 2
-                    }},
                     {"shinespark": {
                       "frames": 39,
                       "excessFrames": 4

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -258,9 +258,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 40
+                      "framesRemaining": 60
                     }},
+                    {"shinespark": {"frames": 40}},
                     {"or": [
                       "canCrouchJump",
                       "Gravity",
@@ -400,9 +400,9 @@
                     "canShinechargeMovementComplex",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 39,
                       "openEnd": 2
                     }},
+                    {"shinespark": {"frames": 39}},
                     {"or": [
                       "canCrouchJump",
                       "Gravity",
@@ -1280,9 +1280,11 @@
                     "canWaterShineCharge",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 37,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 37,
+                      "excessFrames": 3
                     }},
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -1305,9 +1307,11 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 40,
-                      "excessShinesparkFrames": 7,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 40,
+                      "excessFrames": 7
                     }}
                   ]
                 },
@@ -1318,9 +1322,11 @@
                     "canWaterShineCharge",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 40,
-                      "excessShinesparkFrames": 7,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 40,
+                      "excessFrames": 7
                     }},
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -1530,9 +1536,11 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 37,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 37,
+                      "excessFrames": 3
                     }}
                   ]
                 },
@@ -1543,9 +1551,11 @@
                     "canWaterShineCharge",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 37,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 37,
+                      "excessFrames": 3
                     }},
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -1592,7 +1602,6 @@
                       {"canShineCharge": {
                         "usedTiles": 20,
                         "openEnd": 2,
-                        "shinesparkFrames": 0,
                         "steepDownTiles": 1,
                         "steepUpTiles": 1,
                         "gentleDownTiles": 5,
@@ -1629,8 +1638,7 @@
                       "canPlayInSand",
                       {"canShineCharge": {
                         "usedTiles": 32,
-                        "openEnd": 1,
-                        "shinesparkFrames": 0
+                        "openEnd": 1
                       }},
                       "h_canUseSpringBall"
                      ]}
@@ -1652,9 +1660,11 @@
                         {"canComeInCharged": {
                           "fromNode": 2,
                           "framesRemaining": 180,
-                          "shinesparkFrames": 139,
-                          "excessShinesparkFrames": 66,
                           "inRoomPath": [2,4]
+                        }},
+                        {"shinespark": {
+                          "frames": 139,
+                          "excessFrames": 66
                         }}
                       ]}
                     ]}
@@ -1737,9 +1747,9 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 20,
-                      "shinesparkFrames": 25,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 25}}
                   ]
                 }
               ]
@@ -1930,9 +1940,11 @@
                     {"canComeInCharged": {
                       "fromNode": 6,
                       "framesRemaining": 35,
-                      "shinesparkFrames": 78,
-                      "excessShinesparkFrames": 16,
                       "inRoomPath": [6,9]
+                    }},
+                    {"shinespark": {
+                      "frames": 78,
+                      "excessFrames": 16
                     }}
                   ]
                 },
@@ -1944,9 +1956,11 @@
                     {"canComeInCharged": {
                       "fromNode": 6,
                       "framesRemaining": 55,
-                      "shinesparkFrames": 99,
-                      "excessShinesparkFrames": 29,
                       "inRoomPath": [6,9]
+                    }},
+                    {"shinespark": {
+                      "frames": 99,
+                      "excessFrames": 29
                     }}
                   ]
                 },
@@ -2996,7 +3010,6 @@
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 1,
-                      "shinesparkFrames": 0,
                       "gentleDownTiles": 3,
                       "steepDownTiles": 1
                     }}
@@ -3010,9 +3023,11 @@
                     "canSuitlessMaridia",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 159,
-                      "excessShinesparkFrames": 43
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {
+                      "frames": 159,
+                      "excessFrames": 43
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -3081,9 +3096,9 @@
                     {"canComeInCharged": {
                       "framesRemaining": 22,
                       "fromNode": 1,
-                      "shinesparkFrames": 55,
                       "unusableTiles": 1
-                    }}
+                    }},
+                    {"shinespark": {"frames": 55}}
                   ]
                 },
                 {
@@ -3243,20 +3258,22 @@
                     {"or": [
                       {"canComeInCharged": {
                         "fromNode": 4,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }},
-                      {"canComeInCharged": {
-                        "fromNode": 4,
-                        "framesRemaining": 80,
-                        "shinesparkFrames": 115,
-                        "excessShinesparkFrames": 12
-                      }},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 4,
+                          "framesRemaining": 80
+                        }},
+                        {"shinespark": {
+                          "frames": 115,
+                          "excessFrames": 12
+                        }}
+                      ]},
                       {"canShineCharge": {
                         "usedTiles": 22,
                         "gentleDownTiles": 4,
-                        "openEnd": 1,
-                        "shinesparkFrames": 0
+                        "openEnd": 1
                       }}
                     ]}
                   ],
@@ -3269,9 +3286,11 @@
                     "canSuitlessMaridia",
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "framesRemaining": 160,
-                      "shinesparkFrames": 147,
-                      "excessShinesparkFrames": 15
+                      "framesRemaining": 160
+                    }},
+                    {"shinespark": {
+                      "frames": 147,
+                      "excessFrames": 15
                     }}
                   ],
                   "clearsObstacles": ["A"],
@@ -3286,8 +3305,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 4,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -3303,7 +3321,6 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
                     }}
                   ],
@@ -3445,8 +3462,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 4,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -3462,9 +3478,9 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "openEnd": 2,
-                      "shinesparkFrames": 8
-                    }}
+                      "openEnd": 2
+                    }},
+                    {"shinespark": {"frames": 8}}
                   ],
                   "note": "Shinespark diagonally over the zoa pit or run through the speed blocks and shinespark after turning around."
                 },
@@ -3484,9 +3500,11 @@
                     {"canComeInCharged": {
                       "framesRemaining": 20,
                       "fromNode": 4,
-                      "shinesparkFrames": 46,
-                      "excessShinesparkFrames": 3,
                       "unusableTiles": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 46,
+                      "excessFrames": 3
                     }}
                   ]
                 },
@@ -3913,9 +3931,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 20,
-                      "shinesparkFrames": 25
-                    }}
+                      "framesRemaining": 20
+                    }},
+                    {"shinespark": {"frames": 25}}
                   ]
                 },
                 {
@@ -4082,9 +4100,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 30,
-                      "shinesparkFrames": 20
-                    }}
+                      "framesRemaining": 30
+                    }},
+                    {"shinespark": {"frames": 20}}
                   ]
                 },
                 {
@@ -4176,8 +4194,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 2,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -4193,9 +4210,11 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 20,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 20,
+                      "excessFrames": 3
                     }}
                   ]
                 }
@@ -4291,9 +4310,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 30,
-                      "shinesparkFrames": 39,
-                      "excessShinesparkFrames": 4
+                      "framesRemaining": 30
+                    }},
+                    {"shinespark": {
+                      "frames": 39,
+                      "excessFrames": 4
                     }}
                   ]
                 },
@@ -4369,8 +4390,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 2,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -4386,9 +4406,11 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 39,
-                      "excessShinesparkFrames": 4,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 39,
+                      "excessFrames": 4
                     }}
                   ]
                 },
@@ -4425,19 +4447,25 @@
                     "Gravity",
                     "canShinechargeMovementComplex",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 20,
-                        "excessShinesparkFrames": 3,
-                        "openEnd": 0
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 20,
+                          "excessFrames": 3
+                        }}
+                      ]},
                       {"and": [
                         "canMidairShinespark",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 15,
-                          "excessShinesparkFrames": 3,
                           "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 15,
+                          "excessFrames": 3
                         }}
                       ]}
                     ]}
@@ -4483,9 +4511,11 @@
                     "canUseEnemies",
                     {"canComeInCharged": {
                       "framesRemaining": 100,
-                      "fromNode": 3,
-                      "shinesparkFrames": 91,
-                      "excessShinesparkFrames": 4
+                      "fromNode": 3
+                    }},
+                    {"shinespark": {
+                      "frames": 91,
+                      "excessFrames": 4
                     }}
                   ],
                   "note": [
@@ -4531,19 +4561,25 @@
                     "Gravity",
                     "canShinechargeMovementComplex",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 39,
-                        "excessShinesparkFrames": 4,
-                        "openEnd": 0
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 39,
+                          "excessFrames": 4
+                        }}
+                      ]},
                       {"and": [
                         "canMidairShinespark",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 33,
-                          "excessShinesparkFrames": 3,
                           "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 33,
+                          "excessFrames": 3
                         }}
                       ]}
                     ]}
@@ -4983,9 +5019,9 @@
                     "canCarefulJump",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 125
-                    }}
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {"frames": 125}}
                   ]
                 },
                 {
@@ -5179,9 +5215,11 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged": {
                       "framesRemaining": 20,
-                      "fromNode": 2,
-                      "shinesparkFrames": 24,
-                      "excessShinesparkFrames": 6
+                      "fromNode": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 24,
+                      "excessFrames": 6
                     }}
                   ]
                 },
@@ -5356,9 +5394,9 @@
                     "canCarefulJump",
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 125
-                    }}
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {"frames": 125}}
                   ]
                 },
                 {
@@ -5806,9 +5844,11 @@
                     "Gravity",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 40,
-                      "shinesparkFrames": 40,
-                      "excessShinesparkFrames": 8
+                      "framesRemaining": 40
+                    }},
+                    {"shinespark": {
+                      "frames": 40,
+                      "excessFrames": 8
                     }}
                   ]
                 },
@@ -5819,9 +5859,11 @@
                     "canSuitlessMaridia",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 40,
-                      "excessShinesparkFrames": 8
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {
+                      "frames": 40,
+                      "excessFrames": 8
                     }}
                   ],
                   "note": "It takes a bit more time to set up the spark when suitless."
@@ -5868,9 +5910,11 @@
                     }},
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 40,
-                      "excessShinesparkFrames": 8,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 40,
+                      "excessFrames": 8
                     }}
                   ]
                 },
@@ -6126,9 +6170,9 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 22,
-                      "shinesparkFrames": 150,
                       "openEnd": 0
-                    }}
+                    }},
+                    {"shinespark": {"frames": 150}}
                   ],
                   "note": "Shinecharge in-room, then horizontally spark through Draygon multiple times.",
                   "devNote": "150 frames is an approximate sum of all required shinesparks."
@@ -6364,9 +6408,9 @@
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "inRoomPath": [1, 3],
-                      "framesRemaining": 50,
-                      "shinesparkFrames": 25
-                    }}
+                      "framesRemaining": 50
+                    }},
+                    {"shinespark": {"frames": 25}}
                   ]
                 },
                 {
@@ -6384,9 +6428,9 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 22,
-                      "shinesparkFrames": 30,
                       "openEnd": 1
-                    }}
+                    }},
+                    {"shinespark": {"frames": 30}}
                   ]
                 },
                 {
@@ -6397,9 +6441,9 @@
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "inRoomPath": [1, 3],
-                      "framesRemaining": 90,
-                      "shinesparkFrames": 25
-                    }}
+                      "framesRemaining": 90
+                    }},
+                    {"shinespark": {"frames": 25}}
                   ],
                   "note": "Takes more time to setup than suited. but you can spark from a bit farther out because of the water physics."
                 },
@@ -6702,9 +6746,11 @@
                     "Gravity",
                     {"canComeInCharged": {
                       "framesRemaining": 4,
-                      "fromNode": 1,
-                      "shinesparkFrames": 20,
-                      "excessShinesparkFrames": 0
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 20,
+                      "excessFrames": 0
                     }}
                   ]
                 },
@@ -6715,9 +6761,11 @@
                     "canSuitlessMaridia",
                     {"canComeInCharged": {
                       "framesRemaining": 20,
-                      "fromNode": 1,
-                      "shinesparkFrames": 20,
-                      "excessShinesparkFrames": 0
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 20,
+                      "excessFrames": 0
                     }}
                   ]
                 },
@@ -6801,7 +6849,6 @@
           "canLeaveCharged": [
             {
               "framesRemaining": 0,
-              "shinesparkFrames": 10,
               "usedTiles": 33,
               "openEnd": 2,
               "strats": [
@@ -6815,7 +6862,8 @@
                     "SpaceJump",
                     "canShinechargeMovementComplex",
                     "canMidairShinespark",
-                    {"spikeHits": 3}
+                    {"spikeHits": 3},
+                    {"shinespark": {"frames": 10}}
                   ]
                 }
               ]
@@ -7185,9 +7233,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 20,
-                      "shinesparkFrames": 20
-                    }}
+                      "framesRemaining": 20
+                    }},
+                    {"shinespark": {"frames": 20}}
                   ]
                 },
                 {
@@ -7198,11 +7246,13 @@
                     "h_canXMode",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "openEnd": 2,
-                      "shinesparkFrames": 25,
-                      "excessShinesparkFrames": 5
+                      "openEnd": 2
                     }},
-                    {"spikeHits": 3}
+                    {"spikeHits": 3},
+                    {"shinespark": {
+                      "frames": 25,
+                      "excessFrames": 5
+                    }}
                   ]
                 },
                 {
@@ -8602,9 +8652,9 @@
                     ]},
                     {"canComeInCharged": {
                       "framesRemaining": 105,
-                      "fromNode": 1,
-                      "shinesparkFrames": 11
-                    }}
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {"frames": 11}}
                   ],
                   "note": "Jump out of the sand before Shinesparking."
                 }
@@ -8722,17 +8772,17 @@
                         "canPrepareForNextRoom",
                         {"canComeInCharged": {
                           "framesRemaining": 70,
-                          "fromNode": 1,
-                          "shinesparkFrames": 18
-                        }}
+                          "fromNode": 1
+                        }},
+                        {"shinespark": {"frames": 18}}
                       ]},
                       {"and": [
                         "canTrickyJump",
                         {"canComeInCharged": {
                           "framesRemaining": 140,
-                          "fromNode": 1,
-                          "shinesparkFrames": 20
-                        }}
+                          "fromNode": 1
+                        }},
+                        {"shinespark": {"frames": 20}}
                       ]}
                     ]}
                   ],
@@ -9016,9 +9066,11 @@
                         ]},
                         {"canComeInCharged": {
                           "framesRemaining": 150,
-                          "fromNode": 1,
-                          "shinesparkFrames": 24,
-                          "excessShinesparkFrames": 5
+                          "fromNode": 1
+                        }},
+                        {"shinespark": {
+                          "frames": 24,
+                          "excessFrames": 5
                         }}
                       ]},
                       {"and": [
@@ -9027,18 +9079,22 @@
                         "canShinechargeMovementComplex",
                         {"canComeInCharged": {
                           "framesRemaining": 160,
-                          "fromNode": 1,
-                          "shinesparkFrames": 25,
-                          "excessShinesparkFrames": 4
+                          "fromNode": 1
+                        }},
+                        {"shinespark": {
+                          "frames": 25,
+                          "excessFrames": 4
                         }}
                       ]},
                       {"and": [
                         "Wave",
                         {"canComeInCharged": {
                           "framesRemaining": 85,
-                          "fromNode": 1,
-                          "shinesparkFrames": 24,
-                          "excessShinesparkFrames": 5
+                          "fromNode": 1
+                        }},
+                        {"shinespark": {
+                          "frames": 24,
+                          "excessFrames": 5
                         }}
                       ]}
                     ]}

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -207,9 +207,11 @@
                     "canSuitlessMaridia",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 5,
-                      "shinesparkFrames": 40,
-                      "excessShinesparkFrames": 18
+                      "framesRemaining": 5
+                    }},
+                    {"shinespark": {
+                      "frames": 40,
+                      "excessFrames": 18
                     }}
                   ],
                   "note": "Spark diagonally from the right side of the doorway.",
@@ -341,9 +343,11 @@
                     "canShinechargeMovement",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 50,
-                      "shinesparkFrames": 14,
-                      "excessShinesparkFrames": 4
+                      "framesRemaining": 50
+                    }},
+                    {"shinespark": {
+                      "frames": 14,
+                      "excessFrames": 4
                     }}
                   ],
                   "note": "Spark vertically by the first plant on the right to hit the floating island.",
@@ -758,7 +762,6 @@
             {
               "usedTiles": 22,
               "framesRemaining": 0,
-              "shinesparkFrames": 15,
               "openEnd": 2,
               "strats": [
                 {
@@ -766,7 +769,8 @@
                   "notable": false,
                   "requires": [
                     "canShinechargeMovementComplex",
-                    "HiJump"
+                    "HiJump",
+                    {"shinespark": {"frames": 15}}
                   ],
                   "note": "Charge a spark below towards the right then run back and jump up and spark out of the left door."
                 },
@@ -775,7 +779,8 @@
                   "notable": true,
                   "requires": [
                     "canShinechargeMovementComplex",
-                    "canTrickyDashJump"
+                    "canTrickyDashJump",
+                    {"shinespark": {"frames": 15}}
                   ],
                   "note": "Charge a spark below towards the right then run back and jump up and spark out of the left door."
                 }
@@ -784,7 +789,6 @@
             {
               "usedTiles": 20,
               "framesRemaining": 30,
-              "shinesparkFrames": 0,
               "openEnd": 2,
               "strats": [
                 {
@@ -841,7 +845,6 @@
             {
               "usedTiles": 22,
               "framesRemaining": 0,
-              "shinesparkFrames": 30,
               "openEnd": 2,
               "initiateRemotely": {
                 "initiateAt": 3,
@@ -859,7 +862,8 @@
                   "notable": true,
                   "requires": [
                     "canShinechargeMovementComplex",
-                    "canCarefulJump"
+                    "canCarefulJump",
+                    {"shinespark": {"frames": 30}}
                   ],
                   "note": [
                     "Charge below node 1 then carry the spark through the morph tunnel and out the right door.",
@@ -872,7 +876,8 @@
                   "requires": [
                     "Gravity",
                     "canShinechargeMovementComplex",
-                    "canCarefulJump"
+                    "canCarefulJump",
+                    {"shinespark": {"frames": 30}}
                   ],
                   "note": [
                     "Charge below node 1 then carry the spark through the morph tunnel and out the right door.",
@@ -1695,9 +1700,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 120,
-                      "shinesparkFrames": 37,
-                      "excessShinesparkFrames": 10
+                      "framesRemaining": 120
+                    }},
+                    {"shinespark": {
+                      "frames": 37,
+                      "excessFrames": 10
                     }},
                     {"or": [
                       {"enemyDamage": { "enemy": "Choot", "type": "contact", "hits": 1 }},
@@ -1787,18 +1794,24 @@
                     "canWaterShineCharge",
                     "canShinechargeMovementComplex",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 90,
-                        "excessShinesparkFrames": 50,
-                        "openEnd": 2
-                      }},
                       {"and": [
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 90,
-                          "excessShinesparkFrames": 57,
                           "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 90,
+                          "excessFrames": 50                          
+                        }}
+                      ]},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 90,
+                          "excessFrames": 57
                         }},
                         {"or": [
                           "canWalljump",
@@ -1898,9 +1911,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "shinesparkFrames": 1,
-                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
@@ -1955,9 +1970,11 @@
                     "canShinechargeMovementComplex",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 90,
-                      "excessShinesparkFrames": 11,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 90,
+                      "excessFrames": 11
                     }},
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -2048,17 +2065,23 @@
                         "canMidairShinespark",
                         {"canComeInCharged": {
                           "fromNode": 3,
-                          "framesRemaining": 120,
-                          "shinesparkFrames": 30,
-                          "excessShinesparkFrames": 3
+                          "framesRemaining": 120
+                        }},
+                        {"shinespark": {
+                          "frames": 30,
+                          "excessFrames": 3
                         }}
                       ]},
-                      {"canComeInCharged": {
-                        "fromNode": 3,
-                        "framesRemaining": 120,
-                        "shinesparkFrames": 43,
-                        "excessShinesparkFrames": 3
-                      }}
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 3,
+                          "framesRemaining": 120
+                        }},
+                        {"shinespark": {
+                          "frames": 43,
+                          "excessFrames": 3
+                        }}  
+                      ]}
                     ]}
                   ],
                   "note": [
@@ -2188,9 +2211,9 @@
                     "canCarefulJump",
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 145,
-                      "shinesparkFrames": 49
-                    }}
+                      "framesRemaining": 145
+                    }},
+                    {"shinespark": {"frames": 49}}
                   ],
                   "note": [
                     "Shinespark from the tile to the right of the Choot.",
@@ -2237,9 +2260,9 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "framesRemaining": 45,
-                      "shinesparkFrames": 13
-                    }}
+                      "framesRemaining": 45
+                    }},
+                    {"shinespark": {"frames": 13}}
                   ],
                   "note": [
                     "A diagonal spark may take damage from the Choot",
@@ -2719,9 +2742,9 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 10,
-                      "fromNode": 1,
-                      "shinesparkFrames": 20
+                      "fromNode": 1
                     }},
+                    {"shinespark": {"frames": 20}},
                     {"or": [
                       "canPrepareForNextRoom",
                       {"and": [
@@ -2914,9 +2937,9 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 10,
-                      "fromNode": 3,
-                      "shinesparkFrames": 20
+                      "fromNode": 3
                     }},
+                    {"shinespark": {"frames": 20}},
                     {"or": [
                       "canPrepareForNextRoom",
                       {"and": [
@@ -3314,9 +3337,11 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 22,
-                      "excessShinesparkFrames": 12
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 22,
+                      "excessFrames": 12
                     }}
                   ]
                 },
@@ -3420,9 +3445,11 @@
                     {"canComeInCharged": {
                       "fromNode": 2,
                       "inRoomPath": [2, 1],
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 22,
-                      "excessShinesparkFrames": 12
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 22,
+                      "excessFrames": 12
                     }}
                   ]
                 },
@@ -4127,10 +4154,12 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 5,
-                      "shinesparkFrames": 21,
-                      "excessShinesparkFrames": 10
+                      "framesRemaining": 5
                     }},
+                    {"shinespark": {
+                      "frames": 21,
+                      "excessFrames": 10
+                    }},             
                     {"enemyDamage": {
                       "enemy": "Ripper",
                       "type": "contact",
@@ -4177,9 +4206,11 @@
                     ]},
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 45,
-                      "excessShinesparkFrames": 11
+                      "framesRemaining": 60
+                    }},
+                    {"shinespark": {
+                      "frames": 45,
+                      "excessFrames": 11
                     }}
                   ],
                   "note": "Use Hijump or one walljump on the left before a diagonal spark."
@@ -4329,9 +4360,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 20,
-                      "shinesparkFrames": 36,
-                      "excessShinesparkFrames": 10
+                      "framesRemaining": 20
+                    }},
+                    {"shinespark": {
+                      "frames": 36,
+                      "excessFrames": 10
                     }}
                   ]
                 },
@@ -4597,9 +4630,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 20,
-                      "shinesparkFrames": 58,
-                      "excessShinesparkFrames": 6
+                      "framesRemaining": 20
+                    }},
+                    {"shinespark": {
+                      "frames": 58,
+                      "excessFrames": 6
                     }}
                   ]
                 },
@@ -5028,22 +5063,26 @@
                       {"and": [
                         "canShinechargeMovement",
                         "canUseSpeedEchoes",
-                        { "canShineCharge": {
+                        {"canShineCharge": {
                           "usedTiles": 19,
-                          "shinesparkFrames": 1,
-                          "excessShinesparkFrames": 1,
                           "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 1,
+                          "excessFrames": 1
                         }}
                       ]},
                       {"and": [
                         "canShinechargeMovement",
                         "canUseSpeedEchoes",
-                        { "enemyDamage": { "enemy": "Pink Space Pirate (standing)", "type": "contact", "hits": 1 } },
-                        { "canShineCharge": {
+                        {"enemyDamage": { "enemy": "Pink Space Pirate (standing)", "type": "contact", "hits": 1 } },
+                        {"canShineCharge": {
                           "usedTiles": 21,
-                          "shinesparkFrames": 2,
-                          "excessShinesparkFrames": 2,
                           "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 2,
+                          "excessFrames": 2
                         }}
                       ]},
                       {"and": [
@@ -5079,27 +5118,35 @@
                     "canShinechargeMovementComplex",
                     {"canShineCharge": {
                       "usedTiles": 21,
-                      "shinesparkFrames": 30,
-                      "excessShinesparkFrames": 7,
                       "openEnd": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 30,
+                      "excessFrames": 7
                     }},
                     "canUseSpeedEchoes",
                     {"or": [
                       "canCameraManip",
-                      { "canShineCharge": {
-                        "usedTiles": 19,
-                        "shinesparkFrames": 2,
-                        "excessShinesparkFrames": 2,
-                        "openEnd": 0
-                      }},
                       {"and": [
-                        { "canShineCharge": {
-                          "usedTiles": 21,
-                          "shinesparkFrames": 3,
-                          "excessShinesparkFrames": 3,
+                        {"canShineCharge": {
+                          "usedTiles": 19,
                           "openEnd": 0
                         }},
-                        { "enemyDamage": { "enemy": "Pink Space Pirate (standing)", "type": "laser", "hits": 1 } }
+                        {"shinespark": {
+                          "frames": 2,
+                          "excessFrames": 2
+                        }}
+                      ]},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 21,
+                          "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 3,
+                          "excessFrames": 3
+                        }},
+                        {"enemyDamage": {"enemy": "Pink Space Pirate (standing)", "type": "laser", "hits": 1}}
                       ]}
                     ]}
                   ],
@@ -5208,21 +5255,25 @@
                     {"or": [
                       {"and": [
                         "HiJump",
-                        { "canShineCharge": {
+                        {"canShineCharge": {
                           "usedTiles": 21,
-                          "shinesparkFrames": 21,
-                          "excessShinesparkFrames": 7,
                           "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 21,
+                          "excessFrames": 7
                         }}
                       ]},
                       {"and": [
                          "canShinechargeMovementComplex",
                          "canCarefulJump",
-                        { "canShineCharge": {
+                        {"canShineCharge": {
                           "usedTiles": 21,
-                          "shinesparkFrames": 30,
-                          "excessShinesparkFrames": 7,
                           "openEnd": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 30,
+                          "excessFrames": 7
                         }}
                       ]}
                     ]}

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -641,9 +641,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "shinesparkFrames": 1,
-                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 1,
+                      "excessFrames": 1
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
@@ -1556,9 +1558,11 @@
                     "Gravity",
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 150,
-                      "shinesparkFrames": 50,
-                      "excessShinesparkFrames": 2
+                      "framesRemaining": 150
+                    }},
+                    {"shinespark": {
+                      "frames": 50,
+                      "excessFrames": 2
                     }}
                   ],
                   "clearsObstacles": ["A"]
@@ -1572,8 +1576,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 3,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -1590,9 +1593,11 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 62,
-                      "excessShinesparkFrames": 2,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 62,
+                      "excessFrames": 2
                     }}
                   ],
                   "clearsObstacles": ["A"],
@@ -1866,9 +1871,11 @@
                     "Gravity",
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 100,
-                      "shinesparkFrames": 58,
-                      "excessShinesparkFrames": 3
+                      "framesRemaining": 100
+                    }},
+                    {"shinespark": {
+                      "frames": 58,
+                      "excessFrames": 3
                     }}
                   ]
                 },
@@ -1881,9 +1888,11 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 80,
-                      "shinesparkFrames": 50,
-                      "excessShinesparkFrames": 3
+                      "framesRemaining": 80
+                    }},
+                    {"shinespark": {
+                      "frames": 50,
+                      "excessFrames": 3
                     }}
                   ]
                 },
@@ -1901,9 +1910,11 @@
                     }},
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 145,
-                      "shinesparkFrames": 55,
-                      "excessShinesparkFrames": 3
+                      "framesRemaining": 145
+                    }},
+                    {"shinespark": {
+                      "frames": 55,
+                      "excessFrames": 3
                     }}
                   ]
                 },
@@ -1916,8 +1927,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 3,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -1934,9 +1944,11 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 35,
-                      "excessShinesparkFrames": 3,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 35,
+                      "excessFrames": 3
                     }}
                   ],
                   "note": "This can be done with only a door-frame runway in the adjacent room. It can technically be done without a stutter, but it's not really easier."
@@ -1993,8 +2005,7 @@
                         ]},
                         {"canComeInCharged": {
                           "fromNode": 4,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -2561,22 +2572,20 @@
                       {"canShineCharge": {
                         "usedTiles": 17,
                         "steepUpTiles": 1,
-                        "shinesparkFrames": 77,
                         "openEnd": 0
                       }},
                       {"canComeInCharged": {
                         "fromNode": 1,
                         "inRoomPath": [1, 8],
-                        "framesRemaining": 80,
-                        "shinesparkFrames": 77
+                        "framesRemaining": 80
                       }},
                       {"canComeInCharged": {
                         "fromNode": 2,
                         "inRoomPath": [2, 8],
-                        "framesRemaining": 120,
-                        "shinesparkFrames": 77
+                        "framesRemaining": 120
                       }}
-                    ]}
+                    ]},
+                    {"shinespark": {"frames": 77}}
                   ],
                   "clearsObstacles": ["A"],
                   "devNote": [
@@ -2593,16 +2602,15 @@
                       {"canComeInCharged": {
                         "fromNode": 1,
                         "inRoomPath": [1, 8],
-                        "framesRemaining": 120,
-                        "shinesparkFrames": 77
+                        "framesRemaining": 120
                       }},
                       {"canComeInCharged": {
                         "fromNode": 2,
                         "inRoomPath": [2, 8],
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 77
+                        "framesRemaining": 180
                       }}
-                    ]}
+                    ]},
+                    {"shinespark": {"frames": 77}}
                   ],
                   "clearsObstacles": ["A"],
                   "devNote": "FIXME: Add a midair version requiring 0 tanks"
@@ -2779,8 +2787,6 @@
                       {"canShineCharge": {
                         "usedTiles": 17,
                         "steepUpTiles": 1,
-                        "shinesparkFrames": 76,
-                        "excessShinesparkFrames": 3,
                         "openEnd": 0
                       }},
                       {"and": [
@@ -2788,19 +2794,19 @@
                         {"canComeInCharged": {
                           "fromNode": 1,
                           "inRoomPath": [1, 8],
-                          "framesRemaining": 40,
-                          "shinesparkFrames": 76,
-                          "excessShinesparkFrames": 3
+                          "framesRemaining": 40
                         }}
                       ]},
                       {"canComeInCharged": {
                         "fromNode": 2,
                         "inRoomPath": [2, 8],
-                        "framesRemaining": 70,
-                        "shinesparkFrames": 76,
-                        "excessShinesparkFrames": 3
+                        "framesRemaining": 70
                       }}
-                    ]}
+                    ]},
+                    {"shinespark": {
+                      "frames": 76,
+                      "excessFrames": 3
+                    }}
                   ],
                   "note": "To avoid breaking the speed blocks, align Samus on the first plant, just to the left of the door.",
                   "devNote": [
@@ -2819,25 +2825,19 @@
                         {"canComeInCharged": {
                           "fromNode": 1,
                           "inRoomPath": [1, 8],
-                          "framesRemaining": 60,
-                          "shinesparkFrames": 76,
-                          "excessShinesparkFrames": 3
+                          "framesRemaining": 60
                         }}
                       ]},
                       {"canComeInCharged": {
                         "fromNode": 2,
                         "inRoomPath": [2, 8],
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 76,
-                        "excessShinesparkFrames": 3
+                        "framesRemaining": 180
                       }},
                       {"and": [
                         {"canComeInCharged": {
                           "fromNode": 2,
                           "inRoomPath": [2, 8],
-                          "framesRemaining": 100,
-                          "shinesparkFrames": 76,
-                          "excessShinesparkFrames": 3
+                          "framesRemaining": 100
                         }},
                         {"adjacentRunway": {
                           "fromNode": 2,
@@ -2846,7 +2846,11 @@
                           "physics": ["air"]
                         }}
                       ]}
-                    ]}
+                    ]},
+                    {"shinespark": {
+                      "frames": 76,
+                      "excessFrames": 3
+                    }}
                   ],
                   "devNote": "FIXME: Add a midair version requiring 0 tanks",
                   "note": "To avoid breaking the speed blocks, align Samus on the first plant, just to the left of the door."
@@ -3253,9 +3257,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 30,
-                      "shinesparkFrames": 55
-                    }}
+                      "framesRemaining": 30
+                    }},
+                    {"shinespark": {"frames": 55}}
                   ]
                 },
                 {
@@ -3432,19 +3436,25 @@
                   "requires": [
                     "canWaterShineCharge",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 41,
-                        "excessShinesparkFrames": 7,
-                        "openEnd": 2
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 41,
+                          "excessFrames": 7
+                        }}
+                      ]},
                       {"and": [
                         "canMidairShinespark",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 38,
-                          "excessShinesparkFrames": 7,
                           "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 38,
+                          "excessFrames": 7
                         }}
                       ]}
                     ]},
@@ -3517,19 +3527,25 @@
                   "requires": [
                     "canWaterShineCharge",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 43,
-                        "excessShinesparkFrames": 9,
-                        "openEnd": 2
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 43,
+                          "excessFrames": 9
+                        }}
+                      ]},
                       {"and": [
                         "canMidairShinespark",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 38,
-                          "excessShinesparkFrames": 9,
                           "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 38,
+                          "excessFrames": 9
                         }}
                       ]}
                     ]},
@@ -3552,19 +3568,25 @@
                   "requires": [
                     "canWaterShineCharge",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 43,
-                        "excessShinesparkFrames": 26,
-                        "openEnd": 2
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 43,
+                          "excessFrames": 26
+                        }}
+                      ]},
                       {"and": [
                         "canMidairShinespark",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 38,
-                          "excessShinesparkFrames": 25,
                           "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 38,
+                          "excessFrames": 25
                         }}
                       ]}
                     ]},
@@ -3576,8 +3598,8 @@
                       "useFrames": 80
                     }},
                     {"or": [
-                      { "enemyDamage": { "enemy": "Pink Space Pirate (standing)", "type": "contact", "hits": 1 } },
-                      { "enemyKill": {
+                      {"enemyDamage": {"enemy": "Pink Space Pirate (standing)", "type": "contact", "hits": 1}},
+                      {"enemyKill": {
                         "enemies": [ [ "Pink Space Pirate (standing)" ] ],
                         "explicitWeapons": [ "Plasma" ]
                       }}
@@ -3909,9 +3931,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "framesRemaining": 25,
-                      "shinesparkFrames": 90
-                    }}
+                      "framesRemaining": 25
+                    }},
+                    {"shinespark": {"frames": 90}}
                   ],
                   "devNote": [
                     "Spark through 5 into the wall past 4. Then fall down to 1.",
@@ -4048,9 +4070,9 @@
                     "canPrepareForNextRoom",
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "framesRemaining": 10,
-                      "shinesparkFrames": 5
-                    }}
+                      "framesRemaining": 10
+                    }},
+                    {"shinespark": {"frames": 5}}
                   ],
                   "note": "Assumes you enter in a state that can spark immediately."
                 }
@@ -4068,9 +4090,9 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "framesRemaining": 25,
-                      "shinesparkFrames": 85
-                    }}
+                      "framesRemaining": 25
+                    }},
+                    {"shinespark": {"frames": 85}}
                   ],
                   "note": "Immediately spark after the door transition into the wall just to the right of the top right door.",
                   "devNote": [
@@ -4258,7 +4280,6 @@
               },
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 0,
               "openEnd": 2,
               "strats": [
                 {
@@ -4634,9 +4655,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged":{
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 150
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 150}}
                   ]
                 },
                 {
@@ -4739,9 +4760,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged":{
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 60
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 60}}
                   ],
                   "note": "Shinespark up left to get all the way up to the door."
                 },
@@ -4859,9 +4880,9 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 65,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 65}}
                   ],
                   "note": "Shinespark up right through the rightmost gap to land directly by the door."
                 },
@@ -5145,9 +5166,9 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 61,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 61}}
                   ],
                   "note": "Shinespark up in the middle of the three upward pathways near either the right or left wall."
                 },
@@ -5429,9 +5450,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged":{
                       "fromNode": 3,
-                      "framesRemaining": 5,
-                      "shinesparkFrames": 70
-                    }}
+                      "framesRemaining": 5
+                    }},
+                    {"shinespark": {"frames": 70}}
                   ],
                   "note": "Shinespark up left to get onto the platform below the door. If gravity suit is on, hold right to land on the platform.",
                   "devNote": "FIXME: It is possible to get to this from sparking through the door diagonally, but that is not something the logic can handle."
@@ -5449,9 +5470,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged":{
                       "fromNode": 3,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 65
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 65}}
                   ]
                 },
                 {
@@ -5494,9 +5515,9 @@
                     "h_canNavigateUnderwater",
                     {"canComeInCharged":{
                       "fromNode": 4,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 150
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 150}}
                   ]
                 },
                 {
@@ -6262,9 +6283,9 @@
                     {"canComeInCharged":{
                       "fromNode": 5,
                       "inRoomPath": [5, 9],
-                      "framesRemaining": 90,
-                      "shinesparkFrames": 65
-                    }}
+                      "framesRemaining": 90
+                    }},
+                    {"shinespark": {"frames": 65}}
                   ]
                 },
                 {
@@ -6289,9 +6310,9 @@
                     {"canComeInCharged":{
                       "fromNode": 5,
                       "inRoomPath": [5, 9],
-                      "framesRemaining": 90,
-                      "shinesparkFrames": 90
-                    }}
+                      "framesRemaining": 90
+                    }},
+                    {"shinespark": {"frames": 90}}
                   ]
                 },
                 {
@@ -6360,9 +6381,9 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 61,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 61}}
                   ],
                   "devNote": [
                     "Implicitly drops down to 2 first.",
@@ -6793,7 +6814,6 @@
             {
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 10,
               "openEnd": 2,
               "strats": [
                 {
@@ -6807,7 +6827,8 @@
                       "usedTiles": 2,
                       "physics": ["air"],
                       "useFrames": 80
-                    }}
+                    }},
+                    {"shinespark": {"frames": 10}}
                   ]
                 }
               ]
@@ -6871,7 +6892,6 @@
             {
               "usedTiles": 33,
               "framesRemaining": 70,
-              "shinesparkFrames": 0,
               "openEnd": 2,
               "strats": [
                 {
@@ -7227,9 +7247,11 @@
                     "Morph",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 26,
-                      "excessShinesparkFrames": 7
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 26,
+                      "excessFrames": 7
                     }}
                   ]
                 },
@@ -7318,9 +7340,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 5,
-                      "shinesparkFrames": 18,
-                      "excessShinesparkFrames": 11
+                      "framesRemaining": 5
+                    }},
+                    {"shinespark": {
+                      "frames": 18,
+                      "excessFrames": 11
                     }}
                   ]
                 },
@@ -7644,9 +7668,9 @@
                     "canShinechargeMovement",
                     {"canComeInCharged":{
                       "fromNode": 1,
-                      "framesRemaining": 110,
-                      "shinesparkFrames": 60
-                    }}
+                      "framesRemaining": 110
+                    }},
+                    {"shinespark": {"frames": 60}}
                   ],
                   "clearsObstacles": ["B"]
                 },
@@ -7717,8 +7741,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 1,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -7734,19 +7757,25 @@
                     ]},
                     "canShinechargeMovement",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 61,
-                        "excessShinesparkFrames": 7,
-                        "openEnd": 2
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 61,
+                          "excessFrames": 7
+                        }}
+                      ]},
                       {"and": [
                         "canMidairShinespark",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 56,
-                          "excessShinesparkFrames": 7,
                           "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 56,
+                          "excessFrames": 7
                         }}
                       ]}
                     ]}
@@ -7851,9 +7880,9 @@
                     "canShinechargeMovement",
                     {"canComeInCharged":{
                       "fromNode": 1,
-                      "framesRemaining": 80,
-                      "shinesparkFrames": 44
-                    }}
+                      "framesRemaining": 80
+                    }},
+                    {"shinespark": {"frames": 44}}
                   ]
                 },
                 {
@@ -7892,8 +7921,7 @@
                         "canWaterShineCharge",
                         {"canComeInCharged": {
                           "fromNode": 1,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 0
+                          "framesRemaining": 180
                         }}
                       ]},
                       {"and": [
@@ -7909,19 +7937,25 @@
                     ]},
                     "canShinechargeMovement",
                     {"or": [
-                      {"canShineCharge": {
-                        "usedTiles": 33,
-                        "shinesparkFrames": 47,
-                        "excessShinesparkFrames": 5,
-                        "openEnd": 2
-                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 47,
+                          "excessFrames": 5
+                        }}
+                      ]},
                       {"and": [
                         "canMidairShinespark",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "shinesparkFrames": 44,
-                          "excessShinesparkFrames": 5,
                           "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 44,
+                          "excessFrames": 5
                         }}
                       ]}
                     ]}

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -385,9 +385,9 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 50,
                       "openEnd": 2
-                    }}
+                    }},
+                    {"shinespark": {"frames": 50}}
                   ]
                 },
                 {
@@ -688,24 +688,30 @@
                   "notable": false,
                   "requires": [
                     {"or":[
-                      {"canComeInCharged": {
-                        "fromNode": 2,
-                        "inRoomPath": [2, 5],
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 25
-                      }},
-                      {"canComeInCharged": {
-                        "fromNode": 3,
-                        "inRoomPath": [3, 5],
-                        "framesRemaining": 50,
-                        "shinesparkFrames": 25
-                      }},
-                      {"canComeInCharged": {
-                        "fromNode": 4,
-                        "inRoomPath": [4, 5],
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 45
-                      }}
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 2,
+                          "inRoomPath": [2, 5],
+                          "framesRemaining": 0
+                        }},
+                        {"shinespark": {"frames": 25}}
+                      ]},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 3,
+                          "inRoomPath": [3, 5],
+                          "framesRemaining": 50
+                        }},
+                        {"shinespark": {"frames": 25}}
+                      ]},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 4,
+                          "inRoomPath": [4, 5],
+                          "framesRemaining": 0
+                        }},
+                        {"shinespark": {"frames": 45}}
+                      ]}
                     ]}
                   ]
                 },
@@ -1471,9 +1477,9 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 150,
-                      "shinesparkFrames": 40
-                    }}
+                      "framesRemaining": 150
+                    }},
+                    {"shinespark": {"frames": 40}}
                   ],
                   "note" : "Doesn't need hjb. Takes two walljumps, and must do the shinespark at the apex."
                 },
@@ -1498,8 +1504,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }},
                     "canBlueSpaceJump"
                   ],
@@ -1573,9 +1578,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 100,
-                      "shinesparkFrames": 120
-                    }}
+                      "framesRemaining": 100
+                    }},
+                    {"shinespark": {"frames": 120}}
                   ],
                   "clearsObstacles": ["B"]
                 },
@@ -1585,7 +1590,6 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 17,
-                      "shinesparkFrames": 0,
                       "openEnd": 0
                     }}
                   ],
@@ -1652,9 +1656,9 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 32,
-                      "shinesparkFrames": 90,
                       "openEnd": 1
-                    }}
+                    }},
+                    {"shinespark": {"frames": 90}}
                   ],
                   "note": "Fire off the shinespark at the apex of two consecutive walljumps.",
                   "devNote": "You can have a 'max' length runway available here if you break the PB blocks, but we won't duplicate strats for that right now."
@@ -1667,9 +1671,9 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 32,
-                      "shinesparkFrames": 52,
                       "openEnd": 1
-                    }}
+                    }},
+                    {"shinespark": {"frames": 52}}
                   ],
                   "note": "Charge a spark to the right, then come back, run and jump, and do a horizontal spark at the apex.",
                   "devNote": "You can have a 'max' length runway available here if you break the PB blocks, but we won't duplicate strats for that right now."
@@ -1716,9 +1720,9 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 32,
-                      "shinesparkFrames": 40,
                       "openEnd": 1
-                    }}
+                    }},
+                    {"shinespark": {"frames": 40}}
                   ],
                   "devNote": "You can have a capped length runway available here if you break the PB blocks, but we won't duplicate strats for that right now."
                 },
@@ -1910,10 +1914,10 @@
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames":35,
                       "openEnd": 2
                     }},
-                    {"acidFrames": 140}
+                    {"acidFrames": 140},
+                    {"shinespark": {"frames": 35}}
                   ],
                   "clearsObstacles": ["B"],
                   "note": "Gravity makes it possible to charge a spark in the acid in order to break the speed blocks."
@@ -2050,9 +2054,9 @@
                     {"canComeInCharged": {
                       "fromNode": 2,
                       "inRoomPath": [2, 3],
-                      "framesRemaining": 20,
-                      "shinesparkFrames": 40
-                    }}
+                      "framesRemaining": 20
+                    }},
+                    {"shinespark": {"frames": 40}}
                   ]
                 },
                 {
@@ -2304,9 +2308,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 120,
-                      "shinesparkFrames": 30
-                    }}
+                      "framesRemaining": 120
+                    }},
+                    {"shinespark": {"frames": 30}}
                   ]
                 },
                 {
@@ -2476,9 +2480,11 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 56,
-                      "excessShinesparkFrames": 1
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 56,
+                      "excessFrames": 1
                     }}
                   ]
                 },

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -39,7 +39,6 @@
             {
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 10,
               "openEnd": 2,
               "strats": [
                 {
@@ -52,7 +51,8 @@
                     {"or": [
                       "canWalljump",
                       "SpaceJump"
-                    ]}
+                    ]},
+                    {"shinespark": {"frames": 10}}
                   ],
                   "note": "Kill the enemies, break the shot block, then use the bottom to charge a spark. Quickly climb up before the block respawns, and spark through the left door."
                 }
@@ -89,7 +89,6 @@
             {
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 10,
               "openEnd": 2,
               "strats": [
                 {
@@ -98,7 +97,8 @@
                   "requires": [
                     "HiJump",
                     "h_heatProof",
-                    "canShinechargeMovementComplex"
+                    "canShinechargeMovementComplex",
+                    {"shinespark": {"frames": 10}}
                   ],
                   "note": "Kill the enemies and use the bottom to charge a spark. Quickly climb then spark through the right door."
                 }
@@ -425,13 +425,16 @@
                     "h_canNavigateHeatRooms",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 22,
-                      "openEnd": 2,
-                      "excessShinesparkFrames": 3
-                     }},
-                    {"heatFrames": 500}
+                      "openEnd": 2
+                    }},
+                    {"heatFrames": 500},
+                    {"shinespark": {
+                      "frames": 22,
+                      "excessFrames": 3
+                    }}
                   ],
-                  "note": "Jump and shoot the block, then quickly run away and back to charge the shinespark and shine through before the block respawns."
+                  "note": "Jump and shoot the block, then quickly run away and back to charge the shinespark and shine through before the block respawns.",
+                  "devNote": ["FIXME: Some of the heatFrames should come after the shinespark"]
                 },
                 {
                   "name": "Shinespark With Plasma",
@@ -441,17 +444,20 @@
                     "Plasma",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 22,
-                      "openEnd": 2,
-                      "excessShinesparkFrames": 3
-                     }},
-                    {"heatFrames": 250}
+                      "openEnd": 2
+                    }},
+                    {"heatFrames": 250},
+                    {"shinespark": {
+                      "frames": 22,
+                      "excessFrames": 3
+                    }}
                   ],
                   "note": [
                     "With plasma, it is possible to shoot the block from the ground and immediately shinespark.",
                     "Other beams will disappear off-screen before Samus has moved up enough.",
                     "A charge shot can be used instead, as it moves a bit slower, but there is a relatively small window."
-                  ]
+                  ],
+                  "devNote": ["FIXME: Some of the heatFrames should come after the shinespark"]
                 },
                 {
                   "name": "Cathedral Entrance Hero Shot Shinespark",
@@ -461,16 +467,19 @@
                     "canHeroShot",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 22,
-                      "openEnd": 2,
-                      "excessShinesparkFrames": 3
-                     }},
-                    {"heatFrames": 250}
+                      "openEnd": 2
+                    }},
+                    {"heatFrames": 250},
+                    {"shinespark": {
+                      "frames": 22,
+                      "excessFrames": 3
+                    }}
                   ],
                   "note": [
                     "It is possible to shoot upwards from the ground then immediately as the shot is leaving the screen, press up and jump to shinespark without delay.",
                     "A Charge shot can help, as it slows down the shot."
-                  ]
+                  ],
+                  "devNote": ["FIXME: Some of the heatFrames should come after the shinespark"]
                 },
                 {
                   "name": "Cathedral Entrance Speedjump (Right to Left)",
@@ -501,12 +510,15 @@
                     "canShinechargeMovement",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 16,
-                      "openEnd": 2,
-                      "excessShinesparkFrames": 4
-                     }},
-                    {"heatFrames": 380}
-                  ]
+                      "openEnd": 2
+                    }},
+                    {"heatFrames": 380},
+                    {"shinespark": {
+                      "frames": 16,
+                      "excessFrames": 4
+                    }}
+                  ],
+                  "devNote": ["FIXME: Some of the heatFrames should come after the shinespark"]
                 },
                 {
                   "name": "Cathedral Entrance Speedjump (Left to Right)",
@@ -1163,7 +1175,6 @@
                     "canSlowShortCharge",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 1,
                       "unusableTiles": 5
                     }},
@@ -1178,11 +1189,13 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 15,
-                      "fromNode": 2,
-                      "shinesparkFrames": 95,
-                      "excessShinesparkFrames": 5
+                      "fromNode": 2
                     }},
-                    {"heatFrames": 195}
+                    {"heatFrames": 195},
+                    {"shinespark": {
+                      "frames": 95,
+                      "excessFrames": 5
+                    }}
                   ],
                   "note": [
                     "Spark in line with the top of the door.",
@@ -1225,11 +1238,13 @@
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 15,
-                      "fromNode": 2,
-                      "shinesparkFrames": 95,
-                      "excessShinesparkFrames": 3
+                      "fromNode": 2
                     }},
-                    {"heatFrames": 195}
+                    {"heatFrames": 195},
+                    {"shinespark": {
+                      "frames": 95,
+                      "excessFrames": 3
+                    }}
                   ],
                   "note": [
                     "Spark in line with the top of the door.",
@@ -2382,10 +2397,12 @@
                   "requires": [
                     {"canComeInCharged":{
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 42,
-                      "excessShinesparkFrames": 22
-                     }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 42,
+                      "excessFrames": 22
+                    }}
                   ]
                 }
               ],
@@ -2600,9 +2617,11 @@
                   "requires": [
                     {"canComeInCharged":{
                       "fromNode": 7,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 41,
-                      "excessShinesparkFrames": 2
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {
+                      "frames": 41,
+                      "excessFrames": 2
                     }}
                   ],
                   "devNote": "Ending the spark earlier takes a hit from the Waver"
@@ -2615,9 +2634,11 @@
                     "canCarefulJump",
                     {"canComeInCharged": {
                       "framesRemaining": 100,
-                      "fromNode": 7,
-                      "shinesparkFrames": 30,
-                      "excessShinesparkFrames": 6
+                      "fromNode": 7
+                    }},
+                    {"shinespark": {
+                      "frames": 30,
+                      "excessFrames": 6
                     }},
                     {"or": [
                       "canMidairShinespark",
@@ -2647,9 +2668,11 @@
                     {"canComeInCharged":{
                       "fromNode": 6,
                       "inRoomPath": [6, 7],
-                      "framesRemaining": 120,
-                      "shinesparkFrames": 30,
-                      "excessShinesparkFrames": 6
+                      "framesRemaining": 120
+                    }},
+                    {"shinespark": {
+                      "frames": 30,
+                      "excessFrames": 6
                     }}
                   ]
                 },
@@ -2775,22 +2798,28 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      {"canComeInCharged":{
-                        "fromNode": 2,
-                        "inRoomPath": [2, 9],
-                        "framesRemaining": 50,
-                        "shinesparkFrames": 27,
-                        "excessShinesparkFrames": 5
-                       }},
+                      {"and": [
+                        {"canComeInCharged":{
+                          "fromNode": 2,
+                          "inRoomPath": [2, 9],
+                          "framesRemaining": 50
+                        }},
+                        {"shinespark": {
+                          "frames": 27,
+                          "excessFrames": 5
+                        }}
+                      ]},
                       {"and": [
                         "canShinechargeMovement",
                         "canMidairShinespark",
                         {"canComeInCharged": {
                           "fromNode": 2,
                           "inRoomPath": [2,9],
-                          "framesRemaining": 25,
-                          "shinesparkFrames": 19,
-                          "excessShinesparkFrames": 5
+                          "framesRemaining": 25
+                        }},
+                        {"shinespark": {
+                          "frames": 19,
+                          "excessFrames": 5
                         }}
                       ]},
                       {"and": [
@@ -2799,10 +2828,12 @@
                         {"canComeInCharged":{
                           "fromNode": 3,
                           "inRoomPath": [3, 9],
-                          "framesRemaining": 35,
-                          "shinesparkFrames": 35,
-                          "excessShinesparkFrames": 0
-                         }}
+                          "framesRemaining": 3
+                        }},
+                        {"shinespark": {
+                          "frames": 35,
+                          "excessFrames": 0
+                        }}
                       ]}
                     ]}
                   ]
@@ -2890,22 +2921,28 @@
                   "notable": false,
                   "requires": [
                     {"or":[
-                      {"canComeInCharged":{
-                        "fromNode": 2,
-                        "inRoomPath": [2, 9],
-                        "framesRemaining": 5,
-                        "shinesparkFrames": 22,
-                        "excessShinesparkFrames": 2
-                       }},
+                      {"and": [
+                        {"canComeInCharged":{
+                          "fromNode": 2,
+                          "inRoomPath": [2, 9],
+                          "framesRemaining": 5
+                        }},
+                        {"shinespark": {
+                          "frames": 22,
+                          "excessFrames": 2
+                        }}
+                      ]},
                       {"and": [
                         "canShinechargeMovementComplex",
                         "canMidairShinespark",
-                        {"canComeInCharged":{
+                        {"canComeInCharged": {
                           "fromNode": 3,
                           "inRoomPath": [3, 9],
-                          "framesRemaining": 100,
-                          "shinesparkFrames": 26,
-                          "excessShinesparkFrames": 3
+                          "framesRemaining": 100
+                        }},
+                        {"shinespark": {
+                          "frames": 26,
+                          "excessFrames": 3
                         }}
                       ]}
                     ]}
@@ -3268,16 +3305,18 @@
                   "note": "Clear the Dragons while moving towards the items with Space Jump and Screw Attack to make for a faster exit later."
                 },
                 {
-                  "name": "ShineSpark",
+                  "name": "Shinespark",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canMidairShinespark",
                     {"canComeInCharged": {
                       "framesRemaining": 15,
-                      "fromNode": 1,
-                      "shinesparkFrames": 38,
-                      "excessShinesparkFrames": 1
+                      "fromNode": 1
+                    }},
+                    {"shinespark": {
+                      "frames": 38,
+                      "excessFrames": 1
                     }},
                     {"heatFrames": 160}
                   ]
@@ -4948,7 +4987,6 @@
             {
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 5,
               "openEnd": 2,
               "strats": [
                 {
@@ -4959,7 +4997,8 @@
                     "h_canXMode",
                     "canWalljump",
                     {"spikeHits": 3},
-                    {"heatFrames": 540}
+                    {"heatFrames": 540},
+                    {"shinespark": {"frames": 5}}
                   ],
                   "note": "Jump into the spikes and try to bounce on the crumble blocks moving towards the door."
                 }
@@ -5202,11 +5241,13 @@
                       "usedTiles": 28,
                       "gentleUpTiles": 3,
                       "gentleDownTiles": 3,
-                      "shinesparkFrames": 27,
-                      "openEnd": 0,
-                      "excessShinesparkFrames": 4
-                     }},
-                    {"heatFrames": 450}
+                      "openEnd": 0
+                    }},
+                    {"heatFrames": 450},
+                    {"shinespark": {
+                      "frames": 27,
+                      "excessFrames": 4
+                    }}
                   ]
                 },
                 {
@@ -5216,11 +5257,13 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged":{
                       "fromNode": 2,
-                      "framesRemaining": 40,
-                      "shinesparkFrames": 27,
-                      "excessShinesparkFrames": 4
-                     }},
-                    {"heatFrames": 200}
+                      "framesRemaining": 40
+                    }},
+                    {"heatFrames": 200},
+                    {"shinespark": {
+                      "frames": 27,
+                      "excessFrames": 4
+                    }}
                   ]
                 },
                 {
@@ -5315,21 +5358,29 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
+                    {"heatFrames": 140},
                     {"or": [
-                      {"canComeInCharged": {
-                        "framesRemaining": 180,
-                        "fromNode": 3,
-                        "shinesparkFrames": 45,
-                        "excessShinesparkFrames": 14
-                      }},
-                      {"canComeInCharged": {
-                        "framesRemaining": 0,
-                        "fromNode": 3,
-                        "shinesparkFrames": 51,
-                        "excessShinesparkFrames": 14
-                      }}
-                     ]},
-                    {"heatFrames": 140}
+                      {"and": [
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "fromNode": 3
+                        }},
+                        {"shinespark": {
+                          "frames": 45,
+                          "excessFrames": 14
+                        }}
+                      ]},
+                      {"and": [
+                        {"canComeInCharged": {
+                          "framesRemaining": 0,
+                          "fromNode": 3
+                        }},
+                        {"shinespark": {
+                          "frames": 51,
+                          "excessFrames": 14
+                        }}
+                      ]}
+                    ]}
                   ]
                 },
                 {
@@ -5377,12 +5428,14 @@
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "openEnd": 2,
-                      "shinesparkFrames": 12,
-                      "excessShinesparkFrames": 4
+                      "openEnd": 2
                     }},
                     {"spikeHits": 2},
-                    {"heatFrames": 400}
+                    {"heatFrames": 400},
+                    {"shinespark": {
+                      "frames": 12,
+                      "excessFrames": 4
+                    }}
                   ],
                   "note": "A short hop from the door can bounce on the crumbles.  Just be careful of being pushed back onto the crumble blocks by the spikes."
                 },
@@ -5536,11 +5589,13 @@
                       "usedTiles": 28,
                       "gentleUpTiles": 3,
                       "gentleDownTiles": 3,
-                      "openEnd": 0,
-                      "shinesparkFrames": 52,
-                      "excessShinesparkFrames": 6
+                      "openEnd": 0
                     }},
-                    {"heatFrames": 420}
+                    {"heatFrames": 420},
+                    {"shinespark": {
+                      "frames": 52,
+                      "excessFrames": 6
+                    }}
                   ],
                   "note": [
                     "Charge a spark along the bottom of Double Chamber and use it to spark to the right side door.",
@@ -5833,10 +5888,10 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 76
+                      "framesRemaining": 0
                     }},
-                    {"heatFrames": 200}
+                    {"heatFrames": 200},
+                    {"shinespark": {"frames": 76}}
                   ]
                 },
                 {
@@ -5945,10 +6000,10 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 76
+                      "framesRemaining": 0
                     }},
-                    {"heatFrames": 200}
+                    {"heatFrames": 200},
+                    {"shinespark": {"frames": 76}}
                   ]
                 },
                 {
@@ -6721,9 +6776,9 @@
                     "canHorizontalDamageBoost",
                     {"canComeInCharged":{
                       "fromNode": 2,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 33
+                      "framesRemaining": 180
                     }},
+                    {"shinespark": {"frames": 33}},
                     {"heatFrames": 420},
                     {"lavaFrames": 175},
                     {"enemyDamage": {
@@ -8190,8 +8245,7 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 1,
-                      "shinesparkFrames": 0
+                      "fromNode": 1
                     }},
                     {"heatFrames": 140}
                   ]
@@ -8203,8 +8257,7 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 2,
-                      "shinesparkFrames": 0
+                      "fromNode": 2
                     }},
                     {"heatFrames": 140}
                   ]

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -2828,7 +2828,7 @@
                         {"canComeInCharged":{
                           "fromNode": 3,
                           "inRoomPath": [3, 9],
-                          "framesRemaining": 3
+                          "framesRemaining": 35
                         }},
                         {"shinespark": {
                           "frames": 35,

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2382,9 +2382,9 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged":{
                       "fromNode": 1,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 20
+                      "framesRemaining": 60
                     }},
+                    {"shinespark": {"frames": 20}},
                     {"heatFrames": 175}
                   ]
                 },
@@ -2561,9 +2561,9 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged":{
                       "fromNode": 2,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 59
+                      "framesRemaining": 60
                     }},
+                    {"shinespark": {"frames": 59}},
                     {"heatFrames": 250}
                   ],
                   "note": "It has to be setup really close to the left side of the right platforms, otherwise it also requires a crumble jump at the top."
@@ -2676,9 +2676,9 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged":{
                       "fromNode": 2,
-                      "framesRemaining": 30,
-                      "shinesparkFrames": 59
+                      "framesRemaining": 30
                     }},
+                    {"shinespark": {"frames": 59}},
                     {"heatFrames": 250}
                   ],
                   "note": "It is easiest to do a diagonal shinespark up the left wall, then hold left, angle down, and spam shoot to easily grab the item."
@@ -2928,7 +2928,6 @@
             {
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 12,
               "openEnd": 2,
               "strats": [
                 {
@@ -2938,7 +2937,8 @@
                     "h_heatProof",
                     {"obstaclesCleared": ["A"]},
                     "canShinechargeMovementComplex",
-                    "canFastWalljumpClimb"
+                    "canFastWalljumpClimb",
+                    {"shinespark": {"frames": 12}}
                   ],
                   "note": [
                     "Move very quickly to bring a shinespark from the speedway up to the Save Room door.",
@@ -3126,9 +3126,11 @@
                     }},
                     {"canComeInCharged":{
                       "fromNode": 5,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 92,
-                      "excessShinesparkFrames": 10
+                      "framesRemaining": 180
+                    }},
+                    {"shinespark": {
+                      "frames": 92,
+                      "excessFrames": 10
                     }},
                     {"heatFrames": 900}
                   ],
@@ -3191,9 +3193,11 @@
                         {"canComeInCharged":{
                           "fromNode": 3,
                           "inRoomPath": [3, 6],
-                          "framesRemaining": 60,
-                          "shinesparkFrames": 84,
-                          "excessShinesparkFrames": 10
+                          "framesRemaining": 60
+                        }},
+                        {"shinespark": {
+                          "frames": 84,
+                          "excessFrames": 10
                         }},
                         {"heatFrames": 60}
                       ]},
@@ -3202,19 +3206,25 @@
                         {"canComeInCharged":{
                           "fromNode": 4,
                           "inRoomPath": [4, 6],
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 84,
-                          "excessShinesparkFrames": 10
+                          "framesRemaining": 180
+                        }},
+                        {"shinespark": {
+                          "frames": 84,
+                          "excessFrames": 10
                         }},
                         {"heatFrames": 60}
                       ]},
-                      {"canComeInCharged":{
-                        "fromNode": 4,
-                        "inRoomPath": [4, 6],
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 94,
-                        "excessShinesparkFrames": 10
-                      }}
+                      {"and": [
+                        {"canComeInCharged":{
+                          "fromNode": 4,
+                          "inRoomPath": [4, 6],
+                          "framesRemaining": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 94,
+                          "excessFrames": 10
+                        }}
+                      ]}
                     ]},
                     {"heatFrames": 700}
                   ],
@@ -3237,7 +3247,6 @@
                       "fromNode": 4,
                       "inRoomPath": [4,6],
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ],
@@ -3502,9 +3511,11 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "framesRemaining": 110,
-                      "fromNode": 2,
-                      "shinesparkFrames": 70,
-                      "excessShinesparkFrames": 12
+                      "fromNode": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 70,
+                      "excessFrames": 12
                     }},
                     "canShinechargeMovementComplex",
                     {"heatFrames": 330}
@@ -3518,9 +3529,9 @@
                     "h_canNavigateHeatRooms",
                     {"canShineCharge": {
                       "usedTiles": 15,
-                      "shinesparkFrames": 50,
                       "openEnd": 2
                     }},
+                    {"shinespark": {"frames": 50}},
                     {"heatFrames": 600}
                   ]
                 }

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -177,7 +177,7 @@ Generating a shinespark charge using the door's runway (assuming the runway has 
 
 Much like using runways, a `canLeaveCharged` can only be executed if the associated door can be interacted with.
 
-In cases where `canLeaveCharged` represents shinesparking out of the room, energy requirements for the shinespark are specified separately using `shinesparkFrames` and `excessShinesparkFrames` objects.
+In cases where `canLeaveCharged` represents shinesparking out of the room, energy requirements for the shinespark are specified separately using a `shinespark` object.
 
 #### leaveWithGModeSetup
 

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -177,6 +177,8 @@ Generating a shinespark charge using the door's runway (assuming the runway has 
 
 Much like using runways, a `canLeaveCharged` can only be executed if the associated door can be interacted with.
 
+In cases where `canLeaveCharged` represents shinesparking out of the room, energy requirements for the shinespark are specified separately using `shinesparkFrames` and `excessShinesparkFrames` objects.
+
 #### leaveWithGModeSetup
 
 Represents the ability to exit through the door while taking damage during the transition, in a pose such that X-Ray can be used on the first frame of control in the next room. Under certain conditions, taking damage in this way can be used to set up R-mode or G-mode in the next room. 

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -510,15 +510,13 @@
                     {"or": [
                       {"canShineCharge": {
                         "usedTiles": 31,
-                        "openEnd": 1,
-                        "shinesparkFrames": 0
+                        "openEnd": 1
                       }},
                       {"and": [
                         "canCarefulJump",
                         {"canComeInCharged": {
                           "fromNode": 1,
                           "framesRemaining": 180,
-                          "shinesparkFrames": 0,
                           "unusableTiles": 1
                         }}
                       ]}
@@ -626,8 +624,7 @@
                       {"and": [
                         {"canShineCharge": {
                           "usedTiles": 22,
-                          "openEnd": 1,
-                          "shinesparkFrames": 0
+                          "openEnd": 1
                         }},
                         {"metroidFrames": 4}
                       ]},
@@ -636,7 +633,6 @@
                         {"canComeInCharged": {
                           "fromNode": 2,
                           "framesRemaining": 180,
-                          "shinesparkFrames": 0,
                           "unusableTiles": 1
                         }}
                       ]}
@@ -1218,13 +1214,14 @@
             {
               "usedTiles": 29,
               "framesRemaining": 0,
-              "shinesparkFrames": 75,
               "openEnd": 2,
               "strats": [
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"shinespark": {"frames": 75}}
+                  ]
                 }
               ]
             }
@@ -1385,7 +1382,6 @@
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ]
@@ -1491,7 +1487,6 @@
                     {"canComeInCharged": {
                       "fromNode": 2,
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ]
@@ -2121,8 +2116,7 @@
                     "canPrepareForNextRoom",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 180,
-                      "shinesparkFrames": 0
+                      "framesRemaining": 180
                     }},
                     {"or": [
                       "SpaceJump",
@@ -3667,9 +3661,9 @@
                     {"canComeInCharged": {
                       "fromNode": 2,
                       "inRoomPath": [2, 8],
-                      "framesRemaining": 100,
-                      "shinesparkFrames": 15
-                    }}
+                      "framesRemaining": 100
+                    }},
+                    {"shinespark": {"frames": 15}}
                   ],
                   "devNote": "Would be a notable strat, but it already has its own tech."
                 }
@@ -4342,9 +4336,11 @@
                         "canUseSpeedEchoes",
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "openEnd": 2,
-                          "shinesparkFrames": 2,
-                          "excessShinesparkFrames": 2
+                          "openEnd": 2
+                        }},
+                        {"shinespark": {
+                          "frames": 2,
+                          "excessFrames": 2
                         }}
                       ]}
                     ]}
@@ -4357,8 +4353,7 @@
                   "requires": [
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "fromNode": 2,
-                      "shinesparkFrames": 0
+                      "fromNode": 2
                     }}
                   ]
                 }
@@ -4565,7 +4560,6 @@
                       {"canComeInCharged": {
                         "framesRemaining": 180,
                         "fromNode": 2,
-                        "shinesparkFrames": 0,
                         "unusableTiles": 22
                       }}
                     ]},

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -645,14 +645,12 @@
                         "canSlowShortCharge",
                         {"canComeInCharged": {
                           "framesRemaining": 180,
-                          "shinesparkFrames": 0,
                           "fromNode": 6,
                           "unusableTiles": 5
                         }}
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
-                        "shinesparkFrames": 0,
                         "fromNode": 6,
                         "unusableTiles": 14
                       }}
@@ -668,7 +666,6 @@
                     "canSpringBallBounce",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 6,
                       "unusableTiles": 1
                     }}
@@ -801,7 +798,6 @@
                     {"canShineCharge": {
                       "usedTiles": 20,
                       "openEnd": 1,
-                      "shinesparkFrames": 0,
                       "steepDownTiles": 4
                     }}
                   ],
@@ -823,7 +819,6 @@
                     {"canShineCharge": {
                       "usedTiles": 16,
                       "openEnd": 1,
-                      "shinesparkFrames": 0,
                       "steepDownTiles": 4
                     }}
                   ],
@@ -843,7 +838,6 @@
                     {"canShineCharge": {
                       "usedTiles": 16,
                       "openEnd": 0,
-                      "shinesparkFrames": 0,
                       "steepUpTiles": 4
                     }}
                   ],
@@ -859,7 +853,6 @@
                     {"canShineCharge": {
                       "usedTiles": 14,
                       "openEnd": 0,
-                      "shinesparkFrames": 0,
                       "steepUpTiles": 3
                     }}
                   ],
@@ -955,7 +948,6 @@
                         "canSlowShortCharge",
                         {"canComeInCharged": {
                           "framesRemaining": 180,
-                          "shinesparkFrames": 0,
                           "fromNode": 3,
                           "inRoomPath": [3,9],
                           "unusableTiles": 5
@@ -963,7 +955,6 @@
                       ]},
                       {"canComeInCharged": {
                         "framesRemaining": 180,
-                        "shinesparkFrames": 0,
                         "fromNode": 3,
                         "inRoomPath": [3,9],
                         "unusableTiles": 14
@@ -981,7 +972,6 @@
                     "canSpringBallBounce",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 3,
                       "inRoomPath": [3,9],
                       "unusableTiles": 1
@@ -1052,7 +1042,6 @@
                       "fromNode": 5,
                       "inRoomPath": [5,9],
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "unusableTiles": 1
                     }}
                   ],
@@ -1421,7 +1410,6 @@
                     "f_DefeatedPhantoon",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 0,
                       "openEnd": 2
                     }}
                   ],
@@ -1437,7 +1425,6 @@
                     "canSpeedball",
                     {"canShineCharge": {
                       "usedTiles": 22,
-                      "shinesparkFrames": 0,
                       "openEnd": 0
                     }}
                   ],
@@ -1480,7 +1467,6 @@
                     "canSlowShortCharge",
                     {"canComeInCharged": {
                       "framesRemaining": 180,
-                      "shinesparkFrames": 0,
                       "fromNode": 3,
                       "unusableTiles": 2
                     }}
@@ -1925,7 +1911,6 @@
             {
               "usedTiles": 33,
               "framesRemaining": 0,
-              "shinesparkFrames": 80,
               "openEnd": 2,
               "strats": [
                 {
@@ -1933,7 +1918,8 @@
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
-                    "canMidairShinespark"
+                    "canMidairShinespark",
+                    {"shinespark": {"frames": 80}}
                   ]
                 }
               ]
@@ -2466,16 +2452,19 @@
                   "notable": false,
                   "requires": [
                     {"or": [
+                      {"and": [
+                        {"canComeInCharged": {
+                          "fromNode": 1,
+                          "framesRemaining": 0
+                        }},
+                        {"shinespark": {
+                          "frames": 57,
+                          "excessFrames": 13
+                        }}
+                      ]},
                       {"canComeInCharged": {
                         "fromNode": 1,
-                        "framesRemaining": 0,
-                        "shinesparkFrames": 57,
-                        "excessShinesparkFrames": 13
-                      }},
-                      {"canComeInCharged": {
-                        "fromNode": 1,
-                        "framesRemaining": 180,
-                        "shinesparkFrames": 0
+                        "framesRemaining": 180
                       }}
                     ]}
                   ]
@@ -2711,9 +2700,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 90
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 90}}
                   ],
                   "devNote": [
                     "Should we have this one if you're not assumed to know the layout? You can't go out of the room to set it up once you see what room it is.",
@@ -2863,16 +2852,14 @@
                         "f_DefeatedPhantoon",
                         {"canShineCharge": {
                           "usedTiles": 16,
-                          "openEnd": 0,
-                          "shinesparkFrames": 0
+                          "openEnd": 0
                         }}
                       ]},
                       {"and": [
                         {"obstaclesCleared": ["A"]},
                         {"canShineCharge": {
                           "usedTiles": 33,
-                          "openEnd": 2,
-                          "shinesparkFrames": 0
+                          "openEnd": 2
                         }},
                         {"or": [
                           "f_DefeatedPhantoon",
@@ -2899,9 +2886,9 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 40,
                       "openEnd": 2
                     }},
+                    {"shinespark": {"frames": 40}},
                     {"obstaclesCleared": ["A"]}
                   ]
                 },
@@ -2911,9 +2898,9 @@
                   "requires": [
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 40,
                       "openEnd": 2
                     }},
+                    {"shinespark": {"frames": 40}},
                     "h_canUsePowerBombs"
                   ],
                   "clearsObstacles": ["A"]
@@ -3298,8 +3285,7 @@
                     ]},
                     {"canShineCharge": {
                       "usedTiles": 18,
-                      "openEnd": 1,
-                      "shinesparkFrames": 0
+                      "openEnd": 1
                     }}
                   ],
                   "note": [
@@ -3339,8 +3325,7 @@
                     "canKago",
                     {"canShineCharge": {
                       "usedTiles": 14,
-                      "openEnd": 0,
-                      "shinesparkFrames": 0
+                      "openEnd": 0
                     }}
                   ],
                   "note": [
@@ -3621,9 +3606,11 @@
                         "canMidairShinespark",
                         {"canComeInCharged": {
                           "fromNode": 1,
-                          "framesRemaining": 30,
-                          "shinesparkFrames": 39,
-                          "excessShinesparkFrames": 10
+                          "framesRemaining": 30
+                        }},
+                        {"shinespark": {
+                          "frames": 39,
+                          "excessFrames": 10
                         }}
                       ]},
                       {"and": [
@@ -3633,9 +3620,11 @@
                         ]},
                         {"canComeInCharged": {
                           "fromNode": 1,
-                          "framesRemaining": 180,
-                          "shinesparkFrames": 7,
-                          "excessShinesparkFrames": 2
+                          "framesRemaining": 180
+                        }},
+                        {"shinespark": {
+                          "frames": 7,
+                          "excessFrames": 2
                         }}
                       ]}
                     ]}
@@ -3697,9 +3686,11 @@
                     "canStutterWaterShineCharge",
                     {"canShineCharge": {
                       "usedTiles": 33,
-                      "shinesparkFrames": 7,
-                      "excessShinesparkFrames": 2,
                       "openEnd": 2
+                    }},
+                    {"shinespark": {
+                      "frames": 7,
+                      "excessFrames": 2
                     }}
                   ],
                   "note": "Start at least 2 tiles from the water line, and stutter just before entering the water in order to charge a spark in room."
@@ -4163,7 +4154,6 @@
           "canLeaveCharged": [
             {
               "framesRemaining": 0,
-              "shinesparkFrames": 21,
               "usedTiles": 33,
               "openEnd": 2,
               "strats": [
@@ -4177,7 +4167,8 @@
                     "SpaceJump",
                     "HiJump",
                     "canShinechargeMovementComplex",
-                    {"thornHits": 3}
+                    {"thornHits": 3},
+                    {"shinespark": {"frames": 21}}
                   ]
                 },
                 {
@@ -4190,7 +4181,8 @@
                     "SpaceJump",
                     "HiJump",
                     "canShinechargeMovementComplex",
-                    {"thornHits": 3}
+                    {"thornHits": 3},
+                    {"shinespark": {"frames": 21}}
                   ]
                 }
               ]
@@ -4309,9 +4301,9 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 0,
-                      "shinesparkFrames": 58
-                    }}
+                      "framesRemaining": 0
+                    }},
+                    {"shinespark": {"frames": 58}}
                   ]
                 },
                 {

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -749,12 +749,6 @@
                         "title": "Frames Remaining",
                         "description": "The number of frames remaining in the shinespark charge when leaving the room. If this is 0, Samus leaves the room shinesparking."
                       },
-                      "shinesparkFrames": {
-                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/canLeaveCharged/properties/shinesparkFrames",
-                        "type": "integer",
-                        "title": "Shinespark Frames",
-                        "description": "If this requires shinespark out of the room, indicates how many frames that shinespark on the way out will last"
-                      },
                       "initiateRemotely": {
                         "$id": "#/properties/rooms/items/properties/nodes/items/properties/canLeaveCharged/properties/initiateRemotely",
                         "type": "object",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -493,8 +493,7 @@
             "description": "Fulfilled by being able to come into the room via a specific door, with a shinespark charge that has at least a number of frames remaining.",
             "required": [
               "fromNode",
-              "framesRemaining",
-              "shinesparkFrames"
+              "framesRemaining"
             ],
             "additionalProperties": false,
             "properties": {
@@ -524,20 +523,6 @@
                 "title": "Frames Remaining",
                 "description": "The number of frames that must be left on the shinespark charge when coming in."
               },
-              "shinesparkFrames": {
-                "$id": "#/definitions/logicalRequirement/items/properties/canComeInCharged/properties/shinesparkFrames",
-                "type": "integer",
-                "minimum": 0,
-                "title": "Shinespark Frames",
-                "description": "The duration (in frames) of the shinespark that must be executed. This defines the energy cost of the shinespark."
-              },
-              "excessShinesparkFrames": {
-                "$id": "#/definitions/logicalRequirement/items/properties/canComeInCharged/properties/excessShinesparkFrames",
-                "type": "integer",
-                "minimum": 0,
-                "title": "Excess Shinespark Frames",
-                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark.  Subtracting this from the shinesparkFrames defines the lower limit of the shinespark energy cost."
-              },
               "unusableTiles": {
                 "$id": "#/definitions/logicalRequirement/items/properties/canComeInCharged/properties/unusableTiles",
                 "type": "number",
@@ -554,8 +539,7 @@
             "description": "Fulfilled by being able to charge a shinespark under the described conditions.",
             "required": [
               "usedTiles",
-              "openEnd",
-              "shinesparkFrames"
+              "openEnd"
             ],
             "additionalProperties": false,
             "properties": {
@@ -609,22 +593,22 @@
                 "maximum": 2,
                 "title": "Number of Open Ends",
                 "description": "The number of open ends in the runway. An open end is a runway edge that ends in a dropoff rather than a wall. Each open end adds a bit of extra room."
-              },
-              "shinesparkFrames": {
-                "$id": "#/definitions/logicalRequirement/items/properties/canShineCharge/properties/shinesparkFrames",
-                "type": "integer",
-                "minimum": 0,
-                "title": "Shinespark Frames",
-                "description": "The duration (in frames) of the shinespark that must be executed. This defines the energy cost of the shinespark."
-              },
-              "excessShinesparkFrames": {
-                "$id": "#/definitions/logicalRequirement/items/properties/canShineCharge/properties/excessShinesparkFrames",
-                "type": "integer",
-                "minimum": 0,
-                "title": "Excess Shinespark Frames",
-                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark. Subtracting this from the shinesparkFrames defines the lower limit of the shinespark energy cost."
               }
             }
+          },
+          "shinesparkFrames": {
+            "$id": "#/definitions/logicalRequirement/items/properties/shinesparkFrames",
+            "type": "integer",
+            "minimum": 1,
+            "title": "Shinespark Frames",
+            "description": "Fulfilled by spending an amount of energy corresponding to the given number of frames in a shinespark. This requires that Samus' energy must be at least 29 at the end."
+          },
+          "excessShinesparkFrames": {
+            "$id": "#/definitions/logicalRequirement/items/properties/excessShinesparkFrames",
+            "type": "integer",
+            "minimum": 1,
+            "title": "Excess Shinespark Frames",
+            "description": "Fulfilled by spending an amount of energy corresponding to the given number of frames in a shinespark, stopping if Samus' energy reaches 29 (while still fulfilling the requirement)."
           },
           "resetRoom": {
             "$id": "#/definitions/logicalRequirement/items/properties/resetRoom",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -600,21 +600,21 @@
             "$id": "#/definitions/logicalRequirement/items/properties/shinespark",
             "type": "object",
             "title": "Shinespark",
-            "description": "Fulfilled by entering the room in a specified node, and avoid visiting barred nodes and destroying barred obstacles.",
+            "description": "Fulfilled by having sufficient energy to perform a shinespark lasting a given number of frames.",
             "required": [
               "frames"
             ],
             "additionalProperties": false,
             "properties": {
               "frames": {
-                "$id": "#/definitions/logicalRequirement/items/properties/shinespark/properties/shinesparkFrames",
+                "$id": "#/definitions/logicalRequirement/items/properties/shinespark/properties/frames",
                 "type": "integer",
                 "minimum": 1,
                 "title": "Shinespark Frames",
                 "description": "The duration (in frames) of the shinespark that must be executed. This defines the energy cost of the shinespark assuming it is not interrupted by running down to 29 energy."
               },
               "excessFrames": {
-                "$id": "#/definitions/logicalRequirement/items/properties/shinespark/properties/excessShinesparkFrames",
+                "$id": "#/definitions/logicalRequirement/items/properties/shinespark/properties/excessFrames",
                 "type": "integer",
                 "minimum": 0,
                 "title": "Excess Shinespark Frames",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -596,19 +596,30 @@
               }
             }
           },
-          "shinesparkFrames": {
-            "$id": "#/definitions/logicalRequirement/items/properties/shinesparkFrames",
-            "type": "integer",
-            "minimum": 1,
-            "title": "Shinespark Frames",
-            "description": "Fulfilled by spending an amount of energy corresponding to the given number of frames in a shinespark. This requires that Samus' energy must be at least 29 at the end."
-          },
-          "excessShinesparkFrames": {
-            "$id": "#/definitions/logicalRequirement/items/properties/excessShinesparkFrames",
-            "type": "integer",
-            "minimum": 1,
-            "title": "Excess Shinespark Frames",
-            "description": "Fulfilled by spending an amount of energy corresponding to the given number of frames in a shinespark, stopping if Samus' energy reaches 29 (while still fulfilling the requirement)."
+          "shinespark": {
+            "$id": "#/definitions/logicalRequirement/items/properties/shinespark",
+            "type": "object",
+            "title": "Shinespark",
+            "description": "Fulfilled by able to enter the room in a specified node, and avoid visiting barred nodes and destroying barred obstacles.",
+            "required": [
+              "frames"
+            ],
+            "properties": {
+              "frames": {
+                "$id": "#/definitions/logicalRequirement/items/properties/shinespark/properties/shinesparkFrames",
+                "type": "integer",
+                "minimum": 1,
+                "title": "Shinespark Frames",
+                "description": "The duration (in frames) of the shinespark that must be executed. This defines the energy cost of the shinespark assuming it is not interrupted by running down to 29 energy."
+              },
+              "excessFrames": {
+                "$id": "#/definitions/logicalRequirement/items/properties/shinespark/properties/excessShinesparkFrames",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Excess Shinespark Frames",
+                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark. Subtracting this from the `frames` defines the lower limit of the shinespark energy cost."
+              }
+            }
           },
           "resetRoom": {
             "$id": "#/definitions/logicalRequirement/items/properties/resetRoom",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -600,7 +600,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/shinespark",
             "type": "object",
             "title": "Shinespark",
-            "description": "Fulfilled by able to enter the room in a specified node, and avoid visiting barred nodes and destroying barred obstacles.",
+            "description": "Fulfilled by entering the room in a specified node, and avoid visiting barred nodes and destroying barred obstacles.",
             "required": [
               "frames"
             ],
@@ -626,7 +626,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/resetRoom",
             "type": "object",
             "title": "Reset Room",
-            "description": "Fulfilled by able to enter the room in a specified node, and avoid visiting barred nodes and destroying barred obstacles.",
+            "description": "Fulfilled by entering the room in a specified node, and avoid visiting barred nodes.",
             "required": [
               "nodes"
             ],

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -604,6 +604,7 @@
             "required": [
               "frames"
             ],
+            "additionalProperties": false,
             "properties": {
               "frames": {
                 "$id": "#/definitions/logicalRequirement/items/properties/shinespark/properties/shinesparkFrames",


### PR DESCRIPTION
Currently `shinesparkFrames` occurs in several places in the schema, namely in `canShineCharge`, `canLeaveCharged`, and `canComeInCharged`. Also `excessShinesparkFrames` occurs in both `canShineCharge` and `canComeInCharged`.

This PR simplifies the schemas by pulling `shinesparkFrames` and `excessShinesparkFrames` into stand-alone logical requirements (similar to `heatFrames`, `metroidFrames`, etc.), and removing them from `canShineCharge`, `canLeaveCharged`, and `canComeInCharged`.

I believe this is cleaner for a few reasons: 
- `canShineCharge` is primarily a tech/skill requirement (a measure of short-charging ability). It is used in many places where there are no shinespark frames required (e.g. if only blue speed is needed). So it makes sense to split off any shinespark frame requirements, because those are different from the tech/skill required to short charge.
- Properties relating to cross-room strats (`canLeaveCharged` and `canComeInCharged`) are some of the trickiest to consume (by randomizers and other tools that may want to use this data). Keeping these properties as lean as possible by stripping out non-essential parts can make them easier to deal with.

A couple important things to note with this change:
- With `shinesparkFrames` and `excessShinesparkFrames` being separate requirements, their total value should be the total shinespark frames required. Previously we used `shinesparkFrames` for the total, and `excessShinesparkFrames` was a part of that total. 
- `shinesparkFrames` and `excessShinesparkFrames` must appear in that order in the requirements, or it will not be correct.

So far the only region file changed is Blue Brinstar. I wanted to get feedback and continuing to do the rest.