### PR TITLE
Tighten Reverse Croc Speedway shinecharge frames

### DIFF
--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -253,14 +253,14 @@
       "notable": true,
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 60
+          "framesRequired": 35
         }
       },
       "requires": [
         "h_canNavigateHeatRooms",
         "canShinechargeMovement",
-        {"shinespark": {"frames": 84, "excessFrames": 10}},
-        {"heatFrames": 760}
+        {"shinespark": {"frames": 86, "excessFrames": 10}},
+        {"heatFrames": 700}
       ],
       "clearsObstacles": ["A"],
       "reusableRoomwideNotable": "Croc Speedway Reverse Spark",


### PR DESCRIPTION
Tightening the shinecharge frames here since they were fairly loose, and this seemed like an important strat. 

Increased the shinespark frames by a couple since we're no longer assuming you have to get all the way next to the speed blocks before sparking.

I'm planning on implementing leniency for cross-room shinecharge frames probably in the next release of Map Rando, so this is part of why I'm thinking it can a good time to start moving toward tighter shinecharge frames where possible.