### PR TITLE
Schema changes to represent cross-room spark position

### DIFF
--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -158,7 +158,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "note": [
         "It is possible to run through the Yapping Maw while it is attacking a different direction.",
@@ -185,7 +187,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       }
     },
     {
@@ -206,7 +210,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "note": "Freeze the Yapping Maw while it is in the air, extended."
     },
@@ -434,7 +440,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "devNote": "The yapping maw prevents use of an extra runway tile because it will move to grab Samus"
     },
@@ -458,7 +466,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       }
     },
     {
@@ -479,7 +489,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "note": [
         "Jump towards the yapping maw before it is on screen so it moves up.",

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -608,7 +608,9 @@
       "name": "Shinespark",
       "notable": false,
       "entranceCondition": {
-        "comeInWithSpark": {}
+        "comeInWithSpark": {
+          "position": "bottom"
+        }
       },
       "requires": [
         "Gravity",
@@ -620,7 +622,9 @@
       "name": "Suitless Shinespark",
       "notable": false,
       "entranceCondition": {
-        "comeInWithSpark": {}
+        "comeInWithSpark": {
+          "position": "bottom"
+        }
       },
       "requires": [
         {"shinespark": {"frames": 143, "excessFrames": 10}}
@@ -1527,7 +1531,9 @@
       "name": "Suitless Shinespark",
       "notable": false,
       "entranceCondition": {
-        "comeInWithSpark": {}
+        "comeInWithSpark": {
+          "position": "bottom"
+        }
       },
       "requires": [
         {"shinespark": {"frames": 127, "excessFrames": 10}}

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -273,7 +273,14 @@
               "description": "Represents a requirement that Samus come in by shinesparking through the door.",
               "required": [],
               "additionalProperties": false,
-              "properties": {}
+              "properties": {
+                "position": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithSpark/properties/position",
+                  "type": "string",
+                  "description": "Required position in the doorway while entering.",
+                  "enum": ["top", "bottom"]
+                }
+              }
             },
             "comeInStutterShinecharging": {
               "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInStutterShinecharging",
@@ -494,7 +501,14 @@
               "description": "Represents that Samus can leave through this door with a shinespark.",
               "required": [],
               "additionalProperties": false,
-              "properties": {}
+              "properties": {
+                "position": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithSpark/properties/position",
+                  "type": "string",
+                  "description": "Possible positions in the doorway while exiting.",
+                  "enum": ["top", "bottom"]
+                }
+              }
             },
             "leaveWithStoredFallSpeed": {
               "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithStoredFallSpeed",

--- a/strats.md
+++ b/strats.md
@@ -466,7 +466,7 @@ A strat with a `comeInWithSpark` condition should include a `shinespark` require
 
 A `comeInWithSpark` condition must match with either a `leaveWithSpark`, `leaveShinecharged`, or `leaveWithRunway` condition on the other side of the door:
 
-- A match with `leaveWithSpark` is valid as long as the `position` properties are compatible. The `position`` properties of a `leaveWithSpark` and `comeInWithSpark` are compatible if they are equal or if at least one of them are unspecified.
+- A match with `leaveWithSpark` is valid as long as the `position` properties are compatible. The `position` properties of a `leaveWithSpark` and `comeInWithSpark` are compatible if they are equal or if at least one of them are unspecified.
 - A match with `leaveShinecharged` is always valid and does not come with any implicit requirements.
 - A match with `leaveWithRunway` comes with the following implicit requirements (the same as for `comeInShinecharged`) for actions to be performed in the previous room:
   - A `canShinecharge` requirement is included based on the runway length. This includes a `SpeedBooster` item requirement as well as a check that the effective runway length is enough that charging a shinespark is possible.

--- a/strats.md
+++ b/strats.md
@@ -152,7 +152,10 @@ A strat with a `leaveShinecharged` condition should include a `canShinecharge` r
 
 A `leaveWithSpark` exit condition represents that Samus can leave through this door while shinesparking. A strat with a `leaveWithSpark` condition should include a `canShinecharge` and `shinespark` requirements in its `requires`.
 
-The `leaveWithSpark` object currently has no properties. If needed, properties might be added in the future to describe constraints on the position and direction of the spark. Currently it is implicitly assumed that the position can be fully controlled to be whatever is needed in the next room (e.g. to spark through either the top or bottom part of a horizontal door transition); so the requirements of a `leaveWithSpark` strat should be based on the worst-case scenario. The direction of the spark is assumed to be horizontal when sparking through horizontal door transitions, or vertical when sparking through vertical door transitions.
+The `leaveWithSpark` object has the following property:
+- _position_: For a horizontal transition, if specified, this takes two possible values, "top" or "bottom". The value "top" represents that the strat sparks through the doorway high enough to clear a single-tile block level with the bottom of the doorway. The value "bottom" represents that the strat sparks through the doorway low enough to clear a single-tile block level with the top of the doorway. If unspecified, it is understood that the strat can exit through either the top or bottom of the doorway, whichever is needed in the next room.
+
+The direction of the spark is assumed to be horizontal when sparking through horizontal door transitions, or vertical when sparking through vertical door transitions.
 
 *Note*: Using a runway connected to a door to leave the room with a shinespark is already covered by `leaveWithRunway`. Likewise `leaveShinecharged` implicitly includes the possibility of leaving the room with a shinespark. It is only necessary to use `leaveWithSpark` in cases where it would not be possible to reach the door before the shinecharge timer expires.
 
@@ -452,13 +455,19 @@ A `comeInShinecharged` must match with either a `leaveShinecharged` condition or
 
 ### Come In With Spark
 
-A `comeInWithSpark` entrance condition indicates that Samus must shinespark into the room. The `comeInWithSpark` object has no properties. Properties might be added in the future to describe requirements on the position and direction of the spark. Currently it is implicitly assumed that the position can be fully controlled in the previous room, so a `comeInWithSpark` strat may make any assumptions needed about the position. The direction of the spark is assumed to be horizontal when sparking through horizontal door transitions, or vertical when sparking through vertical door transitions.
+A `comeInWithSpark` entrance condition indicates that Samus must shinespark into the room.
+
+The `comeInWithSpark` object has the following property:
+- _position_: For a horizontal transition, if specified, this takes two possible values, "top" or "bottom". The value "top" represents that the strat requires sparking through the doorway high enough to clear a single-tile block level with the bottom of the doorway. The value "bottom" represents that the strat requires sparking through the doorway low enough to clear a single-tile block level with the top of the doorway. If unspecified, it is understood that sparking in any position will work.
+
+The direction of the spark is assumed to be horizontal when sparking through horizontal door transitions, or vertical when sparking through vertical door transitions.
 
 A strat with a `comeInWithSpark` condition should include a `shinespark` requirement in its `requires`.
 
 A `comeInWithSpark` condition must match with either a `leaveWithSpark`, `leaveShinecharged`, or `leaveWithRunway` condition on the other side of the door:
 
-- A match with `leaveWithSpark` or `leaveShinecharged` is always valid and does not come with any implicit requirements.
+- A match with `leaveWithSpark` is valid as long as the `position` properties are compatible. The `position`` properties of a `leaveWithSpark` and `comeInWithSpark` are compatible if they are equal or if at least one of them are unspecified.
+- A match with `leaveShinecharged` is always valid and does not come with any implicit requirements.
 - A match with `leaveWithRunway` comes with the following implicit requirements (the same as for `comeInShinecharged`) for actions to be performed in the previous room:
   - A `canShinecharge` requirement is included based on the runway length. This includes a `SpeedBooster` item requirement as well as a check that the effective runway length is enough that charging a shinespark is possible.
   - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as in `comeInShinecharging`, except here with `comeInShinecharged` there is no second runway to combine with.


### PR DESCRIPTION
This addresses issue #1185 by adding a new property `position` to the exit/entrance conditions `leaveWithSpark`/`comeInWithSpark`. Only horizontal sparks are considered for now, and the new `position` property indicates the vertical position in the doorway during the transition. Just having two positions `top` and `bottom` appears to be precise enough to model everything that we need (for now).

The new property is applied in Gauntlet Entrance and Mt. Everest, fixing the example of unsound logic mentioned in the issue.