### PR TITLE
New Runway Cleanup - Misc Changes

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -222,7 +222,8 @@
                   "clearsObstacles": ["A"],
                   "devNote": [
                     "This is a direct link because clearing the hoppers is unnecessary.",
-                    "One tile is subtracted from the runway length since Samus must be blue before contacting the first Hopper."
+                    "One tile is subtracted from the runway length since Samus must be blue before contacting the first Hopper.",
+                    "There is 1 unusable tile in this runway."
                   ]
                 },
                 {
@@ -1736,7 +1737,8 @@
                     "Morph",
                     "canTemporaryBlue"
                   ],
-                  "clearsObstacles": ["A","B"]
+                  "clearsObstacles": ["A","B"],
+                  "devNote": "There is 1 unusable tile in this runway."
                 }
               ]
             }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -1164,7 +1164,7 @@
                   "requires": []
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "entranceCondition": {
                     "comeInShinecharging": {
@@ -1207,7 +1207,7 @@
                   "requires": []
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "entranceCondition": {
                     "comeInShinecharging": {
@@ -2442,7 +2442,7 @@
                   "requires": []
                 },
                 {
-                  "name": "Leave Charged, Using the Raised Platform",
+                  "name": "Leave Shinecharged, Using the Raised Platform",
                   "notable": false,
                   "requires": [
                     {"canShineCharge": {
@@ -2459,7 +2459,7 @@
                   }
                 },
                 {
-                  "name": "Leave Charged, Using the Left of the Raised Platform",
+                  "name": "Leave Shinecharged, Using the Left of the Raised Platform",
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
@@ -5460,7 +5460,7 @@
                   }
                 },
                 {
-                  "name": "X-Mode, Leave Charged",
+                  "name": "X-Mode, Leave Shinecharged",
                   "notable": false,
                   "requires": [
                     "h_canXMode",
@@ -6429,7 +6429,7 @@
                   "requires": []
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "entranceCondition": {
                     "comeInShinecharging": {
@@ -6445,7 +6445,7 @@
                   }
                 },
                 {
-                  "name": "Leave Charged, In-Room Shortcharge",
+                  "name": "Leave Shinecharged, In-Room Shortcharge",
                   "notable": false,
                   "requires": [
                     {"or": [

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2943,12 +2943,12 @@
                     {"obstaclesCleared": ["A"]},
                     {"or": [
                       {"canShineCharge": {
-                        "usedTiles": 19,
+                        "usedTiles": 18,
                         "openEnd": 0
                       }},
                       {"and": [
                         {"canShineCharge": {
-                          "usedTiles": 20,
+                          "usedTiles": 19,
                           "openEnd": 0
                         }},
                         {"doorUnlockedAtNode": 2}
@@ -3183,7 +3183,8 @@
                     "canSlowShortCharge"
                   ],
                   "reusableRoomwideNotable": "Climb Morph Tunnel SpeedBall",
-                  "note": "Enter the room with a very specific run speed to jump from the door, and land a speedball perfectly in the tunnel to break the Bomb block."
+                  "note": "Enter the room with a very specific run speed to jump from the door, and land a speedball perfectly in the tunnel to break the Bomb block.",
+                  "devNote": "There are 2 unusable tiles in this runway."
                 },
                 {
                   "name": "G-Mode Morph through Bomb Blocks",
@@ -3352,7 +3353,8 @@
                     "canSlowShortCharge"
                   ],
                   "reusableRoomwideNotable": "Climb Morph Tunnel SpeedBall",
-                  "note": "Enter the room with a very specific run speed to jump from the door, squeeze by the ceiling, and land a speedball perfectly in the tunnel to break the Bomb block."
+                  "note": "Enter the room with a very specific run speed to jump from the door, squeeze by the ceiling, and land a speedball perfectly in the tunnel to break the Bomb block.",
+                  "devNote": "There are 2 unusable tiles in this runway."
                 },
                 {
                   "name": "G-Mode Morph through Bomb Blocks",
@@ -4141,7 +4143,8 @@
                       ]}
                     ]}
                   ],
-                  "note": "Bring temporary blue from the right side door all the way to the missile location using Springball, SpaceJump, or Morph-UnMorphs."
+                  "note": "Bring temporary blue from the right side door all the way to the missile location using Springball, SpaceJump, or Morph-UnMorphs.",
+                  "devNote": "There is 1 unusable tile in this runway."
                 },
                 {
                   "name": "G-Mode Morph to Bomb the Bomb Blocks",
@@ -5716,7 +5719,8 @@
                   "requires": [
                     "canSpeedball",
                     "canBlueSpaceJump"
-                  ]
+                  ],
+                  "devNote": "There is 1 unusable tile in this runway."
                 },
                 {
                   "name": "Springball Speedball",
@@ -5746,7 +5750,8 @@
                     "It helps to not be at full run speed when bouncing through the spike pit, but is still possible with very tight jumps.",
                     "Then bounce into the Morph tunnel and use Springball to bounce all of the way through.",
                     "Unmorphing before the Morph tunnel to better control the bounce can help."
-                  ]
+                  ],
+                  "devNote": "There are 2 unusable tiles in this runway."
                 },
                 {
                   "name": "X-Mode BlueSuit",
@@ -5769,8 +5774,9 @@
                   ],
                   "note": "Enter with a shinespark ready, activate XMode by bouncing into the spikes, then activate the shinespark but release XMode during the shinespark windup animation.",
                   "devNote": [
-                    "One leniency spikehit given."
-                  ]
+                    "One leniency spikehit given.",
+                    "There is 1 unusable tile in this runway."
+                  ] 
                 },
                 {
                   "name": "Crateria Supers In-Room X-Mode BlueSuit",

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -974,7 +974,7 @@
                   "requires": []
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "entranceCondition": {
                     "comeInShinecharging": {
@@ -1034,7 +1034,7 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Leave Charged, In-Room Shortcharge",
+                  "name": "Leave Shinecharged, In-Room Shortcharge",
                   "notable": false,
                   "requires": [
                     {"doorUnlockedAtNode": 1},
@@ -1101,7 +1101,7 @@
                   }
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
@@ -1148,7 +1148,7 @@
                   }
                 },
                 {
-                  "name": "Leave Charged",
+                  "name": "Leave Shinecharged",
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
@@ -2351,7 +2351,8 @@
                     "canCarefulJump",
                     "canSlowShortCharge",
                     {"acidFrames": 60}
-                  ]
+                  ],
+                  "devNote": "There are 9 unusable tiles in this runway."
                 },
                 {
                   "name": "Temporary Blue, Roll in Acid",
@@ -2366,7 +2367,8 @@
                     "canTemporaryBlue",
                     "canLateralMidAirMorph",
                     {"acidFrames": 200}
-                  ]
+                  ],
+                  "devNote": "There are 5 unusable tiles in this runway."
                 },
                 {
                   "name": "Temporary Blue, Avoid the Acid",
@@ -2385,7 +2387,8 @@
                       "can3HighMidAirMorph"
                     ]}
                   ],
-                  "note": "A quick jump morph from the top of the slope will bounce into the tunnel and avoid acid damage."
+                  "note": "A quick jump morph from the top of the slope will bounce into the tunnel and avoid acid damage.",
+                  "devNote": "There are 6 unusable tiles in this runway."
                 },
                 {
                   "name": "Temporary Blue, X-Ray Turnaround",
@@ -2400,7 +2403,8 @@
                     "canXRayTurnaround",
                     "canChainTemporaryBlue",
                     {"acidFrames": 27}
-                  ]
+                  ],
+                  "devNote": "There is 1 unusable tile in this runway."
                 }
               ]
             }


### PR DESCRIPTION
Converted references from `Charged` to `Shinecharged`
Added old `unusable tiles` as a dev note, because I think they're still somewhat useful to be able to see
There was a strat in the climb that used to just say 19 tiles. I wasnt sure if that was including the the door already unlocked or not, so I included the opposite option now, not sure which is correct.