### PR TITLE
Add req for Green Pirates Shaft using i-frames

### DIFF
--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -272,7 +272,7 @@
     },
     {
       "link": [2, 4],
-      "name": "Tank the Damage",
+      "name": "Tank the Damage (Use I-Frames to Reduce Damage)",
       "requires": [
         {"enemyDamage": {
           "enemy": "Green Space Pirate (standing)",
@@ -556,8 +556,20 @@
     },
     {
       "link": [4, 2],
-      "name": "Tank the Damage",
+      "name": "Tank the Damage (Get Hit by Each Pirate)",
       "requires": [
+        {"enemyDamage": {
+          "enemy": "Green Space Pirate (standing)",
+          "type": "contact",
+          "hits": 5
+        }}
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Tank the Damage (Use I-Frames to Reduce Damage)",
+      "requires": [
+        "canCarefulJump",
         {"enemyDamage": {
           "enemy": "Green Space Pirate (standing)",
           "type": "contact",


### PR DESCRIPTION
Going top-to-bottom with only 3 pirate hits seems free. But going bottom-to-top needs somewhat precise movement.