### PR TITLE
Make notable false by default, create script to remove notable false

### DIFF
--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -56,7 +56,6 @@
       "type": "object",
       "required": [
         "name",
-        "notable",
         "requires"
       ],
       "additionalProperties": false,
@@ -64,15 +63,11 @@
         {
           "if": {
             "properties": {
-              "notable": {"const": false}
-            }
+              "notable": {"const": true}
+            },
+            "required": ["notable"]
           },
           "then": {
-            "not": {
-              "required": ["reusableRoomwideNotable"]
-            }
-          },
-          "else": {
             "required": ["note"]
           }
         }
@@ -104,7 +99,8 @@
         },
         "notable": {
           "$id": "#/definitions/strat/properties/notable",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "reusableRoomwideNotable": {
           "$id": "#/definitions/strat/properties/reusableRoomwideNotable",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -63,11 +63,15 @@
         {
           "if": {
             "properties": {
-              "notable": {"const": true}
-            },
-            "required": ["notable"]
+              "notable": {"const": false}
+            }
           },
           "then": {
+            "not": {
+              "required": ["reusableRoomwideNotable"]
+            }
+          },
+          "else": {
             "required": ["note"]
           }
         }

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -63,16 +63,17 @@
         {
           "if": {
             "properties": {
-              "notable": {"const": false}
-            }
+              "notable": {"const": true}
+            },
+            "required": ["notable"]
           },
           "then": {
+            "required": ["note"]
+          },
+          "else": {
             "not": {
               "required": ["reusableRoomwideNotable"]
             }
-          },
-          "else": {
-            "required": ["note"]
           }
         }
       ],

--- a/scripts/remove_notable_false.py
+++ b/scripts/remove_notable_false.py
@@ -1,0 +1,18 @@
+# This script removes occurrences of `"notable": false` in strats since this is now the default.
+
+import json
+from pathlib import Path
+import copy
+
+import format_json
+
+
+for path in sorted(Path("../region").glob("**/*.json")):
+    room_json = json.load(path.open("r"))
+    if room_json.get("$schema") != "../../../schema/m3-room.schema.json":
+        continue
+    print("Processing", path)
+    for strat in room_json["strats"]:
+        if strat.get("notable") == False:
+            del strat["notable"]
+    path.write_text(format_json.format(room_json, indent=2))


### PR DESCRIPTION
This changes the room schema to make "notable" an optional property which only needs to be specified if it is "true". A script is created which can then strip out `"notable": false` from all the strats.