### PR TITLE
Rest of Very Deep Stuck strats

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -184,7 +184,7 @@ __Example:__
 
 #### autoReserveTrigger object
 
-An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves, and reserve energy becoming zero. It has two optional properties:
+An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves (capped to energy capacity), and reserve energy becoming zero. It has two optional properties:
 
 * _minReserveEnergy_: The minimum amount of energy in reserves which will satisfy this requirement (default: 1).
 * _maxReserveEnergy_: The maximum amount of energy in reserves which will satisfy this requirement (default: 400).

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -184,7 +184,10 @@ __Example:__
 
 #### autoReserveTrigger object
 
-An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves, and reserve energy becoming zero.
+An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves, and reserve energy becoming zero. It has two optional properties:
+
+* _minReserveEnergy_: The minimum amount of energy in reserves which will satisfy this requirement (default: 1).
+* _maxReserveEnergy_: The maximum amount of energy in reserves which will satisfy this requirement (default: 400).
 
 __Example:__
 ```json

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -182,6 +182,15 @@ __Example:__
 {"energyAtMost": 1}
 ```
 
+#### autoReserveTrigger object
+
+An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves, and reserve energy becoming zero.
+
+__Example:__
+```json
+{"autoReserveTrigger": {}}
+```
+
 #### heatFrames object
 A `heatFrames` object represents the need for Samus to spend time (measured in frames) in a heated room. This is meant to be converted to a flat health value based on item loadout. The vanilla damage for heated rooms is 1 damage every 4 frames, negated by Varia or Gravity Suit. The effect of Gravity suit on heat damage may be modified by randomizers. A `heatFrames` object implicitly includes a requirement `{"or": ["h_heatProof", "canHeatRun"]}`.
 

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -373,10 +373,6 @@
         }
       },
       "requires": [
-        {"or": [
-          "canArtificialMorph",
-          "f_KilledMetroidRoom2"
-        ]},
         "h_canCrystalFlash",
         {"autoReserveTrigger": {}},
         "canXRayClimb",

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -344,6 +344,60 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Very Deep Stuck X-Ray Climb With Ice",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "Ice",
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, and quickly freeze the Metroids (if still alive) and Rinkas.",
+        "Climb up 1 screen, moving quickly to avoid Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Very Deep Stuck X-Ray Climb With Crystal Flash",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"or": [
+          "canArtificialMorph",
+          "f_KilledMetroidRoom2"
+        ]},
+        "h_canCrystalFlash",
+        {"autoReserveTrigger": {}},
+        "canXRayClimb",
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, using artificial morph to avoid the Metroids if they are still alive.",
+        "Go to the top of the room and Crystal Flash, with the Metroids stuck below (if alive).",
+        "The Crystal Flash will leave behind a light orb, which can be used to kill the Metroids.",
+        "Use the Rinkas to damage down.",
+        "Stand in the open doorway to take the last hit to trigger auto reserves, which will cancel G-mode, closing the door on top of Samus.",
+        "Climb up 1 screen, moving quickly to minimize Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "notable": false,

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -345,6 +345,40 @@
     },
     {
       "link": [2, 1],
+      "name": "Very Deep Stuck X-Ray Climb With Immobile",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false,
+          "mobility": "immobile"
+        }
+      },
+      "requires": [
+        "f_KilledMetroidRoom2",
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 1
+        }},
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter immobile with G-mode direct, with the Metroids having been killed previously.",
+        "Take a Rinka hit to regain mobility.",
+        "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
+        "Climb up 1 screen, moving quickly to minimize Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ],
+      "devNote": [
+        "The 'immobile' requirement in the entranceCondition is not necessary but is included for clarity.",
+        "Without coming in immobile, it would not be possible to have enough energy to survive the Rinka hit.",
+        "The enemyDamage in this strat is for a second Rinka hit while climbing.",
+        "The first Rinka hit is included in the gModeImmobile requirement."
+      ]
+    },
+    {
+      "link": [2, 1],
       "name": "Very Deep Stuck X-Ray Climb With Ice",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -359,6 +393,7 @@
       "bypassesDoorShell": true,
       "note": [
         "Enter with G-mode direct, and quickly freeze the Metroids (if still alive) and Rinkas.",
+        "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, moving quickly to avoid Rinka damage.",
         "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]
@@ -388,7 +423,8 @@
         "Go to the top of the room and Crystal Flash, with the Metroids stuck below (if alive).",
         "The Crystal Flash will leave behind a light orb, which can be used to kill the Metroids.",
         "Use the Rinkas to damage down.",
-        "Stand in the open doorway to take the last hit to trigger auto reserves, which will cancel G-mode, closing the door on top of Samus.",
+        "For the final hit that will trigger auto-reserves, stand in the open doorway between 1 and 6 pixels from the transition.",
+        "The auto reserve trigger will cancel G-mode and close the door on top of Samus.",
         "Climb up 1 screen, moving quickly to minimize Rinka damage.",
         "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -202,6 +202,38 @@
     },
     {
       "link": [3, 1],
+      "name": "Very Deep Stuck X-Ray Climb With Immobile",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false,
+          "mobility": "immobile"
+        }
+      },
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 1
+        }},
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter immobile with G-mode direct, taking a Rinka hit to regain mobility.",
+        "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
+        "Climb up 2 screens, moving quickly to minimize Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ],
+      "devNote": [
+        "The 'immobile' requirement in the entranceCondition is not necessary but is included for clarity.",
+        "Without coming in immobile, it would not be possible to have enough energy to survive the Rinka hit.",
+        "The enemyDamage in this strat is for a second Rinka hit while climbing.",
+        "The first Rinka hit is included in the gModeImmobile requirement."
+      ]
+    },
+    {
+      "link": [3, 1],
       "name": "Very Deep Stuck X-Ray Climb With Ice",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -216,6 +248,7 @@
       "bypassesDoorShell": true,
       "note": [
         "Enter with G-mode direct, and freeze the bottom Rinka near the door.",
+        "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, moving quickly to avoid Rinka damage.",
         "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]
@@ -242,7 +275,9 @@
       "bypassesDoorShell": true,
       "note": [
         "Enter with G-mode direct, and go to the top of the room to perform a Crystal Flash to refill on energy without destroying all the bottom Rinkas.",
-        "Stand in the open doorway, and take damage until auto reserves are triggered, which will cancel G-mode and close the door on top of Samus.",
+        "Use the Rinkas to damage down.",
+        "For the final hit that will trigger auto-reserves, stand in the open doorway between 1 and 6 pixels from the transition.",
+        "The auto reserve trigger will cancel G-mode and close the door on top of Samus.",
         "Climb up 2 screens, moving quickly to minimize Rinka damage.",
         "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]
@@ -252,6 +287,38 @@
       "name": "Base",
       "notable": false,
       "requires": []
+    },
+    {
+      "link": [3, 2],
+      "name": "Very Deep Stuck X-Ray Climb With Immobile",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false,
+          "mobility": "immobile"
+        }
+      },
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 1
+        }},
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter immobile with G-mode direct, taking a Rinka hit to regain mobility.",
+        "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
+        "Climb up 1 screen, moving quickly to minimize Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ],
+      "devNote": [
+        "The 'immobile' requirement in the entranceCondition is not necessary but is included for clarity.",
+        "Without coming in immobile, it would not be possible to have enough energy to survive the Rinka hit.",
+        "The enemyDamage in this strat is for a second Rinka hit while climbing.",
+        "The first Rinka hit is included in the gModeImmobile requirement."
+      ]
     },
     {
       "link": [3, 2],
@@ -269,6 +336,7 @@
       "bypassesDoorShell": true,
       "note": [
         "Enter with G-mode direct, and freeze the bottom Rinka near the door.",
+        "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, moving quickly to avoid Rinka damage.",
         "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]
@@ -295,7 +363,9 @@
       "bypassesDoorShell": true,
       "note": [
         "Enter with G-mode direct, and go to the top of the room to perform a Crystal Flash to refill on energy without destroying all the bottom Rinkas.",
-        "Stand in the open doorway, and take damage until auto reserves are triggered, which will cancel G-mode and close the door on top of Samus.",
+        "Use a Rinka to damage down.",
+        "For the final hit that will trigger auto-reserves, stand in the open doorway between 1 and 6 pixels from the transition.",
+        "The auto reserve trigger will cancel G-mode and close the door on top of Samus.",
         "Climb up 1 screen, moving quickly to minimize Rinka damage.",
         "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -127,6 +127,7 @@
     {
       "from": 3,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3}
       ]
@@ -163,6 +164,25 @@
       "requires": []
     },
     {
+      "link": [2, 1],
+      "name": "Very Deep Stuck X-Ray Climb",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
+        "Climb up 1 screen, moving quickly to avoid Rinka hits, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "notable": false,
@@ -181,10 +201,104 @@
       "requires": []
     },
     {
+      "link": [3, 1],
+      "name": "Very Deep Stuck X-Ray Climb With Ice",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "Ice",
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, and freeze the bottom Rinka near the door.",
+        "Climb up 2 screens, moving quickly to avoid Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Very Deep Stuck X-Ray Climb With Crystal Flash",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "h_canCrystalFlash",
+        {"autoReserveTrigger": {}},
+        "canXRayClimb",
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 2
+        }}
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, and go to the top of the room to perform a Crystal Flash to refill on energy without destroying all the bottom Rinkas.",
+        "Stand in the open doorway, and take damage until auto reserves are triggered, which will cancel G-mode and close the door on top of Samus.",
+        "Climb up 2 screens, moving quickly to minimize Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },
+    {
       "link": [3, 2],
       "name": "Base",
       "notable": false,
       "requires": []
+    },
+    {
+      "link": [3, 2],
+      "name": "Very Deep Stuck X-Ray Climb With Ice",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "Ice",
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, and freeze the bottom Rinka near the door.",
+        "Climb up 1 screen, moving quickly to avoid Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Very Deep Stuck X-Ray Climb With Crystal Flash",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "h_canCrystalFlash",
+        {"autoReserveTrigger": {}},
+        "canXRayClimb",
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 2
+        }}
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, and go to the top of the room to perform a Crystal Flash to refill on energy without destroying all the bottom Rinkas.",
+        "Stand in the open doorway, and take damage until auto reserves are triggered, which will cancel G-mode and close the door on top of Samus.",
+        "Climb up 1 screen, moving quickly to minimize Rinka damage.",
+        "Perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
     },
     {
       "link": [3, 3],

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -70,6 +70,7 @@
     {
       "from": 3,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3}
       ]
@@ -150,6 +151,25 @@
         "canDownGrab"
       ]
     },
+    {
+      "link": [3, 1],
+      "name": "Very Deep Stuck X-Ray Climb",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
+        "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },    
     {
       "link": [3, 2],
       "name": "Base",

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -376,6 +376,7 @@
     {
       "from": 5,
       "to": [
+        {"id": 4},
         {"id": 5},
         {"id": 8},
         {"id": 9}
@@ -556,6 +557,26 @@
       "notable": false,
       "requires": []
     },
+    {
+      "link": [5, 4],
+      "name": "Very Deep Stuck X-Ray Climb",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
+        "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door.",
+        "If Phantoon is not defeated then you have to move quickly to prevent the Coverns from hitting you."
+      ]
+    },    
     {
       "link": [5, 5],
       "name": "Leave with Runway",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -312,7 +312,7 @@
                 "type": "integer",
                 "description": "Maximum energy in reserves which will satisfy this requirement",
                 "default": 400
-              },
+              }
             }
           },
           "spikeHits": {

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -300,7 +300,20 @@
             "title": "Auto-reserve Trigger",
             "description": "Fulfilled by taking damage to trigger auto-reserves, which results in Samus' energy becoming equal to the initial reserve energy, and reserve energy becoming zero.",
             "additionalProperties": false,
-            "properties": {}
+            "properties": {
+              "minReserveEnergy": {
+                "$id": "#/definitions/logicalRequirement/items/properties/autoReserveTrigger/properties/minReserveEnergy",
+                "type": "integer",
+                "description": "Minimum energy in reserves which will satisfy this requirement",
+                "default": 1
+              },
+              "maxReserveEnergy": {
+                "$id": "#/definitions/logicalRequirement/items/properties/autoReserveTrigger/properties/maxReserveEnergy",
+                "type": "integer",
+                "description": "Maximum energy in reserves which will satisfy this requirement",
+                "default": 400
+              },
+            }
           },
           "spikeHits": {
             "$id": "#/definitions/logicalRequirement/items/properties/spikeHits",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -294,6 +294,14 @@
             "title": "Energy at Most",
             "description": "Fulfilled by having Samus' energy drop to a maximum of this value, regardless of how much she had coming in."
           },
+          "autoReserveTrigger": {
+            "$id": "#/definitions/logicalRequirement/items/properties/autoReserveTrigger",
+            "type": "object",
+            "title": "Auto-reserve Trigger",
+            "description": "Fulfilled by taking damage to trigger auto-reserves, which results in Samus' energy becoming equal to the initial reserve energy, and reserve energy becoming zero.",
+            "additionalProperties": false,
+            "properties": {}
+          },
           "spikeHits": {
             "$id": "#/definitions/logicalRequirement/items/properties/spikeHits",
             "type": "integer",


### PR DESCRIPTION
This also makes a schema change to add a "autoReserveTrigger" logical requirement, which is necessary to represent some of the strats. This should also be useful in other places, e.g. to allow us to represent double damage boost strats.

After using Crystal Flash in direct G-mode, X-Ray no longer works, so the auto-reserve trigger is used as an alternative way to cancel G-mode and allow X-Ray to be used.