### PR TITLE
Runway migration: a few more Green Brin rooms

### DIFF
--- a/region/brinstar/green/Etecoon Save Room.json
+++ b/region/brinstar/green/Etecoon Save Room.json
@@ -14,21 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019012",
-      "doorEnvironments": [{"physics": "air"}],
-      "runways": [
-        {
-          "name": "Base Runway - Etecoon Save Door (to Etecoon E-Tank)",
-          "length": 3,
-          "strats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": []
-            }
-          ],
-          "openEnd": 1
-        }
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 2,
@@ -43,6 +29,7 @@
     {
       "from": 1,
       "to": [
+        {"id": 1},
         {"id": 2}
       ]
     },
@@ -54,6 +41,18 @@
     }
   ],
   "strats": [
+    {
+      "link": [1, 1],
+      "name": "Leave With Runway",
+      "notable": false,
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 4,
+          "openEnd": 1
+        }
+      },
+      "requires": []
+    },
     {
       "link": [1, 2],
       "name": "Base",

--- a/region/brinstar/green/Etecoon Super Room.json
+++ b/region/brinstar/green/Etecoon Super Room.json
@@ -14,22 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f5e",
-      "doorEnvironments": [{"physics": "air"}],
-      "runways": [
-        {
-          "name": "Base Runway - Etecoon Supers Door (to Etecoon E-Tank)",
-          "length": 2,
-          "strats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": []
-            }
-          ],
-          "usableComingIn": false,
-          "openEnd": 1
-        }
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 2,
@@ -45,6 +30,7 @@
     {
       "from": 1,
       "to": [
+        {"id": 1},
         {"id": 2}
       ]
     },
@@ -56,6 +42,18 @@
     }
   ],
   "strats": [
+    {
+      "link": [1, 1],
+      "name": "Leave With Runway",
+      "notable": false,
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": []
+    },
     {
       "link": [1, 2],
       "name": "Base",

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -104,7 +104,7 @@
         {"enemyDamage": {
           "enemy": "Beetom",
           "type": "contact",
-          "hits": 2
+          "hits": 4
         }}
       ],
       "exitCondition": {

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -15,21 +15,6 @@
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f22",
       "doorEnvironments": [{"physics": "air"}],
-      "runways": [
-        {
-          "name": "Base Runway - Green Brinstar Beetoms Left Door (to Etecoon E-Tank)",
-          "length": 2,
-          "strats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": []
-            }
-          ],
-          "usableComingIn": false,
-          "openEnd": 1
-        }
-      ],
       "leaveWithGModeSetup": [
         {
           "knockback": false,
@@ -50,21 +35,6 @@
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f16",
       "doorEnvironments": [{"physics": "air"}],
-      "runways": [
-        {
-          "name": "Base Runway - Green Brinstar Beetoms Right Door (to Green Shaft)",
-          "length": 2,
-          "strats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": []
-            }
-          ],
-          "usableComingIn": false,
-          "openEnd": 1
-        }
-      ],
       "leaveWithGModeSetup": [
         {
           "knockback": false,
@@ -77,6 +47,13 @@
           ]
         }
       ]
+    }
+  ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Beetoms Dead or Frozen",
+      "obstacleType": "enemies"
     }
   ],
   "enemies": [
@@ -99,11 +76,26 @@
     {
       "from": 2,
       "to": [
-        {"id": 1}
+        {"id": 1},
+        {"id": 2}
       ]
     }
   ],
   "strats": [
+    {
+      "link": [1, 1],
+      "name": "Leave With Runway",
+      "notable": false,
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 3,
+          "openEnd": 1
+        }
+      }
+    },
     {
       "link": [1, 1],
       "name": "Beetom Farm",
@@ -140,6 +132,7 @@
           "excludedWeapons": ["Bombs", "PowerBomb"]
         }}
       ],
+      "clearsObstacles": ["A"],
       "devNote": "They are also possible to jump over with a small runway in the previous room."
     },
     {
@@ -157,6 +150,7 @@
           "hits": 2
         }}
       ],
+      "clearsObstacles": ["A"],
       "note": [
         "You typically need to place two bombs to kill them. Place the second shortly after the first and it will kill the Beetom on your way down.",
         "The remaining Beetoms can be safely killed from the ledge."
@@ -168,7 +162,8 @@
       "notable": false,
       "requires": [
         "Ice"
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 2],
@@ -206,7 +201,8 @@
           "enemies": [["Beetom", "Beetom", "Beetom", "Beetom"]],
           "excludedWeapons": ["Bombs", "PowerBomb"]
         }}
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [2, 1],
@@ -223,6 +219,7 @@
           "hits": 2
         }}
       ],
+      "clearsObstacles": ["A"],
       "note": [
         "You typically need to place two bombs to kill them. Place the second shortly after the first and it will kill the Beetom on your way down.",
         "The remaining Beetoms can be safely killed from the ledge."
@@ -234,7 +231,8 @@
       "notable": false,
       "requires": [
         "Ice"
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [2, 1],
@@ -262,6 +260,20 @@
         }}
       ],
       "note": "Jump on the first possible frame.  Can be buffered to extend the window to 7 frames.  Or jump just before the transition."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Runway",
+      "notable": false,
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 3,
+          "openEnd": 1
+        }
+      }
     }
   ]
 }

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -84,10 +84,28 @@
   "strats": [
     {
       "link": [1, 1],
-      "name": "Leave With Runway",
+      "name": "Leave With Runway (Beetoms Dead or Frozen)",
       "notable": false,
       "requires": [
         {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 3,
+          "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Runway (Tank the Damage)",
+      "notable": false,
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Beetom",
+          "type": "contact",
+          "hits": 2
+        }}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -263,10 +281,28 @@
     },
     {
       "link": [2, 2],
-      "name": "Leave With Runway",
+      "name": "Leave With Runway (Beetoms Dead or Frozen)",
       "notable": false,
       "requires": [
         {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 3,
+          "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Runway (Tank the Damage)",
+      "notable": false,
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Beetom",
+          "type": "contact",
+          "hits": 2
+        }}
       ],
       "exitCondition": {
         "leaveWithRunway": {

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -14,43 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d7e",
-      "doorEnvironments": [{"physics": "air"}],
-      "runways": [
-        {
-          "name": "Base Runway - Green Brinstar Firefleas Left Door (to Missile Recharge)",
-          "length": 6,
-          "strats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": []
-            }
-          ],
-          "openEnd": 1
-        }
-      ],
-      "canLeaveCharged": [
-        {
-          "framesRemaining": 50,
-          "usedTiles": 33,
-          "openEnd": 2,
-          "strats": [
-            {
-              "name": "XMode",
-              "notable": false,
-              "requires": [
-                "h_canXMode",
-                "h_XModeThornHit",
-                "h_XModeThornHit",
-                "h_XModeThornHit",
-                "canShinechargeMovement"
-              ],
-              "note": "Jump into the large patch of thorns from below.",
-              "devNote": "Three thorns hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
-            }
-          ]
-        }
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 2,
@@ -123,11 +87,47 @@
     {
       "from": 2,
       "to": [
-        {"id": 1}
+        {"id": 1},
+        {"id": 2}
       ]
     }
   ],
   "strats": [
+    {
+      "link": [1, 1],
+      "name": "Leave With Runway",
+      "notable": false,
+      "requires": [],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 7,
+          "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Shinecharged (X-Mode)",
+      "notable": false,
+      "requires": [
+        "h_canXMode",
+        "h_XModeThornHit",
+        "h_XModeThornHit",
+        "h_XModeThornHit",
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        "canShinechargeMovement"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 50
+        }
+      },
+      "note": "Jump into the large patch of thorns from below.",
+      "devNote": "Three thorns hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
+    },
     {
       "link": [1, 1],
       "name": "Fireflea Farm",
@@ -151,6 +151,18 @@
       "name": "Base",
       "notable": false,
       "requires": []
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Runway",
+      "notable": false,
+      "requires": [],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 17,
+          "openEnd": 1
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Green Brinstar Beetom Room had the runways as free, which was unsound. Added an obstacle to track the Beetoms being dead or frozen.

In Green Brinstar Fireflea Room, I migrated the left-side X-mode leaveShinecharged, but skipped the right-side one, because it seems like short-charging using the 17-tile runway connected to the door would be easier?