### PR TITLE
Make reverse Shaktool strat notable (for Medium)

### DIFF
--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -309,7 +309,8 @@
     },
     {
       "link": [2, 3],
-      "name": "Reverse Shaktool",
+      "name": "Shaktool Room Reverse",
+      "notable": true,
       "requires": [
         "h_canUsePowerBombs"
       ],


### PR DESCRIPTION
Newer players are often unaware that it is possible to do Shaktool Room in reverse. So this seems like a knowledge check belonging as a Medium notable, similar to reverse Botwoon (with Wave+Charge)