### PR TITLE
Lower Norfair Pillar Room

### DIFF
--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -48,8 +48,11 @@
   ],
   "reusableRoomwideNotable": [
     {
-      "name": "Lower Norfair Pillar Room with Power Bombs",
-      "note": "Cross the Pillar Room with Power Bombs and minimal damage."
+      "name": "Lower Norfair Pillar Room with Two Power Bombs",
+      "note": [
+        "Place the Power Bombs as forward as possible in order to only need to use two.",
+        "This makes it more likely to fall in the acid."
+      ]
     },
     {
       "name": "Lower Norfair Pillar Room with Bombs",
@@ -79,6 +82,9 @@
     {
       "link": [1, 1],
       "name": "Leave With Runway",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [],
       "exitCondition": {
         "leaveWithRunway": {
@@ -90,6 +96,9 @@
     {
       "link": [1, 1],
       "name": "Crystal Flash",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [
         "h_canHeatedCrystalFlash",
         {"resetRoom": {
@@ -174,11 +183,11 @@
     },
     {
       "link": [1, 2],
-      "name": "Pillar Room with Power Bombs (Left to Right)",
+      "name": "Pillar Room with Two Power Bombs (Left to Right)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
+        "canCarefulJump",
         {"ammo": {"type": "PowerBomb", "count": 2}},
         {"or": [
           {"and": [
@@ -190,12 +199,18 @@
             "canWalljump",
             {"heatFrames": 660},
             {"or": [
-              "canWalljumpInstantMorph",
-              {"acidFrames": 28}
+              "canWallJumpInstantMorph",
+              {"acidFrames": 30}
             ]}
           ]},
           {"and": [
+            "Gravity",
+            {"heatFrames": 660},
+            {"acidFrames": 30}
+          ]},
+          {"and": [
             "canTrickyJump",
+            "canSuitlessLavaDive",
             {"heatFrames": 720},
             {"acidFrames": 52}
           ]}
@@ -208,12 +223,13 @@
             {"acidFrames": 56}
           ]},
           {"and": [
+            "canSuitlessLavaDive",
             {"heatFrames": 240},
             {"acidFrames": 96}
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Power Bombs",
+      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Two Power Bombs",
       "note": [
         "Place the PBs next to the pillars in order to only use 2.",
         "Minimize acid by unmorphing high to land back on the jump spot or walljumping before placing the bomb."
@@ -221,18 +237,38 @@
     },
     {
       "link": [1, 2],
-      "name": "Pillar Room with Three Power Bombs (Left to Right)",
+      "name": "Three Power Bombs",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
+        "canCarefulJump",
         "Morph",
         {"ammo": {"type": "PowerBomb", "count": 3}},
-        {"heatFrames": 670}
+        {"or": [
+          "canTrickyJump",
+          {"enemyDamage": {
+            "enemy": "Puromi",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"heatFrames": 670},
+        {"or": [
+          "canTrickyJump",
+          {"and": [
+            "Gravity",
+            {"heatFrames": 180},
+            {"acidFrames": 56}
+          ]},
+          {"and": [
+            "canSuitlessLavaDive",
+            {"heatFrames": 240},
+            {"acidFrames": 96}
+          ]}
+        ]}
       ],
-      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Power Bombs",
       "note": [
         "The power bombs can be placed pretty far from the next pillar in line.",
-        "PB1 - Above the mound of dirt on the ground.  PB2 - On pillar 2.  PB3 - Near pillar 5."
+        "PB1 - Above the mound of dirt on the ground.  PB2 - On pillar 2 (not on the Puromi Fire Snake).  PB3 - Near pillar 5."
       ]
     },
     {
@@ -247,7 +283,7 @@
       },
       "requires": [
         "h_canUseMorphBombs",
-        "canWalljumpInstantMorph",
+        "canWallJumpInstantMorph",
         "canTrickyJump",
         "canResetFallSpeed",
         "canUnmorphBombBoost",
@@ -265,29 +301,38 @@
       "link": [2, 1],
       "name": "Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "canCarefulJump",
         "ScrewAttack",
         {"or": [
           {"and": [
-            "canTrickyJump",
-            {"heatFrames": 480}
+            "canSuitlessLavaDive",
+            {"heatFrames": 1800},
+            {"acidFrames": 116}
           ]},
           {"and": [
-            "canCarefulJump",
-            {"heatFrames": 540},
-            {"or": [
-              "canWalljump",
-              "canLateralMidAirMorph",
-              {"acidFrames": 24}
-            ]}
+            "Gravity",
+            {"heatFrames": 1800},
+            {"acidFrames": 48}
+          ]}
+        ]}
+      ],
+      "note": "Wait for the Puromis to pass so that Samus does not land on them."
+    },
+    {
+      "link": [2, 1],
+      "name": "Tricky Screw Jumps",
+      "requires": [
+        "canTrickyJump",
+        {"heatFrames": 530},
+        {"or": [
+          "canLateralMidAirMorph",
+          {"and": [
+            "canPreciseWalljump",
+            {"heatFrames": 20},
+            {"acidFrames": 10}
           ]},
           {"and": [
-            {"enemyDamage": {
-              "enemy": "Puromi",
-              "type": "contact",
-              "hits": 2
-            }},
-            {"heatFrames": 630},
+            {"heatFrames": 20},
             {"acidFrames": 24}
           ]}
         ]}
@@ -295,13 +340,13 @@
       "note": [
         "Break spin to leave some blocks intact in order to avoid damage from Puromis.",
         "Avoiding acid damage at the last jump is tricky but possible."
-      ]
+      ],
+      "devNote": "FIXME: There are very precise jumps which can cross the room faster and avoid all acid damage."
     },
     {
       "link": [2, 1],
       "name": "Space Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
         "ScrewAttack",
         "SpaceJump",
         {"heatFrames": 350}
@@ -336,7 +381,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canMidairShinespark",
         {"shinespark": {"frames": 78, "excessFrames": 4}},
         {"heatFrames": 210}
@@ -345,55 +389,85 @@
     },
     {
       "link": [2, 1],
-      "name": "Pillar Room with Power Bombs (Right to Left)",
+      "name": "Pillar Room with Two Power Bombs (Right to Left)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"ammo": {"type": "PowerBomb", "count": 2}},
+        "canCarefulJump",
         {"or": [
           {"and": [
-            "canPreciseWalljump",
-            "canTrickyJump",
-            {"heatFrames": 720}
+            "canWallJumpInstantMorph",
+            {"heatFrames": 690}
           ]},
           {"and": [
-            "canCarefulJump",
             "canWalljump",
-            {"heatFrames": 690},
+            {"heatFrames": 660},
             {"acidFrames": 36}
           ]},
           {"and": [
-            {"heatFrames": 780},
-            {"acidFrames": 108}
+            "canSuitlessLavaDive",
+            {"heatFrames": 840},
+            {"acidFrames": 84}
+          ]},
+          {"and": [
+            "Gravity",
+            {"heatFrames": 660},
+            {"acidFrames": 24}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "canTrickyJump",
+            "canLateralMidAirMorph",
+            {"heatFrames": 10},
+            {"acidFrames": 10}
+           ]},
+          {"and": [
+            "canPreciseWalljump",
+            {"heatFrames": 50},
+            {"acidFrames": 32}
+          ]},
+          {"and": [
+            "Gravity",
+            {"heatFrames": 20},
+            {"acidFrames": 20}
+          ]},
+          {"and": [
+            "canSuitlessLavaDive",
+            {"heatFrames": 50},
+            {"acidFrames": 50}
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Power Bombs",
+      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Two Power Bombs",
       "note": [
         "Place the PBs next to the pillars in order to only use 2.",
         "Avoid acid during the first Power Bomb by walljumping before placing the bomb.",
         "Avoiding acid damage at the last jump is tricky but possible."
-      ]
+      ],
+      "devNote": "FIXME: There are very precise jumps which can avoid all acid damage."
     },
     {
       "link": [2, 1],
-      "name": "Pillar Room with Three Power Bombs (Right to Left)",
-      "notable": true,
+      "name": "Three Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
+        "canCarefulJump",
         {"ammo": {"type": "PowerBomb", "count": 3}},
-        {"heatFrames": 720},
         {"or": [
-          "canTrickyJump",
           {"and": [
-            {"heatFrames": 60},
-            {"acidFrames": 60}
+            "canSuitlessLavaDive",
+            {"heatFrames": 840},
+            {"acidFrames": 206}
+          ]},
+          {"and": [
+            "Gravity",
+            {"heatFrames": 810},
+            {"acidFrames": 55}
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Power Bombs",
       "note": [
         "The power bombs can be placed far from the next pillar in line.",
         "PB1 - Near the broken pillar.  PB2 - On the 2nd full pillar.  PB3 - On the 4th full pillar.",
@@ -412,7 +486,7 @@
       },
       "requires": [
         "h_canUseMorphBombs",
-        "canWalljumpInstantMorph",
+        "canWallJumpInstantMorph",
         "canTrickyJump",
         "canResetFallSpeed",
         "canUnmorphBombBoost",
@@ -430,6 +504,9 @@
     {
       "link": [2, 2],
       "name": "Leave With Runway",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [],
       "exitCondition": {
         "leaveWithRunway": {
@@ -441,6 +518,9 @@
     {
       "link": [2, 2],
       "name": "Crystal Flash",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [
         "h_canHeatedCrystalFlash",
         {"resetRoom": {

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -91,7 +91,12 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [1, 1],
@@ -513,7 +518,12 @@
           "length": 4,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 2],

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -50,6 +50,13 @@
     {
       "name": "Lower Norfair Pillar Room with Power Bombs",
       "note": "Cross the Pillar Room with Power Bombs and minimal damage."
+    },
+    {
+      "name": "Lower Norfair Pillar Room with Bombs",
+      "note": [
+        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Some acid damage is expected, but any mistakes greatly increases the time spent in acid."
+      ]
     }
   ],
   "links": [
@@ -57,19 +64,13 @@
       "from": 1,
       "to": [
         {"id": 1},
-        {
-          "id": 2,
-          "devNote": "Potentially doable with bombs and enough energy."
-        }
+        {"id": 2}
       ]
     },
     {
       "from": 2,
       "to": [
-        {
-          "id": 1,
-          "devNote": "Potentially doable with bombs and enough energy."
-        },
+        {"id": 1},
         {"id": 2}
       ]
     }
@@ -226,6 +227,32 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Lower Norfair Pillar Room with Bombs (Left to Right)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 1,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "h_canUseMorphBombs",
+        "canWalljumpInstantMorph",
+        "canTrickyJump",
+        "canResetFallSpeed",
+        "canUnmorphBombBoost",
+        "canSuitlessLavaDive",
+        {"heatFrames": 1320},
+        {"acidFrames": 128}
+      ],
+      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Bombs",
+      "note": [
+        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Some acid damage is expected, but any mistakes greatly increases the time spent in acid."
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Screw",
       "requires": [
@@ -362,6 +389,33 @@
         "The power bombs can be placed far from the next pillar in line.",
         "PB1 - Near the broken pillar.  PB2 - On the 2nd full pillar.  PB3 - On the 4th full pillar.",
         "Wait for the Puromis to avoid damage but wait too long and the acid will cover the door."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Lower Norfair Pillar Room with Bombs (Right to Left)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "h_canUseMorphBombs",
+        "canWalljumpInstantMorph",
+        "canTrickyJump",
+        "canResetFallSpeed",
+        "canUnmorphBombBoost",
+        "canHBJ",
+        "canSuitlessLavaDive",
+        {"heatFrames": 1320},
+        {"acidFrames": 128}
+      ],
+      "reusableRoomwideNotable": "Lower Norfair Pillar Room with Bombs",
+      "note": [
+        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Some acid damage is expected, but any mistakes greatly increases the time spent in acid."
       ]
     },
     {

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -102,20 +102,18 @@
       "link": [1, 2],
       "name": "Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
         "ScrewAttack",
         {"or": [
           "canCarefulJump",
           {"heatFrames": 60}
         ]},
-        {"heatFrames": 480}
+        {"heatFrames": 490}
       ]
     },
     {
       "link": [1, 2],
       "name": "Space Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
         "ScrewAttack",
         "SpaceJump",
         {"heatFrames": 380}
@@ -131,7 +129,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "ScrewAttack",
         "SpaceJump",
         "canCarefulJump",
@@ -147,7 +144,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canMidairShinespark",
         {"shinespark": {"frames": 78, "excessFrames": 8}},
         {"heatFrames": 210}
@@ -194,13 +190,26 @@
             "canWalljump",
             {"heatFrames": 660},
             {"or": [
-              "canPreciseWalljump",
+              "canWalljumpInstantMorph",
               {"acidFrames": 28}
             ]}
           ]},
           {"and": [
-            {"heatFrames": 750},
-            {"acidFrames": 36}
+            "canTrickyJump",
+            {"heatFrames": 720},
+            {"acidFrames": 52}
+          ]}
+        ]},
+        {"or": [
+          "canTrickyJump",
+          {"and": [
+            "Gravity",
+            {"heatFrames": 180},
+            {"acidFrames": 56}
+          ]},
+          {"and": [
+            {"heatFrames": 240},
+            {"acidFrames": 96}
           ]}
         ]}
       ],


### PR DESCRIPTION
The acidless way of crossing the room with Power Bombs were put in a FIXME since I want to attach a harder version of `canTrickyJump` to them.

3PBs was made not notable and Gravity or suitlesslavadive seems fair.  Numbers are a little bit lenient.
2PBs still requires knowing where to put the Power Bombs, `Very Hard` seems wasteful since it can be done with less, but at `Hard` it overlaps with 3PBs a lot.