### PR TITLE
Tourian Crystal Flash strats

### DIFF
--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -83,6 +83,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -328,6 +328,10 @@
           "nodes": [1],
           "mustStayPut": false
         }},
+        {"resetRoom": {
+          "nodes": [2],
+          "mustStayPut": false
+        }},
         "canTrickyJump",
         "h_canCrystalFlash"
       ],
@@ -336,7 +340,8 @@
         "After 6 hops, the bottom Hopper will do three big hops in a row.",
         "Roll under the Hopper while it does the third of those three big hops.",
         "Quickly unmorph and run to the right side of the room.",
-        "If successful, both Hoppers will remain off-camera, so you can safely Crystal Flash."
+        "If successful, both Hoppers will remain off-camera, so you can safely Crystal Flash.",
+        "Reset the room through the top door before returning to the left."
       ]
     }
   ]

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -319,6 +319,25 @@
         }
       },
       "devNote": "FIXME: Add requirements to be able to use this runway."
+    },
+    {
+      "link": [2, 2],
+      "name": "Crystal Flash",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [1],
+          "mustStayPut": false
+        }},
+        "canTrickyJump",
+        "h_canCrystalFlash"
+      ],
+      "note": [
+        "Enter the room from the left door, morph, and wait at the left wall.",
+        "After 6 hops, the bottom Hopper will do three big hops in a row.",
+        "Roll under the Hopper while it does the third of those three big hops.",
+        "Quickly unmorph and run to the right side of the room.",
+        "If successful, both Hoppers will remain off-camera, so you can safely Crystal Flash."
+      ]
     }
   ]
 }

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -322,7 +322,8 @@
     },
     {
       "link": [2, 2],
-      "name": "Crystal Flash",
+      "name": "Tourian Blue Hopper Crystal Flash",
+      "notable": true,
       "requires": [
         {"resetRoom": {
           "nodes": [1],

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -88,6 +88,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Lower Tourian Save Room.json
+++ b/region/tourian/main/Lower Tourian Save Room.json
@@ -54,6 +54,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -231,7 +231,11 @@
     {
       "link": [1, 1],
       "name": "Crystal Flash",
-      "requires": ["h_canCrystalFlash"]
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "h_canCrystalFlash"
+      ],
+      "note": ["Be sure to be at a safe distance from Rinkas before performing the Crystal Flash."]
     },
     {
       "link": [1, 2],
@@ -430,11 +434,7 @@
     {
       "link": [2, 2],
       "name": "Crystal Flash",
-      "requires": [
-        {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash"
-      ],
-      "note": ["Be sure to be at a safe distance from Rinkas before performing the Crystal Flash."]
+      "requires": ["h_canCrystalFlash"]
     },
     {
       "link": [2, 4],

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -229,6 +229,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },
+    {
       "link": [1, 2],
       "name": "Shinespark Midair",
       "notable": false,
@@ -421,6 +426,15 @@
           "framesRemaining": 120
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Crystal Flash",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "h_canCrystalFlash"
+      ],
+      "note": ["Be sure to be at a safe distance from Rinkas before performing the Crystal Flash."]
     },
     {
       "link": [2, 4],

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -368,6 +368,23 @@
         }
       },
       "devNote": "FIXME: Is it worth adding a method with avoiding the Metroids?"
+    },
+    {
+      "link": [2, 2],
+      "name": "Crystal Flash",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "h_canCrystalFlash",
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "note": [
+        "To avoid heavy Rinka damage, you must perform the Crystal Flash on a specific tile: on the third floor tile from the left wall.",
+        "Lay the Power Bomb immediately after destroying both Rinkas."
+      ]
     }
   ]
 }

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -439,6 +439,15 @@
       "exitCondition": {
         "leaveWithSpark": {}
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Crystal Flash",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "h_canCrystalFlash"
+      ],
+      "note": ["Be at a safe distance from Rinkas before performing the Crystal Flash."]
     }
   ]
 }

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -127,6 +127,25 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": [
+        {"or": [
+          {"resetRoom": {
+            "nodes": [1],
+            "mustStayPut": false
+          }},
+          "Ice",
+          {"obstaclesCleared": ["A"]}
+        ]},
+        "h_canCrystalFlash"
+      ],
+      "note": [
+        "To avoid heavy Rinka damage, perform the Crystal Flash while backed against the left door or inside the open door frame.",
+        "Lay the Power Bomb immediately after destroying the Rinka with the closer spawn location."
+      ]
+    },
+    {
       "link": [1, 2],
       "name": "Already Cleared",
       "notable": false,

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -146,6 +146,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -88,6 +88,12 @@
       "note": "If coming from below, carefully get up on the left side of the room without breaking the runway blocks."
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"],
+      "devNote": "If it is needed to use one of the extended runways, then the Crystal Flash can be performed on the opposite side of the room from the needed runway."
+    },    
+    {
       "link": [1, 3],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -72,6 +72,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -78,6 +78,7 @@
     {
       "from": 1,
       "to": [
+        {"id": 1},
         {"id": 2}
       ]
     },
@@ -90,6 +91,11 @@
     }
   ],
   "strats": [
+    {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },    
     {
       "link": [1, 2],
       "name": "Base",

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -103,6 +103,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },
+    {
       "link": [1, 2],
       "name": "Pass Through Pirates",
       "notable": false,
@@ -486,6 +491,11 @@
           "framesRemaining": 120
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
     }
   ]
 }

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -104,7 +104,8 @@
         {
           "id": 2,
           "note": "The acid starts rising when Samus is at the bottom of the long fall"
-        }
+        },
+        {"id": 3}
       ]
     }
   ],
@@ -120,6 +121,11 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
     },
     {
       "link": [1, 3],
@@ -431,6 +437,12 @@
       ],
       "clearsObstacles": ["A"],
       "devNote": "IBJ can be used to avoid wall jumps before the acid starts rising, but a crouch jump down grab is needed near the right door."
+    },
+    {
+      "link": [3, 3],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"],
+      "devNote": "The Crystal Flash should be performed on a platform away from the acid trigger or any Pirates."
     }
   ]
 }

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -71,6 +71,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },    
+    {
       "link": [1, 2],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Tourian First Room.json
+++ b/region/tourian/main/Tourian First Room.json
@@ -76,6 +76,11 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },    
+    {
       "link": [2, 3],
       "name": "Base",
       "notable": false,

--- a/region/tourian/main/Upper Tourian Save Room.json
+++ b/region/tourian/main/Upper Tourian Save Room.json
@@ -54,6 +54,11 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Crystal Flash",
+      "requires": ["h_canCrystalFlash"]
+    },    
+    {
       "link": [1, 2],
       "name": "Base",
       "notable": false,


### PR DESCRIPTION
For Tourian Blue Hopper Room, I was experimenting for a while with a strat to lure both Hoppers to the right when entering from the top, to be able to do a Crystal Flash safely on the left. It works a lot of the time but I wasn't able to find a consistent setup yet so I didn't add that one. The one entering from the left though seems very reliable.