### PR TITLE
Update Screw Attack Transition Jump

### DIFF
--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -314,11 +314,21 @@
         "ScrewAttack",
         "HiJump",
         "SpeedBooster",
-        {"adjacentRunway": {
-          "fromNode": 2,
-          "usedTiles": 2,
-          "physics": ["normal"]
-        }},
+        {"or": [
+          {"adjacentRunway": {
+            "fromNode": 2,
+            "usedTiles": 6,
+            "physics": ["normal"]
+          }},
+          {"and": [
+            {"adjacentRunway": {
+              "fromNode": 2,
+              "usedTiles": 2,
+              "physics": ["normal"]
+            }},
+            "canTrickyDashJump"
+          ]}
+        ]},
         {"heatFrames": 150}
       ],
       "clearsObstacles": ["A"],


### PR DESCRIPTION
Can be done with as low as 1.4375 tiles. It may also be doable with shorter runways with a `canMidairWiggle`, but I figure these can be added when this room is migrated.