### PR TITLE
Schema change for migrating door-lock bypass strats

### DIFF
--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -604,6 +604,28 @@
       "note": "This is a short climb of only a few tiles."
     },
     {
+      "link": [2, 1],
+      "name": "Very Deep Stuck X-Ray Climb",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
+        "Climb up 2 screens.",
+        "When you reach the door, perform a turnaround buffered spin-jump away from the door, and the wall-jump check will trigger the transition, bypassing any lock on the door.",
+        "If you position 1 pixel from the door transition (not recommended), at the start of the climb you will need to use X-ray when turning around toward the door, to avoid triggering the transition back through the door you came in;",
+        "in this case when you reach the destination door, there is no need for a spin-jump, as simply turning around toward the door will trigger the transition."
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave With Runway",
       "notable": false,

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -104,24 +104,6 @@
                 "f_DefeatedDraygon"
               ]
             }
-          ],
-          "bypassStrats": [
-            {
-              "name": "Butterfly Room Door Lock Wall Ice Clip",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                "canWallIceClip",
-                "Wave",
-                {"enemyDamage": {
-                  "enemy": "Zoa",
-                  "type": "contact",
-                  "hits": 2
-                }}
-              ],
-              "note": "Repeatedly freeze the Zoas to slowly push Samus into the wall and through the locked doorway.",
-              "devNote": "The drops will keep Samus at high energy, but 2 hits enemy damage were added as a worst-case scenario where the next-to-last Zoa you kill doesn't give you energy."
-            }
           ]
         }
       ]
@@ -441,6 +423,24 @@
       "requires": [
         {"refill": ["Energy", "Missile", "Super"]}
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Butterfly Room Door Lock Wall Ice Clip",
+      "notable": true,
+      "requires": [
+        "h_canNavigateUnderwater",
+        "canWallIceClip",
+        "Wave",
+        {"enemyDamage": {
+          "enemy": "Zoa",
+          "type": "contact",
+          "hits": 2
+        }}
+      ],
+      "bypassesDoorShell": true,
+      "note": "Repeatedly freeze the Zoas to slowly push Samus into the wall and through the locked doorway.",
+      "devNote": "The drops will keep Samus at high energy, but 2 hits enemy damage were added as a worst-case scenario where the next-to-last Zoa you kill doesn't give you energy."
     },
     {
       "link": [3, 1],

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -74,7 +74,7 @@ The `locks` property is an array that contains different ways a node can be lock
 * _lock:_ The `lock` property lists [logical requirements](../logicalRequirements.md) that must be fulfilled in order for the node to be locked. If this is missing, the node is considered initially locked at game start.
 * _name:_ A name that identifies the lock. This name must be unique across all locks in the model.
 * _unlockStrats:_ The `unlockStrats` property is an array of [strats](../strats.md), each of which may be executed in order to unlock this specific lock. Unlocking a node makes it possible to interact with the node until the end of the game.
-* _bypassStrats:_ The `bypassStrats` property is an array of [strats](../strats.md), each of which may be executed in order to bypass this specific lock, without deactivating it. This allows interaction with the node once, but the lock remains active for future interactions. An unlock or bypass strat will need to be executed again to interact with the node again.
+* _bypassStrats:_ The `bypassStrats` property is an array of [strats](../strats.md), each of which may be executed in order to bypass this specific lock, without deactivating it. This allows interaction with the node once, but the lock remains active for future interactions. An unlock or bypass strat will need to be executed again to interact with the node again. This property is deprecated; the strat property [`bypassesDoorShell`](../strats.md#bypasses-door-shell) should be used instead.
 * _yields:_ Exactly like the `yields` property found directly on a node, the `yields` property is an array of game flags. However, in this case those flags are activated when unlocking a lock.
 
 __Additional considerations__

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -521,6 +521,12 @@
           "additionalProperties": false,
           "properties": {}
         },
+        "bypassesDoorShell": {
+          "$id": "#/definitions/strat/properties/bypassesDoorShell",
+          "type": "boolean",
+          "description": "Indicates that this strat allows Samus to exit through the door transition without first unlocking or opening the door.",
+          "default": false
+        },
         "clearsObstacles": {
           "$id": "#/definitions/strat/properties/clearsObstacles",
           "type": "array",

--- a/strats.md
+++ b/strats.md
@@ -6,13 +6,15 @@ Strats are usually presented within an array of strats, where all individual str
 ## Structure
 
 A `strat` can have the following properties:
-  * _name:_ The name of the strat.
-  * _notable:_ Indicates whether the strat is notable.
-  * _reusableRoomwideNotable:_ The name of the reusable roomwide notable strat. This must share an identical name with an entry in the `reusableRoomwideNotable` array and the other strats that are connected to this one. This is only applicable for strats where `notable` is `true`.
+  * _name_: The name of the strat.
+  * _notable_: Indicates whether the strat is notable.
+  * _reusableRoomwideNotable_: The name of the reusable roomwide notable strat. This must share an identical name with an entry in the `reusableRoomwideNotable` array and the other strats that are connected to this one. This is only applicable for strats where `notable` is `true`.
   * _entranceCondition_: Indicates that this strat requires entering through the door transition in a special way, combining with a strat in the previous room.
-  * _requires:_ The [logical requirements](logicalRequirements.md) that must be fulfilled to execute that strat.
+  * _requires_: The [logical requirements](logicalRequirements.md) that must be fulfilled to execute that strat.
   * _exitCondition_: Indicates that this strat leaves through the door transition in a special way that combines with a strat in the next room. 
-  * _clearsObstacles:_ An array containing the ID of obstacles that will be cleared by executing this strat (if they are not already cleared).
+  * _clearsObstacles_: An array containing the ID of obstacles that will be cleared by executing this strat (if they are not already cleared).
+  * _gModeRegainMobility_: Indicates that this strat allows regaining mobility when entering with G-mode immobile.
+  * _bypassesDoorShell_: Indicates that this strat allows exiting without opening the door.
   
 These properties are described below in more detail.
 ### Example
@@ -73,7 +75,7 @@ There is some variance in how much downward slopes slow Samus' movement, dependi
 
 ## Exit conditions
 
-In all strats with an `exitCondition`, the `to` node of the strat must be a door node or exit node. If the door has a lock on it, it is required to be unlocked before a strat with an `exitCondition` can be executed: door lock bypass strats cannot be combined with strats having an `exitCondition`. An `exitCondition` object must contain exactly one property, which indicates the type of exit condition provided by the strat:
+In all strats with an `exitCondition`, the `to` node of the strat must be a door node or exit node. If the door has a lock on it, it is required to be unlocked before a strat with an `exitCondition` can be executed, unless the strat has the `bypassesDoorShell` property set to `true`. An `exitCondition` object must contain exactly one property, which indicates the type of exit condition provided by the strat:
 
 - _leaveWithRunway_: This indicates that a runway of a certain length is connected to the door, with which Samus can gain speed and run or jump through the door, among other possible actions. 
 - _leaveShinecharged_: This indicates that it is possible to charge a shinespark and leave the room with a certain amount of time remaining on the shinecharge timer (e.g., so that a shinespark can be activated in the next room). 
@@ -637,3 +639,21 @@ A `gModeRegainMobility` object has no properties.
   ],
   "gModeRegainMobility": {}
 }
+```
+
+## Bypasses Door Shell
+
+A `bypassesDoorShell` property on a strat indicates that Samus can leave through the door transition in the `to` node
+without first unlocking or opening the door. For this to be valid, the `to` node must have `"nodeType": "door"`. This can be used even for doors that are easy to open (e.g. blue doors), to support randomizers that may alter door colors. A strat with `"bypassesDoorShell": true` may also have an exit condition, but it is not required to have one.
+
+### Example
+```json
+{
+  "name": "Bypass Door Shell",
+  "notable": false,
+  "requires": [
+    "canWallIceClip"
+  ],
+  "bypassesDoorShell": true
+}
+```


### PR DESCRIPTION
As part of the cross-room strat migration, this PR makes the necessary schema changes to allow converting "bypassStrats" (in of `node/locks`) into regular strats. This also allows more types of door-lock bypass strats to be expressed, since a bypass strat could now start at any node, not necessarily only at the door node that it exits through. A couple examples are included: one for migrating the Butterfly Room gray lock bypass strat, and another for a Very Deep Stuck X-Ray climb in Red Tower that wouldn't have been expressible before.

At some point we will also want to migrate "unlockStrats", e.g. to help us more accurately represent requirements to unlock doors where heat, lava, acid, and/or enemies are a factor; this is more complicated, because it can depend on the door color, meaning multiple possibilities might need to be considered since we want the logic to be able to work with randomized doors.

**Note**: Map Rando never made use of the `bypassStrats` in `node/locks`; as we migrate these to regular strats, it will start using them.
