### PR TITLE
Red Tower top: easier shinespark strats

### DIFF
--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -780,7 +780,7 @@
     },
     {
       "link": [1, 5],
-      "name": "Red Tower Hero Shot Spark (Come In Shinecharged)",
+      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharged)",
       "notable": true,
       "reusableRoomwideNotable": "Red Tower Hero Shot Shinespark",
       "entranceCondition": {

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -340,7 +340,7 @@
       ]
     },
     {
-      "name": "Red Tower Spark",
+      "name": "Red Tower Hero Shot Spark",
       "note": [
         "Come in shinecharged (or shinecharging) from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
         "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
@@ -780,9 +780,9 @@
     },
     {
       "link": [1, 5],
-      "name": "Red Tower Spark (Come In Shinecharged)",
+      "name": "Red Tower Hero Shot Spark (Come In Shinecharged)",
       "notable": true,
-      "reusableRoomwideNotable": "Red Tower Spark",
+      "reusableRoomwideNotable": "Red Tower Hero Shot Spark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 100
@@ -801,9 +801,9 @@
     },
     {
       "link": [1, 5],
-      "name": "Red Tower Spark (Come In Shinecharging)",
+      "name": "Red Tower Hero Shot Spark (Come In Shinecharging)",
       "notable": true,
-      "reusableRoomwideNotable": "Red Tower Spark",
+      "reusableRoomwideNotable": "Red Tower Hero Shot Spark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 10,
@@ -834,6 +834,43 @@
           "HiJump",
           "h_canFly",
           "canWalljump"
+        ]}
+      ]
+    },
+    {
+      "link": [1, 9],
+      "name": "Shinespark (Come In Shinecharged)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 50
+        }
+      },
+      "requires": [
+        {"or": [
+          {"shinespark": {"frames": 68, "excessFrames": 29}},
+          {"and": [
+            "canMidairShinespark",
+            {"shinespark": {"frames": 60, "excessFrames": 28}}
+          ]}
+        ]}
+      ]
+    },
+    {
+      "link": [1, 9],
+      "name": "Shinespark (Come In Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 10,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"or": [
+          {"shinespark": {"frames": 68, "excessFrames": 29}},
+          {"and": [
+            "canMidairShinespark",
+            {"shinespark": {"frames": 60, "excessFrames": 28}}
+          ]}
         ]}
       ]
     },

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -838,25 +838,47 @@
       ]
     },
     {
-      "link": [1, 9],
-      "name": "Shinespark (Come In Shinecharged)",
+      "link": [1, 5],
+      "name": "Instant Diagonal Shinespark (Come In Shinecharged)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 1
+        }
+      },
+      "requires": [
+        {"shinespark": {"frames": 68, "excessFrames": 20}},
+        "canUseFrozenEnemies"
+      ]
+    },
+    {
+      "link": [1, 5],
+      "name": "Vertical Shinespark (Come In Shinecharged)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 20
+        }
+      },
+      "requires": [
+        {"shinespark": {"frames": 68, "excessFrames": 29}},
+        "canUseFrozenEnemies"
+      ]
+    },
+    {
+      "link": [1, 5],
+      "name": "Vertical Mid-Air Shinespark (Come In Shinecharged)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 50
         }
       },
       "requires": [
-        {"or": [
-          {"shinespark": {"frames": 68, "excessFrames": 29}},
-          {"and": [
-            "canMidairShinespark",
-            {"shinespark": {"frames": 60, "excessFrames": 28}}
-          ]}
-        ]}
+        "canMidairShinespark",
+        {"shinespark": {"frames": 60, "excessFrames": 28}},
+        "canUseFrozenEnemies"
       ]
     },
     {
-      "link": [1, 9],
+      "link": [1, 5],
       "name": "Shinespark (Come In Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
@@ -871,7 +893,8 @@
             "canMidairShinespark",
             {"shinespark": {"frames": 60, "excessFrames": 28}}
           ]}
-        ]}
+        ]},
+        "canUseFrozenEnemies"
       ]
     },
     {

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -340,7 +340,7 @@
       ]
     },
     {
-      "name": "Red Tower Hero Shot Spark",
+      "name": "Red Tower Hero Shot Shinespark",
       "note": [
         "Come in shinecharged (or shinecharging) from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
         "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
@@ -782,7 +782,7 @@
       "link": [1, 5],
       "name": "Red Tower Hero Shot Spark (Come In Shinecharged)",
       "notable": true,
-      "reusableRoomwideNotable": "Red Tower Hero Shot Spark",
+      "reusableRoomwideNotable": "Red Tower Hero Shot Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 100
@@ -801,9 +801,9 @@
     },
     {
       "link": [1, 5],
-      "name": "Red Tower Hero Shot Spark (Come In Shinecharging)",
+      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharging)",
       "notable": true,
-      "reusableRoomwideNotable": "Red Tower Hero Shot Spark",
+      "reusableRoomwideNotable": "Red Tower Hero Shot Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 10,

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -780,65 +780,6 @@
     },
     {
       "link": [1, 5],
-      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharged)",
-      "notable": true,
-      "reusableRoomwideNotable": "Red Tower Hero Shot Shinespark",
-      "entranceCondition": {
-        "comeInShinecharged": {
-          "framesRequired": 100
-        }
-      },
-      "requires": [
-        "canHeroShot",
-        {"shinespark": {"frames": 77, "excessFrames": 3}},
-        {"ammo": {"type": "Missile", "count": 1}}
-      ],
-      "note": [
-        "Come in shinecharged from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
-        "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
-        "If done correctly, Samus will pass the Missile, break the bomb block platforms, then be passed by the Missile which will break the shot blocks at the top."
-      ]
-    },
-    {
-      "link": [1, 5],
-      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharging)",
-      "notable": true,
-      "reusableRoomwideNotable": "Red Tower Hero Shot Shinespark",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 10,
-          "openEnd": 1
-        }
-      },
-      "requires": [
-        "canHeroShot",
-        {"shinespark": {"frames": 77, "excessFrames": 3}},
-        {"ammo": {"type": "Missile", "count": 1}}
-      ],
-      "note": [
-        "Come in shinecharging from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
-        "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
-        "If done correctly, Samus will pass the Missile, break the bomb block platforms, then be passed by the Missile which will break the shot blocks at the top."
-      ]
-    },
-    {
-      "link": [1, 6],
-      "name": "Base",
-      "requires": []
-    },
-    {
-      "link": [1, 9],
-      "name": "Base",
-      "requires": [
-        {"or": [
-          "HiJump",
-          "h_canFly",
-          "canWalljump"
-        ]}
-      ]
-    },
-    {
-      "link": [1, 5],
       "name": "Instant Diagonal Shinespark (Come In Shinecharged)",
       "entranceCondition": {
         "comeInShinecharged": {
@@ -895,6 +836,65 @@
           ]}
         ]},
         "canUseFrozenEnemies"
+      ]
+    },
+    {
+      "link": [1, 5],
+      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharged)",
+      "notable": true,
+      "reusableRoomwideNotable": "Red Tower Hero Shot Shinespark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "canHeroShot",
+        {"shinespark": {"frames": 77, "excessFrames": 3}},
+        {"ammo": {"type": "Missile", "count": 1}}
+      ],
+      "note": [
+        "Come in shinecharged from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
+        "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
+        "If done correctly, Samus will pass the Missile, break the bomb block platforms, then be passed by the Missile which will break the shot blocks at the top."
+      ]
+    },
+    {
+      "link": [1, 5],
+      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharging)",
+      "notable": true,
+      "reusableRoomwideNotable": "Red Tower Hero Shot Shinespark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 10,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canHeroShot",
+        {"shinespark": {"frames": 77, "excessFrames": 3}},
+        {"ammo": {"type": "Missile", "count": 1}}
+      ],
+      "note": [
+        "Come in shinecharging from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
+        "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
+        "If done correctly, Samus will pass the Missile, break the bomb block platforms, then be passed by the Missile which will break the shot blocks at the top."
+      ]
+    },
+    {
+      "link": [1, 6],
+      "name": "Base",
+      "requires": []
+    },
+    {
+      "link": [1, 9],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          "HiJump",
+          "h_canFly",
+          "canWalljump"
+        ]}
       ]
     },
     {


### PR DESCRIPTION
This adds alternative, easier shinespark strats for getting up the top of Red Tower without the hero shot. These need Ice in order to get the rest of the way up, but they have lower requirements in terms of tech, energy, and shinecharge frames. In particular they allow getting up without a tank, whereas the hero shot method requires a tank.