### PR TITLE
Entrance/exit condition schemas for jumpways

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -346,6 +346,9 @@ __Additional considerations__
 Please note that fulfilling this logical element requires interaction with the door in the adjacent room to be possible (so no active locks on it, and fulfilling its interaction requirements). Fulfilling this logical element also causes the room to be reset, which means all obstacles respawn.
 
 #### adjacentJumpway object
+
+_Note_: This logical requirement is deprecated. The entrance conditions [comeInWithWallJumpBelow](../strats.md#come-in-with-wall-jump-below), [comeInWithSpaceJumpBelow](../strats.md#come-in-with-space-jump-below), and [comeInWithPlatformBelow](../strats.md#come-in-with-platform-below) should be used instead.
+
 An `adjacentJumpway` object represents the need for Samus to be able to jump into the room from a door frame or platform in an adjacent room. Currently supported jumpway types involve jumping up through a vertical doorway. The object has the following properties:
 * _fromNode:_ Indicates from what door this logical requirement expects Samus to enter the room
 * _jumpwayType:_ Possible values are "doorFrameBelow" and "platformBelow". The logical requirement can only be satisfied by jumpways having a matching type.

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -121,6 +121,9 @@ Runways on both sides of a door are meant to be combined when determining how mu
 * Storing a shinespark after entering a room through a door requires some runway space. How much space is needed depends on Samus' momentum, which depends on how many tiles the logic options expect Samus to use. This is because short charging reduces not only the number of tiles needed to achieve a charge, but also the momentum at which that charge is achieved. Because of this, even a runway that is `usableComingIn` may be too short to be used if Samus has too much momentum. This project will not define how many tiles the destination runway needs to have to be used, but this should generally be between 3 and 6-7 tiles, depending on the minimum runway length required to achieve a spark.
 
 #### jumpways
+
+_Note_: This node property is deprecated. The exit conditions [leaveWithDoorFrameBelow](../strats.md#leave-with-door-frame-below) [leaveWithPlatformBelow](../strats.md#leave-with-platform-below) should be used instead.
+
 Represents an array of jumpways connected to a door. A jumpway is a wall or platform which Samus can use to carry momentum into the next room. Unlike runways, jumpways do not need to be directly connected to a door, and it is not possible to use a jumpway to run into the neighboring room. Naturally, a jumpway can only be used if interaction with the connected door is possible (no active locks, and interaction requirements fulfilled). Jumpways have the following properties:
 
 * _name:_ A name, which only needs to be unique for the given node.

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -398,7 +398,58 @@
                   "description": "Whether Samus must come in mobile, immobile, or either."
                 }
               }
-            }  
+            },
+            "comeInWithWallJumpBelow": {
+              "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithWallJumpBelow",
+              "type": "object",
+              "description": "Represents that Samus must come up through this door with momentum by wall-jumping in the door frame below.",
+              "required": [],
+              "additionalProperties": false,
+              "properties": {
+                "minHeight": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithWallJumpBelow/properties/minHeight",
+                  "type": "number",
+                  "description": "Minimum height of door frame (tiles below the transition tiles) that will satisfy the condition."
+                }
+              }
+            },
+            "comeInWithSpaceJumpBelow": {
+              "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithSpaceJumpBelow",
+              "type": "object",
+              "description": "Represents that Samus must come up through this door with momentum by using Space Jump in the door frame below.",
+              "required": [],
+              "additionalProperties": false,
+              "properties": {}
+            },
+            "comeInWithPlatformBelow": {
+              "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithPlatformBelow",
+              "type": "object",
+              "description": "Represents that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.",
+              "required": [],
+              "additionalProperties": false,
+              "properties": {
+                "minHeight": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithPlatformBelow/properties/minHeight",
+                  "type": "number",
+                  "description": "Minimum height of the platform that will satisfy the condition."
+                },
+                "maxHeight": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithPlatformBelow/properties/maxHeight",
+                  "type": "number",
+                  "description": "Maximum height of the platform that will satisfy the condition."
+                },
+                "maxLeftPosition": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithPlatformBelow/properties/maxLeftPosition",
+                  "type": "number",
+                  "description": "Maximum value of the platform leftPosition that will satisfy the condition."
+                },
+                "minRightPosition": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithPlatformBelow/properties/minRightPosition",
+                  "type": "number",
+                  "description": "Minimum value of the platform rightPosition that will satisfy the condition."
+                }
+              }
+            }
           }
         },
         "requires": {
@@ -557,6 +608,44 @@
                   "type": "boolean",
                   "title": "Morphed",
                   "description": "If true, then this strat results in leaving the room in a morphed state, either by maintaining artificial morph or by having the Morph item."
+                }
+              }
+            },
+            "leaveWithDoorFrameBelow": {
+              "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithDoorFrameBelow",
+              "type": "object",
+              "description": "Represents that Samus can leave through this door with a jump in the door frame, e.g. using a wall-jump or Space Jump.",
+              "required": ["height"],
+              "additionalProperties": false,
+              "properties": {
+                "height": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithDoorFrameBelow/properties/height",
+                  "type": "number",
+                  "description": "The number of tiles beneath the door transition usable for wall-jumping."
+                }
+              }
+            },
+            "leaveWithPlatformBelow": {
+              "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithPlatformBelow",
+              "type": "object",
+              "description": "Represents that Samus can leave through this door by jumping from a platform below, possibly with run speed.",
+              "required": ["leftPosition", "rightPosition", "height"],
+              "additionalProperties": false,
+              "properties": {
+                "height": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithPlatformBelow/properties/height",
+                  "type": "number",
+                  "description": "The number of tiles between the door transition and the platform. A horizontal slope tile counts as a half tile."
+                },
+                "leftPosition": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithPlatformBelow/properties/leftPosition",
+                  "type": "number",
+                  "description": "Position of the left end of the platform, measured as the number of tiles to the right of the center of the door. An open end should be represented as an extra half tile."
+                },
+                "rightPosition": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithPlatformBelow/properties/rightPosition",
+                  "type": "number",
+                  "description": "Position of the right end of the platform, measured as the number of tiles to the right of the center of the door. An open end should be represented as an extra half tile."
                 }
               }
             }

--- a/strats.md
+++ b/strats.md
@@ -86,6 +86,8 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveWithStoredFallSpeed_: This indicates that is is possible to walk through the door with the stored velocity to clip through floor tiles using a Moonfall.
 - _leaveWithGModeSetup_: This indicates that Samus can take enemy damage through the door transition, to set up R-mode or direct G-mode in the next room.
 - _leaveWithGMode_: This indicates that Samus can carry G-mode into the next room (where it will become indirect G-mode).
+- _leaveWithDoorFrameBelow_: This indicates that Samus can go up through this door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump.
+- _leaveWithPlatformBelow_: This indicates that Samus can go up through this door with momentum by jumping from a platform below, possibly with run speed.
 
 Each of these properties is described in more detail below.
 
@@ -264,6 +266,59 @@ and another where the `false` values for `morphed` are replaced with `true`. Her
 
 Aside from the implicit strats, there are a limited amount of `leaveWithGMode` strats possible. Normally entering a room with G-mode (or a G-mode setup) and then leaving with G-mode through a different door is not possible, since door shells cannot be opened while in G-mode. However, some door transitions do not have door shells (e.g. in Crateria Tube, Glass Tunnel, Crab Hole, Big Pink; also elevators and sand transitions), and some door shells are possible to bypass using glitches, so `leaveWithGMode` can be used in these situations.
 
+### Leave With Door Frame Below
+
+A `leaveWithDoorFrameBelow` exit condition represents that Samus can go up through this door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump. A `leaveWithDoorFrameBelow` exit condition can satisfy `comeInWithWallJumpBelow` and `comeInWithSpaceJumpBelow` entrance conditions in the room above.
+
+A `leaveWithDoorFrameBelow` object has the following property:
+
+- _height_: The number of tiles beneath the door transition (not including the transition tiles) usable for wall-jumping.
+
+In a heated room, heat frames must be explicitly included in the strat `requires`, based on an assumption of wall-jumping up through the door. If the strat in the neighboring room has a `comeInWithSpaceJumpBelow` entrance condition, then additional heat frames will be implicitly included to use Space Jump, so that does not need to be included in the `leaveWithDoorFrameBelow` strat. Likewise, requirements for `canWalljump` or `SpaceJump` do not need to included, as these will be implicitly included in the corresponding entrance conditions.
+
+#### Example
+```json
+{
+  "name": "Leave With Door Frame Below",
+  "requires": [],
+  "exitCondition": {
+    "leaveWithDoorFrame": {
+      "height": 2
+    }
+  }
+}
+```
+
+### Leave With Platform Below
+
+A `leaveWithPlatformBelow` exit condition represents that that Samus can go up through this door with momentum by jumping from a platform below, possibly with run speed. A `leaveWithPlatformBelow` exit condition can satisfy a `comeInWithPlatformBelow` entrance condition in the room above.
+
+A `leaveWithPlatformBelow` object has the following properties:
+
+- _height_: The number of tiles between the door transition and the platform, not including the transition tiles or platform itself. A horizontal slope tile (as in Blue Hopper Room) counts as a half tile.
+- _leftPosition_: This indicates the position of the furthest left usable tile of the platform, relative to the center of the door. A negative values indicates a position to the left of the door center, while a positive value indicates a position to the right of the door center. An open end, if applicable, is represented by an extra half tile.
+- _rightPosition_: This indicates the position of the furthest right usable tile of the platform, relative to the center of the door. A negative values indicates a position to the left of the door center, while a positive value indicates a position to the right of the door center. An open end, if applicable, is represented by an extra half tile.
+- _comeInWithWallJumpBelow_: This indicates that Samus must come up through this door with momentum by wall-jumping in the door frame below.
+- _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below.
+- _comeInWithPlatformBelow_: This indicates that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.
+
+In a heated room, heat frames must be explicitly included in the strat `requires`, based on a worst-case assumption of how the platform could need to be used.
+
+#### Example
+```json
+{
+  "name": "Leave With Platform Below",
+  "requires": [],
+  "exitCondition": {
+    "leaveWithDoorFrame": {
+      "height": 7,
+      "leftPosition": -2.5,
+      "rightPosition": 2.5,
+    }
+  }
+}
+```
+
 ## Entrance conditions
 
 In all strats with an `entranceCondition`, the `from` node of the strat must be a door node or entrance node. An `entranceCondition` object must contain exactly one property:
@@ -278,7 +333,11 @@ In all strats with an `entranceCondition`, the `from` node of the strat must be 
 - _comeInWithDoorStuckSetup_: This indicates that Samus must enter the room in a way that allows getting stuck in the door as it closes.
 - _comeInSpeedballing_: This indicates that Samus must enter the room either in a speedball from the previous room, or in a process of running, jumping, or falling into a speedball.
 - _comeInWithStoredFallSpeed_: This indicates that Samus must enter the room with fall speed stored, and is able to clip through a floor with a Moonfall.
+- _comeInWithRMode_: This indicates that Samus must have or obtain R-mode while coming through this door.
 - _comeInWithGMode_: This indicates that Samus must have or obtain G-mode (direct or indirect) while coming through this door. 
+- _comeInWithWallJumpBelow_: This indicates that Samus must come up through this door with momentum by wall-jumping in the door frame below.
+- _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below.
+- _comeInWithPlatformBelow_: This indicates that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.
 
 Each of these properties is described in more detail below.
 
@@ -682,6 +741,42 @@ __Example:__
 }
 ```
 
+### Come In With Wall Jump Below
+
+A `comeInWithWallJumpBelow` entrance condition indicates that Samus must come up through this door with momentum by wall-jumping in the door frame below.
+
+A `comeInWithWallJumpBelow` object has the following property:
+
+- _minHeight_: Minimum height of door frame (tiles below the transition tiles) that will satisfy the condition.
+
+A `comeInWithWallJumpBelow` entrance condition must match with a `leaveWithDoorFrameBelow` exit condition on the other side of the door:
+- A match is valid provided the `height` property on the `leaveWithDoorFrameBelow` is at least as large as the `minHeight` property on the `comeInWithWallJumpBelow`.
+
+A `comeInWithWallJumpBelow` implicitly includes a `canWalljump` tech requirement.
+
+### Come In With Space Jump Below
+
+A `comeInWithSpaceJumpBelow` entrance condition indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below. It has no properties.
+
+A `comeInWithSpaceJumpBelow` entrance condition must match with a `leaveWithDoorFrameBelow` exit condition on the other side of the door.
+
+A `comeInWithWallJumpBelow` implicitly includes a `SpaceJump` item requirement. If the room below is heated, then a requirement of `{"heatFrames": 30}` is implicitly included.
+
+### Come In With Platform Below
+
+A `comeInWithPlatformBelow` entrance condition indicates that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed. It has the following properties:
+
+* _minHeight:_ Minimum height of the platform below that can satisfy this condition. It expresses that the platform must be positioned at least a certain distance below the door transition (in tiles, not including the transition tiles or platform tiles).
+* _maxHeight:_ Maximum height of the platform below that can satisfy this condition. It expresses that the platform must be positioned at most a certain distance below the door transition.
+* _maxLeftPosition:_ Maximum value of "leftPosition" of the platform below that can satisfy this condition. It expresses that the platform extends at least a certain distance to the left (in tiles, relative to the center of the door, with negative values indicating a position to the left of the door center).
+* _minRightPosition:_ Minimum value of "rightPosition" of the platform below that can satisfy this condition. It expresses that the platform extends at least a certain distance to the right (in tiles, relative to the center of the door, with negative values indicating a position to the left of the door center).
+
+A `comeInWithPlatformBelow` entrance condition must match with a `leaveWithPlatformBelow` exit condition on the other side of the door. A match is valid provided the `height`, `leftPosition`, and `rightPosition` properties on the `leaveWithDoorFrameBelow` satisfy all applicable constraints indicated by properties in the `comeInWithPlatformBelow`:
+$$\text{minHeight} \leq \text{height} \leq \text{maxHeight}$$
+$$\text{leftPosition} \leq \text{maxLeftPosition}$$
+$$\text{rightPosition} \geq \text{minRightPosition}$$
+
+A `comeInWithPlatformBelow` entrance condition has no implicit requirements.
 
 ## G-Mode Regain Mobility
 

--- a/strats.md
+++ b/strats.md
@@ -298,9 +298,6 @@ A `leaveWithPlatformBelow` object has the following properties:
 - _height_: The number of tiles between the door transition and the platform, not including the transition tiles or platform itself. A horizontal slope tile (as in Blue Hopper Room) counts as a half tile.
 - _leftPosition_: This indicates the position of the furthest left usable tile of the platform, relative to the center of the door. A negative values indicates a position to the left of the door center, while a positive value indicates a position to the right of the door center. An open end, if applicable, is represented by an extra half tile.
 - _rightPosition_: This indicates the position of the furthest right usable tile of the platform, relative to the center of the door. A negative values indicates a position to the left of the door center, while a positive value indicates a position to the right of the door center. An open end, if applicable, is represented by an extra half tile.
-- _comeInWithWallJumpBelow_: This indicates that Samus must come up through this door with momentum by wall-jumping in the door frame below.
-- _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below.
-- _comeInWithPlatformBelow_: This indicates that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.
 
 In a heated room, heat frames must be explicitly included in the strat `requires`, based on a worst-case assumption of how the platform could need to be used.
 
@@ -754,6 +751,21 @@ A `comeInWithWallJumpBelow` entrance condition must match with a `leaveWithDoorF
 
 A `comeInWithWallJumpBelow` implicitly includes a `canWalljump` tech requirement.
 
+__Example:__
+```json
+{
+  "name": "Cross Room Jump - Wall Jump",
+  "entranceCondition": {
+    "comeInWithWallJumpBelow": {
+      "minHeight": 2
+    }
+  },
+  "requires": [
+    "canCrossRoomJumpIntoWater"
+  ]
+}
+```
+
 ### Come In With Space Jump Below
 
 A `comeInWithSpaceJumpBelow` entrance condition indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below. It has no properties.
@@ -761,6 +773,19 @@ A `comeInWithSpaceJumpBelow` entrance condition indicates that Samus must come u
 A `comeInWithSpaceJumpBelow` entrance condition must match with a `leaveWithDoorFrameBelow` exit condition on the other side of the door.
 
 A `comeInWithWallJumpBelow` implicitly includes a `SpaceJump` item requirement. If the room below is heated, then a requirement of `{"heatFrames": 30}` is implicitly included.
+
+__Example:__
+```json
+{
+  "name": "Cross Room Jump - Space Jump",
+  "entranceCondition": {
+    "comeInWithSpaceJumpBelow": {}
+  },
+  "requires": [
+    "canCrossRoomJumpIntoWater"
+  ]
+}
+```
 
 ### Come In With Platform Below
 
@@ -777,6 +802,24 @@ $$\text{leftPosition} \leq \text{maxLeftPosition}$$
 $$\text{rightPosition} \geq \text{minRightPosition}$$
 
 A `comeInWithPlatformBelow` entrance condition has no implicit requirements.
+
+__Example:__
+```json
+{
+  "name": "Cross Room Jump - Standing Jump",
+  "entranceCondition": {
+    "comeInWithPlatformBelow": {
+      "minHeight": 6,
+      "maxHeight": 6,
+      "maxLeftPosition": 1,
+      "minRightPosition": 2
+    }
+  },
+  "requires": [
+    "canCrossRoomJumpIntoWater"
+  ]
+}
+```
 
 ## G-Mode Regain Mobility
 

--- a/strats.md
+++ b/strats.md
@@ -274,7 +274,7 @@ A `leaveWithDoorFrameBelow` object has the following property:
 
 - _height_: The number of tiles beneath the door transition (not including the transition tiles) usable for wall-jumping.
 
-In a heated room, heat frames must be explicitly included in the strat `requires`, based on an assumption of wall-jumping up through the door. If the strat in the neighboring room has a `comeInWithSpaceJumpBelow` entrance condition, then additional heat frames will be implicitly included to use Space Jump, so that does not need to be included in the `leaveWithDoorFrameBelow` strat. Likewise, requirements for `canWalljump` or `SpaceJump` do not need to included, as these will be implicitly included in the corresponding entrance conditions.
+In a heated room, heat frames must be explicitly included in the strat `requires`, based on an assumption of wall-jumping up through the door. If the strat in the neighboring room has a `comeInWithSpaceJumpBelow` entrance condition, then additional heat frames will be implicitly included to use Space Jump, so that does not need to be included in the `leaveWithDoorFrameBelow` strat. Likewise, requirements for `canWalljump` or `SpaceJump` do not need to included, as these will be implicitly included in the corresponding entrance conditions. If a strat starts at the same (door) node that it ends at, then heat frames should include the time required to fall down from the door, shoot it open, and then wall-jump back out.
 
 #### Example
 ```json
@@ -299,7 +299,7 @@ A `leaveWithPlatformBelow` object has the following properties:
 - _leftPosition_: This indicates the position of the furthest left usable tile of the platform, relative to the center of the door. A negative values indicates a position to the left of the door center, while a positive value indicates a position to the right of the door center. An open end, if applicable, is represented by an extra half tile.
 - _rightPosition_: This indicates the position of the furthest right usable tile of the platform, relative to the center of the door. A negative values indicates a position to the left of the door center, while a positive value indicates a position to the right of the door center. An open end, if applicable, is represented by an extra half tile.
 
-In a heated room, heat frames must be explicitly included in the strat `requires`, based on a worst-case assumption of how the platform could need to be used.
+In a heated room, heat frames must be explicitly included in the strat `requires`, based on a worst-case assumption of how the platform could need to be used. If a strat starts at the same (door) node that it ends at, then heat frames should include the time required to fall down from the door, shoot it open, position at the far end of the runway, and jump out.
 
 #### Example
 ```json


### PR DESCRIPTION
This PR introduces the schema changes needed to migrate jumpways to the new style of cross-room strat, continuing the work of #1059.

The mechanics of the matching is mostly left unchanged; i.e., as in the old jumpway schema, the strat in the upper room specifies constraints on the `height`, `leftPosition`, and `rightPosition` properties of the matching strat in the lower room. The most significant change is that rather than having a single generic leaveWithJumpway/comeInWithJumpway with multiple possible jumpwayTypes, I split it up a bit more into finer-grained conditions, eliminating the need for a `jumpwayType`:

- Exit conditions: `leaveWithDoorFrameBelow`, `leaveWithPlatformBelow`
- Entrance conditions: `comeInWithWallJumpBelow`, `comeInWithSpaceJumpBelow`, `comeInWithPlatformBelow`

The main reason for splitting up `comeInWithWallJumpBelow` and `comeInWithSpaceJumpBelow` as entrance conditions is because of the somewhat substantial difference in heat frames between these two, if the lower room is heated. Strats which do a Spring Ball jump in the lower room can be expressed with `leaveWithPlatformBelow`/`comeInWithPlatformBelow`; I don't currently see a need for it to have its own entrance condition.