### PR TITLE
Add helpers for X-mode leniency

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -516,7 +516,7 @@
             "canXMode",
             "Morph"
           ]
-        }
+        },
         {
           "name": "h_canSpikeXMode",
           "requires": [

--- a/helpers.json
+++ b/helpers.json
@@ -185,6 +185,18 @@
             {"ammo": {"type": "PowerBomb","count": 10}}
           ],
           "devNote": "1 Power bomb leniency per attempt, 10 leniency attempts."
+        },
+        {
+          "name": "h_spikeXModeLeniency",
+          "requires": [
+            {"spikeHits": 1}
+          ]
+        },
+        {
+          "name": "h_thornXModeLeniency",
+          "requires": [
+            {"thornHits": 1}
+          ]
         }
       ]
     },
@@ -503,6 +515,24 @@
           "requires": [
             "canXMode",
             "Morph"
+          ]
+        }
+        {
+          "name": "h_canSpikeXMode",
+          "requires": [
+            "canXMode",
+            "Morph",
+            {"spikeHits": 1},
+            "h_spikeXModeLeniency"
+          ]
+        },
+        {
+          "name": "h_canThornXMode",
+          "requires": [
+            "canXMode",
+            "Morph",
+            {"thornHits": 1},
+            "h_thornXModeLeniency"
           ]
         },
         {

--- a/helpers.json
+++ b/helpers.json
@@ -518,21 +518,25 @@
           ]
         },
         {
-          "name": "h_canSpikeXMode",
+          "name": "h_XModeSpikeHit",
           "requires": [
-            "canXMode",
-            "Morph",
             {"spikeHits": 1},
-            "h_spikeXModeLeniency"
+            "h_XModeSpikeHitLeniency"
+          ],
+          "devNote": [
+            "Some strats require multiple spike hits, in which case h_canSpikeXMode will be included multiple times.",
+            "In this case, the total leniency is the base leniency h_XModeSpikeHitLeniency multiplied by the number of hits."
           ]
         },
         {
-          "name": "h_canThornXMode",
+          "name": "h_XModeThornHit",
           "requires": [
-            "canXMode",
-            "Morph",
             {"thornHits": 1},
-            "h_thornXModeLeniency"
+            "h_XModeThornHitLeniency"
+          ],
+          "devNote": [
+            "Some strats require multiple thorn hits, in which case h_canThornXMode will be included multiple times.",
+            "In this case, the total leniency is the base leniency h_XModeThornHitLeniency multiplied by the number of hits."
           ]
         },
         {

--- a/helpers.json
+++ b/helpers.json
@@ -187,13 +187,13 @@
           "devNote": "1 Power bomb leniency per attempt, 10 leniency attempts."
         },
         {
-          "name": "h_spikeXModeLeniency",
+          "name": "h_XModeSpikeHitLeniency",
           "requires": [
             {"spikeHits": 1}
           ]
         },
         {
-          "name": "h_thornXModeLeniency",
+          "name": "h_XModeThornHitLeniency",
           "requires": [
             {"thornHits": 1}
           ]

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2477,9 +2477,8 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
-                    "canShinechargeMovement",
-                    {"thornHits": 3}
+                    "h_canThornXMode",
+                    "canShinechargeMovement"
                   ],
                   "note": "Jump into the large patch of thorns from below."
                 }
@@ -2518,8 +2517,7 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
-                    {"thornHits": 3},
+                    "h_canThornXMode",
                     {"or": [
                       "HiJump",
                       "canWalljump",

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2477,10 +2477,14 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canThornXMode",
+                    "h_canXMode",
+                    "h_XModeThornHit",
+                    "h_XModeThornHit",
+                    "h_XModeThornHit",
                     "canShinechargeMovement"
                   ],
-                  "note": "Jump into the large patch of thorns from below."
+                  "note": "Jump into the large patch of thorns from below.",
+                  "devNote": "Three thorns hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -2517,7 +2521,10 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canThornXMode",
+                    "h_canXMode",
+                    "h_XModeThornHit",
+                    "h_XModeThornHit",
+                    "h_XModeThornHit",
                     {"or": [
                       "HiJump",
                       "canWalljump",
@@ -2525,7 +2532,8 @@
                     ]},
                     {"shinespark": {"frames": 45}}
                   ],
-                  "note": "Jump into the large patch of thorns from below."
+                  "note": "Jump into the large patch of thorns from below.",
+                  "devNote": "Three thorns hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2525,6 +2525,7 @@
                     "h_XModeThornHit",
                     "h_XModeThornHit",
                     "h_XModeThornHit",
+                    "canShinechargeMovement",
                     {"or": [
                       "HiJump",
                       "canWalljump",

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -2877,10 +2877,9 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "canShinechargeMovement",
-                    {"obstaclesCleared": ["A"]},
-                    {"spikeHits": 2}
+                    {"obstaclesCleared": ["A"]}
                   ]
                 }
               ]

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -2877,10 +2877,13 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "canShinechargeMovement",
                     {"obstaclesCleared": ["A"]}
-                  ]
+                  ],
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1287,7 +1287,7 @@
                   "requires": [
                     "canMidairShinespark",
                     "h_canXMode",
-                    "h_XModeSpikeHit",
+                    {"spikeHits": 1},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1052,7 +1052,9 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "canIframeSpikeJump",
                     {"or": [
                       "SpaceJump",
@@ -1061,7 +1063,8 @@
                     {"shinespark": {
                       "frames": 50
                     }}
-                  ]
+                  ],
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -1116,13 +1119,16 @@
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
-                    "h_canSpikeXMode"
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit"
                   ],
                   "note": [
                     "Jump from the entry runway to bounce onto spikes for XMode.",
                     "Store a spark in XMode and use that to shinepark across the room.",
                     "Bumping a solid tile before activating XMode will remove dash state, preventing shinecharging."
-                  ]
+                  ],
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -1281,7 +1287,7 @@
                   "requires": [
                     "canMidairShinespark",
                     "h_canXMode",
-                    {"spikeHits": 1},
+                    "h_XModeSpikeHit",
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1058,11 +1058,15 @@
                     "canIframeSpikeJump",
                     {"or": [
                       "SpaceJump",
-                      {"spikeHits": 2}
+                     "h_XModeSpikeHit"
                     ]},
                     {"shinespark": {
                       "frames": 50
                     }}
+                  ],
+                  "note": [
+                    "Use the Spikes in the center of the room to build a Shinespark with X-Mode.",
+                    "There are sections of the room where using more complex movement can be used to save a Spike hit when X-Moding."
                   ],
                   "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
@@ -1125,7 +1129,7 @@
                   ],
                   "note": [
                     "Jump from the entry runway to bounce onto spikes for XMode.",
-                    "Store a spark in XMode and use that to shinepark across the room.",
+                    "Store a spark in XMode and use that to leave with a Shinecharge.",
                     "Bumping a solid tile before activating XMode will remove dash state, preventing shinecharging."
                   ],
                   "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
@@ -1287,7 +1291,7 @@
                   "requires": [
                     "canMidairShinespark",
                     "h_canXMode",
-                    {"spikeHits": 1},
+                    {"spikeHits": 2},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1052,9 +1052,8 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "canIframeSpikeJump",
-                    {"spikeHits": 2},
                     {"or": [
                       "SpaceJump",
                       {"spikeHits": 2}
@@ -1117,8 +1116,7 @@
                   "notable": false,
                   "requires": [
                     "canShinechargeMovement",
-                    "h_canXMode",
-                    {"spikeHits": 2}
+                    "h_canSpikeXMode"
                   ],
                   "note": [
                     "Jump from the entry runway to bounce onto spikes for XMode.",
@@ -1283,6 +1281,7 @@
                   "requires": [
                     "canMidairShinespark",
                     "h_canXMode",
+                    {"spikeHits": 1},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
@@ -1290,14 +1289,14 @@
                     {"shinespark": {
                       "frames": 146,
                       "excessFrames": 6
-                    }},
-                    {"spikeHits": 1}
+                    }}
                   ],
                   "note": [
                     "Jump from the entry runway to bounce onto spikes for XMode.",
                     "Store a spark in XMode and use that to shinepark across the room.",
                     "Bumping a solid tile before activating XMode will remove dash state, preventing shinecharging."
-                  ]
+                  ],
+                  "devNote": "Omitting leniency spikeHits, since the firefleas provide an opportunity to farm after a failed attempt."
                 },
                 {
                   "name": "X-Ray Access Ice Bridge",

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -5485,7 +5485,9 @@
                   "name": "X-Mode, Leave Shinecharged",
                   "notable": false,
                   "requires": [
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "canShinechargeMovement",
                     "canIframeSpikeJump",
                     {"canShineCharge": {
@@ -5493,6 +5495,7 @@
                       "openEnd": 2
                     }}
                   ],
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount).",
                   "exitCondition": {
                     "leaveShinecharged": {
                       "framesRemaining": 70

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -5485,10 +5485,9 @@
                   "name": "X-Mode, Leave Shinecharged",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "canShinechargeMovement",
                     "canIframeSpikeJump",
-                    {"spikeHits": 2},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -9557,7 +9557,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     {"or": [
                       {"and": [
                         {"enemyKill": {
@@ -9593,7 +9595,8 @@
                       ]}
                     ]}
                   ],
-                  "note": "Clear the Alcoon then bounce into the spike patch."
+                  "note": "Clear the Alcoon then bounce into the spike patch.",
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -9557,8 +9557,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canXMode",
-                    {"spikeHits": 2},
+                    "h_canSpikeXMode",
                     {"or": [
                       {"and": [
                         {"enemyKill": {

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6861,7 +6861,10 @@
                     "h_canXMode",
                     "h_XModeSpikeHit",
                     "h_XModeSpikeHit",
-                    "h_XModeSpikeHit",
+                    {"or": [
+                      "h_XModeSpikeHit",
+                      "canStationarySpinJump"
+                    ]},
                     "Gravity",
                     "HiJump",
                     "SpaceJump",
@@ -6869,7 +6872,7 @@
                     "canMidairShinespark",
                     {"shinespark": {"frames": 10}}
                   ],
-                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -6910,14 +6913,17 @@
                     "h_canXMode",
                     "h_XModeSpikeHit",
                     "h_XModeSpikeHit",
-                    "h_XModeSpikeHit",
+                    {"or": [
+                      "h_XModeSpikeHit",
+                      "canStationarySpinJump"
+                    ]},
                     "Gravity",
                     "HiJump",
                     "SpaceJump",
                     "canShinechargeMovementComplex",
                     "canMidairShinespark"
                   ],
-                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -7254,7 +7260,11 @@
                     "h_canXMode",
                     "h_XModeSpikeHit",
                     "h_XModeSpikeHit",
-                    "h_XModeSpikeHit",
+                    ```suggestion
+                    {"or": [
+                      "h_XModeSpikeHit",
+                      "canStationarySpinJump"
+                    ]},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
@@ -7264,7 +7274,7 @@
                       "excessFrames": 5
                     }}
                   ],
-                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 },
                 {
                   "name": "Cross Room Jump with Assist",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -7260,7 +7260,6 @@
                     "h_canXMode",
                     "h_XModeSpikeHit",
                     "h_XModeSpikeHit",
-                    ```suggestion
                     {"or": [
                       "h_XModeSpikeHit",
                       "canStationarySpinJump"

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6858,14 +6858,18 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "Gravity",
                     "HiJump",
                     "SpaceJump",
                     "canShinechargeMovementComplex",
                     "canMidairShinespark",
                     {"shinespark": {"frames": 10}}
-                  ]
+                  ],
+                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -6903,13 +6907,17 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "Gravity",
                     "HiJump",
                     "SpaceJump",
                     "canShinechargeMovementComplex",
                     "canMidairShinespark"
-                  ]
+                  ],
+                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -7243,7 +7251,10 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
@@ -7252,7 +7263,8 @@
                       "frames": 25,
                       "excessFrames": 5
                     }}
-                  ]
+                  ],
+                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 },
                 {
                   "name": "Cross Room Jump with Assist",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6858,13 +6858,12 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "Gravity",
                     "HiJump",
                     "SpaceJump",
                     "canShinechargeMovementComplex",
                     "canMidairShinespark",
-                    {"spikeHits": 3},
                     {"shinespark": {"frames": 10}}
                   ]
                 }
@@ -6904,13 +6903,12 @@
                   "name": "XMode",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "Gravity",
                     "HiJump",
                     "SpaceJump",
                     "canShinechargeMovementComplex",
-                    "canMidairShinespark",
-                    {"spikeHits": 3}
+                    "canMidairShinespark"
                   ]
                 }
               ]
@@ -7245,12 +7243,11 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
                     }},
-                    {"spikeHits": 3},
                     {"shinespark": {
                       "frames": 25,
                       "excessFrames": 5

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1841,8 +1841,7 @@
                     {"heatFrames": 120},
                     "h_canHeatedBlueGateGlitch"
                   ],
-                  "clearsObstacles": ["A"],
-                  "devNote": "Omitting gate glitch leniency, since the nearby Gamet farm allows refilling energy and ammo."
+                  "clearsObstacles": ["A"]
                 }
               ]
             },

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1838,12 +1838,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 220},
-                    "canGateGlitch",
-                    {"or": [
-                      {"ammo": { "type": "Missile", "count": 1 }},
-                      {"ammo": { "type": "Super", "count": 1 }}
-                    ]}
+                    {"heatFrames": 120},
+                    "h_canHeatedBlueGateGlitch"
                   ],
                   "clearsObstacles": ["A"],
                   "devNote": "Omitting gate glitch leniency, since the nearby Gamet farm allows refilling energy and ammo."

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1838,10 +1838,15 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 120},
-                    "h_canHeatedBlueGateGlitch"
+                    {"heatFrames": 220},
+                    "canGateGlitch",
+                    {"or": [
+                      {"ammo": { "type": "Missile", "count": 1 }},
+                      {"ammo": { "type": "Super", "count": 1 }}
+                    ]}
                   ],
-                  "clearsObstacles": ["A"]
+                  "clearsObstacles": ["A"],
+                  "devNote": "Omitting gate glitch leniency, since the nearby Gamet farm allows refilling energy and ammo."
                 }
               ]
             },
@@ -5114,9 +5119,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "canWalljump",
-                    {"spikeHits": 3},
                     {"heatFrames": 540},
                     {"shinespark": {"frames": 5}}
                   ],
@@ -5134,9 +5138,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "HiJump",
-                    {"spikeHits": 3},
                     {"heatFrames": 480}
                   ]
                 }
@@ -5543,14 +5546,13 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "canTrickyJump",
                     "canMidairShinespark",
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
                     }},
-                    {"spikeHits": 2},
                     {"heatFrames": 400},
                     {"shinespark": {
                       "frames": 12,

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -5119,12 +5119,16 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "canWalljump",
                     {"heatFrames": 540},
                     {"shinespark": {"frames": 5}}
                   ],
-                  "note": "Jump into the spikes and try to bounce on the crumble blocks moving towards the door."
+                  "note": "Jump into the spikes and try to bounce on the crumble blocks moving towards the door.",
+                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             },
@@ -5138,13 +5142,17 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "HiJump",
                     {"heatFrames": 480}
                   ]
                 }
               ],
-              "note": "Jump into the spikes and try to bounce on the crumble blocks moving towards the door."
+              "note": "Jump into the spikes and try to bounce on the crumble blocks moving towards the door.",
+              "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
             }
           ],
           "locks": [
@@ -5546,7 +5554,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "canTrickyJump",
                     "canMidairShinespark",
                     {"canShineCharge": {
@@ -5559,7 +5569,8 @@
                       "excessFrames": 4
                     }}
                   ],
-                  "note": "A short hop from the door can bounce on the crumbles.  Just be careful of being pushed back onto the crumble blocks by the spikes."
+                  "note": "A short hop from the door can bounce on the crumbles.  Just be careful of being pushed back onto the crumble blocks by the spikes.",
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 },
                 {
                   "name": "Double Chamber HiJumpless Wall Jump",

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2825,9 +2825,8 @@
                   "notable": false,
                   "requires": [
                     "f_DefeatedPhantoon",
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "canIframeSpikeJump",
-                    {"spikeHits": 3},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
@@ -2926,8 +2925,7 @@
                   "name": "X-Mode",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
-                    {"spikeHits": 1}
+                    "h_canSpikeXMode"
                   ],
                   "note": "Move in X-Mode until the Chozo Statue becomes visible and then jump before releasing XRay."
                 },
@@ -4078,9 +4076,8 @@
                   "notable": false,
                   "requires": [
                     "f_DefeatedPhantoon",
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "Gravity",
-                    {"spikeHits": 2},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
@@ -4202,9 +4199,8 @@
                   "notable": false,
                   "requires": [
                     "f_DefeatedPhantoon",
-                    "h_canXMode",
+                    "h_canSpikeXMode",
                     "Gravity",
-                    {"spikeHits": 2},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2
@@ -4512,11 +4508,10 @@
                   "name": "X-Mode and Space Jump, Leave with Shinespark",
                   "notable": false,
                   "requires": [
-                    "h_canXMode",
+                    "h_canThornXMode",
                     "SpaceJump",
                     "HiJump",
                     "canShinechargeMovementComplex",
-                    {"thornHits": 3},
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "openEnd": 2

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -4522,7 +4522,6 @@
                     "h_canXMode",
                     "h_XModeThornHit",
                     "h_XModeThornHit",
-                    "h_XModeThornHit",
                     "SpaceJump",
                     "HiJump",
                     "canShinechargeMovementComplex",
@@ -4546,7 +4545,7 @@
                     "leaveWithSpark": {}
                   },
                   "devNote": [
-                    "Three thorn hits are expected per attempt (with any additional leniency hits being multiplied by this amount).",
+                    "Two thorn hits are expected per attempt (with any additional leniency hits being multiplied by this amount).",
                     "FIXME: There is likely a fast wall jump climb strat with more spark frames."
                   ]
                 }

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2825,7 +2825,10 @@
                   "notable": false,
                   "requires": [
                     "f_DefeatedPhantoon",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "canIframeSpikeJump",
                     {"canShineCharge": {
                       "usedTiles": 33,
@@ -2837,7 +2840,8 @@
                     "leaveShinecharged": {
                       "framesRemaining": 70
                     }
-                  }
+                  },
+                  "devNote": "Three spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 },
                 {
                   "name": "Leave Shinecharged, Phantoon Alive",
@@ -2925,7 +2929,8 @@
                   "name": "X-Mode",
                   "notable": false,
                   "requires": [
-                    "h_canSpikeXMode"
+                    "h_canXMode",
+                    "h_XModeSpikeHit"
                   ],
                   "note": "Move in X-Mode until the Chozo Statue becomes visible and then jump before releasing XRay."
                 },
@@ -4076,7 +4081,9 @@
                   "notable": false,
                   "requires": [
                     "f_DefeatedPhantoon",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
@@ -4089,7 +4096,8 @@
                       "framesRemaining": 80
                     }
                   },
-                  "note": "Jumping from the door and bouncing on the platform enemy works pretty well."
+                  "note": "Jumping from the door and bouncing on the platform enemy works pretty well.",
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             },
@@ -4199,7 +4207,9 @@
                   "notable": false,
                   "requires": [
                     "f_DefeatedPhantoon",
-                    "h_canSpikeXMode",
+                    "h_canXMode",
+                    "h_XModeSpikeHit",
+                    "h_XModeSpikeHit",
                     "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
@@ -4212,7 +4222,8 @@
                       "framesRemaining": 80
                     }
                   },
-                  "note": "Jumping from the door and bouncing on the platform enemy works pretty well."
+                  "note": "Jumping from the door and bouncing on the platform enemy works pretty well.",
+                  "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
                 }
               ]
             }
@@ -4508,7 +4519,10 @@
                   "name": "X-Mode and Space Jump, Leave with Shinespark",
                   "notable": false,
                   "requires": [
-                    "h_canThornXMode",
+                    "h_canXMode",
+                    "h_XModeThornHit",
+                    "h_XModeThornHit",
+                    "h_XModeThornHit",
                     "SpaceJump",
                     "HiJump",
                     "canShinechargeMovementComplex",
@@ -4531,7 +4545,10 @@
                   "exitCondition": {
                     "leaveWithSpark": {}
                   },
-                  "devNote": "FIXME: There is likely a fast wall jump climb strat with more spark frames."
+                  "devNote": [
+                    "Three thorn hits are expected per attempt (with any additional leniency hits being multiplied by this amount).",
+                    "FIXME: There is likely a fast wall jump climb strat with more spark frames."
+                  ]
                 }
               ]
             },


### PR DESCRIPTION
This standardizes all the X-mode strats to have a leniency of 1 extra spike hit, easily adjustable by being centralized to leniency helpers.

I'm the assuming the varying amount of hits in the existing logic were just representing different amounts of lenience and had no significance. If some of these strats actually have a required second (or third) hit for some reason, these will need to be added back.

This PR also removes the leniency from the Upper Norfair Farming Room gate glitch strat, due to the availability of the good farm right next to the gate.