### PR TITLE
Refine leaveShinecharged in Spore Spawn Kihunter Room

### DIFF
--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -137,16 +137,18 @@
           "h_hasBeamUpgrade"
         ]},
         {"canShineCharge": {
-          "usedTiles": 32,
+          "usedTiles": 25,
           "openEnd": 0
         }},
-        "canShinechargeMovement"
+        "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 30
+          "framesRemaining": 75
         }
-      }
+      },
+      "note": "Store a shinecharge with enough space remaining to run and jump over all the steps with a single jump.",
+      "devNote": "The runway is 32 tiles, but about 7 of those should be used to run after getting the shinecharge."
     },
     {
       "link": [1, 1],
@@ -200,16 +202,18 @@
       "name": "Leave Shinecharged",
       "requires": [
         {"canShineCharge": {
-          "usedTiles": 32,
+          "usedTiles": 25,
           "openEnd": 0
         }},
-        "canShinechargeMovement"
+        "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 40
+          "framesRemaining": 70
         }
-      }
+      },
+      "note": "Store a shinecharge with enough space remaining to run and jump over all the steps with a single jump.",
+      "devNote": "The runway is 32 tiles, but about 7 of those should be used to run after getting the shinecharge."
     },
     {
       "link": [2, 2],


### PR DESCRIPTION
Using the full 32 tiles of runway to get a shinecharge makes it not really practical to get up the steps with any frames remaining (technically possible, but hard and pointless). So this PR rewrites the strat to require a 25-tile charge, to leave room to gain run speed to jump up the steps. 

I think the movement here goes beyond expectations of "canShinechargeMovement", so this PR changes it to "canShinechargeMovementComplex". And the frames remaining are increased significantly, which for example will put it in logic to be used with Reverse Croc Speedway.