### PR TITLE
Check node types

### DIFF
--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -86,6 +86,43 @@
                     }}
                   ],
                   "devNote": "To avoid making another obstacle, it is assumed the item at 3 is collected by other means."
+                },
+                {
+                  "name": "Moat SpringBall Bounce, Run Through the Door",
+                  "notable": true,
+                  "entranceCondition": {
+                    "comeInRunning": {
+                      "speedBooster": "any",
+                      "minTiles": 1
+                    }
+                  },
+                  "requires": [ 
+                    "canSpringBallBounce",
+                    "canDisableEquipment",
+                    {"obstaclesNotCleared": ["A"]}
+                  ],
+                  "reusableRoomwideNotable": "Moat SpringBall Bounce",
+                  "note": "Run, jump, lateral midair morph on the way down, then bounce off the pedestal to get to the other side."
+                },
+                {
+                  "name": "Moat Continuous Walljump, Run Through the Door",
+                  "notable": false,
+                  "entranceCondition": {
+                    "comeInRunning": {
+                      "speedBooster": "any",
+                      "minTiles": 1.4
+                    }
+                  },
+                  "requires": [
+                    "canCWJ",
+                    "canDisableEquipment",
+                    {"obstaclesNotCleared": ["A"]}
+                  ],
+                  "note": [
+                    "Aligning against the closed door shell on the other side of the transition.",
+                    "Run towards the water and jump on the last possible frame.",
+                    "Perform the CWJ off of the item pedestal to cross to the other side."
+                  ]
                 }
               ]
             },
@@ -335,23 +372,6 @@
                   "note": "Open the door and step as close to the transition as possible. Run, jump, lateral midair morph on the way down, then bounce off the pedestal to get to the other side."
                 },
                 {
-                  "name": "Moat SpringBall Bounce, Run Through the Door",
-                  "notable": true,
-                  "entranceCondition": {
-                    "comeInRunning": {
-                      "speedBooster": "any",
-                      "minTiles": 1
-                    }
-                  },
-                  "requires": [ 
-                    "canSpringBallBounce",
-                    "canDisableEquipment",
-                    {"obstaclesNotCleared": ["A"]}
-                  ],
-                  "reusableRoomwideNotable": "Moat SpringBall Bounce",
-                  "note": "Run, jump, lateral midair morph on the way down, then bounce off the pedestal to get to the other side."
-                },
-                {
                   "name": "Moat Continuous Walljump, Open Doorway",
                   "notable": false,
                   "requires": [
@@ -367,26 +387,6 @@
                   ],
                   "note": [
                     "Stand on the farthest pixel into the door possible using moonwalk, X-Ray, or morphball turn around.",
-                    "Run towards the water and jump on the last possible frame.",
-                    "Perform the CWJ off of the item pedestal to cross to the other side."
-                  ]
-                },
-                {
-                  "name": "Moat Continuous Walljump, Run Through the Door",
-                  "notable": false,
-                  "entranceCondition": {
-                    "comeInRunning": {
-                      "speedBooster": "any",
-                      "minTiles": 1.4
-                    }
-                  },
-                  "requires": [
-                    "canCWJ",
-                    "canDisableEquipment",
-                    {"obstaclesNotCleared": ["A"]}
-                  ],
-                  "note": [
-                    "Aligning against the closed door shell on the other side of the transition.",
                     "Run towards the water and jump on the last possible frame.",
                     "Perform the CWJ off of the item pedestal to cross to the other side."
                   ]

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -1325,6 +1325,30 @@
           "from": 2,
           "to": [
             {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "entranceCondition": {
+                    "comeInShinecharged": {
+                      "framesRequired": 40
+                    }
+                  },
+                  "requires": [
+                    "f_TourianOpen",
+                    "h_canNavigateUnderwater",
+                    "canShinechargeMovement",
+                    {"shinespark": {
+                      "frames": 21,
+                      "excessFrames": 7
+                    }}
+                  ],
+                  "note": "Jump to either side and diagonal spark out."
+                }
+              ]
+            },
+            {
               "id": 4,
               "strats": [
                 {
@@ -1402,25 +1426,6 @@
                     "HiJump",
                     "canSpringBallJumpMidAir"
                   ]
-                },
-                {
-                  "name": "Shinespark",
-                  "notable": false,
-                  "entranceCondition": {
-                    "comeInShinecharged": {
-                      "framesRequired": 40
-                    }
-                  },
-                  "requires": [
-                    "f_TourianOpen",
-                    "h_canNavigateUnderwater",
-                    "canShinechargeMovement",
-                    {"shinespark": {
-                      "frames": 21,
-                      "excessFrames": 7
-                    }}
-                  ],
-                  "note": "Jump to either side and diagonal spark out."
                 },
                 {
                   "name": "Golden Four Underwater Walljumps",
@@ -2313,30 +2318,10 @@
                   "requires": []
                 }
               ]
-            }
-          ]
-        },
-        {
-          "from": 3,
-          "to": [
-            {
-              "id": 2,
-              "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": []
-                }
-              ]
             },
             {
               "id": 4,
               "strats": [
-                {
-                  "name": "Base",
-                  "notable": false,
-                  "requires": [ "h_canBombThings" ]
-                },
                 {
                   "name": "Speedball",
                   "notable": false,
@@ -2405,6 +2390,31 @@
                     {"acidFrames": 27}
                   ],
                   "devNote": "There is 1 unusable tile in this runway."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "from": 3,
+          "to": [
+            {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Base",
+                  "notable": false,
+                  "requires": []
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "Base",
+                  "notable": false,
+                  "requires": [ "h_canBombThings" ]
                 }
               ]
             }

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -488,8 +488,10 @@ for r,d,f in os.walk(os.path.join(".","region")):
 
                         # Document Nodes
                         # Validate Nodes
+                        node_lookup = {}
                         for node in room["nodes"]:
                             if "id" in node:
+                                node_lookup[node['id']] = node
                                 nodeRef = f"{roomRef}:{node['id']}"
                                 if node["id"] in roomData["nodes"]["froms"]:
                                     msg = f"🔴ERROR: Node ID not unique! {nodeRef}"
@@ -544,10 +546,22 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                             }
                                             if "strats" in to:
                                                 for strat in to["strats"]:
+                                                    stratRef = f"{roomRef}:LINK:FromNode[{fromNode}]:ToNode[{toNode}]:'{strat['name']}'"
                                                     roomData["links"] \
                                                       ["from"][str(fromNode)] \
                                                       ["to"][str(toNode)] \
                                                       ["strats"].append(strat["name"])
+                                                    if "entranceCondition" in strat:
+                                                        if node_lookup[fromNode]["nodeType"] not in ["door", "entrance"]:
+                                                            msg = f"🔴ERROR: Strat has entranceCondition but From Node is not door or entrance:{stratRef}"
+                                                            messages["reds"].append(msg)
+                                                            messages["counts"]["reds"] += 1
+                                                    if "exitCondition" in strat:
+                                                        if node_lookup[toNode]["nodeType"] not in ["door", "exit"]:
+                                                            msg = f"🔴ERROR: Strat has entranceCondition but To Node is not door or exit:{stratRef}"
+                                                            messages["reds"].append(msg)
+                                                            messages["counts"]["reds"] += 1
+
 
                             # Validate "enemies"
                             if "enemies" in room:

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -558,7 +558,7 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                                             messages["counts"]["reds"] += 1
                                                     if "exitCondition" in strat:
                                                         if node_lookup[toNode]["nodeType"] not in ["door", "exit"]:
-                                                            msg = f"🔴ERROR: Strat has entranceCondition but To Node is not door or exit:{stratRef}"
+                                                            msg = f"🔴ERROR: Strat has exitCondition but To Node is not door or exit:{stratRef}"
                                                             messages["reds"].append(msg)
                                                             messages["counts"]["reds"] += 1
 


### PR DESCRIPTION
The new cross-room strat schema has specific requirements on node types of the `from` and `to` nodes:
- In strats with an entrance condition, the `from` node must have `nodeType` either `door` or `entrance`.
- In strats with an entrance condition, the `to` node must have `nodeType` either `door` or `exit`. 

In the old style, cross-room strats often started at junctions instead of a door node, which makes it easy to violate the new constaints by forgetting to change the `from` node as part of the migration. To prevent problems like this, this PR adds tests that will fail if the new constraints are not satisfied.

This PR also fixes all the existing strats that were caught failing the new tests.