### PR TITLE
Update Cross-Room X-Ray Climbs

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -528,33 +528,6 @@
             "canCrouchJump",
             "canTrickySpringBallJump"
           ]
-        },
-        {
-          "name": "h_canLeftDoorXRayClimb",
-          "requires": [
-            "canXRayClimb",
-            "canStationarySpinJump"
-          ]
-        },
-        {
-          "name": "h_canRightDoorXRayClimb",
-          "requires": [
-            "canXRayClimb",
-            "canRightSideDoorStuck"
-          ]
-        },
-        {
-          "name": "h_canRightDoorXRayClimbFromWater",
-          "requires": [
-            "canXRayClimb",
-            {"or": [
-              "canRightSideDoorStuckFromWater",
-              {"and": [
-                "Gravity",
-                "canRightSideDoorStuck"
-              ]}
-            ]}
-          ]
         }
       ]
     },

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -650,31 +650,11 @@
                 {
                   "name": "Green Brinstar Main Shaft Right-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [7],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 7,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 7,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen."
                 },
@@ -717,18 +697,11 @@
                 {
                   "name": "Green Brinstar Main Shaft Left-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [8],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 8,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     "canBePatient"
                   ],
                   "note": "Climb up 4 screens."
@@ -3294,18 +3267,11 @@
                 {
                   "name": "Etecoon E-Tank X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom": {
-                      "nodes": [3],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 3,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen.",
                   "devNote": "In truth this goes to node 1, but there's no need to make a link for this since movement between 1 and 2 is free (via 5)."

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -294,18 +294,11 @@
                 {
                   "name": "X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom": {
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     "canBeVeryPatient"
                   ],
                   "note": "6 screen X-Ray climb, and global Zeelas are still active even off camera."
@@ -1579,18 +1572,11 @@
                 {
                   "name": "Big Pink Left-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [5]
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 5,
-                      "inRoomPath": [14, 5],
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen.",
                   "devNote": [
@@ -1923,31 +1909,11 @@
                 {
                   "name": "Big Pink Right-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [8],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 8,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 8,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen."
                 }
@@ -3187,31 +3153,11 @@
                 {
                   "name": "Pink Brinstar Power Bombs X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen."
                 }
@@ -4067,14 +4013,11 @@
                 {
                   "name": "X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     "canBeVeryPatient"
                   ],
                   "note": "Climb up 8 screens."

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -545,18 +545,11 @@
                 {
                   "name": "Red Tower X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
+                    "canXRayClimb"
                   ],
                   "note": "This is a short climb of only a few tiles."
                 }
@@ -1850,31 +1843,11 @@
                 {
                   "name": "Below Spazer X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen."
                 }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -6085,7 +6085,7 @@
                     "Morph",
                     {"or": [
                       "canRiskPermanentLossOfAccess",
-                      "h_canLeftDoorXRayClimb"
+                      "canXRayClimb"
                     ]},
                     {"ammo": { "type": "PowerBomb", "count": 9 }},
                     "canBeVeryPatient",

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -768,9 +768,11 @@
                 {
                   "name": "X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateHeatRooms",
-                    "h_canLeftDoorXRayClimb",
+                    "canXRayClimb",
                     {"enemyDamage": {
                        "enemy": "Yellow Space Pirate (wall)",
                        "type": "contact",
@@ -779,12 +781,6 @@
                     {"enemyKill": {
                       "enemies": [ [ "Yellow Space Pirate (standing)", "Yellow Space Pirate (wall)" ] ],
                       "explicitWeapons": ["Missile","Super"]
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 1,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
                     }},
                     {"heatFrames": 1260}
                   ],
@@ -1865,19 +1861,11 @@
                 {
                   "name": "Writg X-Ray Climb",
                   "notable": true,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateHeatRooms",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     {"enemyDamage": {
                       "enemy": "Namihe",
                       "type": "fireball",
@@ -4505,19 +4493,11 @@
                 {
                   "name": "Wasteland X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateHeatRooms",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes":[1],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 1,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     {"heatFrames": 2800}
                   ],
                   "note": "Climb up 2 screens.",

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -1737,19 +1737,11 @@
                 {
                   "name": "Screw Attack Room Left-Side X-Ray Climb (to Middle Door)",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateHeatRooms",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 1,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     {"heatFrames": 1000}
                   ],
                   "note": "Climb up half a screen.",
@@ -1781,19 +1773,11 @@
                 {
                   "name": "Screw Attack Room Left-Side X-Ray Climb (to Top Door)",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateHeatRooms",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 1,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     {"heatFrames": 2800}
                   ],
                   "note": "Climb up 2 screens.",
@@ -1901,32 +1885,11 @@
                 {
                   "name": "Screw Attack Right-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateHeatRooms",
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]},
+                    "canXRayClimb",
                     {"heatFrames": 1600}
                   ],
                   "note": "Climb up 1 screen.",

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -127,20 +127,10 @@
                 {
                   "name": "Oasis Left-Side X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "h_canNavigateUnderwater",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 1,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "This is a short climb, only a few tiles."
                 }
               ],
@@ -167,32 +157,10 @@
                 {
                   "name": "Oasis Right-Side X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "h_canRightDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "This is a short climb, only a few tiles."
                 }
               ],
@@ -2521,19 +2489,11 @@
                 {
                   "name": "Pants Room Left-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateUnderwater",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 1,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }},
+                    "canXRayClimb",
                     "canBePatient"
                   ],
                   "note": [
@@ -2587,31 +2547,11 @@
                 {
                   "name": "Pants Room Right-Side X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [3],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 3,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 3,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]},
+                    "canXRayClimb",
                     "canBePatient"
                   ],
                   "note": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -3670,26 +3670,6 @@
                   "notable": false,
                   "requires": [ "f_DefeatedDraygon" ]
                 }
-              ],
-              "bypassStrats": [
-                {
-                  "name": "Halfie Climb Room Xray Climb Grapple Clip",
-                  "notable": true,
-                  "entranceCondition": {
-                    "comeInWithDoorStuckSetup": {}
-                  },
-                  "requires": [
-                    "canXRayClimb",
-                    "canGrappleClip"
-                  ],
-                  "note": [
-                    "Perform an Xray Climb until you are just above the door into Cacatac Alley.",
-                    "Walk left into the gap between pipes, behind the grapple blocks.",
-                    "Walk to the left wall, turn around, crouch, grapple the block and release.",
-                    "Samus will fall into the door transition.",
-                    "The camera Does not follow Samus but the pipes are still visually in the same position.  And the camera does not break after the transition."
-                  ]
-                }
               ]
             }
           ]
@@ -4162,6 +4142,25 @@
                       "excessFrames": 3
                     }}
                   ]
+                },
+                {
+                  "name": "Halfie Climb Room Xray Climb Grapple Clip",
+                  "notable": true,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": [
+                    "canXRayClimb",
+                    "canGrappleClip"
+                  ],
+                  "note": [
+                    "Perform an Xray Climb until you are just above the door into Cacatac Alley.",
+                    "Walk left into the gap between pipes, behind the grapple blocks.",
+                    "Walk to the left wall, turn around, crouch, grapple the block and release.",
+                    "Samus will fall into the door transition.",
+                    "The camera Does not follow Samus but the pipes are still visually in the same position.  And the camera does not break after the transition."
+                  ],
+                  "devNote": "FIXME: This strat can bypass the door lock, which is not yet representable."
                 }
               ]
             },

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -983,20 +983,10 @@
                 {
                   "name": "Aqueduct Left-Side X-Ray Climb (Upper)",
                   "notable": true,
-                  "requires": [
-                    "h_canNavigateUnderwater",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [1],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 1,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": [
                     "Climb up 1 screen.",
                     "Aim to end this XRay climb when Samus is visually near but not above the top of the left side door.",
@@ -1079,20 +1069,10 @@
                 {
                   "name": "Aqueduct Left-Side X-Ray Climb (Lower)",
                   "notable": false,
-                  "requires": [
-                    "h_canNavigateUnderwater",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up 1 screen."
                 },
                 {
@@ -1760,32 +1740,10 @@
                 {
                   "name": "Aqueduct Right-Side X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [5],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 5,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 5,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up 1 screen."
                 }
               ]
@@ -3717,21 +3675,12 @@
                 {
                   "name": "Halfie Climb Room Xray Climb Grapple Clip",
                   "notable": true,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateUnderwater",
-                    "h_canLeftDoorXRayClimb",
-                    "canGrappleClip",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
-
+                    "canXRayClimb",
+                    "canGrappleClip"
                   ],
                   "note": [
                     "Perform an Xray Climb until you are just above the door into Cacatac Alley.",
@@ -4146,20 +4095,10 @@
                 {
                   "name": "Halfie Climb X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "canSuitlessMaridia",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up 1 screen."
                 },
                 {
@@ -5295,27 +5234,11 @@
                 {
                   "name": "X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]},
+                    "canXRayClimb",
                     {"or": [
                       "Ice",
                       "Wave",
@@ -5873,20 +5796,10 @@
                 {
                   "name": "Precious Room X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "h_canNavigateUnderwater",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up 2 screens."
                 },
                 {
@@ -6710,20 +6623,10 @@
                 {
                   "name": "X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "canSuitlessMaridia",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                     "nodes": [1],
-                     "mustStayPut": true
-                   }},
-                   {"adjacentRunway": {
-                     "fromNode": 1,
-                     "usedTiles": 0.5,
-                     "overrideRunwayRequirements": true,
-                     "useFrames": 200
-                   }}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up a little less than 1 screen."
                 },
                 {
@@ -7355,27 +7258,11 @@
                 {
                   "name": "X-Ray Climb Space Jump",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canRightDoorXRayClimb",
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]},
+                    "canXRayClimb",
                     "SpaceJump"
                   ],
                   "note": [

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1484,28 +1484,10 @@
                 {
                   "name": "X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "h_canRightDoorXRayClimb",
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up 1 screen."
                 }
               ],
@@ -9005,20 +8987,10 @@
                 {
                   "name": "Crab Hole Left-Side X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "h_canNavigateUnderwater",
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up 1 screen."
                 },
                 {
@@ -9195,32 +9167,10 @@
                 {
                   "name": "Crab Hole Right-Side X-Ray Climb",
                   "notable": false,
-                  "requires": [
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [3],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 3,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 3,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]}
-                  ],
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
+                  "requires": ["canXRayClimb"],
                   "note": "Climb up 1 screen."
                 },
                 {

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -2530,18 +2530,11 @@
                 {
                   "name": "Bubble Mountain X-Ray Climb (Top-Mid to Top)",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom": {
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen."
                 }
@@ -2569,18 +2562,11 @@
                 {
                   "name": "Bubble Mountain X-Ray Climb (Bot-Mid to Top)",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom": {
-                      "nodes": [3],
-                      "mustStayPut": true
-                    }}  ,
-                    {"adjacentRunway": {
-                      "fromNode": 3,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 2 screens."
                 }
@@ -2618,18 +2604,11 @@
                 {
                   "name": "Bubble Mountain X-Ray Climb (Bottom)",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom": {
-                      "nodes": [4],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 4,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 1 screen."
                 }

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -1088,18 +1088,11 @@
                 {
                   "name": "Ice Beam Gate Room X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canLeftDoorXRayClimb",
-                    {"resetRoom":{
-                      "nodes":[2],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 2,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "useFrames": 200
-                    }}
+                    "canXRayClimb"
                   ],
                   "note": "Climb up 2 screens."
                 }
@@ -2583,32 +2576,11 @@
                 {
                   "name": "Crumble Shaft X-Ray Climb",
                   "notable": false,
+                  "entranceCondition": {
+                    "comeInWithDoorStuckSetup": {}
+                  },
                   "requires": [
-                    "h_canNavigateHeatRooms",
-                    "h_canRightDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [2],
-                      "mustStayPut": true
-                    }},
-                    {"or": [
-                      {"adjacentRunway": {
-                        "fromNode": 2,
-                        "usedTiles": 0.5,
-                        "overrideRunwayRequirements": true,
-                        "physics": ["normal"],
-                        "useFrames": 200
-                      }},
-                      {"and": [
-                        "h_canRightDoorXRayClimbFromWater",
-                        {"adjacentRunway": {
-                          "fromNode": 2,
-                          "usedTiles": 0.5,
-                          "overrideRunwayRequirements": true,
-                          "physics": ["water"],
-                          "useFrames": 200
-                        }}
-                      ]}
-                    ]},
+                    "canXRayClimb",
                     {"heatFrames": 4000},
                     "canBePatient"
                   ],


### PR DESCRIPTION
This was prioritized because currently new and old x-ray climbs have different leniency factors.

I did get rid of some `canNavigateUnderwater` (not really affecting x-ray movement and wont matter at this difficulty) and `canHeatRun` (implied by the heat frames and wont matter at this difficulty).