### PR TITLE
G-Mode Migration: Crateria Central Pt. 1

### DIFF
--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -262,13 +262,13 @@
     {
       "link": [1, 2],
       "name": "G-Mode through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }}
-      ],
+          "morphed": false
+        }
+      },
+      "requires": [],
       "note": "Overload PLMs using scroll blocks a few tiles in front of the bomb blocks."
     },
     {
@@ -297,12 +297,13 @@
     {
       "link": [1, 3],
       "name": "G-Mode Morph through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "h_canArtificialMorphMovement"
       ],
       "note": "Overload PLMs using the scroll block next to the bomb blocks.",
@@ -311,13 +312,13 @@
     {
       "link": [1, 4],
       "name": "G-Mode Morph through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
-      ],
+          "morphed": true
+        }
+      },
+      "requires": [],
       "note": "Overload PLMs using the scroll block next to the bomb blocks."
     },
     {
@@ -394,13 +395,14 @@
       "link": [2, 3],
       "name": "Climb G-Mode Morph Blind Climb to the Top",
       "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "h_canArtificialMorphMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [2],
-          "mode": "any",
-          "artificialMorph": true
-        }},
         "canOffScreenMovement"
       ],
       "note": [
@@ -481,13 +483,14 @@
     {
       "link": [2, 4],
       "name": "G-Mode Morph Blind",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "h_canArtificialMorphMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [2],
-          "mode": "any",
-          "artificialMorph": true
-        }},
         "canOffScreenMovement"
       ],
       "note": [
@@ -631,13 +634,13 @@
     {
       "link": [2, 6],
       "name": "G-Mode through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }}
-      ],
+          "morphed": false
+        }
+      },
+      "requires": [],
       "note": "Overload PLMs using the scroll blocks immediately in front of the bomb wall"
     },
     {
@@ -652,12 +655,13 @@
     {
       "link": [3, 2],
       "name": "G-Mode through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [3],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "SpringBall",
           "Bombs",
@@ -694,12 +698,13 @@
     {
       "link": [3, 4],
       "name": "G-Mode Morph through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [3],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "SpringBall",
           "Bombs",
@@ -744,12 +749,13 @@
     {
       "link": [3, 6],
       "name": "G-Mode Morph through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [3],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "SpringBall",
           "Bombs",
@@ -765,12 +771,13 @@
     {
       "link": [4, 2],
       "name": "G-Mode Morph through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [4],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "SpringBall",
           "Bombs",
@@ -820,12 +827,13 @@
     {
       "link": [4, 3],
       "name": "G-Mode Morph",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [4],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "SpringBall",
           "Morph"
@@ -840,14 +848,15 @@
       "link": [4, 3],
       "name": "Climb G-Mode Morph Insane IBJ to Top (from Crateria Supers Bottom)",
       "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "h_canArtificialMorphIBJ",
-        "canBeVeryPatient",
-        {"comeInWithGMode": {
-          "fromNodes": [4],
-          "mode": "any",
-          "artificialMorph": true
-        }}
+        "canBeVeryPatient"
       ],
       "reusableRoomwideNotable": "Climb G-Mode Morph Insane IBJ to Top",
       "note": [
@@ -858,13 +867,14 @@
     {
       "link": [4, 3],
       "name": "G-Mode Morph IBJ with PBs",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "h_canArtificialMorphIBJ",
-        {"comeInWithGMode": {
-          "fromNodes": [4],
-          "mode": "any",
-          "artificialMorph": true
-        }},
         {"ammo": {"type": "PowerBomb", "count": 7}}
       ],
       "note": [
@@ -919,12 +929,13 @@
     {
       "link": [4, 6],
       "name": "G-Mode Morph through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [4],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "SpringBall",
           "Bombs",
@@ -1059,13 +1070,13 @@
     {
       "link": [5, 2],
       "name": "G-Mode through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [5],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }}
-      ]
+          "morphed": false
+        }
+      },
+      "requires": []
     },
     {
       "link": [5, 3],
@@ -1087,12 +1098,13 @@
     {
       "link": [5, 3],
       "name": "G-Mode Morph",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [5],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "SpringBall",
           "Morph"
@@ -1107,12 +1119,13 @@
       "link": [5, 3],
       "name": "Climb G-Mode Morph Insane IBJ to Top (from Pit Room)",
       "notable": true,
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [5],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "h_canArtificialMorphIBJ",
         "canBeVeryPatient"
       ],
@@ -1125,13 +1138,14 @@
     {
       "link": [5, 3],
       "name": "G-Mode Morph IBJ with PBs",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "h_canArtificialMorphIBJ",
-        {"comeInWithGMode": {
-          "fromNodes": [5],
-          "mode": "any",
-          "artificialMorph": true
-        }},
         {"ammo": {"type": "PowerBomb", "count": 8}}
       ],
       "note": [
@@ -1160,12 +1174,13 @@
     {
       "link": [5, 4],
       "name": "G-Mode Morph",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [5],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "Morph",
           {"and": [

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -215,12 +215,13 @@
     {
       "link": [1, 3],
       "name": "Direct G-Mode Morph",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "direct",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "h_canArtificialMorphDiagonalBombJump",
           "h_canArtificialMorphCeilingBombJump"
@@ -231,12 +232,13 @@
     {
       "link": [1, 3],
       "name": "G-Mode Morph",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"or": [
           "h_canArtificialMorphDiagonalBombJump",
           "h_canArtificialMorphCeilingBombJump",
@@ -307,12 +309,13 @@
     {
       "link": [1, 5],
       "name": "G-Mode Morph and Bombs to Overload Speed Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "Bombs",
         {"or": [
           {"and": [
@@ -353,12 +356,13 @@
     {
       "link": [1, 5],
       "name": "G-Mode and Grapple to Overload Grapple Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }},
+          "morphed": false
+        }
+      },
+      "requires": [
         "Morph",
         "Grapple",
         {"or": [
@@ -382,15 +386,16 @@
     {
       "link": [1, 5],
       "name": "G-Mode Morph Overload PLMs by PBing Super Item",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
       "requires": [
         {"itemNotCollectedAtNode": 3},
         "canRiskPermanentLossOfAccess",
         {"ammo": {"type": "PowerBomb", "count": 2}},
-        {"comeInWithGMode": {
-          "fromNodes": [1],
-          "mode": "direct",
-          "artificialMorph": true
-        }},
         {"or": [
           {"and": [
             "SpringBall",
@@ -771,6 +776,12 @@
       "link": [2, 3],
       "name": "Crateria Supers G-Mode Up with PBs",
       "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
       "requires": [
         {"itemNotCollectedAtNode": 3},
         "canConsecutiveWalljump",
@@ -781,11 +792,6 @@
         ]},
         {"ammo": {"type": "PowerBomb", "count": 9}},
         "canBeVeryPatient",
-        {"comeInWithGMode": {
-          "fromNodes": [2],
-          "mode": "direct",
-          "artificialMorph": false
-        }},
         {"or": [
           "canUseFrozenEnemies",
           "canTrickyJump",
@@ -817,14 +823,15 @@
       "link": [2, 3],
       "name": "Crateria Supers G-Mode Morph Long Ceiling Bomb Jump",
       "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "h_canArtificialMorphCeilingBombJump",
-        "canBeVeryPatient",
-        {"comeInWithGMode": {
-          "fromNodes": [2],
-          "mode": "any",
-          "artificialMorph": true
-        }}
+        "canBeVeryPatient"
       ],
       "note": [
         "Ascend with a long IBJ, then ceiling bomb jump against the speed blocks to overload the PLMs. Falling is very unforgiving.",

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -14,41 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x0018ac6",
-      "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGMode": [
-        {
-          "leavesWithArtificialMorph": false,
-          "strats": [
-            {
-              "name": "Carry G-Mode Through Tube (Right to Left)",
-              "notable": false,
-              "requires": [
-                {"comeInWithGMode": {
-                  "fromNodes": [2],
-                  "artificialMorph": false,
-                  "mode": "any"
-                }}
-              ]
-            }
-          ]
-        },
-        {
-          "leavesWithArtificialMorph": true,
-          "strats": [
-            {
-              "name": "Carry G-Mode Morph Through Tube (Right to Left)",
-              "notable": false,
-              "requires": [
-                {"comeInWithGMode": {
-                  "fromNodes": [2],
-                  "artificialMorph": true,
-                  "mode": "any"
-                }}
-              ]
-            }
-          ]
-        }
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 2,
@@ -56,41 +22,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x0018ad2",
-      "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGMode": [
-        {
-          "leavesWithArtificialMorph": false,
-          "strats": [
-            {
-              "name": "Carry G-Mode Through Tube (Left to Right)",
-              "notable": false,
-              "requires": [
-                {"comeInWithGMode": {
-                  "fromNodes": [1],
-                  "artificialMorph": false,
-                  "mode": "any"
-                }}
-              ]
-            }
-          ]
-        },
-        {
-          "leavesWithArtificialMorph": true,
-          "strats": [
-            {
-              "name": "Carry G-Mode Morph Through Tube (Left to Right)",
-              "notable": false,
-              "requires": [
-                {"comeInWithGMode": {
-                  "fromNodes": [1],
-                  "artificialMorph": true,
-                  "mode": "any"
-                }}
-              ]
-            }
-          ]
-        }
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     }
   ],
   "enemies": [],
@@ -195,6 +127,40 @@
       }
     },
     {
+      "link": [1, 2],
+      "name": "Carry G-Mode Through Tube (Left to Right)",
+      "notable": false,
+      "requires": [],
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry G-Mode Morph Through Tube (Left to Right)",
+      "notable": false,
+      "requires": [],
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []
@@ -256,6 +222,40 @@
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
+        }
+      }
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Through Tube (Right to Left)",
+      "notable": false,
+      "requires": [],
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Morph Through Tube (Right to Left)",
+      "notable": false,
+      "requires": [],
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
         }
       }
     },

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -130,13 +130,13 @@
       "link": [1, 2],
       "name": "Carry G-Mode Through Tube (Left to Right)",
       "notable": false,
-      "requires": [],
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
           "morphed": false
         }
       },
+      "requires": [],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": false
@@ -147,13 +147,13 @@
       "link": [1, 2],
       "name": "Carry G-Mode Morph Through Tube (Left to Right)",
       "notable": false,
-      "requires": [],
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
           "morphed": true
         }
       },
+      "requires": [],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": true
@@ -229,13 +229,13 @@
       "link": [2, 1],
       "name": "Carry G-Mode Through Tube (Right to Left)",
       "notable": false,
-      "requires": [],
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
           "morphed": false
         }
       },
+      "requires": [],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": false
@@ -246,13 +246,13 @@
       "link": [2, 1],
       "name": "Carry G-Mode Morph Through Tube (Right to Left)",
       "notable": false,
-      "requires": [],
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
           "morphed": true
         }
       },
+      "requires": [],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": true

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -130,12 +130,13 @@
     {
       "link": [2, 1],
       "name": "G-mode Morph with Bombs",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "Bombs"
       ],
       "note": "Repeatedly bomb the crumble blocks until the PLMs are overloaded."

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -14,16 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bb6",
-      "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Mellow",
-            "notable": false,
-            "requires": []
-          }
-        ]}
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 2,
@@ -32,15 +23,6 @@
       "nodeSubType": "red",
       "nodeAddress": "0x0018bc2",
       "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Mellow",
-            "notable": false,
-            "requires": []
-          }
-        ]}
-      ],
       "locks": [
         {
           "name": "Flyway Red Lock (to Bomb Torizo)",
@@ -135,6 +117,15 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "G-Mode Setup - Get Hit By Mellow",
+      "notable": false,
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      }
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []
@@ -169,6 +160,15 @@
         "leaveShinecharged": {
           "framesRemaining": 90
         }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit By Mellow",
+      "notable": false,
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
       }
     }
   ]

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -314,13 +314,13 @@
     {
       "link": [1, 4],
       "name": "G-Mode through Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }}
-      ],
+          "morphed": false
+        }
+      },
+      "requires": [],
       "note": [
         "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
         "Then pass through the bomb blocks (which will have become air).",
@@ -345,13 +345,14 @@
     {
       "link": [1, 8],
       "name": "G-Mode Morph",
-      "requires": [
-        "Bombs",
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Bombs"
       ],
       "note": [
         "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
@@ -421,13 +422,13 @@
     {
       "link": [2, 8],
       "name": "G-Mode Morph",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
-      ]
+          "morphed": true
+        }
+      },
+      "requires": []
     },
     {
       "link": [3, 1],
@@ -577,13 +578,13 @@
     {
       "link": [3, 8],
       "name": "G-Mode Morph",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [3],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
-      ]
+          "morphed": true
+        }
+      },
+      "requires": []
     },
     {
       "link": [4, 1],
@@ -771,12 +772,13 @@
     {
       "link": [4, 3],
       "name": "G-Mode Deep Stuck X-Ray Climb",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [4],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "direct",
-          "artificialMorph": false
-        }},
+          "morphed": false
+        }
+      },
+      "requires": [
         "canXRayClimb",
         "canBePatient"
       ],
@@ -860,13 +862,14 @@
     {
       "link": [4, 8],
       "name": "G-Mode Morph",
-      "requires": [
-        "h_canArtificialMorphMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [4],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
       ]
     },
     {

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -372,7 +372,6 @@
       ],
       "devNote": [
         "FIXME: There is a double G-mode strat that could be added, using artificial morph and Power Bombs coming in from the right (and a Crystal Flash to refill reserves), but it can't be correctly expressed without first changing how cross-room strats are structured.",
-        "FIXME: Coming in from the left with speed could be dropped if coming from the right.",
         "FIXME: Add a way to come from the right, only requiring a single PB to break the bomb blocks."
       ]
     },
@@ -406,10 +405,7 @@
         "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
         "This opens a path for the Geemer to hit Samus through the transition."
       ],
-      "devNote": [
-        "FIXME: There is a double G-mode strat that could be added, using artificial morph and Power Bombs coming in from the right (and a Crystal Flash to refill reserves), but it can't be correctly expressed without first changing how cross-room strats are structured.",
-        "FIXME: Coming in from the left with speed could be dropped if coming from the right."
-      ]
+      "devNote": "FIXME: Coming in from the left with speed could be dropped if coming from the right."
     },
     {
       "link": [1, 1],
@@ -437,10 +433,7 @@
         "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
         "This opens a path for the Geemer to hit Samus through the transition."
       ],
-      "devNote": [
-        "FIXME: There is a double G-mode strat that could be added, using artificial morph and Power Bombs coming in from the right (and a Crystal Flash to refill reserves), but it can't be correctly expressed without first changing how cross-room strats are structured.",
-        "FIXME: Coming in from the left with speed could be dropped if coming from the right."
-      ]
+      "devNote": "FIXME: Coming in from the left with speed could be dropped if coming from the right."
     },
     {
       "link": [1, 2],
@@ -765,14 +758,17 @@
       },
       "requires": [
         {"or": [
-          {"not": "f_ZebesAwake"},
           "h_canArtificialMorphMovement",
           {"ammo": {"type": "PowerBomb", "count": 1}},
           {"enemyDamage": {
             "enemy": "Geemer (blue)",
             "type": "contact",
             "hits": 1
-          }}
+          }},
+          {"and": [
+            {"not": "f_ZebesAwake"},
+            "canRiskPermanentLossOfAccess"
+          ]}
         ]}
       ],
       "note": [

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -15,79 +15,6 @@
       "nodeSubType": "blue",
       "nodeAddress": "0x001895e",
       "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {
-          "strats": [
-            {
-              "name": "Bomb the Blocks and Get Hit By Geemer",
-              "notable": false,
-              "requires": [
-                "f_ZebesAwake",
-                "h_canDestroyBombWalls"
-              ],
-              "note": [
-                "Destroy the bomb wall to open a path for the Geemer to hit Samus through the transition.",
-                "If using a PB be careful not to kill the Geemer. Place the PB far left, next to the door, or below the bomb blocks, as the Geemer is leaving the flat part of the ceiling."
-              ],
-              "devNote": "FIXME: Add a way to come from the right, only requiring a single PB to break the bomb blocks."
-            },
-            {
-              "name": "Speed Through the Blocks then Get Hit By Geemer",
-              "notable": false,
-              "entranceCondition": {
-                "comeInShinecharging": {
-                  "length": 13,
-                  "openEnd": 0,
-                  "steepUpTiles": 2,
-                  "steepDownTiles": 2
-                }
-              },
-              "requires": [
-                "f_ZebesAwake",
-                "canCarefulJump",
-                {"canShineCharge": {
-                  "usedTiles": 25,
-                  "steepUpTiles": 3,
-                  "steepDownTiles": 3,
-                  "openEnd": 1
-                }}
-              ],
-              "note": [
-                "From the left, break the bomb blocks with blue speed from the neighboring room.",
-                "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
-                "This opens a path for the Geemer to hit Samus through the transition."
-              ]
-            },
-            {
-              "name": "Shinespark Through the Blocks then Get Hit By Geemer",
-              "notable": false,
-              "entranceCondition": {
-                "comeInWithSpark": {}
-              },
-              "requires": [
-                "f_ZebesAwake",
-                {"shinespark": {"frames": 67, "excessFrames": 42}},
-                "canCarefulJump",
-                {"canShineCharge": {
-                  "usedTiles": 25,
-                  "steepUpTiles": 3,
-                  "steepDownTiles": 3,
-                  "openEnd": 1
-                }}
-              ],
-              "note": [
-                "From the left, break the bomb blocks by shinesparking from the neighboring room.",
-                "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
-                "This opens a path for the Geemer to hit Samus through the transition."
-              ]
-            }
-          ],
-          "devNote": [
-            "FIXME: There is a double G-mode strat that could be added, using artificial morph and Power Bombs coming in from the right (and a Crystal Flash to refill reserves), but it can't be correctly expressed without first changing how cross-room strats are structured.",
-            "FIXME: Coming in from the left with speed could be dropped if coming from the right."
-          ]
-        }
-      ],
       "locks": [
         {
           "name": "Parlor Top Left Escape Lock (to Terminator)",
@@ -112,29 +39,6 @@
       "nodeSubType": "blue",
       "nodeAddress": "0x001899a",
       "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Geemer",
-            "notable": false,
-            "requires": [
-              "f_ZebesAwake"
-            ],
-            "note": "Wait for a global Geemer, or use a Super to grab a closer one."
-          }
-        ]}
-      ],
-      "gModeImmobile": {
-        "requires": [
-          {"enemyDamage": {
-            "enemy": "Geemer (blue)",
-            "type": "contact",
-            "hits": 1
-          }},
-          "f_ZebesAwake"
-        ],
-        "note": "Wait for a global Geemer."
-      },
       "locks": [
         {
           "name": "Parlor Middle Left Escape Lock (to Save)",
@@ -159,29 +63,6 @@
       "nodeSubType": "blue",
       "nodeAddress": "0x00189a6",
       "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Geemer",
-            "notable": false,
-            "requires": [
-              "f_ZebesAwake"
-            ],
-            "note": "Wait for a global Geemer, or use a Super to grab a closer one."
-          }
-        ]}
-      ],
-      "gModeImmobile": {
-        "requires": [
-          {"enemyDamage": {
-            "enemy": "Geemer (blue)",
-            "type": "contact",
-            "hits": 1
-          }},
-          "f_ZebesAwake"
-        ],
-        "note": "Wait for a global Geemer."
-      },
       "locks": [
         {
           "name": "Parlor Bottom Left Escape Lock (to Final Missile Bombway)",
@@ -205,28 +86,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001896a",
-      "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Geemer",
-            "notable": false,
-            "requires": [
-              "f_ZebesAwake"
-            ]
-          }
-        ]}
-      ],
-      "gModeImmobile": {
-        "requires": [
-          {"enemyDamage": {
-            "enemy": "Geemer (blue)",
-            "type": "contact",
-            "hits": 1
-          }},
-          "f_ZebesAwake"
-        ]
-      }
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 5,
@@ -234,42 +94,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018982",
-      "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Geemer",
-            "notable": false,
-            "requires": [
-              "f_ZebesAwake",
-              {"or": [
-                "canBeVeryPatient",
-                {"ammo": {"type": "Super", "count": 1}}
-              ]}
-            ],
-            "note": "It takes approximately 3.5 minutes for a global Geemer to reach this location, but this can be reduced by using a Super to make a Geemer fall and take a shorter path."
-          }
-        ]}
-      ],
-      "gModeImmobile": {
-        "requires": [
-          {"enemyDamage": {
-            "enemy": "Geemer (blue)",
-            "type": "contact",
-            "hits": 1
-          }},
-          "f_ZebesAwake",
-          {"or": [
-            "canBeVeryPatient",
-            {"ammo": {"type": "Super", "count": 1}}
-          ]}
-        ],
-        "note": [
-          "It takes approximately 3.5 minutes for a global Geemer to reach this location.",
-          "If using a Super, fire between 19 and 33 seconds after entering the room, then wait approximately 30 more seconds to be hit."
-        ],
-        "devNote": "FIXME: Should manipulating global enemies off screen be a tech?"
-      }
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 6,
@@ -306,30 +131,7 @@
             }
           ]
         }
-      ],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Geemer",
-            "notable": false,
-            "requires": [
-              "f_ZebesAwake"
-            ],
-            "note": "Wait for a global Geemer, or use a Super to grab a closer one."
-          }
-        ]}
-      ],
-      "gModeImmobile": {
-        "requires": [
-          {"enemyDamage": {
-            "enemy": "Geemer (blue)",
-            "type": "contact",
-            "hits": 1
-          }},
-          "f_ZebesAwake"
-        ],
-        "note": "Wait for a global Geemer."
-      }
+      ]
     },
     {
       "id": 7,
@@ -353,40 +155,7 @@
             }
           ]
         }
-      ],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Parlor Downward G-Mode Setup with Ice",
-            "notable": true,
-            "requires": [
-              "f_ZebesAwake",
-              "canEnemyStuckMoonfall",
-              "canTrickyUseFrozenEnemies",
-              "canDownwardGModeSetup"
-            ],
-            "note": [
-              "Freeze a Geemer on the bottom of the overhang just below the door to Final Missile Bombway. Freeze a second Geemer on the top left of its platform and setup a moonfall between them.",
-              "Fall off the Geemers and clip into the tile left of the door. Press up to get out of crouch and lose the stored vertical speed (so that X-Ray works). Then turn-around, open the door, and go into the door transition as the third Geemer hits you.",
-              "Falling off the frozen Geemers requires relatively high precision: This setup is a 4 frame window, not too far left, so you can get to the door transition, not too far right such that you enter the transition when falling."
-            ]
-          }
-        ]}
-      ],
-      "gModeImmobile": {
-        "requires": [
-          {"enemyDamage": {
-            "enemy": "Geemer (blue)",
-            "type": "contact",
-            "hits": 1
-          }},
-          "f_ZebesAwake"
-        ],
-        "note": [
-          "Line up with the far right or left side of doorframe in the room below, to be able to not fall back through after entry, as the door remains open.",
-          "Be careful not to fall into the door while being hit by the Geemer."
-        ]
-      }
+      ]
     },
     {
       "id": 8,
@@ -587,15 +356,103 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "G-Mode Setup - Bomb the Blocks and Get Hit By Geemer",
+      "notable": false,
+      "requires": [
+        "f_ZebesAwake",
+        "h_canDestroyBombWalls"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "Destroy the bomb wall to open a path for the Geemer to hit Samus through the transition.",
+        "If using a PB be careful not to kill the Geemer. Place the PB far left, next to the door, or below the bomb blocks, as the Geemer is leaving the flat part of the ceiling."
+      ],
+      "devNote": [
+        "FIXME: There is a double G-mode strat that could be added, using artificial morph and Power Bombs coming in from the right (and a Crystal Flash to refill reserves), but it can't be correctly expressed without first changing how cross-room strats are structured.",
+        "FIXME: Coming in from the left with speed could be dropped if coming from the right.",
+        "FIXME: Add a way to come from the right, only requiring a single PB to break the bomb blocks."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Setup - Speed Through the Blocks then Get Hit By Geemer",
+      "notable": false,
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0,
+          "steepUpTiles": 2,
+          "steepDownTiles": 2
+        }
+      },
+      "requires": [
+        "f_ZebesAwake",
+        "canCarefulJump",
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "From the left, break the bomb blocks with blue speed from the neighboring room.",
+        "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
+        "This opens a path for the Geemer to hit Samus through the transition."
+      ],
+      "devNote": [
+        "FIXME: There is a double G-mode strat that could be added, using artificial morph and Power Bombs coming in from the right (and a Crystal Flash to refill reserves), but it can't be correctly expressed without first changing how cross-room strats are structured.",
+        "FIXME: Coming in from the left with speed could be dropped if coming from the right."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Setup - Shinespark Through the Blocks then Get Hit By Geemer",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithSpark": {}
+      },
+      "requires": [
+        "f_ZebesAwake",
+        {"shinespark": {"frames": 67, "excessFrames": 42}},
+        "canCarefulJump",
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "From the left, break the bomb blocks by shinesparking from the neighboring room.",
+        "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
+        "This opens a path for the Geemer to hit Samus through the transition."
+      ],
+      "devNote": [
+        "FIXME: There is a double G-mode strat that could be added, using artificial morph and Power Bombs coming in from the right (and a Crystal Flash to refill reserves), but it can't be correctly expressed without first changing how cross-room strats are structured.",
+        "FIXME: Coming in from the left with speed could be dropped if coming from the right."
+      ]
+    },
+    {
       "link": [1, 2],
       "name": "G-Mode Morph through Terminator Bomb Blocks into Save",
-      "requires": [
-        "canOffScreenMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
+          "morphed": true
+        }
+      },
+      "requires": [
+        "canOffScreenMovement"
       ],
       "note": [
         "There are scroll PLMs one tile to the left of the Terminator bomb blocks which can be used to overload PLMs.",
@@ -607,6 +464,12 @@
     {
       "link": [1, 5],
       "name": "G-Mode Morph through Terminator Bomb Blocks into Alcatraz",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         {"or": [
           "h_canArtificialMorphMovement",
@@ -620,12 +483,7 @@
               "hits": 1
             }}
           ]}
-        ]},
-        {"comeInWithGMode": {
-          "fromNodes": [1],
-          "mode": "any",
-          "artificialMorph": true
-        }}
+        ]}
       ],
       "note": [
         "There are scroll PLMs one tile to the left of the bomb blocks which can be used to overload PLMs.",
@@ -667,13 +525,13 @@
     {
       "link": [1, 8],
       "name": "G-Mode through Terminator Bomb Blocks (from Left)",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }}
-      ],
+          "morphed": false
+        }
+      },
+      "requires": [],
       "note": [
         "There are scroll PLMs one tile to the left of the bomb blocks which can be used to overload PLMs.",
         "The bomb blocks then become air and can be passed through."
@@ -682,13 +540,13 @@
     {
       "link": [2, 1],
       "name": "G-Mode Morph through Terminator Bomb Blocks (from Save)",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
-      ],
+          "morphed": true
+        }
+      },
+      "requires": [],
       "note": [
         "Use G-Mode Morph to pass through the tunnel as you enter the room.",
         "Then unmorph and get up to the top of the room normally.",
@@ -708,15 +566,44 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit By Geemer",
+      "notable": false,
+      "requires": [
+        "f_ZebesAwake"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "Wait for a global Geemer, or use a Super to grab a closer one."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Regain Mobility",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "f_ZebesAwake"
+      ],
+      "gModeRegainMobility": {},
+      "note": "Wait for a global Geemer."
+    },
+    {
       "link": [2, 5],
       "name": "G-Mode Morph into Alcatraz (from Save)",
-      "requires": [
-        "h_canArtificialMorphMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
       ],
       "note": [
         "Use G-Mode Morph to pass through the tunnel as you enter the room.",
@@ -755,13 +642,13 @@
     {
       "link": [2, 8],
       "name": "G-Mode Morph out of Save",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
-      ]
+          "morphed": true
+        }
+      },
+      "requires": []
     },
     {
       "link": [3, 3],
@@ -776,6 +663,34 @@
       }
     },
     {
+      "link": [3, 3],
+      "name": "G-Mode Setup - Get Hit By Geemer",
+      "notable": false,
+      "requires": [
+        "f_ZebesAwake"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "Wait for a global Geemer, or use a Super to grab a closer one."
+      ]
+    },
+    {
+      "link": [3, 3],
+      "name": "G-Mode Regain Mobility",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "f_ZebesAwake"
+      ],
+      "gModeRegainMobility": {},
+      "note": "Wait for a global Geemer."
+    },
+    {
       "link": [3, 8],
       "name": "Base",
       "requires": []
@@ -783,17 +698,18 @@
     {
       "link": [4, 2],
       "name": "G-Mode Morph into Save (from Landing Site)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "canOffScreenMovement",
         {"or": [
           "h_canArtificialMorphMovement",
           "h_canArtificialMorphBombHorizontally"
-        ]},
-        {"comeInWithGMode": {
-          "fromNodes": [4],
-          "mode": "any",
-          "artificialMorph": true
-        }}
+        ]}
       ],
       "note": [
         "A single Power Bomb, placed precisely and as early as possible, can get you over the Geemers and onto the ledge above Alcatraz without taking a hit.",
@@ -815,8 +731,38 @@
       }
     },
     {
+      "link": [4, 4],
+      "name": "G-Mode Setup - Get Hit By Geemer",
+      "notable": false,
+      "requires": [
+        "f_ZebesAwake"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      }
+    },
+    {
+      "link": [4, 4],
+      "name": "G-Mode Regain Mobility",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "f_ZebesAwake"
+      ],
+      "gModeRegainMobility": {}
+    },
+    {
       "link": [4, 5],
       "name": "G-Mode Morph into Alcatraz (from Landing Site)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         {"or": [
           {"not": "f_ZebesAwake"},
@@ -827,12 +773,7 @@
             "type": "contact",
             "hits": 1
           }}
-        ]},
-        {"comeInWithGMode": {
-          "fromNodes": [4],
-          "mode": "any",
-          "artificialMorph": true
-        }}
+        ]}
       ],
       "note": [
         "There are scroll PLMs one tile to the right of the bomb blocks which can be used to overload PLMs, turning the bomb blocks to air.",
@@ -851,14 +792,15 @@
     {
       "link": [5, 1],
       "name": "G-Mode Morph through Terminator Blocks (from Alcatraz)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "canOffScreenMovement",
-        "h_canArtificialMorphMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [5],
-          "mode": "any",
-          "artificialMorph": true
-        }}
+        "h_canArtificialMorphMovement"
       ],
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing.",
@@ -870,14 +812,15 @@
     {
       "link": [5, 2],
       "name": "G-Mode Morph through Parlor Save Morph Tunnel (from Alcatraz)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
         "canOffScreenMovement",
-        "h_canArtificialMorphMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [5],
-          "mode": "any",
-          "artificialMorph": true
-        }}
+        "h_canArtificialMorphMovement"
       ],
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing.",
@@ -904,6 +847,46 @@
       "requires": [
         "h_canCrystalFlash"
       ]
+    },
+    {
+      "link": [5, 5],
+      "name": "G-Mode Setup - Get Hit By Geemer",
+      "notable": false,
+      "requires": [
+        "f_ZebesAwake",
+        {"or": [
+          "canBeVeryPatient",
+          {"ammo": {"type": "Super", "count": 1}}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "It takes approximately 3.5 minutes for a global Geemer to reach this location, but this can be reduced by using a Super to make a Geemer fall and take a shorter path."
+      ]
+    },
+    {
+      "link": [5, 5],
+      "name": "G-Mode Regain Mobility",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "f_ZebesAwake",
+        {"or": [
+          "canBeVeryPatient",
+          {"ammo": {"type": "Super", "count": 1}}
+        ]}
+      ],
+      "gModeRegainMobility": {},
+      "note": [
+        "It takes approximately 3.5 minutes for a global Geemer to reach this location.",
+        "If using a Super, fire between 19 and 33 seconds after entering the room, then wait approximately 30 more seconds to be hit."
+      ],
+      "devNote": "FIXME: Should manipulating global enemies off screen be a tech?"
     },
     {
       "link": [5, 8],
@@ -983,13 +966,14 @@
     {
       "link": [5, 8],
       "name": "G-Mode Morph Alcatraz Escape",
-      "requires": [
-        "h_canArtificialMorphMovement",
-        {"comeInWithGMode": {
-          "fromNodes": [5],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }}
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
       ],
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing.",
@@ -1008,6 +992,34 @@
           "steepUpTiles": 1
         }
       }
+    },
+    {
+      "link": [6, 6],
+      "name": "G-Mode Setup - Get Hit By Geemer",
+      "notable": false,
+      "requires": [
+        "f_ZebesAwake"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "Wait for a global Geemer, or use a Super to grab a closer one."
+      ]
+    },
+    {
+      "link": [6, 6],
+      "name": "G-Mode Regain Mobility",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "f_ZebesAwake"
+      ],
+      "gModeRegainMobility": {},
+      "note": "Wait for a global Geemer."
     },
     {
       "link": [6, 8],
@@ -1058,6 +1070,42 @@
         "Fall off the Geemers and clip past the floating platform below, past the door shell, and into the transition.",
         "This setup is highly precise; if you do not have the right speed you may land on the platform below or the door shell.",
         "Falling with too much speed can also cause Samus to go out of bounds."
+      ]
+    },
+    {
+      "link": [7, 7],
+      "name": "G-Mode Setup - Parlor Downward G-Mode Setup with Ice",
+      "notable": true,
+      "requires": [
+        "f_ZebesAwake",
+        "canEnemyStuckMoonfall",
+        "canTrickyUseFrozenEnemies",
+        "canDownwardGModeSetup"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "Freeze a Geemer on the bottom of the overhang just below the door to Final Missile Bombway. Freeze a second Geemer on the top left of its platform and setup a moonfall between them.",
+        "Fall off the Geemers and clip into the tile left of the door. Press up to get out of crouch and lose the stored vertical speed (so that X-Ray works). Then turn-around, open the door, and go into the door transition as the third Geemer hits you.",
+        "Falling off the frozen Geemers requires relatively high precision: This setup is a 4 frame window, not too far left, so you can get to the door transition, not too far right such that you enter the transition when falling."
+      ]
+    },
+    {
+      "link": [7, 7],
+      "name": "G-Mode Regain Mobility",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "f_ZebesAwake"
+      ],
+      "gModeRegainMobility": {},
+      "note": [
+        "Line up with the far right or left side of doorframe in the room below, to be able to not fall back through after entry, as the door remains open.",
+        "Be careful not to fall into the door while being hit by the Geemer."
       ]
     },
     {

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -46,18 +46,6 @@
       "nodeSubType": "grey",
       "nodeAddress": "0x0018b86",
       "doorEnvironments": [{"physics": "air"}],
-      "gModeImmobile": {
-        "requires": [
-          {"enemyDamage": {
-            "enemy": "Grey Space Pirate (wall)",
-            "type": "contact",
-            "hits": 1
-          }},
-          "Missile",
-          "Morph"
-        ],
-        "note": "The enemies do not spawn in this room unless Missiles and Morph are collected (even if Zebes is awake)."
-      },
       "locks": [
         {
           "name": "Pit Room Right Grey Lock (to Elevator)",
@@ -231,12 +219,13 @@
     {
       "link": [1, 3],
       "name": "G-Mode Morph to Bomb the Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "Bombs"
       ],
       "clearsObstacles": ["A"],
@@ -249,12 +238,13 @@
     {
       "link": [1, 3],
       "name": "G-Mode Morph to Power Bomb the Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         {"ammo": {"type": "PowerBomb", "count": 1}}
       ],
       "clearsObstacles": ["A"],
@@ -267,13 +257,13 @@
     {
       "link": [1, 3],
       "name": "G-Mode Through the Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }}
-      ],
+          "morphed": false
+        }
+      },
+      "requires": [],
       "note": [
         "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",
         "Using X-Ray to cancel G-mode will lead to a soft lock if the item there can't be used to get Samus out."
@@ -309,6 +299,21 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "G-Mode Regain Mobility",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Grey Space Pirate (wall)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "Missile",
+        "Morph"
+      ],
+      "gModeRegainMobility": {},
+      "note": "The enemies do not spawn in this room unless Missiles and Morph are collected (even if Zebes is awake)."
+    },
+    {
       "link": [2, 3],
       "name": "Full Room Temporary Blue",
       "entranceCondition": {
@@ -341,12 +346,13 @@
     {
       "link": [2, 3],
       "name": "G-Mode Morph to Bomb the Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "h_canArtificialMorphIBJ"
       ],
       "clearsObstacles": ["A"],
@@ -360,12 +366,13 @@
     {
       "link": [2, 3],
       "name": "G-Mode Morph to Power Bomb the Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "h_canArtificialMorphBombHorizontally",
         {"ammo": {"type": "PowerBomb", "count": 2}},
         {"or": [
@@ -406,12 +413,13 @@
     {
       "link": [2, 3],
       "name": "G-Mode Morph Spring Ball to Power Bomb the Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": true
-        }},
+          "morphed": true
+        }
+      },
+      "requires": [
         "SpringBall",
         {"ammo": {"type": "PowerBomb", "count": 1}}
       ],
@@ -426,13 +434,13 @@
     {
       "link": [2, 3],
       "name": "G-Mode Through the Bomb Blocks",
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [2],
+      "entranceCondition": {
+        "comeInWithGMode": {
           "mode": "any",
-          "artificialMorph": false
-        }}
-      ],
+          "morphed": false
+        }
+      },
+      "requires": [],
       "note": [
         "Be careful not to touch any of the pirates spawned lasers.",
         "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -14,16 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bce",
-      "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Mellow",
-            "notable": false,
-            "requires": []
-          }
-        ]}
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 2,
@@ -31,16 +22,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bda",
-      "doorEnvironments": [{"physics": "air"}],
-      "leaveWithGModeSetup": [
-        {"strats": [
-          {
-            "name": "Get Hit By Mellow",
-            "notable": false,
-            "requires": []
-          }
-        ]}
-      ]
+      "doorEnvironments": [{"physics": "air"}]
     }
   ],
   "enemies": [
@@ -106,6 +88,15 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "G-Mode Setup - Get Hit By Mellow",
+      "notable": false,
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      }
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []
@@ -124,6 +115,15 @@
           "length": 3,
           "openEnd": 1
         }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit By Mellow",
+      "notable": false,
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
       }
     }
   ]


### PR DESCRIPTION
This PR was based off of #1212. It contains the output of the g-mode migration script with a thorough review and a few small edits. Only errors in the migration itself are included, not errors in the strats (unless severe), new strats, nor strats from non-door nodes. Those will be included in a follow up PR.

Edits included in this PR:
- Strats with a leave with g-mode have problems in that their `requires` is before the `entrance condition` instead of after it. (Crateria Tube)
- Places with multiple strats in a `leave with gmode setup` with a devnote are split and the note is duplicated. This is expected, but not ideal. (Parlor)
- There was a major error in one strat which included a `{"not": "f_ZebesAwake"}`, but neglected `canRiskPermanentLossOfAccess`.

Edits that will be included in a follow-up PR:
- Strats that started at a junction: Landing Site, Parlor, Blue Brin Elevator
- Crateria Supers
  - This room is a bit of a mess and could greatly benefit from another node at 4 or 6.
  - 1->3->1, 1->3->5 remote acquire
- Pit Room 2->3 with artificial morph and PBs works around the pirates, however they won't spawn without morph
- Parlor
  - Doors 2-7 setups and immobile need to be timed to see if they need `canBePatient` (they were encoded before the lower-level tech existed).
  - Setups leaving through 1 can now be encoded without starting at 1.