### PR TITLE
Fix malformed 'Wave+Spazer' req in Bubble Mountain

### DIFF
--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1148,7 +1148,10 @@
         "canHeroShot",
         {"shinespark": {"frames": 25}},
         {"or": [
-          "Wave+Spazer",
+          {"and": [
+            "Wave",
+            "Spazer"
+          ]},
           "Plasma",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 2}}


### PR DESCRIPTION
Odd that the tests didn't catch this. I guess the tests would see "Wave+Spazer" in weapons.json and assume it would be a valid logical requirement.