### PR TITLE
Add G-Mode Strats to Everest and Glass Tunnel, Update Glass Tunnel

### DIFF
--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -90,19 +90,7 @@
               "name": "Base",
               "notable": false,
               "requires": [
-                "h_canUsePowerBombs"
-              ]
-            },
-            {
-              "name": "G-Mode Morph PB",
-              "notable": false,
-              "requires": [
-                {"comeInWithGMode": {
-                  "fromNodes": [1, 3],
-                  "mode": "any",
-                  "artificialMorph": true
-                }},
-                {"ammo": {"type": "PowerBomb", "count": 1}}
+                {"obstaclesCleared": ["A"]}
               ]
             }
           ]
@@ -125,21 +113,8 @@
               "name": "Base",
               "notable": false,
               "requires": [
-                "h_canUsePowerBombs"
+                {"obstaclesCleared": ["A"]}
               ]
-            },
-            {
-              "name": "G-Mode Morph PB",
-              "notable": false,
-              "requires": [
-                {"comeInWithGMode": {
-                  "fromNodes": [4],
-                  "mode": "any",
-                  "artificialMorph": true
-                }},
-                {"ammo": {"type": "PowerBomb", "count": 1}}
-              ],
-              "devNote": "Be sure not to overload PLMs with the camera scroll blocks which are next to the tube. It is possible to exit g-mode before the PB goes off to be safe."
             }
           ]
         }
@@ -161,20 +136,10 @@
               "name": "Base",
               "notable": false,
               "requires": [
-                "h_canUsePowerBombs"
-              ]
-            },
-            {
-              "name": "G-Mode Morph PB",
-              "notable": false,
-              "requires": [
-                {"comeInWithGMode": {
-                  "fromNodes": [2],
-                  "mode": "any",
-                  "artificialMorph": true
-                }},
-                {"ammo": {"type": "PowerBomb", "count": 1}},
-                "h_canArtificialMorphMovement"
+                {"or": [
+                  "h_canUsePowerBombs",
+                  {"obstaclesCleared": ["A"]}
+                ]}
               ]
             }
           ]
@@ -182,31 +147,16 @@
       ],
       "yields": ["f_MaridiaTubeBroken"],
       "note": "Represents the area just below the tube; unlocking this node breaks the tube"
-    },
-    {
-      "id": 8,
-      "name": "Maridia Tube Gravity Jump",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Maridia Tube Gravity Jump Event Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [],
-              "note": "This requires nothing, as its requirements are instead needed to get to this node."
-            }
-          ]
-        }
-      ],
-      "yields": ["f_MaridiaTubeBroken"],
-      "note": "This node is for triggering a suitless gravity jump while breaking the tube, which can only be done once."
     }
   ],
   "enemies": [],
+  "obstacles": [
+    {
+      "id": "A",
+      "obstacleType": "abstract",
+      "name": "Breaking the Tube"
+    }
+  ],
   "reusableRoomwideNotable": [
     {
       "name": "Glass Tunnel Maridia Tube Clip",
@@ -224,7 +174,7 @@
         {"id": 3},
         {
           "id": 4,
-          "note": "This link is only for the cross room jump. Other strats should go 1 -> 5 -> 6 -> 8 -> 4."
+          "note": "This link is only for the cross room jump. Other strats should go 1 -> 5 -> 6 -> 4."
         },
         {"id": 5}
       ]
@@ -237,7 +187,7 @@
         {"id": 3},
         {
           "id": 4,
-          "note": "This link is only for the cross room jump. Other strats should go 2 -> 7 -> 5 -> 6 -> 8 -> 4."
+          "note": "This link is only for the cross room jump. Other strats should go 2 -> 7 -> 5 -> 6 -> 4."
         },
         {"id": 7}
       ]
@@ -249,7 +199,7 @@
         {"id": 3},
         {
           "id": 4,
-          "note": "This link is only for the cross room jump. Other strats should go 3 -> 5 -> 6 -> 8 -> 4."
+          "note": "This link is only for the cross room jump. Other strats should go 3 -> 5 -> 6 -> 4."
         },
         {"id": 5}
       ]
@@ -267,20 +217,18 @@
       "to": [
         {"id": 1},
         {"id": 3},
+        {"id": 4},
+        {"id": 5},
         {"id": 6},
-        {"id": 7},
-        {
-          "id": 8,
-          "note": "While breaking the tube, gravity jump up to the top door. This can only be attempted once.",
-          "devNote": "This link is only used for getting a gravity jump through the top door while breaking the Maridia Tube."
-        }
+        {"id": 7}
       ]
     },
     {
       "from": 6,
       "to": [
         {"id": 4},
-        {"id": 5}
+        {"id": 5},
+        {"id": 6}
       ]
     },
     {
@@ -288,12 +236,6 @@
       "to": [
         {"id": 2},
         {"id": 5}
-      ]
-    },
-    {
-      "from": 8,
-      "to": [
-        {"id": 4}
       ]
     }
   ],
@@ -455,6 +397,22 @@
       "link": [1, 5],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [1, 5],
+      "name": "G-Mode Morph Power Bomb",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"not": "f_MaridiaTubeBroken"},
+        {"ammo": {"type": "PowerBomb", "count": 1}}
+      ],
+      "clearsObstacles": ["A"],
+      "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
     },
     {
       "link": [2, 1],
@@ -634,6 +592,23 @@
       "requires": []
     },
     {
+      "link": [2, 7],
+      "name": "G-Mode Morph Power Bomb",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"not": "f_MaridiaTubeBroken"},
+        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphMovement"
+      ],
+      "clearsObstacles": ["A"],
+      "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
+    },
+    {
       "link": [3, 1],
       "name": "Shinespark Through Room",
       "entranceCondition": {
@@ -785,6 +760,22 @@
       "requires": []
     },
     {
+      "link": [3, 5],
+      "name": "G-Mode Morph Power Bomb",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"not": "f_MaridiaTubeBroken"},
+        {"ammo": {"type": "PowerBomb", "count": 1}}
+      ],
+      "clearsObstacles": ["A"],
+      "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
+    },
+    {
       "link": [4, 1],
       "name": "Carry G-Mode Through Tube (Top to Left)",
       "notable": false,
@@ -866,6 +857,26 @@
       "requires": []
     },
     {
+      "link": [4, 6],
+      "name": "G-Mode Morph Power Bomb",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"not": "f_MaridiaTubeBroken"},
+        {"ammo": {"type": "PowerBomb", "count": 1}}
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later.",
+        "Be sure not to overload PLMs with the camera scroll blocks which are next to the tube.",
+        "It is possible to exit G-Mode before the Power Bomb goes off to be safe."
+      ]
+    },
+    {
       "link": [5, 1],
       "name": "Base",
       "requires": []
@@ -874,6 +885,32 @@
       "link": [5, 3],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [5, 4],
+      "name": "Breaking the Maridia Tube Gravity Jump",
+      "notable": true,
+      "requires": [
+        "f_MaridiaTubeBroken",
+        {"obstaclesCleared": ["A"]},
+        "canRiskPermanentLossOfAccess",
+        "canSuitlessMaridia",
+        "canTrickyJump"
+      ],
+      "note": [
+        "Jump as the first action after breaking the tube to gravity jump to the top of the room.",
+        "Open the door and go through it during the ascent. This can only be attempted once."
+      ],
+      "devNote": "This strat requires the tube to be broken, while the obstacle being set requires the tube to not yet be broken."
+    },
+    {
+      "link": [5, 5],
+      "name": "Break the Tube with a Power Bomb",
+      "requires": [
+        {"not": "f_MaridiaTubeBroken"},
+        "h_canUsePowerBombs"
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [5, 6],
@@ -906,44 +943,6 @@
       "name": "Base",
       "requires": [
         "f_MaridiaTubeBroken"
-      ]
-    },
-    {
-      "link": [5, 8],
-      "name": "Breaking the Maridia Tube Gravity Jump",
-      "notable": true,
-      "requires": [
-        {"not": "f_MaridiaTubeBroken"},
-        "canRiskPermanentLossOfAccess",
-        "h_canUsePowerBombs",
-        "canSuitlessMaridia",
-        "canTrickyJump"
-      ],
-      "note": [
-        "Jump as the first action after breaking the tube to gravity jump to the top of the room.",
-        "Open the door and go through it during the ascent. This can only be attempted once."
-      ]
-    },
-    {
-      "link": [5, 8],
-      "name": "G-Mode Morph Breaking the Maridia Tube Gravity Jump",
-      "notable": true,
-      "requires": [
-        {"comeInWithGMode": {
-          "fromNodes": [1, 3],
-          "mode": "any",
-          "artificialMorph": true
-        }},
-        {"ammo": {"type": "PowerBomb", "count": 1}},
-        {"not": "f_MaridiaTubeBroken"},
-        "canRiskPermanentLossOfAccess",
-        "canSuitlessMaridia",
-        "canTrickyJump"
-      ],
-      "note": [
-        "Jump as the first action after breaking the tube to gravity jump to the top of the room.",
-        "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later.",
-        "Open the door and go through it during the ascent. This can only be attempted once."
       ]
     },
     {
@@ -1009,6 +1008,15 @@
       ]
     },
     {
+      "link": [6, 6],
+      "name": "Break the Tube with a Power Bomb",
+      "requires": [
+        {"not": "f_MaridiaTubeBroken"},
+        "h_canUsePowerBombs"
+      ],
+      "clearsObstacles": ["A"]
+    },
+    {
       "link": [7, 2],
       "name": "Base",
       "requires": []
@@ -1018,14 +1026,9 @@
       "name": "Base",
       "requires": [
         "f_MaridiaTubeBroken"
-      ]
-    },
-    {
-      "link": [8, 4],
-      "name": "Base",
-      "requires": [
-        "f_MaridiaTubeBroken"
-      ]
+      ],
+      "resetsObstacles": ["A"],
+      "devNote": "The obstacle is reset, as 7 is too low to jump to 4."
     }
   ]
 }

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -568,6 +568,7 @@
       },
       "requires": [
         {"or": [
+          "Morph",
           "SpringBall",
           {"and": [
             "Gravity",
@@ -577,12 +578,48 @@
             "Gravity",
             "h_canArtificialMorphBombHorizontally"
           ]},
+          {"and": [
+            {"enemyDamage": {
+              "enemy": "Sciser",
+              "type": "contact",
+              "hits": 1
+            }},
+            {"or": [
+              "h_EverestMorphTunnelExpanded",
+              {"enemyDamage": {
+                "enemy": "Sciser",
+                "type": "contact",
+                "hits": 1
+              }}
+            ]}
+          ]}
+        ]}
+      ]
+    },
+    {
+      "link": [1, 12],
+      "name": "G-Mode Morph Suitless Bounce Into Tunnel",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canTrickyJump",
+        {"or": [
+          "h_EverestMorphTunnelExpanded",
           {"enemyDamage": {
             "enemy": "Sciser",
             "type": "contact",
             "hits": 1
           }}
         ]}
+      ],
+      "note": [
+        "Bounce from the right peak into the morph tunnel.",
+        "Samus can't bounce twice in a single fall, so start from the right ground, not the raised scaffolding by the door."
       ]
     },
     {
@@ -1108,7 +1145,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "devNote": "FIXME: Add strats to get here with Morph."
     },
     {
       "link": [3, 3],
@@ -1647,6 +1685,7 @@
       "requires": [
         "Gravity",
         {"or": [
+          "Morph",
           {"and": [
             "SpringBall",
             {"or": [
@@ -1657,7 +1696,8 @@
           "h_canArtificialMorphIBJ",
           "h_canArtificialMorphSpringBallBombJump"
         ]}
-      ]
+      ],
+      "devNote": "FIXME: Add strats to get here with Morph, suitless."
     },
     {
       "link": [5, 1],
@@ -1816,6 +1856,7 @@
       },
       "requires": [
         {"or": [
+          "Morph",
           "SpringBall",
           {"and": [
             "Gravity",
@@ -1826,6 +1867,37 @@
             "h_canArtificialMorphBombHorizontally"
           ]}
         ]}
+      ]
+    },
+    {
+      "link": [5, 12],
+      "name": "G-Mode Morph Suitless Bounce Into Tunnel",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canTrickyJump",
+        {"enemyDamage": {
+          "enemy": "Sciser",
+          "type": "contact",
+          "hits": 1
+        }},
+        {"or": [
+          "h_EverestMorphTunnelExpanded",
+          {"enemyDamage": {
+            "enemy": "Sciser",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ],
+      "note": [
+        "Bounce from the right peak into the morph tunnel.",
+        "Samus can't bounce twice in a single fall, so pause on the top platform or avoid it completely."
       ]
     },
     {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -87,6 +87,13 @@
       "name": "Upper Left Ledge Junction",
       "nodeType": "junction",
       "nodeSubType": "junction"
+    },
+    {
+      "id": 12,
+      "name": "G-Mode Junction (In Morph Tunnel)",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "note": "Represents being in the morph tunnel with G-Mode and morph or artificial morph"
     }
   ],
   "obstacles": [
@@ -206,7 +213,6 @@
       "to": [
         {"id": 1},
         {"id": 4, "note": "Shinespark direct link"},
-        {"id": 6},
         {
           "id": 9,
           "devNote": [
@@ -214,7 +220,8 @@
             "It is also possible to have a precise amount of energy to fall onto the blocks."
           ]
         },
-        {"id": 11}
+        {"id": 11},
+        {"id": 12}
       ]
     },
     {
@@ -230,7 +237,6 @@
           "note": "One-way link for shinesparking"
         },
         {"id": 5},
-        {"id": 6},
         {"id": 7},
         {"id": 8},
         {
@@ -240,7 +246,8 @@
         {
           "id": 11,
           "devNote": "One-way link for superless crab climb and cross-room jump."
-        }
+        },
+        {"id": 12}
       ]
     },
     {
@@ -270,7 +277,6 @@
           "note": "This link is for shinespark and cross room jumps. All other strats should take other routes."
         },
         {"id": 4},
-        {"id": 6},
         {
           "id": 9,
           "devNote": [
@@ -279,7 +285,8 @@
           ]
         },
         {"id": 10},
-        {"id": 11}
+        {"id": 11},
+        {"id": 12}
       ]
     },
     {
@@ -288,8 +295,8 @@
         {"id": 1},
         {"id": 4},
         {"id": 5},
-        {"id": 6},
-        {"id": 9}
+        {"id": 9},
+        {"id": 12}
       ]
     },
     {
@@ -362,6 +369,12 @@
         {"id": 8},
         {"id": 9}
       ]
+    },
+    {
+      "from": 12,
+      "to": [
+        {"id": 6}
+      ]
     }
   ],
   "strats": [
@@ -389,16 +402,65 @@
       "notable": false,
       "requires": [
         "Gravity",
-        "SpaceJump"
+        "canBePatient",
+        {"or": [
+          "SpaceJump",
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"or": [
+              "HiJump",
+              "canSpringBallJumpMidAir",
+              "canGravityJump",
+              "canConsecutiveWalljump",
+              "SpeedBooster"
+            ]}
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
       "note": [
         "Follow the crab from the bottom right door to the top left door. This takes approximately 90 seconds.",
-        "It is also possible to knock the crab off of the middle peak with a super and follow it to the left to save time."
+        "It is also possible to knock the crab off of the middle peak with a super and follow it to the left which may save time."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Setup - Get Hit By Sciser - Very Long Lure",
+      "notable": false,
+      "requires": [
+        "canBeVeryPatient",
+        {"or": [
+          "canGravityJump",
+          {"and": [
+            "canPreciseGrapple",
+            {"or": [
+              "HiJump",
+              "Gravity"
+            ]}
+          ]},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"or": [
+              "canTrickyUseFrozenEnemies",
+              {"and": [
+                "HiJump",
+                "canSpringBallJumpMidAir"
+              ]}
+            ]}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "note": [
+        "Follow the crab from the bottom right door to the top left door with Gravity or Grapple.",
+        "It is also possible to knock the crab off of the middle peak with a super and follow it to the left with Ice or HiJump and Spring Ball."
       ],
       "devNote": [
+        "These strats take approximately 2 minutes each, but because it is just for a G-Mode Setup, canBeVeryPatient was added.",
         "This could be done with many other sets of item combinations, but it would be very tedious for a g-mode setup."
       ]
     },
@@ -443,77 +505,6 @@
         "h_canArtificialMorphIBJ",
         "Gravity"
       ]
-    },
-    {
-      "link": [1, 6],
-      "name": "G-Mode Morph",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"or": [
-          "SpringBall",
-          {"and": [
-            "Gravity",
-            "h_canArtificialMorphIBJ"
-          ]},
-          {"and": [
-            "Gravity",
-            "h_canArtificialMorphBombHorizontally"
-          ]},
-          {"enemyDamage": {
-            "enemy": "Sciser",
-            "type": "contact",
-            "hits": 1
-          }}
-        ]}
-      ],
-      "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
-    },
-    {
-      "link": [1, 6],
-      "name": "Carry G-Mode Morph Through Tunnel From Top Left",
-      "notable": false,
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        "Morph",
-        {"or": [
-          {"and": [
-            "Gravity",
-            {"or": [
-              "HiJump",
-              "canWalljump",
-              "SpeedBooster",
-              "h_canFly",
-              "canSpringBallJumpMidAir",
-              "h_canSpringBallBombJump"
-            ]}
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump",
-            "canSpringBallJumpMidAir"
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "canTrickyUseFrozenEnemies",
-            "Grapple"
-          ]}
-        ]}
-      ],
-      "exitCondition": {
-        "leaveWithGMode": {
-          "morphed": true
-        }
-      }
     },
     {
       "link": [1, 9],
@@ -561,6 +552,34 @@
       "link": [1, 11],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [1, 12],
+      "name": "G-Mode Morph",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"or": [
+          "SpringBall",
+          {"and": [
+            "Gravity",
+            "h_canArtificialMorphIBJ"
+          ]},
+          {"and": [
+            "Gravity",
+            "h_canArtificialMorphBombHorizontally"
+          ]},
+          {"enemyDamage": {
+            "enemy": "Sciser",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ]
     },
     {
       "link": [2, 1],
@@ -700,79 +719,6 @@
         "This strat applies only with Post Crocomire Jump Room below.",
         "In Crocomire's Room, the different platform height affects which vertical speeds are obtainable, and apparently none of them work."
       ]
-    },
-    {
-      "link": [2, 6],
-      "name": "G-Mode Morph",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "Gravity",
-        {"or": [
-          "h_canArtificialMorphIBJ",
-          {"and": [
-            "SpringBall",
-            {"or": [
-              "canGravityJump",
-              "HiJump"
-            ]}
-          ]},
-          {"and": [
-            "h_canArtificialMorphSpringBallBombJump",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
-          ]}
-        ]}
-      ],
-      "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
-    },
-    {
-      "link": [2, 6],
-      "name": "Carry G-Mode Morph Through Tunnel From Bottom Left",
-      "notable": false,
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        "Morph",
-        {"or": [
-          {"and": [
-            "Gravity",
-            {"or": [
-              "HiJump",
-              "canWalljump",
-              "SpeedBooster",
-              "h_canFly",
-              "canSpringBallJumpMidAir",
-              "h_canSpringBallBombJump"
-            ]}
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump",
-            "canSpringBallJumpMidAir"
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "canTrickyUseFrozenEnemies",
-            "Grapple"
-          ]}
-        ]}
-      ],
-      "exitCondition": {
-        "leaveWithGMode": {
-          "morphed": true
-        }
-      }
     },
     {
       "link": [2, 7],
@@ -1128,6 +1074,36 @@
       },
       "requires": [
         {"shinespark": {"frames": 58, "excessFrames": 16}}
+      ]
+    },
+    {
+      "link": [2, 12],
+      "name": "G-Mode Morph",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphIBJ",
+          {"and": [
+            "SpringBall",
+            {"or": [
+              "canGravityJump",
+              "HiJump"
+            ]}
+          ]},
+          {"and": [
+            "h_canArtificialMorphSpringBallBombJump",
+            {"or": [
+              "Bombs",
+              {"ammo": {"type": "PowerBomb", "count": 1}}
+            ]}
+          ]}
+        ]}
       ]
     },
     {
@@ -1522,39 +1498,6 @@
       ]
     },
     {
-      "link": [4, 1],
-      "name": "G-Mode Morph IBJ",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "h_canArtificialMorphIBJ",
-        "Gravity"
-      ]
-    },
-    {
-      "link": [4, 1],
-      "name": "G-Mode Morph SpringBall Bomb Jump",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "Gravity",
-        "h_canArtificialMorphSpringBallBombJump",
-        {"or": [
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 1}}
-        ]}
-      ],
-      "note": "This requires two spring ball bomb jumps."
-    },
-    {
       "link": [4, 4],
       "name": "Leave with Runway",
       "requires": [],
@@ -1589,78 +1532,6 @@
       "devNote": [
         "This could be done with many other sets of item combinations, but it would be very tedious for a g-mode setup."
       ]
-    },
-    {
-      "link": [4, 6],
-      "name": "G-Mode Morph",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "Gravity",
-        {"or": [
-          {"and": [
-            "SpringBall",
-            {"or": [
-              "canGravityJump",
-              "HiJump"
-            ]}
-          ]},
-          "h_canArtificialMorphIBJ",
-          "h_canArtificialMorphSpringBallBombJump"
-        ]}
-      ],
-      "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
-    },
-    {
-      "link": [4, 6],
-      "name": "Carry G-Mode Morph Through Tunnel From Top Right",
-      "notable": false,
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        "Morph",
-        {"or": [
-          "canGravityJump",
-          {"and": [
-            "Gravity",
-            "canInsaneWalljump"
-          ]},
-          {"and": [
-            "Gravity",
-            "HiJump",
-            "canTrickyDashJump",
-            "canWalljump"
-          ]},
-          {"and": [
-            "Gravity",
-            "h_canFly"
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "Grapple",
-            "HiJump",
-            "canSpringBallJumpMidAir"
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "canTrickyUseFrozenEnemies",
-            "Grapple"
-          ]}
-        ]}
-      ],
-      "exitCondition": {
-        "leaveWithGMode": {
-          "morphed": true
-        }
-      }
     },
     {
       "link": [4, 9],
@@ -1743,6 +1614,30 @@
         }}
       ],
       "devNote": "With enough energy, this goes all the way to 1, but with less it stops prematurely at 11."
+    },
+    {
+      "link": [4, 12],
+      "name": "G-Mode Morph",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          {"and": [
+            "SpringBall",
+            {"or": [
+              "canGravityJump",
+              "HiJump"
+            ]}
+          ]},
+          "h_canArtificialMorphIBJ",
+          "h_canArtificialMorphSpringBallBombJump"
+        ]}
+      ]
     },
     {
       "link": [5, 1],
@@ -1869,7 +1764,12 @@
       }
     },
     {
-      "link": [5, 6],
+      "link": [5, 9],
+      "name": "Base",
+      "requires": []
+    },
+    {
+      "link": [5, 12],
       "name": "G-Mode Morph",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1889,62 +1789,7 @@
             "h_canArtificialMorphBombHorizontally"
           ]}
         ]}
-      ],
-      "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
-    },
-    {
-      "link": [5, 6],
-      "name": "Carry G-Mode Morph Through Tunnel From Top Middle",
-      "notable": false,
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        "Morph",
-        {"or": [
-          {"and": [
-            "canGravityJump",
-            {"or": [
-              "HiJump",
-              "canTrickyJump",
-              "canLateralMidAirMorph"
-            ]}
-          ]},
-          {"and": [
-            "Gravity",
-            "HiJump",
-            "SpeedBooster"
-          ]},
-          {"and": [
-            "Gravity",
-            "h_canFly"
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "Grapple",
-            "HiJump",
-            "canSpringBallJumpMidAir"
-          ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "canTrickyUseFrozenEnemies",
-            "Grapple"
-          ]}
-        ]}
-      ],
-      "exitCondition": {
-        "leaveWithGMode": {
-          "morphed": true
-        }
-      }
-    },
-    {
-      "link": [5, 9],
-      "name": "Base",
-      "requires": []
+      ]
     },
     {
       "link": [6, 2],
@@ -3002,6 +2847,22 @@
         "canDoubleSpringBallJumpMidAir"
       ],
       "note": "Start the spring ball jumps from the bottom of the slope."
+    },
+    {
+      "link": [12, 6],
+      "name": "Base",
+      "requires": [],
+      "devNote": "This technically requires h_EverestMorphTunnelExpanded or going through the transition while in G-Mode, but that shouldn't cause a problem."
+    },
+    {
+      "link": [12, 6],
+      "name": "Carry G-Mode Through the Tunnel",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
     }
   ],
   "devNote": [

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -205,6 +205,10 @@
         "Gain a shinecharge on the ledge near the top-left door.",
         "This is a very short runway, making it an exceptionally difficult short-charge."
       ]
+    },
+    {
+      "name": "Mt. Everest SpringBall out of Morph Tunnel",
+      "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
     }
   ],
   "links": [
@@ -1517,17 +1521,33 @@
     },
     {
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Sciser - Long Lure",
+      "name": "G-Mode Setup - Get Hit By Sciser - Lure From Bottom Right",
       "notable": false,
       "requires": [
-        "Gravity",
-        "SpaceJump"
+        {"or": [
+          {"and": [
+            "Gravity",
+            "SpaceJump"
+          ]},
+          "canGravityJump",
+          {"and": [
+            "Grapple",
+            {"or": [
+              "HiJump",
+              "Gravity"
+            ]}
+          ]},
+          {"and": [
+            "canDoubleSpringBallJumpMidAir",
+            "HiJump"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
       "note": [
-        "Follow the crab from the bottom right door to the top right door. This takes approximately 30 seconds."
+        "Follow the crab from the bottom right door to the top right door. Depending on the item setup, this takes 30-50 seconds."
       ],
       "devNote": [
         "This could be done with many other sets of item combinations, but it would be very tedious for a g-mode setup."
@@ -1750,9 +1770,26 @@
       "name": "G-Mode Setup - Frozen Sciser",
       "notable": false,
       "requires": [
-        "Gravity",
+        {"or": [
+          {"and": [
+            "Gravity",
+            "SpaceJump"
+          ]},
+          {"and": [
+            "HiJump",
+            "canPreciseGrapple",
+            {"or": [
+              "Gravity",
+              "canSpringBallJumpMidAir"
+            ]}
+          ]},
+          {"and": [
+            "HiJump",
+            "canGravityJump",
+            "canBeVeryPatient"
+          ]}
+        ]},
         "canUpwardGModeSetup",
-        "SpaceJump",
         "canTrickyUseFrozenEnemies",
         {"or": [
           "Morph",
@@ -1815,6 +1852,21 @@
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {
+      "link": [6, 4],
+      "name": "G-Mode Morph Indirect IBJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphIBJ",
+        "Gravity"
+      ],
+      "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
+    },
+    {
       "link": [6, 6],
       "name": "Leave with Runway",
       "requires": [
@@ -1861,6 +1913,89 @@
     },
     {
       "link": [6, 7],
+      "name": "G-Mode Morph IBJ or SpringBall Bomb Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_EverestMorphTunnelExpanded",
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphIBJ",
+          "h_canArtificialMorphSpringBallBombJump"
+        ]}
+      ],
+      "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
+    },
+    {
+      "link": [6, 7],
+      "name": "G-Mode Morph Indirect IBJ or SpringBall Bomb Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphIBJ",
+          "h_canArtificialMorphSpringBallBombJump"
+        ]}
+      ],
+      "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
+    },
+    {
+      "link": [6, 8],
+      "name": "Mt. Everest SpringBall out of Morph Tunnel",
+      "notable": true,
+      "requires": [
+        "canTrickyJump",
+        "h_canUseSpringBall"
+      ],
+      "reusableRoomwideNotable": "Mt. Everest SpringBall out of Morph Tunnel",
+      "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
+    },
+    {
+      "link": [6, 8],
+      "name": "Mt. Everest SpringBall out of Morph Tunnel (Artificial Morph)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_EverestMorphTunnelExpanded",
+        "canTrickyJump",
+        "SpringBall"
+      ],
+      "reusableRoomwideNotable": "Mt. Everest SpringBall out of Morph Tunnel",
+      "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
+    },
+    {
+      "link": [6, 8],
+      "name": "Mt. Everest SpringBall out of Morph Tunnel (Artificial Morph, Indirect)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "SpringBall"
+      ],
+      "reusableRoomwideNotable": "Mt. Everest SpringBall out of Morph Tunnel",
+      "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
+    },
+    {
+      "link": [6, 9],
       "name": "G-Mode Morph IBJ",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1876,45 +2011,15 @@
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {
-      "link": [6, 7],
-      "name": "G-Mode Morph SpringBall Bomb Jump",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "h_EverestMorphTunnelExpanded",
-        "Gravity",
-        "h_canArtificialMorphSpringBallBombJump"
-      ],
-      "note": [
-        "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab.",
-        "This requires one spring ball bomb jump."
-      ]
-    },
-    {
-      "link": [6, 8],
-      "name": "Mt. Everest SpringBall out of Morph Tunnel",
-      "notable": true,
-      "requires": [
-        "canTrickyJump",
-        "h_canUseSpringBall"
-      ],
-      "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
-    },
-    {
       "link": [6, 9],
-      "name": "G-Mode Morph IBJ",
+      "name": "G-Mode Morph Indirect IBJ",
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "indirect",
           "morphed": true
         }
       },
       "requires": [
-        "h_EverestMorphTunnelExpanded",
         "h_canArtificialMorphIBJ",
         "Gravity"
       ],

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1897,7 +1897,7 @@
       ],
       "note": [
         "Bounce from the right peak into the morph tunnel.",
-        "Samus can't bounce twice in a single fall, so pause on the top platform or avoid it completely."
+        "Samus can't bounce twice in a single fall, so come to a stop on the top platform or avoid it completely."
       ]
     },
     {


### PR DESCRIPTION
Everest
- Reduce unnecessary requirements from the old schema which were used to leave at 6
- Reduce duplication by adding a g-mode node at 6
- Add more options for setting up g-mode out the top 3 doors
- Fix some errors and add some strats

Glass Tunnel
- Migrate strats with multiple fromNodes
  - This was difficult, as g-mode strats must start at a door, but flag yielding strats must start at event nodes
- Add an obstacle to fix these and remove a now unnecessary node (still need to update the room diagram)