### PR TITLE
Adding missing Base strat in Etecoon ETank Room

### DIFF
--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -318,6 +318,11 @@
     },
     {
       "link": [2, 3],
+      "name": "Base",
+      "requires": []
+    },
+    {
+      "link": [2, 3],
       "name": "Leave Shinecharged (Fall Through Crumbles)",
       "notable": false,
       "exitCondition": {


### PR DESCRIPTION
This is the strat that just falls down through the crumble blocks. Somehow I accidentally deleted it during the runway migration.