### PR TITLE
Create script for auto-formatting the JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 .vscode/*
+scripts/.idea/*
 
 __pycache__
 *.pyc

--- a/scripts/autoformat.py
+++ b/scripts/autoformat.py
@@ -1,0 +1,22 @@
+# Tool to auto-format all the region files in a standard way.
+#
+# To use, run "python autoformat.py" from a working directory of "sm-json-data/scripts".
+
+import json
+from pathlib import Path
+
+import format_json
+
+for path in sorted(Path("../region/").glob("**/*.json")):
+    region_json = json.load(path.open("r"))
+    if region_json.get("$schema") != "../../schema/m3-region.schema.json":
+        continue
+
+    print("Processing", path)
+    new_region_json = format_json.format(region_json, indent=2)
+
+    # Validate that the new JSON is equivalent to the old (i.e. the differences affect formatting only):
+    assert json.loads(new_region_json) == region_json
+
+    # Write the auto-formatted output:
+    path.write_text(new_region_json)

--- a/scripts/format_json.py
+++ b/scripts/format_json.py
@@ -1,0 +1,73 @@
+# Library for formatting JSON in a standard way for this project.
+
+import json
+
+
+def is_one_liner_dict(obj, nesting_allowed=True):
+    if len(json.dumps(obj)) > 50:
+        return False
+    if len(obj) == 0:
+        return True
+    if len(obj) == 1:
+        value = next(iter(obj.values()))
+        return is_one_liner(value, nesting_allowed=nesting_allowed)
+    else:
+        return all(isinstance(x, (str, int, float, bool)) for x in obj.values())
+
+
+def is_one_liner_list(obj, nesting_allowed=True):
+    if len(json.dumps(obj)) > 50:
+        return False
+    if len(obj) == 0:
+        return True
+    if len(obj) == 1:
+        return is_one_liner(obj[0], nesting_allowed=nesting_allowed)
+    else:
+        return all(isinstance(x, (str, int, float, bool)) for x in obj)
+
+
+def is_one_liner(obj, nesting_allowed=True):
+    # Only one level of nesting is allowed inside a one-line object or list:
+    if isinstance(obj, dict):
+        return nesting_allowed and is_one_liner_dict(obj, nesting_allowed=False)
+    elif isinstance(obj, list):
+        return nesting_allowed and is_one_liner_list(obj, nesting_allowed=False)
+    else:
+        return True
+
+
+def format(obj, indent, current_indent=0, one_liner_dict_allowed=True):
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return json.dumps(obj)
+    if isinstance(obj, list):
+        if is_one_liner_list(obj):
+            return json.dumps(obj)
+        next_indent = current_indent + indent
+        output_list = []
+        output_list.append("[\n")
+        for i, value in enumerate(obj):
+            output_list.append(next_indent * " " + format(value, indent, next_indent))
+            if i != len(obj) - 1:
+                output_list.append(",\n")
+        output_list.append("\n" + current_indent * " " + "]")
+        return ''.join(output_list)
+    if isinstance(obj, dict):
+        if len(obj) == 0 or (one_liner_dict_allowed and is_one_liner_dict(obj)):
+            return json.dumps(obj)
+        if one_liner_dict_allowed and len(obj) == 1:
+            key, value = next(iter(obj.items()))
+            return '{' + json.dumps(key) + ': ' + format(value, indent, current_indent,
+                                                         one_liner_dict_allowed=False) + '}'
+        next_indent = current_indent + indent
+        output_list = []
+        output_list.append("{\n")
+        keys = list(obj.keys())
+        for i, key in enumerate(keys):
+            value = obj[key]
+            output_list.append(next_indent * ' ' + json.dumps(key) + ": " + format(value, indent, next_indent,
+                                                                                   one_liner_dict_allowed=False))
+            if i != len(keys) - 1:
+                output_list.append(",\n")
+        output_list.append('\n' + current_indent * " " + "}")
+        return ''.join(output_list)
+    raise ValueError("Unexpected object type {}: {}".format(type(obj), obj))


### PR DESCRIPTION
This PR adds a script (and library) that can be used to automatically format all the region JSON files in a standardized way.

The main goal of this is to prepare the way to making large-scale changes using tools that operate on the JSON data abstractly, such as splitting apart the region files into separate room files. A secondary purpose is that it cleans up our formatting, ironing out inconsistencies in the use of whitespace.

Note that the script includes a validation to ensure the reformatting is correct: each output parses to an object equivalent to the input.

To run the auto-formatting locally, run "python autoformat.py" from a working directory of `sm-json-data/scripts`.

This PR includes the script only. Afterward a separate PR will apply the output of the script (PR #1115). By splitting it up in this way, it allows pending PRs to avoid conflicts (after the script output is merged) by pulling in the script and running it independently.