### PR TITLE
Cross Room Runways in Central Crateria, Pt 3

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -4851,21 +4851,7 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x0018c82",
-          "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Final Missile Bombway Left Door (to Final Missile)",
-              "length": 3,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 0
-            }
-          ]
+          "doorEnvironments": [{"physics": "air"}]
         },
         {
           "id": 2,
@@ -4896,6 +4882,22 @@
           "from": 1,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 4,
+                      "openEnd": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
               "id": 2,
               "strats": [
                 {
@@ -4923,21 +4925,24 @@
                   "notable": false,
                   "requires": [
                     "canSpeedball",
-                    {"or": [
-                      {"and": [
-                        "canSlowShortCharge",
-                        {"canComeInCharged": {
-                          "framesRemaining": 180,
-                          "fromNode": 2,
-                          "unusableTiles": 5
-                        }}
-                      ]},
-                      {"canComeInCharged": {
-                        "framesRemaining": 180,
-                        "fromNode": 2,
-                        "unusableTiles": 14
-                      }}
-                    ]}
+                    {"canComeInCharged": {
+                      "framesRemaining": 180,
+                      "fromNode": 2,
+                      "unusableTiles": 14
+                    }}
+                  ]
+                },
+                {
+                  "name": "Slow Speedball",
+                  "notable": false,
+                  "requires": [
+                    "canSpeedball",
+                    "canSlowShortCharge",
+                    {"canComeInCharged": {
+                      "framesRemaining": 180,
+                      "fromNode": 2,
+                      "unusableTiles": 5
+                    }}
                   ]
                 },
                 {
@@ -4965,6 +4970,22 @@
                     "Bombs"
                   ],
                   "note": "Repeatedly bomb the crumble blocks until the PLMs are overloaded."
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 4,
+                      "openEnd": 0
+                    }
+                  }
                 }
               ]
             }
@@ -5336,25 +5357,6 @@
               ],
               "openEnd": 1
             }
-          ],
-          "canLeaveCharged": [
-            {
-              "framesRemaining": 70,
-              "usedTiles": 33,
-              "openEnd": 2,
-              "strats": [
-                {
-                  "name": "XMode",
-                  "notable": false,
-                  "requires": [
-                    "h_canXMode",
-                    "canShinechargeMovement",
-                    "canIframeSpikeJump",
-                    {"spikeHits": 2}
-                  ]
-                }
-              ]
-            }
           ]
         },
         {
@@ -5363,34 +5365,7 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x0018c76",
-          "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Crateria Super Room Bottom Left Door (to Climb Middle)",
-              "length": 35,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 0
-            },
-            {
-              "name": "Frozon Boyon Runway - Crateria Super Room Bottom Left Door (to Climb Middle)",
-              "length": 45,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [ "canUseFrozenEnemies" ]
-                }
-              ],
-              "openEnd": 1,
-              "usableComingIn": false
-            }
-          ]
+          "doorEnvironments": [{"physics": "air"}]
         },
         {
           "id": 3,
@@ -5471,6 +5446,46 @@
         {
           "from": 1,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 6,
+                      "openEnd": 1
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "X-Mode, Leave Charged",
+                  "notable": false,
+                  "requires": [
+                    "h_canXMode",
+                    "canShinechargeMovement",
+                    "canIframeSpikeJump",
+                    {"spikeHits": 2},
+                    {"canShineCharge": {
+                      "usedTiles": 33,
+                      "openEnd": 2
+                    }}
+                  ],
+                  "exitCondition": {
+                    "leaveShinecharged": {
+                      "framesRemaining": 70
+                    }
+                  }
+                }
+              ]
+            },
             {
               "id": 3,
               "strats": [
@@ -5554,13 +5569,10 @@
                 {
                   "name": "Shinespark",
                   "notable": false,
-                  "requires": [
-                    {"canComeInCharged": {
-                      "fromNode": 1,
-                      "framesRemaining": 0
-                    }},
-                    {"shinespark": {"frames": 65}}
-                  ]
+                  "entranceCondition": {
+                    "comeInWithSpark": {}
+                  },
+                  "requires": [ {"shinespark": {"frames": 65}} ]
                 },
                 {
                   "name": "Bomb Jump Over Spikes",
@@ -5701,29 +5713,31 @@
                 {
                   "name": "SpaceJump Speedball",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 4,
+                      "openEnd": 1
+                    }
+                  },
                   "requires": [
                     "canSpeedball",
-                    "canBlueSpaceJump",
-                    {"canComeInCharged": {
-                      "fromNode": 1,
-                      "framesRemaining": 180,
-                      "unusableTiles": 1
-                    }}
+                    "canBlueSpaceJump"
                   ]
                 },
                 {
                   "name": "Springball Speedball",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 3,
+                      "openEnd": 1
+                    }
+                  },
                   "requires": [
                     "canSpeedball",
                     "canTemporaryBlue",
                     "canCarefulJump",
                     "canSpringBallBounce",
-                    {"canComeInCharged": {
-                      "framesRemaining": 180,
-                      "fromNode": 1,
-                      "unusableTiles": 2
-                    }},
                     {"or": [
                       "canTrickyJump",
                       {"canShineCharge":{
@@ -5743,14 +5757,15 @@
                 {
                   "name": "X-Mode BlueSuit",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 4,
+                      "openEnd": 1
+                    }
+                  },
                   "requires": [
                     "canSuperJump",
                     "Morph",
-                    {"canComeInCharged": {
-                      "fromNode": 1,
-                      "framesRemaining": 180,
-                      "unusableTiles": 1
-                    }},
                     {"spikeHits": 3},
                     {"or": [
                       {"spikeHits": 3},
@@ -5788,45 +5803,67 @@
                 {
                   "name": "SpeedKeep for Temporary Blue",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInRunning": {
+                      "speedBooster": true,
+                      "minTiles": 12
+                    }
+                  },
                   "requires": [
                     "canSpeedKeep",
                     "canCarefulJump",
+                    "canSlowShortCharge",
+                    "can3HighMidAirMorph",
+                    {"spikeHits": 1},
+                    "canSpeedball"
+                  ],
+                  "note": [
+                    "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
+                    "Bouncing on the platform near the door can save a spike hit, if the running space is available.",
+                    "Or a DamageBoost SpeedKeep could be used instead of a Spike SpeedKeep with enough runspeed."
+                  ]
+                },
+                {
+                  "name": "SpeedKeep for Temporary Blue",
+                  "notable": false,
+                  "requires": [
+                    "canSpeedKeep",
+                    "canCarefulJump",
+                    "can3HighMidAirMorph",
+                    {"canComeInCharged": {
+                      "framesRemaining": 180,
+                      "fromNode": 1,
+                      "unusableTiles": 13
+                    }},
+                    {"spikeHits": 1},
+                    "canSpeedball"
+                  ],
+                  "note": [
+                    "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
+                    "Bouncing on the platform near the door can save a spike hit, if the running space is available.",
+                    "Or a DamageBoost SpeedKeep could be used instead of a Spike SpeedKeep with enough runspeed."
+                  ]
+                },
+                {
+                  "name": "SpeedKeep for Temporary Blue",
+                  "notable": false,
+                  "entranceCondition": {
+                    "comeInRunning": {
+                      "speedBooster": true,
+                      "minTiles": 4
+                    }
+                  },
+                  "requires": [
+                    "canSpeedKeep",
+                    "canCarefulJump",
+                    {"canShineCharge": {
+                      "usedTiles": 21,
+                      "openEnd": 2
+                    }},
+                    {"spikeHits": 1},
                     {"or": [
-                      {"and": [
-                        "canSlowShortCharge",
-                        "can3HighMidAirMorph",
-                        {"adjacentRunway": {
-                          "fromNode": 1,
-                          "usedTiles": 12,
-                          "physics": ["normal"]
-                        }},
-                        {"spikeHits": 1}
-                      ]},
-                      {"and": [
-                        "can3HighMidAirMorph",
-                        {"canComeInCharged": {
-                          "framesRemaining": 180,
-                          "fromNode": 1,
-                          "unusableTiles": 13
-                        }},
-                        {"spikeHits": 1}
-                      ]},
-                      {"and": [
-                        {"canShineCharge": {
-                          "usedTiles": 21,
-                          "openEnd": 2
-                        }},
-                        {"adjacentRunway": {
-                          "fromNode": 1,
-                          "usedTiles": 4,
-                          "physics": ["normal"]
-                        }},
-                        {"spikeHits": 1},
-                        {"or": [
-                          {"spikeHits": 1},
-                          "canChainTemporaryBlue"
-                        ]}
-                      ]}
+                      {"spikeHits": 1},
+                      "canChainTemporaryBlue"
                     ]},
                     "canSpeedball"
                   ],
@@ -5884,21 +5921,41 @@
                 {
                   "name": "X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     "canBeVeryPatient"
                   ],
                   "note": "Climb up 7 screens."
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 35,
+                      "openEnd": 0
+                    }
+                  }
+                },
+                {
+                  "name": "Leave with Runway, Frozen Boyon Bridge",
+                  "notable": false,
+                  "requires": [ "canUseFrozenEnemies" ],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 45,
+                      "openEnd": 1
+                    }
+                  }
                 }
               ]
             },
@@ -6329,20 +6386,6 @@
           "nodeType": "door",
           "nodeSubType": "elevator",
           "nodeAddress": "0x0018b9e",
-          "canLeaveCharged": [
-            {
-              "framesRemaining": 130,
-              "usedTiles": 14,
-              "strats": [
-                {
-                  "name": "In-Room Shortcharge",
-                  "notable": false,
-                  "requires": [{"doorUnlockedAtNode": 1}]
-                }
-              ],
-              "openEnd": 0
-            }
-          ],
           "leaveWithGMode": [
             {
               "leavesWithArtificialMorph": false,

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -5459,12 +5459,7 @@
                       "openEnd": 1
                     }
                   }
-                }
-              ]
-            },
-            {
-              "id": 3,
-              "strats": [
+                },
                 {
                   "name": "X-Mode, Leave Charged",
                   "notable": false,

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2955,7 +2955,6 @@
                       ]}
                     ]}
                   ],
-                  "clearsObstacles": ["A"],
                   "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
                   "note": "A Temporary Blue Chain with movement assists to climb up and destroy the bomb blocks blocking the bottom morph tunnel."
                 },
@@ -4089,7 +4088,7 @@
                 {
                   "name": "Leave with Runway",
                   "notable": false,
-                  "requires": [ {"obstaclesNotCleared": ["A"]} ],
+                  "requires": [],
                   "exitCondition": {
                     "leaveWithRunway": {
                       "length": 3,
@@ -4359,7 +4358,7 @@
                   }
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
@@ -4427,7 +4426,7 @@
                   }
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -6321,21 +6321,7 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x0018b92",
-          "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Blue Brinstar Elevator Room Door (to Pit Room)",
-              "length": 13,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 0
-            }
-          ]
+          "doorEnvironments": [{"physics": "air"}]
         },
         {
           "id": 2,
@@ -6344,23 +6330,6 @@
           "nodeSubType": "elevator",
           "nodeAddress": "0x0018b9e",
           "canLeaveCharged": [
-            {
-              "framesRemaining": 130,
-              "usedTiles": 33,
-              "strats": [
-                {
-                  "name": "Come In Charged",
-                  "notable": false,
-                  "requires": [
-                    {"canComeInCharged": {
-                      "framesRemaining": 180,
-                      "fromNode": 1
-                    }}
-                  ]
-                }
-              ],
-              "openEnd": 0
-            },
             {
               "framesRemaining": 130,
               "usedTiles": 14,
@@ -6400,12 +6369,68 @@
           "from": 1,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 14,
+                      "openEnd": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
               "id": 2,
               "strats": [
                 {
                   "name": "Base",
                   "notable": false,
                   "requires": []
+                },
+                {
+                  "name": "Leave Charged",
+                  "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 13,
+                      "openEnd": 0
+                    }
+                  },
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveShinecharged": {
+                      "framesRemaining": 130
+                    }
+                  }
+                },
+                {
+                  "name": "Leave Charged, In-Room Shortcharge",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      {"canShineCharge": {
+                        "usedTiles": 13,
+                        "openEnd": 0
+                      }},
+                      {"and": [
+                        {"doorUnlockedAtNode": 1},
+                        {"canShineCharge": {
+                          "usedTiles": 14,
+                          "openEnd": 0
+                        }}
+                      ]}
+                    ]}
+                  ],
+                  "exitCondition": {
+                    "leaveShinecharged": {
+                      "framesRemaining": 130
+                    }
+                  }
                 }
               ]
             }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -3817,36 +3817,6 @@
           "nodeSubType": "grey",
           "nodeAddress": "0x0018b7a",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Pit Room Left Door (to Climb)",
-              "length": 7,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [],
-                  "note": "The door is grey unless Samus has Morph and Missiles, even if Zebes is awake."
-                }
-              ],
-              "openEnd": 1,
-              "usableComingIn": false
-            },
-            {
-              "name": "Runway Left of Bomb Blocks - Pit Room Left Door (to Climb)",
-              "length": 3,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [],
-                  "note": "The door is grey unless Samus has Morph and Missiles, even if Zebes is awake."
-                }
-              ],
-              "openEnd": 1,
-              "usableComingIn": true
-            }
-          ],
           "locks": [
             {
               "name": "Pit Room Left Grey Lock (to Climb)",
@@ -3878,21 +3848,6 @@
           "nodeSubType": "grey",
           "nodeAddress": "0x0018b86",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Pit Room Right Door (to Elevator)",
-              "length": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 1
-            }
-          ],
           "gModeImmobile": {
             "requires": [
               {
@@ -3996,6 +3951,33 @@
           "from": 1,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [ {"obstaclesNotCleared": ["A"]} ],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 8,
+                      "openEnd": 1
+                    }
+                  }
+                },
+                {
+                  "name": "Leave with Runway, Broken Floor",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 4,
+                      "openEnd": 1
+                    }
+                  }
+                }
+              ]
+            },
+            {
               "id": 2,
               "strats": [
                 {
@@ -4022,15 +4004,16 @@
                 {
                   "name": "Temporary Blue",
                   "notable": false,
-                  "requires": [
-                    "canTemporaryBlue",
-                    {"canComeInCharged": {
-                      "framesRemaining": 180,
-                      "fromNode": 1
-                    }}
-                  ],
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 3,
+                      "openEnd": 1
+                    }
+                  },
+                  "requires": [ "canTemporaryBlue" ],
                   "clearsObstacles": ["A"],
-                  "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks."
+                  "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks.",
+                  "devNote": "FIXME: Add chain strat with x-ray turnaround and a 7 tile runway."
                 },
                 {
                   "name": "G-Mode Morph to Bomb the Bomb Blocks",
@@ -4104,6 +4087,17 @@
               "id": 2,
               "strats": [
                 {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [ {"obstaclesNotCleared": ["A"]} ],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 3,
+                      "openEnd": 1
+                    }
+                  }
+                },
+                {
                   "name": "Space Pirate Farm",
                   "notable": false,
                   "requires": [
@@ -4124,14 +4118,15 @@
                 {
                   "name": "Full Room Temporary Blue",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 1,
+                      "openEnd": 1
+                    }
+                  },
                   "requires": [
                     "canTemporaryBlue",
                     "canCarefulJump",
-                    {"canComeInCharged": {
-                      "fromNode": 2,
-                      "framesRemaining": 180,
-                      "unusableTiles": 1
-                    }},
                     {"or": [
                       "canChainTemporaryBlue",
                       {"and": [

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2593,34 +2593,6 @@
           "nodeSubType": "grey",
           "nodeAddress": "0x0018b6e",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Climb Bottom Left Door (from Tourian Escape)",
-              "length": 14,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 0
-            },
-            {
-              "name": "Runway with Broken Blocks - Climb Bottom Left Door (from Tourian Escape)",
-              "length": 28,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [ {"obstaclesCleared": ["A"]} ],
-                  "note": "This longer runway requires the bottom bomb wall to be destroyed."
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 0
-            }
-          ],
           "locks": [
             {
               "name": "Climb Tourian Grey Lock (to Tourian Escape)",
@@ -2642,21 +2614,6 @@
           "nodeSubType": "grey",
           "nodeAddress": "0x0018b4a",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Climb Top Right Door (from Crateria Supers Top)",
-              "length": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 0
-            }
-          ],
           "locks": [
             {
               "name": "Climb Top Right Grey Lock (to Crateria Supers Top)",
@@ -2678,20 +2635,6 @@
           "nodeSubType": "yellow",
           "nodeAddress": "0x0018b56",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Climb Middle Right Door (to Crateria Supers Bottom)",
-              "length": 3,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 0
-            }
-          ],
           "locks": [
             {
               "name": "Climb Middle Right Yellow Lock (to Crateria Supers Bottom)",
@@ -2725,34 +2668,6 @@
           "nodeSubType": "blue",
           "nodeAddress": "0x0018b62",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Climb Bottom Right Door (to Pit Room)",
-              "length": 12,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 0
-            },
-            {
-              "name": "Runway with Broken Blocks - Climb Bottom Right Door (to Pit Room)",
-              "length": 28,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [ {"obstaclesCleared": ["A"]} ],
-                  "note": "This longer runway requires the bottom bomb wall to be destroyed."
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 0
-            }
-          ],
           "locks": [
             {
               "name": "Climb Bottom Right Escape Lock (to Pit Room)",
@@ -2846,16 +2761,17 @@
                 {
                   "name": "Climb Behemoth Shinespark (Top Door)",
                   "notable": true,
+                  "entranceCondition": {
+                    "comeInShinecharged": {
+                      "framesRequired": 65
+                    }
+                  },
                   "requires": [
                     "canShinechargeMovementComplex",
                     {"or": [
                       "canCrouchJump",
                       "canMidairShinespark"
                     ]},
-                    {"canComeInCharged": {
-                      "framesRemaining": 65,
-                      "fromNode": 1
-                    }},
                     {"shinespark": {"frames": 5}}
                   ],
                   "reusableRoomwideNotable": "Climb Behemoth Shinespark",
@@ -2913,6 +2829,47 @@
           "from": 2,
           "to": [
             {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 15,
+                      "openEnd": 0
+                    }
+                  }
+                },
+                {
+                  "name": "Leave with Extended Runway",
+                  "notable": false,
+                  "requires": [ {"obstaclesCleared": ["A"]} ],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 29,
+                      "openEnd": 0
+                    }
+                  }
+                },
+                {
+                  "name": "Leave with Extended Runway, Open Both Doors",
+                  "notable": false,
+                  "requires": [
+                    {"obstaclesCleared": ["A"]},
+                    {"doorUnlockedAtNode": 5}
+                  ],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 30,
+                      "openEnd": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
               "id": 3,
               "strats": [
                 {
@@ -2923,19 +2880,11 @@
                     "canXRayTurnaround",
                     "canTrickyJump",
                     "canBePatient",
-                    {"or": [
-                      {"canComeInCharged": {
-                        "fromNode": 2,
-                        "framesRemaining": 180
-                      }},
-                      {"and": [
-                        {"canShineCharge": {
-                          "usedTiles": 28,
-                          "openEnd": 0
-                        }},
-                        {"obstaclesCleared": ["A"]}
-                      ]}
-                    ]}
+                    {"canShineCharge": {
+                      "usedTiles": 28,
+                      "openEnd": 0
+                    }},
+                    {"obstaclesCleared": ["A"]}
                   ],
                   "clearsObstacles": ["A"],
                   "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
@@ -2971,26 +2920,18 @@
                     "canChainTemporaryBlue",
                     "canXRayTurnaround",
                     "canTrickyJump",
-                    {"or": [
-                      {"canComeInCharged": {
-                        "fromNode": 2,
-                        "framesRemaining": 180
-                      }},
-                      {"and": [
-                        {"canShineCharge": {
-                          "usedTiles": 28,
-                          "openEnd": 0
-                        }},
-                        {"obstaclesCleared": ["A"]}
-                      ]}
-                    ]}
+                    {"canShineCharge": {
+                      "usedTiles": 28,
+                      "openEnd": 0
+                    }},
+                    {"obstaclesCleared": ["A"]}
                   ],
                   "clearsObstacles": ["A"],
                   "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
                   "note": "A Temporary Blue Chain with x-ray turnarounds to climb up and destroy the bomb blocks blocking the bottom morph tunnel."
                 },
                 {
-                  "name": "Climb Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom)",
+                  "name": "Climb Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, In-Room)",
                   "notable": true,
                   "requires": [
                     "canChainTemporaryBlue",
@@ -2999,19 +2940,41 @@
                       "canTrickySpringBallJump"
                     ]},
                     "canTrickyJump",
+                    {"obstaclesCleared": ["A"]},
                     {"or": [
-                      {"canComeInCharged": {
-                        "fromNode": 2,
-                        "framesRemaining": 180
+                      {"canShineCharge": {
+                        "usedTiles": 19,
+                        "openEnd": 0
                       }},
                       {"and": [
                         {"canShineCharge": {
-                          "usedTiles": 19,
+                          "usedTiles": 20,
                           "openEnd": 0
                         }},
-                        {"obstaclesCleared": ["A"]}
+                        {"doorUnlockedAtNode": 2}
                       ]}
                     ]}
+                  ],
+                  "clearsObstacles": ["A"],
+                  "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
+                  "note": "A Temporary Blue Chain with movement assists to climb up and destroy the bomb blocks blocking the bottom morph tunnel."
+                },
+                {
+                  "name": "Climb Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, Cross-Room)",
+                  "notable": true,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 14,
+                      "openEnd": 0
+                    }
+                  },
+                  "requires": [
+                    "canChainTemporaryBlue",
+                    {"or": [
+                      "HiJump",
+                      "canTrickySpringBallJump"
+                    ]},
+                    "canTrickyJump"
                   ],
                   "clearsObstacles": ["A"],
                   "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
@@ -3055,11 +3018,10 @@
                 {
                   "name": "Shinespark",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithSpark": {}
+                  },
                   "requires": [
-                    {"canComeInCharged": {
-                      "fromNode": 2,
-                      "framesRemaining": 0
-                    }},
                     {"shinespark": {
                       "frames": 43,
                       "excessFrames": 17
@@ -3070,11 +3032,32 @@
                 {
                   "name": "Speedbooster",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 14,
+                      "openEnd": 0
+                    }
+                  },
+                  "requires": [],
+                  "clearsObstacles": ["A"]
+                },
+                {
+                  "name": "In Room Shinecharge, Left Side",
+                  "notable": false,
                   "requires": [
-                    {"canComeInCharged": {
-                      "fromNode": 2,
-                      "framesRemaining": 180
-                    }}
+                    {"or": [
+                      {"canShineCharge": {
+                        "usedTiles": 14,
+                        "openEnd": 0
+                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 15,
+                          "openEnd": 0
+                        }},
+                        {"doorUnlockedAtNode": 2}
+                      ]}
+                    ]}
                   ],
                   "clearsObstacles": ["A"]
                 },
@@ -3134,6 +3117,22 @@
               ]
             },
             {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 3,
+                      "openEnd": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
               "id": 4,
               "strats": [
                 {
@@ -3173,15 +3172,16 @@
                 {
                   "name": "Climb Morph Tunnel SpeedBall (Top Right)",
                   "notable": true,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 0,
+                      "openEnd": 0
+                    }
+                  },
                   "requires": [
                     "canSpeedball",
                     "canTrickyDashJump",
-                    "canSlowShortCharge",
-                    {"canComeInCharged": {
-                      "framesRemaining": 180,
-                      "fromNode": 3,
-                      "unusableTiles": 2
-                    }}
+                    "canSlowShortCharge"
                   ],
                   "reusableRoomwideNotable": "Climb Morph Tunnel SpeedBall",
                   "note": "Enter the room with a very specific run speed to jump from the door, and land a speedball perfectly in the tunnel to break the Bomb block."
@@ -3249,31 +3249,11 @@
                 {
                   "name": "Right-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [4],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 4,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 4,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]},
+                    "canXRayClimb",
                     "canBeVeryPatient"
                   ],
                   "note": "Climb up 7 screens."
@@ -3335,6 +3315,22 @@
               ]
             },
             {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 4,
+                      "openEnd": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
               "id": 6,
               "strats": [
                 {
@@ -3345,15 +3341,16 @@
                 {
                   "name": "Climb Morph Tunnel SpeedBall (Lower Right)",
                   "notable": true,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 1,
+                      "openEnd": 0
+                    }
+                  },
                   "requires": [
                     "canSpeedball",
                     "canTrickyDashJump",
-                    "canSlowShortCharge",
-                    {"canComeInCharged": {
-                      "framesRemaining": 180,
-                      "fromNode": 3,
-                      "unusableTiles": 2
-                    }}
+                    "canSlowShortCharge"
                   ],
                   "reusableRoomwideNotable": "Climb Morph Tunnel SpeedBall",
                   "note": "Enter the room with a very specific run speed to jump from the door, squeeze by the ceiling, and land a speedball perfectly in the tunnel to break the Bomb block."
@@ -3389,6 +3386,52 @@
               "id": 2,
               "strats": [
                 {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "entranceCondition": {
+                    "comeInWithSpark": {}
+                  },
+                  "requires": [
+                    {"shinespark": {
+                      "frames": 43,
+                      "excessFrames": 17
+                    }}
+                  ],
+                  "clearsObstacles": ["A"]
+                },
+                {
+                  "name": "Speedbooster",
+                  "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharging": {
+                      "length": 12,
+                      "openEnd": 0
+                    }
+                  },
+                  "requires": [],
+                  "clearsObstacles": ["A"]
+                },
+                {
+                  "name": "In Room Shinecharge, Right Side",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      {"canShineCharge": {
+                        "usedTiles": 12,
+                        "openEnd": 0
+                      }},
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 13,
+                          "openEnd": 0
+                        }},
+                        {"doorUnlockedAtNode": 5}
+                      ]}
+                    ]}
+                  ],
+                  "clearsObstacles": ["A"]
+                },
+                {
                   "name": "G-Mode through Bomb Blocks",
                   "notable": false,
                   "requires": [
@@ -3405,46 +3448,16 @@
               "id": 3,
               "strats": [
                 {
-                  "name": "Climb Temporary Blue Chain Through Bomb Blocks (Bottom Right to Top)",
-                  "notable": true,
-                  "requires": [
-                    "canChainTemporaryBlue",
-                    "canXRayTurnaround",
-                    "canTrickyJump",
-                    "canBePatient",
-                    {"canComeInCharged": {
-                      "fromNode": 5,
-                      "framesRemaining": 180
-                    }}
-                  ],
-                  "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
-                  "note": "A long Temporary Blue Chain with x-ray turnarounds to climb up and destroy the bomb blocks blocking the top morph tunnel."
-                },
-                {
                   "name": "X-Ray Climb to Break Bomb Block with Screw Attack",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
                     "ScrewAttack",
                     "Morph",
                     "canBeVeryPatient",
-                    "h_canRightDoorXRayClimb",
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 5,
-                        "usedTiles": 0.5,
-                        "useFrames": 200,
-                        "physics": ["normal"]
-                      }},
-                      {"and": [
-                        "canRightSideDoorStuckFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 5,
-                          "usedTiles": 0.5,
-                          "useFrames": 200,
-                          "physics": ["normal"]
-                        }}
-                      ]}
-                    ]}
+                    "canXRayClimb"
                   ],
                   "note": [
                     "Use an X-Ray climb to position Samus to where she can break the Bomb block with Screw Attack.",
@@ -3512,44 +3525,15 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Climb Temporary Blue Chain Through Bomb Blocks (Bottom Right to Bottom)",
-                  "notable": true,
-                  "requires": [
-                    "canChainTemporaryBlue",
-                    "canXRayTurnaround",
-                    "canTrickyJump",
-                    {"canComeInCharged": {
-                      "fromNode": 5,
-                      "framesRemaining": 180
-                    }}
-                  ],
-                  "reusableRoomwideNotable": "Climb Temporary Blue Chain Through Bomb Blocks",
-                  "note": "A Temporary Blue Chain with x-ray turnarounds to climb up and destroy the bomb blocks blocking the bottom morph tunnel."
-                },
-                {
                   "name": "X-Ray Climb to Break Bomb Block with Screw Attack",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
                     "ScrewAttack",
                     "Morph",
-                    "h_canRightDoorXRayClimb",
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 5,
-                        "usedTiles": 0.5,
-                        "useFrames": 200,
-                        "physics": ["normal"]
-                      }},
-                      {"and": [
-                        "canRightSideDoorStuckFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 5,
-                          "usedTiles": 0.5,
-                          "useFrames": 200,
-                          "physics": ["normal"]
-                        }}
-                      ]}
-                    ]}
+                    "canXRayClimb"
                   ],
                   "note": [
                     "Use an X-Ray climb to position Samus to where she can break the Bomb block with Screw Attack.",
@@ -3594,6 +3578,47 @@
               ]
             },
             {
+              "id": 5,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 13,
+                      "openEnd": 0
+                    }
+                  }
+                },
+                {
+                  "name": "Leave with Extended Runway",
+                  "notable": false,
+                  "requires": [ {"obstaclesCleared": ["A"]} ],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 29,
+                      "openEnd": 0
+                    }
+                  }
+                },
+                {
+                  "name": "Leave with Extended Runway, Open Both Doors",
+                  "notable": false,
+                  "requires": [
+                    {"obstaclesCleared": ["A"]},
+                    {"doorUnlockedAtNode": 2}
+                  ],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 30,
+                      "openEnd": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
               "id": 6,
               "strats": [
                 {
@@ -3629,32 +3654,6 @@
                       "h_canDestroyBombWalls",
                       {"obstaclesCleared": ["A"]}
                     ]}
-                  ],
-                  "clearsObstacles": ["A"]
-                },
-                {
-                  "name": "Shinespark",
-                  "notable": false,
-                  "requires": [
-                    {"canComeInCharged": {
-                      "fromNode": 5,
-                      "framesRemaining": 0
-                    }},
-                    {"shinespark": {
-                      "frames": 43,
-                      "excessFrames": 17
-                    }}
-                  ],
-                  "clearsObstacles": ["A"]
-                },
-                {
-                  "name": "Speedbooster",
-                  "notable": false,
-                  "requires": [
-                    {"canComeInCharged": {
-                      "fromNode": 5,
-                      "framesRemaining": 180
-                    }}
                   ],
                   "clearsObstacles": ["A"]
                 },

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -4279,35 +4279,6 @@
           "nodeSubType": "blue",
           "nodeAddress": "0x0018bb6",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Flyway Left Door (to Alcatraz)",
-              "length": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 1
-            }
-          ],
-          "canLeaveCharged": [
-            {
-              "usedTiles": 33,
-              "framesRemaining": 90,
-              "openEnd": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [ "canShinechargeMovement" ]
-                }
-              ]
-            }
-          ],
           "leaveWithGModeSetup": [
             {
               "strats": [
@@ -4327,35 +4298,6 @@
           "nodeSubType": "red",
           "nodeAddress": "0x0018bc2",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Flyway Right Door (to Bomb Torizo)",
-              "length": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 1
-            }
-          ],
-          "canLeaveCharged": [
-            {
-              "usedTiles": 33,
-              "framesRemaining": 90,
-              "openEnd": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [ "canShinechargeMovement" ]
-                }
-              ]
-            }
-          ],
           "leaveWithGModeSetup": [
             {
               "strats": [
@@ -4406,6 +4348,33 @@
               "id": 1,
               "strats": [
                 {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 3,
+                      "openEnd": 1
+                    }
+                  }
+                },
+                {
+                  "name": "Leave Charged",
+                  "notable": false,
+                  "requires": [
+                    "canShinechargeMovement",
+                    {"canShineCharge": {
+                      "usedTiles": 33,
+                      "openEnd": 2
+                    }}
+                  ],
+                  "exitCondition": {
+                    "leaveShinecharged": {
+                      "framesRemaining": 90
+                    }
+                  }
+                },
+                {
                   "name": "Mellow Farm",
                   "notable": false,
                   "requires": [
@@ -4442,6 +4411,38 @@
                   "requires": []
                 }
               ]
+            },
+            {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 3,
+                      "openEnd": 1
+                    }
+                  }
+                },
+                {
+                  "name": "Leave Charged",
+                  "notable": false,
+                  "requires": [
+                    "canShinechargeMovement",
+                    {"canShineCharge": {
+                      "usedTiles": 33,
+                      "openEnd": 2
+                    }}
+                  ],
+                  "exitCondition": {
+                    "leaveShinecharged": {
+                      "framesRemaining": 90
+                    }
+                  }
+                }
+              ]
             }
           ]
         }
@@ -4463,21 +4464,6 @@
           "nodeSubType": "blue",
           "nodeAddress": "0x0018bce",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Pre-Map Flyway Left Door (to Parlor)",
-              "length": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 1
-            }
-          ],
           "leaveWithGModeSetup": [
             {
               "strats": [
@@ -4497,21 +4483,6 @@
           "nodeSubType": "blue",
           "nodeAddress": "0x0018bda",
           "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Pre-Map Flyway Right Door (to Map)",
-              "length": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "usableComingIn": false,
-              "openEnd": 1
-            }
-          ],
           "leaveWithGModeSetup": [
             {
               "strats": [
@@ -4549,6 +4520,17 @@
               "id": 1,
               "strats": [
                 {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 3,
+                      "openEnd": 1
+                    }
+                  }
+                },
+                {
                   "name": "Mellow and Reo Farm",
                   "notable": false,
                   "requires": [
@@ -4585,6 +4567,22 @@
                   "requires": []
                 }
               ]
+            },
+            {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 3,
+                      "openEnd": 1
+                    }
+                  }
+                }
+              ]
             }
           ]
         }
@@ -4605,21 +4603,7 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x0018c2e",
-          "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Crateria Map Room Door (to Pre-Map)",
-              "length": 3,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 1
-            }
-          ]
+          "doorEnvironments": [{"physics": "air"}]
         },
         {
           "id": 2,
@@ -4634,6 +4618,22 @@
         {
           "from": 1,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 4,
+                      "openEnd": 1
+                    }
+                  }
+                }
+              ]
+            },
             {
               "id": 2,
               "strats": [
@@ -4678,21 +4678,7 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x00189be",
-          "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Crateria Save Room Door (to Parlor)",
-              "length": 3,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 1
-            }
-          ]
+          "doorEnvironments": [{"physics": "air"}]
         },
         {
           "id": 2,
@@ -4707,6 +4693,22 @@
         {
           "from": 1,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 4,
+                      "openEnd": 1
+                    }
+                  }
+                }
+              ]
+            },
             {
               "id": 2,
               "strats": [
@@ -4751,21 +4753,7 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x0018c9a",
-          "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Final Missile Door (to Final Missile Bombway)",
-              "length": 9,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 0
-            }
-          ]
+          "doorEnvironments": [{"physics": "air"}]
         },
         {
           "id": 2,
@@ -4803,6 +4791,22 @@
         {
           "from": 1,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 10,
+                      "openEnd": 0
+                    }
+                  }
+                }
+              ]
+            },
             {
               "id": 2,
               "strats": [
@@ -5010,20 +5014,6 @@
                 }
               ]
             }
-          ],
-          "runways": [
-            {
-              "name": "Base Runway - Bomb Torizo Room Door (to Flyway)",
-              "length": 0,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 1
-            }
           ]
         },
         {
@@ -5097,6 +5087,22 @@
         {
           "from": 1,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 1,
+                      "openEnd": 1
+                    }
+                  }
+                }
+              ]
+            },
             {
               "id": 3,
               "strats": [
@@ -5192,21 +5198,7 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x00189b2",
-          "doorEnvironments": [{"physics": "air"}],
-          "runways": [
-            {
-              "name": "Base Runway - Crateria Power Bomb Room Door (to Landing Site)",
-              "length": 3,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ],
-              "openEnd": 1
-            }
-          ]
+          "doorEnvironments": [{"physics": "air"}]
         },
         {
           "id": 2,
@@ -5233,6 +5225,17 @@
             {
               "id": 1,
               "strats": [
+                {
+                  "name": "Leave with Runway",
+                  "notable": false,
+                  "requires": [],
+                  "exitCondition": {
+                    "leaveWithRunway": {
+                      "length": 4,
+                      "openEnd": 1
+                    }
+                  }
+                },
                 {
                   "name": "Alcoon Farm",
                   "notable": false,

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -5801,7 +5801,7 @@
                   "devNote": "One leniency spikehit given."
                 },
                 {
-                  "name": "SpeedKeep for Temporary Blue",
+                  "name": "SpeedKeep for Temporary Blue, Slow Entry, Bounce on Runway",
                   "notable": false,
                   "entranceCondition": {
                     "comeInRunning": {
@@ -5819,12 +5819,12 @@
                   ],
                   "note": [
                     "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
-                    "Bouncing on the platform near the door can save a spike hit, if the running space is available.",
+                    "Bouncing on the platform near the door saves a spike hit.",
                     "Or a DamageBoost SpeedKeep could be used instead of a Spike SpeedKeep with enough runspeed."
                   ]
                 },
                 {
-                  "name": "SpeedKeep for Temporary Blue",
+                  "name": "SpeedKeep for Temporary Blue, Bounce on Runway",
                   "notable": false,
                   "requires": [
                     "canSpeedKeep",
@@ -5840,7 +5840,7 @@
                   ],
                   "note": [
                     "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
-                    "Bouncing on the platform near the door can save a spike hit, if the running space is available.",
+                    "Bouncing on the platform near the door saves a spike hit.",
                     "Or a DamageBoost SpeedKeep could be used instead of a Spike SpeedKeep with enough runspeed."
                   ]
                 },
@@ -5869,8 +5869,7 @@
                   ],
                   "note": [
                     "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
-                    "Bouncing on the platform near the door can save a spike hit, if the running space is available.",
-                    "Or a DamageBoost SpeedKeep could be used instead of a Spike SpeedKeep with enough runspeed."
+                    "A DamageBoost SpeedKeep could be used instead of a Spike SpeedKeep with enough runspeed."
                   ]
                 },
                 {

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -988,6 +988,30 @@
                       "framesRemaining": 130
                     }
                   }
+                },
+                {
+                  "name": "Leave Charged, In-Room Shortcharge",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      {"canShineCharge": {
+                        "usedTiles": 13,
+                        "openEnd": 0
+                      }},
+                      {"and": [
+                        {"doorUnlockedAtNode": 1},
+                        {"canShineCharge": {
+                          "usedTiles": 14,
+                          "openEnd": 0
+                        }}
+                      ]}
+                    ]}
+                  ],
+                  "exitCondition": {
+                    "leaveShinecharged": {
+                      "framesRemaining": 130
+                    }
+                  }
                 }
               ]
             }

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -990,7 +990,7 @@
                   }
                 },
                 {
-                  "name": "Leave Charged, In-Room Shortcharge",
+                  "name": "Leave Shinecharged, In-Room Shortcharge",
                   "notable": false,
                   "requires": [
                     {"or": [

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -75,6 +75,8 @@
                   "title": "Speed Booster",
                   "description": "Whether or not this run should be performed with Speed Booster.",
                   "enum": [
+                    true,
+                    false,
                     "any"
                   ]
                 },


### PR DESCRIPTION
Things of note:
- I kept the strats that had more unusable tiles than their in-room runway had. And I kept their node's runways. This is not yet representable.
- I deleted some strats in the Climb that climb with temporary blue that come from a doorway. I think the 28 tiles in room should be plenty for strats this complex.
- There are 3 strats in Crateria Supers that I had to split, called `SpeedKeep for Temporary Blue`. I'm not I properly renamed them and edited their notes.