### PR TITLE
Brinstar unlocksDoors

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -134,7 +134,8 @@
         "leaveShinecharged": {
           "framesRemaining": 100
         }
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 2],
@@ -152,6 +153,7 @@
           "framesRemaining": 60
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Shoot the bridge to see where it ends.",
         "Opening the door requires a shot that is fired while Samus has some momentum from running to the right.",
@@ -235,6 +237,16 @@
       "note": [
         "It's a delayed walljump while the water is low, followed by a tight walljump off the bridge.",
         "This strat is easily bypassed by jumping through the door, or if the door can be opened."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Speedy Airball",
+      "requires": [
+        {"doorUnlockedAtNode": 2},
+        "SpeedBooster",
+        "canLateralMidAirMorph",
+        "canCarefulJump"
       ]
     },
     {

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -153,7 +153,10 @@
           "framesRemaining": 60
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": []},
+        {"types": ["missiles", "super"], "requires": ["canTrickyJump"]}
+      ],
       "note": [
         "Shoot the bridge to see where it ends.",
         "Opening the door requires a shot that is fired while Samus has some momentum from running to the right.",

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -154,7 +154,11 @@
         "leaveShinecharged": {
           "framesRemaining": "auto"
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
@@ -172,7 +176,11 @@
         "leaveWithSpark": {
           "position": "bottom"
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 4],
@@ -194,7 +202,11 @@
         "leaveShinecharged": {
           "framesRemaining": "auto"
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -249,7 +261,11 @@
         "leaveShinecharged": {
           "framesRemaining": "auto"
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 4],

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -288,7 +288,8 @@
         "leaveShinecharged": {
           "framesRemaining": 130
         }
-      }
+      },
+      "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 4],

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -558,6 +558,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Charge a spark, then break the shot blocks, drop through, and spark out the bottom right door."
     },
     {

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1660,6 +1660,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
       "note": [
         "Jump over the bug pipe while blue and roll into the morph tunnel to break the bomb block.",
         "Shortcharge too much and the jump will not be able to reach the morph tunnel."
@@ -1708,6 +1709,7 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": "Shinecharge towards the top right door.  Then turn around for a fast mockball after jumping the bug pipe.",
       "devNote": "FIXME: add a leaveWithSpeedball here once the schema for that is ready."
     },
@@ -1939,7 +1941,8 @@
             {"shinespark": {"frames": 38, "excessFrames": 7}}
           ]}
         ]}
-      ]
+      ],
+      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}]
     },
     {
       "link": [13, 10],

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -304,56 +304,6 @@
     },
     {
       "link": [1, 3],
-      "name": "Blockade Leave with Moondance",
-      "requires": [
-        "h_canUseMorphBombs",
-        "canMoondance",
-        "SpeedBooster"
-      ],
-      "exitCondition": {
-        "leaveWithStoredFallSpeed": {
-          "fallSpeedInTiles": 1
-        }
-      },
-      "note": [
-        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
-        "Clear all enemies before starting.",
-        "Unmorph while on the top block to begin the Moondance.",
-        "Wiggle out to the left and use SpeedBooster to run through to the right side door."
-      ]
-    },
-    {
-      "link": [1, 3],
-      "name": "Blockade Leave with Extended Moondance",
-      "notable": true,
-      "requires": [
-        "h_canUseMorphBombs",
-        {"or": [
-          "SpeedBooster",
-          {"and": [
-            "ScrewAttack",
-            "canDisableEquipment"
-          ]}
-        ]},
-        "canExtendedMoondance"
-      ],
-      "exitCondition": {
-        "leaveWithStoredFallSpeed": {
-          "fallSpeedInTiles": 2
-        }
-      },
-      "reusableRoomwideNotable": "Dachora Room Blockade Extended Moondance",
-      "note": [
-        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
-        "Clear all enemies before starting.",
-        "Unmorph while on the top block to begin the Moondance.",
-        "Exactly 145 moonfalls after clipping into the bottom block (321 total), wiggle out to the left.",
-        "The next moonfall will clip Samus down two tiles.",
-        "Finally use Screw Attack or SpeedBooster to break the Bomb blocks and reach the right side door."
-      ]
-    },
-    {
-      "link": [1, 3],
       "name": "Transition with Stored Fall Speed",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
@@ -367,7 +317,11 @@
         "leaveWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
@@ -390,7 +344,11 @@
         "leaveWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
@@ -615,6 +573,7 @@
           "fallSpeedInTiles": 1
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Freeze one of the Metarees at a height where Samus can become stuck and then use it to Moondance.",
         "Stop after 175 Moonfalls, before Samus clips into the ground."
@@ -635,7 +594,11 @@
         "leaveWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 1],
@@ -658,7 +621,11 @@
         "leaveWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 1],
@@ -751,6 +718,56 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [3, 3],
+      "name": "Blockade Leave with Moondance",
+      "requires": [
+        "h_canUseMorphBombs",
+        "canMoondance",
+        "SpeedBooster"
+      ],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "note": [
+        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
+        "Clear all enemies before starting.",
+        "Unmorph while on the top block to begin the Moondance.",
+        "Wiggle out to the left and use SpeedBooster to run through to the right side door."
+      ]
+    },
+    {
+      "link": [3, 3],
+      "name": "Blockade Leave with Extended Moondance",
+      "notable": true,
+      "requires": [
+        "h_canUseMorphBombs",
+        {"or": [
+          "SpeedBooster",
+          {"and": [
+            "ScrewAttack",
+            "canDisableEquipment"
+          ]}
+        ]},
+        "canExtendedMoondance"
+      ],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 2
+        }
+      },
+      "reusableRoomwideNotable": "Dachora Room Blockade Extended Moondance",
+      "note": [
+        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
+        "Clear all enemies before starting.",
+        "Unmorph while on the top block to begin the Moondance.",
+        "Exactly 145 moonfalls after clipping into the bottom block (321 total), wiggle out to the left.",
+        "The next moonfall will clip Samus down two tiles.",
+        "Finally use Screw Attack or SpeedBooster to break the Bomb blocks and reach the right side door."
+      ]
     },
     {
       "link": [3, 3],

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -190,6 +190,7 @@
       "link": [1, 1],
       "name": "Blockade Leave with Moondance",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "h_canUseMorphBombs",
         "canMoondance"
       ],
@@ -208,6 +209,7 @@
       "name": "Blockade Leave with Extended Moondance",
       "notable": true,
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "h_canUseMorphBombs",
         "canExtendedMoondance"
       ],
@@ -247,6 +249,7 @@
       "name": "Blockade Extended Moondance Clip",
       "notable": true,
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "h_canUseMorphBombs",
         "ScrewAttack",
         "canExtendedMoondance",
@@ -301,6 +304,60 @@
         ]}
       ],
       "clearsObstacles": ["A"]
+    },
+    {
+      "link": [1, 3],
+      "name": "Blockade Leave with Moondance",
+      "requires": [
+        {"obstaclesNotCleared": ["A"]},
+        "h_canUseMorphBombs",
+        "canMoondance",
+        "SpeedBooster"
+      ],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
+        "Clear all enemies before starting.",
+        "Unmorph while on the top block to begin the Moondance.",
+        "Wiggle out to the left and use SpeedBooster to run through to the right side door."
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Blockade Leave with Extended Moondance",
+      "notable": true,
+      "requires": [
+        {"obstaclesNotCleared": ["A"]},
+        "h_canUseMorphBombs",
+        {"or": [
+          "SpeedBooster",
+          {"and": [
+            "ScrewAttack",
+            "canDisableEquipment"
+          ]}
+        ]},
+        "canExtendedMoondance"
+      ],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 2
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "reusableRoomwideNotable": "Dachora Room Blockade Extended Moondance",
+      "note": [
+        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
+        "Clear all enemies before starting.",
+        "Unmorph while on the top block to begin the Moondance.",
+        "Exactly 145 moonfalls after clipping into the bottom block (321 total), wiggle out to the left.",
+        "The next moonfall will clip Samus down two tiles.",
+        "Finally use Screw Attack or SpeedBooster to break the Bomb blocks and reach the right side door."
+      ]
     },
     {
       "link": [1, 3],
@@ -718,56 +775,6 @@
           "openEnd": 1
         }
       }
-    },
-    {
-      "link": [3, 3],
-      "name": "Blockade Leave with Moondance",
-      "requires": [
-        "h_canUseMorphBombs",
-        "canMoondance",
-        "SpeedBooster"
-      ],
-      "exitCondition": {
-        "leaveWithStoredFallSpeed": {
-          "fallSpeedInTiles": 1
-        }
-      },
-      "note": [
-        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
-        "Clear all enemies before starting.",
-        "Unmorph while on the top block to begin the Moondance.",
-        "Wiggle out to the left and use SpeedBooster to run through to the right side door."
-      ]
-    },
-    {
-      "link": [3, 3],
-      "name": "Blockade Leave with Extended Moondance",
-      "notable": true,
-      "requires": [
-        "h_canUseMorphBombs",
-        {"or": [
-          "SpeedBooster",
-          {"and": [
-            "ScrewAttack",
-            "canDisableEquipment"
-          ]}
-        ]},
-        "canExtendedMoondance"
-      ],
-      "exitCondition": {
-        "leaveWithStoredFallSpeed": {
-          "fallSpeedInTiles": 2
-        }
-      },
-      "reusableRoomwideNotable": "Dachora Room Blockade Extended Moondance",
-      "note": [
-        "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
-        "Clear all enemies before starting.",
-        "Unmorph while on the top block to begin the Moondance.",
-        "Exactly 145 moonfalls after clipping into the bottom block (321 total), wiggle out to the left.",
-        "The next moonfall will clip Samus down two tiles.",
-        "Finally use Screw Attack or SpeedBooster to break the Bomb blocks and reach the right side door."
-      ]
     },
     {
       "link": [3, 3],

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -250,6 +250,7 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": "Charge a spark on the dry platform, and jump into a mid-air spark across the room and through the door."
     },
     {
@@ -268,6 +269,7 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": "Charge a spark going left, then build speed and jump far to the right into a mid-air spark across the room and through the door."
     },
     {

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -98,9 +98,10 @@
     {
       "link": [1, 1],
       "name": "Open the Door",
-      "requires": [],
-      "clearsObstacles": ["A"],
-      "devNote": "A doorUnlockedAtNode requirement is not included, since it is implicitly included in the exitCondition of strats that rely on this."
+      "requires": [
+        {"doorUnlockedAtNode": 1}
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 1],
@@ -289,7 +290,9 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "note": "Use the really small runway in the pit in the middle of the room. The door must be already opened."
+      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "note": "Use the really small runway in the pit in the middle of the room. The door must be already opened.",
+      "devNote": "Unlocking the door is free since obstacle A being cleared implies it was already unlocked earlier if needed."
     },
     {
       "link": [2, 1],
@@ -334,13 +337,17 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
       "note": [
         "Jump from the runway near the right door to bounce onto spikes for X-Mode.",
         "Store a spark in X-Mode and use that to shinepark across the room.",
         "Bumping a solid tile before activating X-Mode will remove dash state, preventing shinecharging.",
         "The left door must have been opened previously, in order to shinespark through it."
       ],
-      "devNote": "Omitting leniency spikeHits, since the firefleas provide an opportunity to farm after a failed attempt."
+      "devNote": [
+        "Omitting leniency spikeHits, since the firefleas provide an opportunity to farm after a failed attempt.",
+        "Unlocking the door is free since obstacle A being cleared implies it was already unlocked earlier if needed."
+      ]
     },
     {
       "link": [2, 1],
@@ -499,7 +506,8 @@
           "mustStayPut": false
         }},
         {"refill": ["Energy", "PowerBomb"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "link": [2, 2],

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -604,6 +604,10 @@
           "fallSpeedInTiles": 1
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
+      ],
       "note": [
         "Break the Power Bomb Blocks without killing the Beetom",
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
@@ -625,6 +629,10 @@
         }},
         "h_ExtendedMoondanceBeetomLeniency"
       ],
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
+      ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
@@ -655,6 +663,27 @@
           "fallSpeedInTiles": 1
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {
+          "types": ["powerbomb"], 
+          "requires": [
+            {"or": [
+              "canWalljump",
+              "h_canFly",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "HiJump",
+                "SpeedBooster"
+              ]}
+            ]}
+          ],
+          "note": [
+            "Using a Power Bomb here requires leaving the Beetom above and going back for it.",
+            "The Power Bomb will destroy the nearby Rippers, which is why there are additional requirements to get back up."
+          ]
+        }
+      ],
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
@@ -679,6 +708,27 @@
           "fallSpeedInTiles": 2
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {
+          "types": ["powerbomb"], 
+          "requires": [
+            {"or": [
+              "canWalljump",
+              "h_canFly",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "HiJump",
+                "SpeedBooster"
+              ]}
+            ]}
+          ],
+          "note": [
+            "Using a Power Bomb here requires leaving the Beetom above and going back for it.",
+            "The Power Bomb will destroy the nearby Rippers, which is why there are additional requirements to get back up."
+          ]
+        }
+      ],
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "After 175 Moonfalls, reposition the Beetom to chest height.",
@@ -703,6 +753,27 @@
           "fallSpeedInTiles": 1
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {
+          "types": ["powerbomb"], 
+          "requires": [
+            {"or": [
+              "canWalljump",
+              "h_canFly",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "HiJump",
+                "SpeedBooster"
+              ]}
+            ]}
+          ],
+          "note": [
+            "Using a Power Bomb here requires leaving the Beetom above and going back for it.",
+            "The Power Bomb will destroy the nearby Rippers, which is why there are additional requirements to get back up."
+          ]
+        }
+      ],
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
@@ -727,6 +798,27 @@
           "fallSpeedInTiles": 2
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {
+          "types": ["powerbomb"], 
+          "requires": [
+            {"or": [
+              "canWalljump",
+              "h_canFly",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "HiJump",
+                "SpeedBooster"
+              ]}
+            ]}
+          ],
+          "note": [
+            "Using a Power Bomb here requires leaving the Beetom above and going back for it.",
+            "The Power Bomb will destroy the nearby Rippers, which is why there are additional requirements to get back up."
+          ]
+        }
+      ],
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "After 175 Moonfalls, reposition the Beetom to chest height.",
@@ -738,6 +830,11 @@
       "name": "Leave with Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
+        {"or": [
+          "HiJump",
+          "SpaceJump",
+          "canWalljump"
+        ]},
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {
@@ -751,6 +848,7 @@
           "fallSpeedInTiles": 1
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
@@ -761,6 +859,11 @@
       "name": "Leave with Extended Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
+        {"or": [
+          "HiJump",
+          "SpaceJump",
+          "canWalljump"
+        ]},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {
@@ -775,6 +878,7 @@
           "fallSpeedInTiles": 2
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "After 175 Moonfalls, reposition the Beetom to chest height.",
@@ -981,7 +1085,8 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [{"nodeId": 4, "types": ["ammo"], "requires": []}]
     },
     {
       "link": [3, 4],
@@ -1280,7 +1385,8 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}]
     },
     {
       "link": [4, 6],


### PR DESCRIPTION
In addition to adding `unlocksDoors` there are a couple more little things:
- A new "Speedy Airball" strat in "Blue Brinstar Boulder Room" (pointed out by insomniaspeed).
- Fix to Red Tower 1 -> 5 "Leave with Moondance" strats; it seemed to be missing requirements for how to get to the top of the room; freezing the Rippers alone is not enough.