### PR TITLE
Change room name of green brin main shaft

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -3,7 +3,7 @@
   "rooms": [
     {
       "id": 44,
-      "name": "Green Brinstar Main Shaft / Etecoon Room",
+      "name": "Green Brinstar Main Shaft",
       "area": "Brinstar",
       "subarea": "Green",
       "playable": true,


### PR DESCRIPTION
The slash in the name was going to create a problem when we split region files into room files. Also, this way the room name now matches the name in the Wiki (https://wiki.supermetroid.run/Green_Brinstar_Main_Shaft).