### PR TITLE
Add Bombs requirement to Main Street strat

### DIFF
--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -2045,6 +2045,7 @@
                     ]},
                     "canTrickyUseFrozenEnemies",
                     "Wave",
+                    "Bombs",
                     {"or":[
                       "SpringBall",
                       {"and":[


### PR DESCRIPTION
The other variations on this strat looked ok.  Requiring either PBs or h_canUseBombs or h_canArtificialMorphIBJ to climb from the bottom of the room.