### PR TITLE
Update docs to clarify that h_canNavigateHeatRooms is no longer needed

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -199,6 +199,9 @@
               "h_heatProof",
               "canHeatRun"
             ]}
+          ],
+          "devNote": [
+            "This helper is deprecated, as these requirements are now implicitly included in heatFrame requirements."
           ]
         },
         {

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -183,7 +183,7 @@ __Example:__
 ```
 
 #### heatFrames object
-A `heatFrames` object represents the need for Samus to spend time (measured in frames) in a heated room. This is meant to be converted to a flat health value based on item loadout. The vanilla damage for heated rooms is 1 damage every 4 frames, negated by Varia or Gravity Suit.
+A `heatFrames` object represents the need for Samus to spend time (measured in frames) in a heated room. This is meant to be converted to a flat health value based on item loadout. The vanilla damage for heated rooms is 1 damage every 4 frames, negated by Varia or Gravity Suit. The effect of Gravity suit on heat damage may be modified by randomizers. A `heatFrames` object implicitly includes a requirement `{"or": ["h_heatProof", "canHeatRun"]}`.
 
 __Example:__
 ```json


### PR DESCRIPTION
The helper `h_canNavigateHeatRooms` can be deleted after its uses are removed. This PR doesn't try to remove them yet, as there are >900 occurrences, making it not straightforward to do manually. This could probably be done quickly as an automated large-scale change if auto-formatting is accepted (PR #1114 and PR #1115).

Note: The implicit requirement `{"or": ["h_heatProof", "canHeatRun"]}` within heat frames (from `heatFrames` logical requirements as well as from implicit requirements in cross-room strats) is already implemented in Map Rando. 