### PR TITLE
Add script to rename room diagrams

### DIFF
--- a/scripts/rename_room_diagrams.py
+++ b/scripts/rename_room_diagrams.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+import copy
+
+for path in sorted(Path("../region/").glob("**/roomDiagrams/*.png")):
+    parts = path.stem.split("_")
+    assert len(parts) == 3
+    new_stem = "_".join([parts[0], parts[2], parts[1]])
+    new_filename = new_stem + ".png"
+    new_path = Path(path.parent) / new_filename
+    print("Renaming", path, " -> ", new_path)
+    path.rename(new_path)
+


### PR DESCRIPTION
This implements @kjbranch's proposal to put the room ID at the end of the room diagram filename, so that the order of these filenames (when sorted alphabetically) will be consistent with that of the room JSON files.

Run it locally by executing `python rename_room_diagrams.py` from a working directory of `scripts/`. The output should be committed in a separate PR.