### PR TITLE
Remove G-Mode Strats That CF and Exit G-Mode

### DIFF
--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -1572,20 +1572,6 @@
                     ]}
                   ],
                   "devNote": "FIXME: It is not currently possible to represent coming in from the opposite door with a shinecharge."
-                },
-                {
-                  "name": "Enter G-Mode, CF, Leave in Direct G-Mode",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [1],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }},
-                    "h_canArtificialMorphCrystalFlash"
-                  ],
-                  "note": "Place the PB to free but not kill the Waver. After using CF, lower back down using the acid or the Waver.",
-                  "devNote": "There is no real point to using artificial morph and bombs, as you need to CF to refill your energy."
                 }
               ]
             }
@@ -1687,20 +1673,6 @@
                     ]}
                   ],
                   "devNote": "FIXME: It is not currently possible to represent coming in from the opposite door with a shinecharge."
-                },
-                {
-                  "name": "Enter G-Mode, CF, Leave in Direct G-Mode",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }},
-                    "h_canArtificialMorphCrystalFlash"
-                  ],
-                  "note": "Place the PB to free but not kill the Waver. After using CF, lower back down using the acid or the Waver.",
-                  "devNote": "There is no real point to using artificial morph and bombs, as you need to CF to refill your energy."
                 }
               ]
             }


### PR DESCRIPTION
It's not possible to exit G-mode by using x-ray after using a CF. Exiting by having the reserves trigger is not useful in these instances, because your reserves would then need to have energy in them, and there is no farm in this room.