### PR TITLE
Unlock doors WS, Upper Norfair, Tourian

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -75,6 +75,11 @@
           "devNote": "In Vanilla, the camera is fixed to the bottom left tile if Kraid is alive. When entering from the right, Samus will spawn in the middle of the room, likely dropping into the thorns."
         },
         {
+          "name": "h_CrocomireCameraFix",
+          "requires": [ "never" ],
+          "devNote": "In Vanilla, the camera is messed up when entering from the left with Crocomire alive."
+        },
+        {
           "name": "h_MissileRefillStationAllAmmo",
           "requires": [ "never" ],
           "devNote": "In Vanilla, Missile refill stations only refill Missiles. This and 'h_useMissileRefillStation' can be changed if the stations refill Missiles, Supers, and Power Bombs."

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -334,7 +334,10 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 2],
@@ -366,6 +369,9 @@
           "framesRemaining": 120
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": "Get a normal height jump by not pressing run while SpeedBooster is equipped, as the Shinespark is stored."
     },
     {
@@ -383,7 +389,10 @@
         "leaveShinecharged": {
           "framesRemaining": 65
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 2],
@@ -400,7 +409,10 @@
         "leaveShinecharged": {
           "framesRemaining": 140
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 2],
@@ -417,7 +429,10 @@
         "leaveShinecharged": {
           "framesRemaining": 90
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 4],

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -203,11 +203,49 @@
     {
       "link": [1, 1],
       "name": "Leave with Runway",
-      "requires": [],
+      "requires": [
+        {"or": [
+          "h_CrocomireCameraFix",
+          "f_DefeatedCrocomire"
+        ]}
+      ],
       "exitCondition": {
         "leaveWithRunway": {
           "length": 3,
           "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave ShineCharged, Croc Alive",
+      "requires": [
+        "h_CrocomireCameraFix",
+        {"canShineCharge": {
+          "usedTiles": 14,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 45
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Shinecharged",
+      "requires": [
+        "f_DefeatedCrocomire",
+        "canShinechargeMovement",
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 60
         }
       }
     },
@@ -321,25 +359,6 @@
       ]
     },
     {
-      "link": [5, 1],
-      "name": "Leave Shinecharged",
-      "requires": [
-        "canShinechargeMovement",
-        {"canShineCharge": {
-          "usedTiles": 33,
-          "openEnd": 2
-        }}
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 50
-        }
-      },
-      "unlocksDoors": [
-        {"types": ["ammo"], "requires": []}
-      ]
-    },
-    {
       "link": [5, 2],
       "name": "Base",
       "requires": [
@@ -356,17 +375,23 @@
       "link": [5, 2],
       "name": "Leave Shinecharged with Walljump",
       "requires": [
-        "canCarefulJump",
         "canWalljump",
         "canShinechargeMovement",
         {"canShineCharge": {
           "usedTiles": 33,
           "openEnd": 2
-        }}
+        }},
+        {"or": [
+          "f_DefeatedCrocomire",
+          {"canShineCharge": {
+            "usedTiles": 22,
+            "openEnd": 1
+          }}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 120
+          "framesRemaining": 130
         }
       },
       "unlocksDoors": [
@@ -378,16 +403,22 @@
       "link": [5, 2],
       "name": "Leave Shinecharged with Speedy Jump",
       "requires": [
-        "canTrickyDashJump",
         "canShinechargeMovement",
         {"canShineCharge": {
           "usedTiles": 33,
           "openEnd": 2
-        }}
+        }},
+        {"or": [
+          "f_DefeatedCrocomire",
+          {"canShineCharge": {
+            "usedTiles": 31,
+            "openEnd": 0
+          }}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 65
+          "framesRemaining": 80
         }
       },
       "unlocksDoors": [
@@ -403,7 +434,14 @@
         {"canShineCharge": {
           "usedTiles": 33,
           "openEnd": 2
-        }}
+        }},
+        {"or": [
+          "f_DefeatedCrocomire",
+          {"canShineCharge": {
+            "usedTiles": 22,
+            "openEnd": 1
+          }}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -423,16 +461,44 @@
         {"canShineCharge": {
           "usedTiles": 33,
           "openEnd": 2
-        }}
+        }},
+        {"or": [
+          "f_DefeatedCrocomire",
+          {"canShineCharge": {
+            "usedTiles": 22,
+            "openEnd": 1
+          }}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 90
+          "framesRemaining": 100
         }
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
       ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Leave Sparking",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        {"or": [
+          "f_DefeatedCrocomire",
+          {"canShineCharge": {
+            "usedTiles": 31,
+            "openEnd": 0
+          }}
+        ]},
+        {"shinespark": {"frames": 9}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      }
     },
     {
       "link": [5, 4],

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -498,7 +498,10 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 4],

--- a/region/norfair/crocomire/Grapple Tutorial Room 1.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 1.json
@@ -83,6 +83,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Build some run speed to jump to the opposite runway to open the door before Shinesparking."
     },
     {
@@ -91,18 +95,7 @@
       "requires": []
     },
     {
-      "link": [2, 2],
-      "name": "Leave with Runway",
-      "requires": [],
-      "exitCondition": {
-        "leaveWithRunway": {
-          "length": 9,
-          "openEnd": 1
-        }
-      }
-    },
-    {
-      "link": [2, 2],
+      "link": [2, 1],
       "name": "Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
@@ -118,7 +111,21 @@
           "framesRemaining": 40
         }
       },
-      "note": "Jump to the opposite runway to open the door before Shinesparking."
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Runway",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 9,
+          "openEnd": 1
+        }
+      }
     }
   ]
 }

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -190,7 +190,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 5],
@@ -302,7 +306,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 1],
@@ -324,6 +332,10 @@
           "framesRemaining": 20
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Kill the Gamets with SpeedBooster and then jump directly up to the top left door."
     },
     {
@@ -342,6 +354,10 @@
           "framesRemaining": 120
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "devNote": "The Gamets are killed with SpeedBooster"
     },
     {
@@ -364,6 +380,10 @@
           "framesRemaining": 120
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "devNote": "The Gamets are killed with SpeedBooster"
     },
     {
@@ -417,7 +437,11 @@
         "leaveShinecharged": {
           "framesRemaining": 15
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 4],
@@ -437,7 +461,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 4],
@@ -457,7 +485,11 @@
         "leaveShinecharged": {
           "framesRemaining": 45
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 4],
@@ -481,6 +513,10 @@
           "framesRemaining": 15
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Shoot the Gamets while entering the room for more runway."
     },
     {
@@ -574,7 +610,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 4],
@@ -672,6 +712,10 @@
           ]}
         ]},
         {"shinespark": {"frames": 25, "excessFrames": 5}}
+      ],
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"types": ["ammo"], "requires": []}
       ]
     },
     {
@@ -726,6 +770,10 @@
           "framesRemaining": 10
         }
       },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": "Shortcharge to the right and then jump from below the floating platform to reach the top left door."
     },
     {
@@ -759,7 +807,11 @@
         "leaveShinecharged": {
           "framesRemaining": 130
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 3],
@@ -778,6 +830,9 @@
           "gentleDownTiles": 2
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": "Leave some drops after killing the Gamets so they don't respawn."
     },
     {
@@ -852,6 +907,9 @@
           ]}
         ]},
         {"shinespark": {"frames": 25}}
+      ],
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []}
       ]
     },
     {
@@ -882,7 +940,11 @@
         "leaveShinecharged": {
           "framesRemaining": 10
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 4],
@@ -911,7 +973,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 5],

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -714,8 +714,7 @@
         {"shinespark": {"frames": 25, "excessFrames": 5}}
       ],
       "unlocksDoors": [
-        {"nodeId": 3, "types": ["ammo"], "requires": []},
-        {"types": ["ammo"], "requires": []}
+        {"nodeId": 3, "types": ["ammo"], "requires": []}
       ]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
+++ b/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
@@ -65,7 +65,6 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ]
     },
@@ -73,7 +72,6 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 65}
       ]
     },
@@ -81,7 +79,6 @@
       "link": [2, 1],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 55}
       ],
       "exitCondition": {
@@ -89,7 +86,12 @@
           "length": 5,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
+      ]
     }
   ]
 }

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -140,6 +140,10 @@
           "framesRemaining": 100
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": [
         "Get a normal height jump by releasing run with SpeedBooster and no HiJump.",
         "Break spin to reach the transition without a wall jump."
@@ -201,6 +205,10 @@
           "framesRemaining": 50
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": [
         "Align with the runway while falling to avoid all of the platforms.",
         "The door can also be opened while falling to save some time."
@@ -309,6 +317,9 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": [
         "Knock a Viola off of its platform and keep it on camera as it climbs to the top of the room."
       ]

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -52,7 +52,6 @@
           "name": "Crouch 3 tiles over Gamets",
           "cycleFrames": 165,
           "requires": [
-            "h_canNavigateHeatRooms",
             {"heatFrames": 165}
           ]
         },
@@ -60,7 +59,6 @@
           "name": "Lava Gamets down shots",
           "cycleFrames": 120,
           "requires": [
-            "h_canNavigateHeatRooms",
             {"heatFrames": 120},
             {"lavaFrames": 120}
           ],
@@ -117,7 +115,6 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 70}
       ]
     },
@@ -143,7 +140,6 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 80}
       ]
     },
@@ -151,7 +147,6 @@
       "link": [2, 3],
       "name": "In-Room Shortcharge",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"canShineCharge": {
             "usedTiles": 13,
@@ -187,7 +182,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 8}},
         {"heatFrames": 50}
       ],
@@ -210,7 +204,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 80}
       ],
       "exitCondition": {
@@ -282,7 +275,6 @@
       "link": [2, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 210}
       ]
     },
@@ -290,7 +282,6 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 55}
       ]
     },
@@ -361,7 +352,6 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 210}
       ]
     },
@@ -369,7 +359,6 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 80}
       ]
     },
@@ -377,7 +366,6 @@
       "link": [4, 1],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 10}
       ],
       "exitCondition": {
@@ -394,7 +382,6 @@
       "link": [4, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 210}
       ]
     },
@@ -402,7 +389,6 @@
       "link": [4, 2],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 155}
       ],
       "exitCondition": {
@@ -421,7 +407,6 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 210}
       ]
     },
@@ -429,7 +414,6 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 210}
       ]
     },

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -392,6 +392,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 210}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": []}
       ]
     },
     {
@@ -407,7 +410,7 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 40}]},
         {"types": ["super"], "requires": []},
         {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
       ]

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -169,9 +169,14 @@
         }
       },
       "unlocksDoors": [
-        {"nodeId": 2, "types": ["ammo"], "requires": []},
-        {"types": ["ammo"], "requires": []}
-      ]
+        {"nodeId": 2, "types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"nodeId": 2, "types": ["super"], "requires": []},
+        {"nodeId": 2, "types": ["powerbomb"], "requires": [{"heatFrames": 110}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ],
+      "devNote": "FIXME: One Power Bomb would open both doors."
     },
     {
       "link": [2, 3],
@@ -221,7 +226,7 @@
       "link": [2, 3],
       "name": "Leave With Door Frame Below",
       "requires": [
-        {"heatFrames": 80}
+        {"heatFrames": 65}
       ],
       "exitCondition": {
         "leaveWithDoorFrameBelow": {
@@ -229,7 +234,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["ammo"], "requires": []}
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
       ]
     },
     {
@@ -264,7 +271,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["ammo"], "requires": []}
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
       ],
       "devNote": [
         "This includes time to moonwalk back against the right door, without shooting it open.",

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -172,7 +172,11 @@
         "leaveShinecharged": {
           "framesRemaining": 90
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["ammo"], "requires": []},
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [2, 3],
@@ -189,7 +193,12 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": "FIXME: Missiles could unlock the door with more shinespark frames available."
     },
     {
       "link": [2, 3],
@@ -208,7 +217,12 @@
         "leaveShinecharged": {
           "framesRemaining": 90
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": "FIXME: Missiles could unlock the door but would end with fewer shinespark frames available."
     },
     {
       "link": [2, 3],
@@ -220,7 +234,10 @@
         "leaveWithDoorFrameBelow": {
           "height": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [2, 3],
@@ -234,16 +251,16 @@
           "leftPosition": -2,
           "rightPosition": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [2, 3],
       "name": "Leave With Platform Below (Full Runway)",
       "requires": [
-        {"or": [
-          "canXRayTurnaround",
-          "canMoonwalk"
-        ]},
+        "h_canBackIntoCorner",
         {"heatFrames": 100}
       ],
       "exitCondition": {
@@ -253,6 +270,9 @@
           "rightPosition": 6
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "devNote": [
         "This includes time to moonwalk back against the right door, without shooting it open.",
         "An additional tile could be used by opening the right door but there is not yet any known application."
@@ -365,7 +385,10 @@
           "length": 14,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [4, 2],
@@ -387,7 +410,12 @@
           "length": 14,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 3],
@@ -415,7 +443,12 @@
         "leaveWithDoorFrameBelow": {
           "height": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 3],
@@ -429,7 +462,12 @@
           "leftPosition": -7.5,
           "rightPosition": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 3],

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -52,7 +52,6 @@
           "name": "Crouch over Gamets",
           "cycleFrames": 120,
           "requires": [
-            "h_canNavigateHeatRooms",
             {"heatFrames": 120}
           ]
         }

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -217,6 +217,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Fall through the shot blocks and shoot around the Skree to open the door without falling into the lava to shinespark out of the room."
     },
     {
@@ -235,6 +239,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Fall through the shot blocks and shoot around the Skree to open the door without falling into the lava to shinespark out of the room."
     },
     {
@@ -281,6 +289,9 @@
           "openEnd": 1
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "devNote": [
         "The blocks respawn, so no need to split this in two runways.",
         "While waiting for respawn would take additional heat frames, the spawner makes that more or less inconsequential."

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -898,11 +898,7 @@
           "length": 6,
           "openEnd": 0
         }
-      },
-      "unlocksDoors": [
-        {"types": ["missiles", "super"], "requires": []},
-        {"types": ["powerbomb"], "requires": ["never"]}
-      ]
+      }
     },
     {
       "link": [3, 7],

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -312,7 +312,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
@@ -330,6 +334,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Slide off the edge to kill the Waver with blue, or jump over it."
     },
     {
@@ -623,7 +631,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 7],
@@ -838,7 +850,11 @@
         "leaveShinecharged": {
           "framesRemaining": 45
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 2],
@@ -854,7 +870,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 3],
@@ -878,7 +898,11 @@
           "length": 6,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 7],
@@ -1032,7 +1056,11 @@
         "leaveShinecharged": {
           "framesRemaining": 105
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [5, 4],
@@ -1053,7 +1081,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [5, 5],
@@ -1175,7 +1207,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [6, 7],
@@ -1195,7 +1231,11 @@
         "leaveShinecharged": {
           "framesRemaining": 45
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [7, 1],
@@ -1335,7 +1375,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [7, 6],
@@ -1351,7 +1395,11 @@
         "leaveShinecharged": {
           "framesRemaining": 55
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [7, 7],

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -507,6 +507,11 @@
           "framesRemaining": 35
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 240}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 40}]}
+      ],
       "note": "Kill the enemies, break the shot block, then use the bottom to charge a spark. Quickly climb up before the block respawns, and continue through the left door."
     },
     {
@@ -532,6 +537,11 @@
           "framesRemaining": 25
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 500}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 180}]}
+      ],
       "note": "Kill the enemies, then use the bottom to charge a spark. Shoot the shot block from the ground and follow it up so that it breaks, and continue through the left door."
     },
     {
@@ -585,6 +595,11 @@
           "framesRemaining": 60
         }
       },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 180}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 120}]}
+      ],
       "note": "Kill the enemies and use the bottom to charge a spark. Quickly climb then spark through the right door."
     },
     {
@@ -644,7 +659,12 @@
           "length": 5,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [5, 2],

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -152,7 +152,6 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150}
       ]
     },
@@ -178,7 +177,6 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150}
       ]
     },
@@ -186,7 +184,6 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canBombThings",
         {"heatFrames": 450}
       ],
@@ -196,7 +193,6 @@
       "link": [3, 1],
       "name": "Base with Spring Ball",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canUseSpringBall",
         {"heatFrames": 375}
       ]
@@ -205,7 +201,6 @@
       "link": [3, 1],
       "name": "Sova Boost",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canNeutralDamageBoost",
         "Morph",
         {"enemyDamage": {
@@ -233,7 +228,6 @@
       "link": [3, 1],
       "name": "Up from Below",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canPreciseWalljump",
           "SpaceJump",
@@ -253,7 +247,6 @@
       "name": "Cathedral Entrance Left Door Frozen Sova Step",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         "canTrickyJump",
         "canCameraManip",
@@ -272,7 +265,6 @@
       "link": [3, 2],
       "name": "Frozen Sova",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 950}
       ]
@@ -282,7 +274,6 @@
       "name": "Cathedral Entrance Sova Morph Only Boost",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canInsaneWalljump",
         "Morph",
         "canNeutralDamageBoost",
@@ -341,7 +332,6 @@
       "link": [3, 4],
       "name": "Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Plasma",
         {"heatFrames": 100}
       ]
@@ -350,7 +340,6 @@
       "link": [3, 4],
       "name": "Screw Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "ScrewAttack",
         {"heatFrames": 100}
       ]
@@ -359,7 +348,6 @@
       "link": [3, 4],
       "name": "Ammo Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Sm. Dessgeega", "Sm. Dessgeega"]],
           "explicitWeapons": ["Missile", "Super"]
@@ -371,7 +359,6 @@
       "link": [3, 4],
       "name": "Intermediate Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "Wave",
           "Spazer"
@@ -383,7 +370,6 @@
       "link": [3, 4],
       "name": "Power Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 350}
       ]
     },
@@ -391,7 +377,6 @@
       "link": [3, 5],
       "name": "Tank a Hit",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150},
         {"enemyDamage": {
           "enemy": "Sm. Dessgeega",
@@ -404,7 +389,6 @@
       "link": [3, 5],
       "name": "Mockball Through",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canMockball",
         {"heatFrames": 100}
       ]
@@ -413,7 +397,6 @@
       "link": [4, 1],
       "name": "Shinespark",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"canShineCharge": {
           "usedTiles": 33,
           "openEnd": 2
@@ -430,7 +413,6 @@
       "link": [4, 1],
       "name": "Shinespark With Plasma",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Plasma",
         {"canShineCharge": {
           "usedTiles": 33,
@@ -452,7 +434,6 @@
       "link": [4, 1],
       "name": "Cathedral Entrance Hero Shot Shinespark",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canHeroShot",
         {"canShineCharge": {
           "usedTiles": 33,
@@ -474,7 +455,6 @@
       "name": "Cathedral Entrance Speedjump (Right to Left)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyDashJump",
         {"heatFrames": 150}
       ],
@@ -548,7 +528,6 @@
       "link": [4, 2],
       "name": "Shinespark",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canWalljump",
         "canShinechargeMovement",
         {"canShineCharge": {
@@ -567,7 +546,6 @@
       "name": "Cathedral Entrance Speedjump (Left to Right)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyDashJump",
         "canWalljump",
         {"heatFrames": 150}
@@ -625,7 +603,6 @@
       "link": [5, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             "HiJump",
@@ -642,7 +619,6 @@
       "link": [5, 2],
       "name": "Move Assist Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             "HiJump",
@@ -710,7 +686,6 @@
       "link": [5, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canDodgeWhileShooting",
         {"heatFrames": 350}
       ]
@@ -719,7 +694,6 @@
       "link": [5, 3],
       "name": "Tank a Hit",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 160},
         {"enemyDamage": {
           "enemy": "Sm. Dessgeega",
@@ -732,7 +706,6 @@
       "link": [5, 4],
       "name": "Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Plasma",
         {"heatFrames": 100}
       ]
@@ -741,7 +714,6 @@
       "link": [5, 4],
       "name": "Screw Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "ScrewAttack",
         {"heatFrames": 100}
       ]
@@ -750,7 +722,6 @@
       "link": [5, 4],
       "name": "Ammo Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Sm. Dessgeega", "Sm. Dessgeega"]],
           "explicitWeapons": ["Missile", "Super"]
@@ -762,7 +733,6 @@
       "link": [5, 4],
       "name": "Intermediate Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "Wave",
           "Spazer"
@@ -774,7 +744,6 @@
       "link": [5, 4],
       "name": "Power Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 350}
       ]
     }

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -324,6 +324,11 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 250}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 60}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -341,9 +346,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 60}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -352,6 +357,11 @@
       "requires": [
         "canTrickyJump",
         {"heatFrames": 160}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 60}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -370,9 +380,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 60}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -308,6 +308,9 @@
           {"obstaclesCleared": ["A"]}
         ]},
         {"heatFrames": 280}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 50}]}
       ]
     },
     {
@@ -316,6 +319,9 @@
       "requires": [
         "canCarefulJump",
         {"heatFrames": 176}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 25}]}
       ],
       "note": "Build speed on the central platform and jump to the door."
     },

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -150,7 +150,6 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 300}
       ]
     },
@@ -164,7 +163,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 200}
       ]
@@ -179,7 +177,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 140}
       ]
@@ -188,7 +185,6 @@
       "link": [1, 4],
       "name": "Tricky Platforming",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 220}
       ],
@@ -204,7 +200,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyJump"
       ],
       "devNote": "FIXME: Jumping fully over the platform, and killing the sova before landing on it is a little faster, with no movement items."
@@ -219,7 +214,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCarefulJump",
         "canMockball",
         {"heatFrames": 180}
@@ -250,7 +244,6 @@
       "link": [2, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 250}
       ]
     },
@@ -258,7 +251,6 @@
       "link": [2, 4],
       "name": "Tricky Platforming",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"or": [
           "ScrewAttack",
@@ -282,7 +274,6 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 200},
         {"or": [
           {"lavaFrames": 50},
@@ -305,7 +296,6 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "Plasma",
           "ScrewAttack",
@@ -324,7 +314,6 @@
       "link": [4, 1],
       "name": "Careful Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCarefulJump",
         {"heatFrames": 176}
       ],
@@ -334,7 +323,6 @@
       "link": [4, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 250}
       ]
     },
@@ -362,7 +350,6 @@
       "link": [4, 2],
       "name": "Tricky Platforming",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 160}
       ]
@@ -392,7 +379,6 @@
       "link": [4, 3],
       "name": "Kill the Geruta",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 350},
         {"or": [
@@ -428,7 +414,6 @@
       "link": [4, 3],
       "name": "Tank the Geruta",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 350},
         {"or": [

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -351,7 +351,12 @@
           "gentleDownTiles": 2,
           "startingDownTiles": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 2],
@@ -376,7 +381,12 @@
           "gentleDownTiles": 2,
           "startingDownTiles": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 3],

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -201,7 +201,11 @@
         "leaveShinecharged": {
           "framesRemaining": 45
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 4],
@@ -428,7 +432,12 @@
         "leaveShinecharged": {
           "framesRemaining": 30
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 240}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 100}]}
+      ]
     },
     {
       "link": [2, 2],
@@ -848,7 +857,12 @@
           "length": 6,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 3],
@@ -863,7 +877,12 @@
           "length": 6,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 3],
@@ -878,7 +897,12 @@
           "length": 6,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 3],

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -179,7 +179,6 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150}
       ]
     },
@@ -193,7 +192,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovement",
         {"heatFrames": 150}
       ],
@@ -211,7 +209,6 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 250}
       ],
       "clearsObstacles": ["A"]
@@ -221,7 +218,6 @@
       "name": "Double Chamber Walljump Climb Using the Kamer",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canPreciseWalljump",
         "canConsecutiveWalljump",
         "canUseEnemies",
@@ -260,7 +256,6 @@
       "name": "Double Chamber Walljump Climb Using the Kamer with HiJump",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "canUseEnemies",
         "canWalljump",
@@ -282,7 +277,6 @@
       "link": [2, 1],
       "name": "Delayed Walljump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canDelayedWalljump",
         "canConsecutiveWalljump",
         "canTrickyJump",
@@ -301,7 +295,6 @@
       "link": [2, 1],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 300}
       ]
@@ -310,7 +303,6 @@
       "link": [2, 1],
       "name": "IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         {"heatFrames": 1450}
       ]
@@ -319,7 +311,6 @@
       "link": [2, 1],
       "name": "Charge Shinespark",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"canShineCharge": {
           "usedTiles": 28,
           "gentleUpTiles": 3,
@@ -390,7 +381,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 27, "excessFrames": 4}},
         {"heatFrames": 200}
       ]
@@ -399,7 +389,6 @@
       "link": [2, 1],
       "name": "Speedjump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpeedBooster",
         "HiJump",
         {"heatFrames": 350}
@@ -410,7 +399,6 @@
       "link": [2, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovementComplex",
         "HiJump",
         {"or": [
@@ -461,7 +449,6 @@
       "link": [2, 2],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovement",
         {"heatFrames": 300},
         {"canShineCharge": {
@@ -481,7 +468,6 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 200}
       ]
@@ -509,7 +495,6 @@
       "name": "Double Chamber Shinespark through Wave Beam Door (Top Path)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         {"or": [
           "SpaceJump",
@@ -554,7 +539,6 @@
       "name": "Double Chamber Shinespark through Wave Beam Door (Through Crumbles)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "Morph",
         {"or": [
@@ -591,7 +575,6 @@
       "link": [3, 3],
       "name": "XMode with Walljump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -611,7 +594,6 @@
       "link": [3, 3],
       "name": "XMode with HiJump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -632,7 +614,6 @@
       "link": [3, 4],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Grapple",
         {"heatFrames": 180}
       ]
@@ -641,7 +622,6 @@
       "link": [3, 4],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 160}
       ]
@@ -658,7 +638,6 @@
       "link": [3, 4],
       "name": "Double Chamber Spike SpringBall",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canIframeSpikeJump",
         {"spikeHits": 1},
         "canSpringBallJumpMidAir",
@@ -669,7 +648,6 @@
       "link": [3, 4],
       "name": "Double Chamber Spike HiJump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canIframeSpikeJump",
         {"spikeHits": 1},
         "canWalljump",
@@ -687,7 +665,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canHorizontalShinespark",
         {"heatFrames": 140},
         {"shinespark": {"frames": 45, "excessFrames": 14}}
@@ -700,7 +677,6 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 140},
         {"shinespark": {"frames": 51, "excessFrames": 14}}
       ]
@@ -709,7 +685,6 @@
       "link": [3, 4],
       "name": "Double Chamber Spike Speedjump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canIframeSpikeJump",
         {"spikeHits": 1},
         "SpeedBooster",
@@ -722,7 +697,6 @@
       "name": "Hijumpless Double Chamber Spike Speedjump",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canIframeSpikeJump",
         {"spikeHits": 1},
         "SpeedBooster",
@@ -745,7 +719,6 @@
       "link": [3, 4],
       "name": "XMode Shinespark",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -787,7 +760,6 @@
       "link": [3, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 250}
       ]
     },
@@ -795,7 +767,6 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 250},
         {"or": [
           {"and": [
@@ -811,7 +782,6 @@
       "link": [4, 1],
       "name": "Gate Glitch",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 250},
         "h_canHeatedBlueGateGlitch"
       ],
@@ -821,7 +791,6 @@
       "link": [4, 3],
       "name": "Walljump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canWalljump",
         {"heatFrames": 300}
       ]
@@ -830,7 +799,6 @@
       "link": [4, 3],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Grapple",
         {"heatFrames": 180}
       ]
@@ -839,7 +807,6 @@
       "link": [4, 3],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 160}
       ]
@@ -848,7 +815,6 @@
       "link": [4, 3],
       "name": "Walljump Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canWalljump",
         {"heatFrames": 280}
       ],
@@ -868,7 +834,6 @@
       "link": [4, 3],
       "name": "Grapple Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Grapple",
         {"heatFrames": 160}
       ],
@@ -888,7 +853,6 @@
       "link": [4, 3],
       "name": "Space Jump Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 140}
       ],
@@ -916,7 +880,6 @@
       "link": [4, 3],
       "name": "MidAir SpringBall",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canIframeSpikeJump",
         {"spikeHits": 1},
         "canSpringBallJumpMidAir",
@@ -927,7 +890,6 @@
       "link": [4, 3],
       "name": "Speedjump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canIframeSpikeJump",
         {"spikeHits": 1},
         "HiJump",
@@ -939,7 +901,6 @@
       "link": [4, 3],
       "name": "XMode Shinespark",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -967,7 +928,6 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 160}
       ]
     },
@@ -975,7 +935,6 @@
       "link": [5, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 200}
       ]

--- a/region/norfair/east/Frog Savestation.json
+++ b/region/norfair/east/Frog Savestation.json
@@ -94,7 +94,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -109,7 +113,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
@@ -132,7 +140,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -147,7 +159,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -160,7 +160,12 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [3, 3],

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -147,6 +147,11 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 150}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 80}]}
       ]
     },
     {
@@ -162,9 +167,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 80}]}
       ]
     },
     {

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -169,7 +169,6 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ]
     },
@@ -182,7 +181,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 21}},
         {"heatFrames": 60}
       ],
@@ -204,7 +202,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ],
       "exitCondition": {
@@ -221,7 +218,6 @@
       "link": [1, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 110}
       ]
     },
@@ -260,7 +256,6 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 225},
         {"or": [
@@ -275,7 +270,6 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 165},
         {"or": [
@@ -290,7 +284,6 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 260},
         {"or": [
@@ -307,7 +300,6 @@
       "link": [3, 2],
       "name": "Gate Glitch",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 260},
         "h_canHeatedBlueGateGlitch"
@@ -362,7 +354,6 @@
       "link": [3, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 130}
       ]
     },
@@ -370,7 +361,6 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ]
     },
@@ -383,7 +373,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 21}},
         {"heatFrames": 60}
       ],
@@ -405,7 +394,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ],
       "exitCondition": {
@@ -454,7 +442,6 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ]
     },
@@ -462,7 +449,6 @@
       "link": [5, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150}
       ]
     },
@@ -470,7 +456,6 @@
       "link": [5, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 150},
         {"or": [
@@ -487,7 +472,6 @@
       "link": [5, 2],
       "name": "Gate Glitch",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 150},
         "h_canHeatedBlueGateGlitch"
@@ -498,7 +482,6 @@
       "link": [5, 2],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 150},
         {"or": [
@@ -527,7 +510,6 @@
       "link": [5, 2],
       "name": "Leave with Runway (Gate Glitch)",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 150},
         "h_canHeatedBlueGateGlitch"
@@ -550,7 +532,6 @@
       "link": [5, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 130}
       ]
     },
@@ -558,7 +539,6 @@
       "link": [5, 3],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 160}
       ],
       "exitCondition": {
@@ -577,7 +557,6 @@
       "link": [5, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150}
       ]
     },

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -188,7 +188,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 4],
@@ -207,7 +211,11 @@
         "leaveShinecharged": {
           "framesRemaining": 85
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 5],
@@ -381,7 +389,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 1],
@@ -400,7 +412,11 @@
         "leaveShinecharged": {
           "framesRemaining": 85
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 4],
@@ -500,7 +516,12 @@
           "gentleDownTiles": 4
         }
       },
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 70}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [5, 2],
@@ -518,7 +539,12 @@
           "gentleDownTiles": 4
         }
       },
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 90}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [5, 3],
@@ -540,7 +566,12 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 90}]}
+      ]
     },
     {
       "link": [5, 4],

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -170,6 +170,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 100}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]}
       ]
     },
     {
@@ -264,7 +267,10 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
+      ]
     },
     {
       "link": [2, 5],
@@ -362,6 +368,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 100}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]}
       ]
     },
     {
@@ -533,6 +542,11 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 130}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -550,7 +564,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 90}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -68,7 +68,6 @@
       "link": [1, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"canShineCharge": {
           "usedTiles": 16,
           "openEnd": 1
@@ -92,7 +91,6 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"or": [
           "h_lavaProof",
@@ -107,7 +105,6 @@
       "link": [1, 2],
       "name": "Reverse Lava Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         {"heatFrames": 600},
         {"lavaFrames": 500}
@@ -117,7 +114,6 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"or": [
           "h_lavaProof",
@@ -139,7 +135,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"or": [
           "h_lavaProof",
@@ -166,7 +161,6 @@
       "link": [2, 1],
       "name": "Lava Dive Gravity Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         "canGravityJump",
         "HiJump",
@@ -180,7 +174,6 @@
       "link": [2, 1],
       "name": "Hjless Lava Dive Gravity Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canGravityJump",
         "canSuitlessLavaDive",
         "canStaggeredWalljump",
@@ -242,7 +235,6 @@
       "link": [2, 1],
       "name": "Double IBJ with Ice Plasma",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"or": [
           "h_lavaProof",
@@ -265,7 +257,6 @@
       "link": [2, 1],
       "name": "Springwall",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "h_lavaProof",
           "canSuitlessLavaDive"
@@ -298,7 +289,6 @@
       "name": "Lava Dive HiJumpless Suitless Double Springball Jump",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         "canDoubleSpringBallJumpMidAir",
         "canSpringwall",
@@ -318,7 +308,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         "canStaggeredWalljump",
         "canBounceBall",
@@ -337,7 +326,6 @@
       "link": [2, 1],
       "name": "Lava Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         "canStaggeredWalljump",
         "canUseEnemies",
@@ -358,7 +346,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         "canIframeSpikeJump",
         "canStaggeredWalljump",
@@ -391,7 +378,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         "canIframeSpikeJump",
         "canStaggeredWalljump",

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -122,6 +122,9 @@
         "SpaceJump",
         {"heatFrames": 600},
         {"lavaFrames": 325}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ]
     },
     {
@@ -151,6 +154,9 @@
           "hits": 1
         }}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
+      ],
       "note": [
         "Store the shinespark on the last possible pixels of runway.",
         "Quickly drop to the nearby namihe and damage boost using its flame.",
@@ -168,6 +174,9 @@
         {"lavaFrames": 250},
         {"gravitylessLavaFrames": 100},
         {"gravitylessHeatFrames": 100}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ]
     },
     {
@@ -181,6 +190,9 @@
         {"lavaFrames": 250},
         {"gravitylessLavaFrames": 250},
         {"gravitylessHeatFrames": 250}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ],
       "devNote": "FIXME This is assuming Samus waits to equip Gravity until after the lava dive is complete."
     },
@@ -248,6 +260,9 @@
         {"heatFrames": 1530},
         {"lavaFrames": 1350}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
+      ],
       "note": [
         "Align with the above platform and scroll the camera left.",
         "Freeze both left side Namihes and begin bomb jumping"
@@ -267,6 +282,9 @@
         {"heatFrames": 900},
         {"lavaFrames": 700}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
+      ],
       "devNote": "Works with or without Gravity"
     },
     {
@@ -278,6 +296,9 @@
         "canDoubleSpringBallJumpMidAir",
         {"heatFrames": 620},
         {"lavaFrames": 460}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ],
       "note": [
         "Stand one platform below the bottommost right-side Namihe and Double SpringBall Jump while holding left.",
@@ -295,6 +316,9 @@
         "canUseEnemies",
         {"heatFrames": 1300},
         {"lavaFrames": 1100}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ],
       "note": "Double springball jump out of a walljump starting from the top of the left wall Namihe."
     },
@@ -316,6 +340,9 @@
         {"heatFrames": 900},
         {"lavaFrames": 700}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
+      ],
       "note": "Jump through the door for a speedy entry.  Morph before entering the lava.",
       "devNote": [
         "In room bounceball works and saves 50 health (no heat/lava protection) over morphless entry but loses 50 health compared to this strat.",
@@ -332,6 +359,9 @@
         "HiJump",
         {"heatFrames": 1000},
         {"lavaFrames": 800}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ],
       "note": "Big jumps continue your speed for longer and keep flames from spawning."
     },
@@ -360,6 +390,9 @@
           "type": "fireball",
           "hits": 1
         }}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ],
       "note": [
         "Use the bottommost right side namihe to generate a flame and walk with it to the bottommost left namihe head",
@@ -391,6 +424,9 @@
           "type": "fireball",
           "hits": 1
         }}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ],
       "note": [
         "Use the bottommost right side namihe to generate a flame and walk with it to the bottommost left namihe head",

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -107,7 +107,12 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"nodeId": 2, "types": ["super"], "requires": []},
+        {"nodeId": 2, "types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [1, 1],
@@ -133,7 +138,11 @@
         "leaveShinecharged": {
           "framesRemaining": 155
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -150,7 +159,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
@@ -198,7 +211,11 @@
         "leaveShinecharged": {
           "framesRemaining": 155
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -215,7 +232,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -239,7 +260,12 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 1, "types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"nodeId": 1, "types": ["super"], "requires": []},
+        {"nodeId": 1, "types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 2],
@@ -339,7 +365,15 @@
         "leaveShinecharged": {
           "framesRemaining": 130
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 1, "types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"nodeId": 1, "types": ["super"], "requires": []},
+        {"nodeId": 1, "types": ["powerbomb"], "requires": [{"heatFrames": 110}]},
+        {"nodeId": 2, "types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"nodeId": 2, "types": ["super"], "requires": []},
+        {"nodeId": 2, "types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 1],
@@ -357,7 +391,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 2],
@@ -375,7 +413,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 3],

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -301,6 +301,9 @@
       "requires": [
         {"heatFrames": 30}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]}
+      ],
       "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 4->3."
     },
     {
@@ -308,6 +311,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 30}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]}
       ],
       "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 4->3."
     },

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -131,7 +131,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 55}
       ],
       "exitCondition": {
@@ -153,7 +152,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 21}},
         {"heatFrames": 45}
       ],
@@ -169,7 +167,6 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 30}
       ],
       "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 3->4."
@@ -184,7 +181,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_LowerNorfairElevatorDownwardFrames",
         {"heatFrames": 40}
       ],
@@ -204,7 +200,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 55}
       ],
       "exitCondition": {
@@ -226,7 +221,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 21}},
         {"heatFrames": 45}
       ],
@@ -278,7 +272,6 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 30}
       ],
       "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 3->4."
@@ -293,7 +286,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_LowerNorfairElevatorDownwardFrames",
         {"heatFrames": 40}
       ],
@@ -307,7 +299,6 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 30}
       ],
       "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 4->3."
@@ -316,7 +307,6 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 30}
       ],
       "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 4->3."
@@ -325,7 +315,6 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_LowerNorfairElevatorDownwardFrames",
         {"heatFrames": 10}
       ]
@@ -334,7 +323,6 @@
       "link": [3, 4],
       "name": "In-Room Shortcharge",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             {"doorUnlockedAtNode": 1},
@@ -384,7 +372,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_LowerNorfairElevatorUpwardFrames",
         {"shinespark": {"frames": 6}},
         {"heatFrames": 40}
@@ -406,7 +393,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_LowerNorfairElevatorUpwardFrames",
         {"shinespark": {"frames": 6}},
         {"heatFrames": 40}
@@ -423,7 +409,6 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_LowerNorfairElevatorUpwardFrames",
         {"heatFrames": 10}
       ]

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -97,7 +97,6 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 500}
       ]
     },
@@ -105,7 +104,6 @@
       "link": [1, 2],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"enemyKill": {
           "enemies": [["Multiviola"]],
@@ -118,7 +116,6 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 550}
       ]
     },
@@ -126,7 +123,6 @@
       "link": [2, 1],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 350}
       ]

--- a/region/norfair/east/Nutella Refill.json
+++ b/region/norfair/east/Nutella Refill.json
@@ -95,7 +95,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -112,6 +116,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Jump onto the Refill station before Shinesparking."
     },
     {
@@ -130,6 +138,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Crouch before sparking to gain the height to go over the refill station.",
       "devNote": "A midair shinespark is harder and slower."
     },
@@ -154,7 +166,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -171,6 +187,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Jump onto the Refill station before Shinesparking."
     },
     {
@@ -189,6 +209,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Crouch before sparking to gain the height to go over the refill station.",
       "devNote": "A midair shinespark is harder and slower."
     },

--- a/region/norfair/east/Purple Farming Room.json
+++ b/region/norfair/east/Purple Farming Room.json
@@ -86,6 +86,9 @@
           "gentleUpTiles": 1
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": "Involves leaving some drops hanging after killing the Gamets so they don't respawn.",
       "devNote": "Health drops are collected while using this runway, offsetting any heat frames used to get into position."
     },

--- a/region/norfair/east/Purple Farming Room.json
+++ b/region/norfair/east/Purple Farming Room.json
@@ -36,7 +36,6 @@
           "name": "Crouch over Gamets",
           "cycleFrames": 120,
           "requires": [
-            "h_canNavigateHeatRooms",
             {"heatFrames": 120}
           ]
         }

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -101,6 +101,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 120}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -118,7 +121,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -282,6 +285,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 120}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -299,7 +305,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -349,13 +355,20 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 145}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
       "link": [3, 2],
       "name": "HiJump",
       "requires": [
+        "HiJump",
         {"heatFrames": 120}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -392,7 +405,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -114,7 +114,12 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [1, 2],
@@ -131,7 +136,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -158,7 +167,12 @@
         "leaveWithDoorFrameBelow": {
           "height": 3
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 1],
@@ -172,7 +186,12 @@
           "leftPosition": 0,
           "rightPosition": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 1],
@@ -187,7 +206,12 @@
           "leftPosition": 0,
           "rightPosition": 2
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 1],
@@ -207,7 +231,11 @@
         "leaveShinecharged": {
           "framesRemaining": 35
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -225,7 +253,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -263,7 +295,12 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 3],
@@ -281,7 +318,11 @@
         "leaveShinecharged": {
           "framesRemaining": 60
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 3],
@@ -297,7 +338,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 2],
@@ -343,7 +388,12 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [3, 2],
@@ -363,6 +413,10 @@
           "framesRemaining": 30
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "devNote": "2.5 unusable tiles so that Samus is close enough to the door to leave with meaningful framesRemaining."
     },
     {
@@ -381,7 +435,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 2],
@@ -398,7 +456,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 3],

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -133,7 +133,6 @@
       "link": [1, 2],
       "name": "Platforming",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             "canTrickyJump",
@@ -153,7 +152,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"enemyDamage": {
           "enemy": "Sova",
@@ -180,7 +178,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSpeedball",
         "canSlowShortCharge",
         {"heatFrames": 360}
@@ -201,7 +198,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canMidairShinespark",
         {"heatFrames": 210},
         {"shinespark": {"frames": 90, "excessFrames": 5}}
@@ -220,7 +216,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canMidairShinespark",
         {"heatFrames": 205},
         {"shinespark": {"frames": 92, "excessFrames": 5}}
@@ -237,7 +232,6 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canMidairShinespark",
         {"heatFrames": 195},
         {"shinespark": {"frames": 95, "excessFrames": 5}}
@@ -326,7 +320,6 @@
       "link": [2, 1],
       "name": "Platforming",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 540},
         {"or": [
           "canTrickyJump",
@@ -345,7 +338,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"enemyDamage": {
           "enemy": "Dragon",
@@ -371,7 +363,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         "canTrickyJump",
         "canMockball",

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -329,6 +329,10 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 200}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 10}]}
       ]
     },
     {
@@ -347,7 +351,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 30}]}
       ]
     },
     {
@@ -526,6 +530,10 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 220}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 10}]}
       ]
     },
     {
@@ -541,9 +549,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 65}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 30}]}
       ]
     },
     {
@@ -649,6 +657,10 @@
           "h_canCrouchJumpDownGrab"
         ]},
         {"heatFrames": 100}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 70}]}
       ]
     },
     {
@@ -671,7 +683,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 70}]}
       ]
     },
     {
@@ -696,6 +708,10 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 150}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 20}]}
       ]
     },
     {
@@ -711,9 +727,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 20}]}
       ]
     },
     {

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -193,7 +193,6 @@
       "link": [1, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ]
     },
@@ -220,7 +219,6 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -234,7 +232,6 @@
       "link": [2, 3],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -266,7 +263,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovementComplex",
         {"or": [
           "HiJump",
@@ -294,7 +290,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "canShinechargeMovementComplex",
         "canTrickyJump",
@@ -316,7 +311,6 @@
       "link": [2, 3],
       "name": "IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         {"heatFrames": 1200}
       ]
@@ -325,7 +319,6 @@
       "link": [2, 3],
       "name": "Frozen Multiviola",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 450}
       ],
@@ -335,7 +328,6 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 200}
       ]
     },
@@ -343,7 +335,6 @@
       "link": [3, 2],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 140}
       ],
       "exitCondition": {
@@ -369,7 +360,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 5}},
         {"heatFrames": 220}
       ],
@@ -390,7 +380,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovement",
         {"shinespark": {"frames": 18}},
         {"heatFrames": 190}
@@ -425,7 +414,6 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -439,7 +427,6 @@
       "link": [3, 4],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -470,7 +457,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "canTrickyJump",
         "canShinechargeMovementComplex",
@@ -489,7 +475,6 @@
       "link": [3, 4],
       "name": "IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         {"heatFrames": 1950}
       ],
@@ -499,7 +484,6 @@
       "link": [3, 4],
       "name": "Frozen Enemies",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 1300}
       ],
@@ -518,7 +502,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "canTrickyJump",
         "canShinechargeMovementComplex",
@@ -542,7 +525,6 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 220}
       ]
     },
@@ -550,7 +532,6 @@
       "link": [4, 3],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 200}
       ],
       "exitCondition": {
@@ -587,7 +568,6 @@
       "link": [4, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -601,7 +581,6 @@
       "link": [4, 6],
       "name": "IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         {"heatFrames": 750}
       ],
@@ -611,7 +590,6 @@
       "link": [4, 6],
       "name": "Frozen Enemies",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 830}
       ],
@@ -639,7 +617,6 @@
       "link": [5, 6],
       "name": "Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "ScrewAttack",
         {"heatFrames": 780}
@@ -649,7 +626,6 @@
       "link": [5, 6],
       "name": "Power Bomb",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",
         {"heatFrames": 850}
       ]
@@ -658,7 +634,6 @@
       "link": [5, 6],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canUseMorphBombs",
         {"heatFrames": 1130}
       ]
@@ -667,7 +642,6 @@
       "link": [6, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -681,7 +655,6 @@
       "link": [6, 1],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -705,7 +678,6 @@
       "link": [6, 1],
       "name": "IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         {"heatFrames": 1500}
       ],
@@ -715,7 +687,6 @@
       "link": [6, 1],
       "name": "Frozen Enemies",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 600}
       ]
@@ -724,7 +695,6 @@
       "link": [6, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150}
       ]
     },
@@ -732,7 +702,6 @@
       "link": [6, 4],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 120}
       ],
       "exitCondition": {

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -248,7 +248,12 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 3],
@@ -272,7 +277,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 3],
@@ -296,6 +305,10 @@
           "framesRemaining": 60
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Quickly ledge grab the platform to run below the Multiviola and get ahead of it.",
       "devNote": "1 unused tile since you must jump earlier for this strat."
     },
@@ -339,7 +352,12 @@
           "openEnd": 0,
           "gentleDownTiles": 4
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [3, 2],
@@ -357,7 +375,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 2],
@@ -375,7 +397,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 3],
@@ -427,7 +453,12 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [3, 4],
@@ -448,7 +479,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 4],
@@ -497,7 +532,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 3],
@@ -519,7 +558,12 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [4, 4],
@@ -650,7 +694,12 @@
           "length": 8,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [6, 1],
@@ -691,7 +740,12 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [6, 6],

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -162,7 +162,12 @@
           "openEnd": 1
         }
       },
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [1, 2],
@@ -199,7 +204,11 @@
           "framesRemaining": 145
         }
       },
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -217,6 +226,10 @@
         }
       },
       "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Shoot from the middle of the second set of crumble blocks from the left."
     },
     {
@@ -273,7 +286,12 @@
           "openEnd": 1
         }
       },
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 1],
@@ -301,7 +319,11 @@
           "framesRemaining": 145
         }
       },
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -319,6 +341,10 @@
         }
       },
       "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Shoot while climbing the highest ramp for the shot to open the door."
     },
     {

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -147,7 +147,10 @@
         {"obstaclesNotCleared": ["A"]},
         {"heatFrames": 650}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]}
+      ]
     },
     {
       "link": [1, 2],
@@ -239,7 +242,10 @@
         {"obstaclesNotCleared": ["A"]},
         {"heatFrames": 650}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]}
+      ]
     },
     {
       "link": [2, 1],
@@ -270,6 +276,9 @@
             {"lavaFrames": 60}
           ]}
         ]}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]}
       ],
       "devNote": "This can be used for collecting the item without needing to reset the room."
     },

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -382,7 +382,6 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 25}
       ]
     },
@@ -390,7 +389,6 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 25}
       ]
     }

--- a/region/norfair/east/Speed Booster Room.json
+++ b/region/norfair/east/Speed Booster Room.json
@@ -86,7 +86,12 @@
           "length": 3.5,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     }
   ]
 }

--- a/region/norfair/east/Speed Booster Room.json
+++ b/region/norfair/east/Speed Booster Room.json
@@ -73,6 +73,11 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 80}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 50}]}
       ]
     },
     {
@@ -88,9 +93,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     }
   ]

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -85,7 +85,6 @@
       "link": [1, 2],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Grapple",
         {"heatFrames": 450}
       ]
@@ -94,7 +93,6 @@
       "link": [1, 2],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 420}
       ]
@@ -109,7 +107,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 285}
       ]
@@ -118,7 +115,6 @@
       "link": [1, 2],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 520},
         {"lavaFrames": 80},
         {"spikeHits": 3},
@@ -140,7 +136,6 @@
       "link": [1, 2],
       "name": "Tank the Damage with Gravity",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"heatFrames": 350},
         {"lavaFrames": 100},
@@ -162,7 +157,6 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 80, "excessFrames": 4}},
         {"heatFrames": 210}
       ]
@@ -177,7 +171,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             "canHorizontalShinespark",
@@ -198,7 +191,6 @@
       "name": "Spiky Acid Snake Frozen Platforms (Left to Right)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
@@ -228,7 +220,6 @@
       "link": [2, 1],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Grapple",
         {"heatFrames": 450}
       ]
@@ -237,7 +228,6 @@
       "link": [2, 1],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 420}
       ]
@@ -252,7 +242,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 285}
       ]
@@ -261,7 +250,6 @@
       "link": [2, 1],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 520},
         {"lavaFrames": 80},
         {"spikeHits": 3},
@@ -283,7 +271,6 @@
       "link": [2, 1],
       "name": "Tank the Damage with Gravity",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"heatFrames": 350},
         {"lavaFrames": 100},
@@ -305,7 +292,6 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 80, "excessFrames": 4}},
         {"heatFrames": 210}
       ]
@@ -320,7 +306,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             "canHorizontalShinespark",
@@ -341,7 +326,6 @@
       "name": "Spiky Acid Snake Frozen Platforms (Right to Left)",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -83,7 +83,6 @@
       "link": [1, 2],
       "name": "Gravity",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"heatFrames": 360},
         {"lavaFrames": 130},
@@ -98,7 +97,6 @@
       "link": [1, 2],
       "name": "Tripper Morphing",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 1050}
       ]
@@ -107,7 +105,6 @@
       "link": [1, 2],
       "name": "Double Lava Bath",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSuitlessLavaDive",
         {"heatFrames": 750},
         {"lavaFrames": 120},
@@ -132,7 +129,6 @@
       "link": [1, 2],
       "name": "Single Lava Bath",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canTrickyJump",
           "Morph"
@@ -197,7 +193,6 @@
       "link": [2, 1],
       "name": "Gravity",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Gravity",
         {"heatFrames": 360},
         {"lavaFrames": 130},
@@ -212,7 +207,6 @@
       "link": [2, 1],
       "name": "Tripper Morphing",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 1050}
       ]

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -74,7 +74,6 @@
           "name": "Gamet down shots",
           "cycleFrames": 120,
           "requires": [
-            "h_canNavigateHeatRooms",
             {"heatFrames": 120}
           ],
           "note": "Just crouching over them is slower because they have to rise a bit after spawning. "
@@ -144,7 +143,6 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 75}
       ]
     },
@@ -179,7 +177,6 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 120},
         {"or": [
           {"heatFrames": 30},
@@ -210,7 +207,6 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 75}
       ]
     },
@@ -218,7 +214,6 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 75}
       ]
     },
@@ -242,7 +237,6 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 75}
       ]
     },
@@ -266,7 +260,6 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 35}
       ]
     },
@@ -299,7 +292,6 @@
       "link": [5, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -312,7 +304,6 @@
       "link": [5, 4],
       "name": "Crouch Jump Down Grab",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canCrouchJumpDownGrab",
         {"heatFrames": 125}
       ]
@@ -321,7 +312,6 @@
       "link": [5, 4],
       "name": "IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         {"heatFrames": 850}
       ],
@@ -331,7 +321,6 @@
       "link": [5, 4],
       "name": "Frozen Gamet",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 250}
       ]
@@ -340,7 +329,6 @@
       "link": [5, 5],
       "name": "Wave Beam the Gate",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 60},
         "Wave"
       ],
@@ -350,7 +338,6 @@
       "link": [5, 5],
       "name": "Gate Glitch",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 135},
         "h_canHeatedBlueGateGlitch"
       ],

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -215,6 +215,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 75}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ]
     },
     {
@@ -240,6 +243,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 75}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 10}]}
       ]
     },
     {

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -230,7 +230,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["ammo"], "requires": []}
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
       ]
     },
     {
@@ -253,7 +255,9 @@
         }
       },
       "unlocksDoors": [
-        {"types": ["ammo"], "requires": []}
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
       ]
     },
     {

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -233,7 +233,10 @@
           "length": 12,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [4, 3],
@@ -254,7 +257,10 @@
           "length": 12,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [4, 5],
@@ -284,7 +290,10 @@
           "length": 11,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 4],

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -159,7 +159,6 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"or": [
           "canMockball",
@@ -172,7 +171,6 @@
       "link": [2, 1],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"or": [
           "canMockball",
@@ -196,7 +194,6 @@
       "link": [2, 1],
       "name": "SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "SpaceJump",
         {"or": [

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -165,6 +165,10 @@
           {"heatFrames": 25}
         ]},
         {"heatFrames": 480}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 20}]},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {
@@ -187,7 +191,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
       ]
     },
     {

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -185,7 +185,12 @@
           "length": 8,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [2, 1],

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -261,7 +261,11 @@
         "leaveShinecharged": {
           "framesRemaining": 70
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
@@ -288,7 +292,11 @@
         "leaveShinecharged": {
           "framesRemaining": 30
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 5],
@@ -306,6 +314,10 @@
           "framesRemaining": 20
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Run off of the entry runway after storing the Shinespark to skip the platform with a Sova."
     },
     {
@@ -325,7 +337,11 @@
         "leaveShinecharged": {
           "framesRemaining": 70
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 6],
@@ -344,7 +360,13 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 1, "types": ["super"], "requires": []},
+        {"nodeId": 1, "types": ["missiles", "powerbomb"], "requires": ["never"]},
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 7],
@@ -363,7 +385,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 8],
@@ -411,7 +437,11 @@
         "leaveShinecharged": {
           "framesRemaining": 30
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -434,7 +464,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -461,7 +495,11 @@
         "leaveShinecharged": {
           "framesRemaining": 70
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 5],
@@ -477,7 +515,11 @@
         "leaveShinecharged": {
           "framesRemaining": 45
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 6],
@@ -496,7 +538,11 @@
         "leaveShinecharged": {
           "framesRemaining": 10
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 6],
@@ -521,7 +567,11 @@
         "leaveShinecharged": {
           "framesRemaining": 30
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 7],
@@ -542,6 +592,10 @@
           "framesRemaining": 10
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Requires very effecient movement.",
       "devNote": "1 unusable tile."
     },
@@ -584,7 +638,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 2],
@@ -620,7 +678,11 @@
         "leaveShinecharged": {
           "framesRemaining": 30
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 2],
@@ -639,7 +701,11 @@
         "leaveShinecharged": {
           "framesRemaining": 30
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 2],
@@ -658,7 +724,11 @@
         "leaveShinecharged": {
           "framesRemaining": 50
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 3],
@@ -682,7 +752,10 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 5,"types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [3, 4],
@@ -702,6 +775,10 @@
           "framesRemaining": 30
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
     },
     {
@@ -722,6 +799,10 @@
           "framesRemaining": 50
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
     },
     {
@@ -738,7 +819,11 @@
         "leaveShinecharged": {
           "framesRemaining": 150
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 5],
@@ -753,7 +838,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 6],
@@ -771,7 +860,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [3, 8],
@@ -795,7 +888,11 @@
         "leaveShinecharged": {
           "framesRemaining": 20
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 3],
@@ -815,7 +912,11 @@
         "leaveShinecharged": {
           "framesRemaining": 35
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 4],
@@ -864,7 +965,11 @@
         "leaveShinecharged": {
           "framesRemaining": 20
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 5],
@@ -884,7 +989,11 @@
         "leaveShinecharged": {
           "framesRemaining": 35
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 6],
@@ -922,15 +1031,17 @@
       "requires": [
         "HiJump",
         "canMidairShinespark",
-        "canShinechargeMovementComplex",
-        "canFastWalljumpClimb",
+        "canShinechargeMovementTricky",
         {"shinespark": {"frames": 10}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "note": "Quickly climb the right side of the room to just have enough time to shinespark out the door.",
-      "devNote": "FIXME: Fast Climbing is required but you can make it up without walljumping."
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Quickly climb the right side of the room to just have enough time to shinespark out the door."
     },
     {
       "link": [5, 2],
@@ -948,7 +1059,11 @@
         "leaveShinecharged": {
           "framesRemaining": 40
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [5, 3],
@@ -964,7 +1079,11 @@
         "leaveShinecharged": {
           "framesRemaining": 160
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [5, 3],
@@ -979,7 +1098,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [5, 4],
@@ -999,6 +1122,10 @@
           "framesRemaining": 30
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
     },
     {
@@ -1019,6 +1146,10 @@
           "framesRemaining": 50
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
     },
     {
@@ -1043,7 +1174,10 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [5, 6],
@@ -1075,15 +1209,17 @@
       "requires": [
         "HiJump",
         "canMidairShinespark",
-        "canShinechargeMovementComplex",
-        "canFastWalljumpClimb",
+        "canShinechargeMovementTricky",
         {"shinespark": {"frames": 10}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "note": "Quickly climb the right side of the room to just have enough time to shinespark out the door.",
-      "devNote": "FIXME: Fast Climbing is required but you can make it up without walljumping."
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Quickly climb the right side of the room to just have enough time to shinespark out the door."
     },
     {
       "link": [5, 8],
@@ -1106,7 +1242,11 @@
         "leaveShinecharged": {
           "framesRemaining": 70
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [6, 1],
@@ -1121,7 +1261,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [6, 2],
@@ -1140,6 +1284,10 @@
           "framesRemaining": 75
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Shoot the top Sova while falling to delay its movement."
     },
     {
@@ -1161,6 +1309,10 @@
           "framesRemaining": 75
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Shoot the top Sova while falling."
     },
     {
@@ -1183,7 +1335,11 @@
         "leaveShinecharged": {
           "framesRemaining": 45
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [6, 3],
@@ -1195,15 +1351,18 @@
         }
       },
       "requires": [
-        "canShinechargeMovementComplex",
-        "canDownBack",
-        "canTrickyJump"
+        "canShinechargeMovementTricky",
+        "canDownBack"
       ],
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": 20
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": [
         "Weave down the left side of the room by first DownBacking left and then moving to the right to avoid landing on any platforms.",
         "Shoot the first Sova to delay its movements."
@@ -1224,7 +1383,11 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [6, 5],
@@ -1242,7 +1405,11 @@
         "leaveShinecharged": {
           "framesRemaining": 15
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [6, 6],
@@ -1272,6 +1439,10 @@
           "framesRemaining": 30
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Jump over or kill the Sova."
     },
     {

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -140,7 +140,6 @@
       "link": [2, 3],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Grapple",
         {"heatFrames": 600}
       ]
@@ -149,7 +148,6 @@
       "link": [2, 3],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 600}
       ]
@@ -158,7 +156,6 @@
       "link": [2, 3],
       "name": "Speedjump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "SpeedBooster",
         "canWalljump",
@@ -169,7 +166,6 @@
       "link": [2, 3],
       "name": "Croc Escape Jump IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canJumpIntoIBJ",
         {"heatFrames": 1650}
       ]
@@ -188,7 +184,6 @@
       "link": [2, 3],
       "name": "MidAir SpringBall",
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "canSpringBallJumpMidAir",
         {"heatFrames": 600}
@@ -199,7 +194,6 @@
       "name": "Croc Escape SpringBall Bomb Boost",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSpringBallJumpMidAir",
         "canUnmorphBombBoost",
         "h_canCrouchJumpDownGrab",
@@ -215,7 +209,6 @@
       "name": "Croc Escape SpringBall Freeze",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyUseFrozenEnemies",
         "canSpringBallJumpMidAir",
         {"heatFrames": 1600},
@@ -231,7 +224,6 @@
       "link": [2, 3],
       "name": "Croc Escape HiJump Freeze",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         "HiJump",
         {"heatFrames": 1150}
@@ -243,7 +235,6 @@
       "name": "Croc Escape Ice Only Geruta Platforming",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyUseFrozenEnemies",
         "canCarefulJump",
         {"or": [
@@ -275,7 +266,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 70, "excessFrames": 12}},
         "canShinechargeMovementComplex",
@@ -293,7 +283,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 70, "excessFrames": 12}},
         "canShinechargeMovementComplex",
@@ -305,7 +294,6 @@
       "link": [2, 3],
       "name": "Croc Escape Short Short Charge",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canHorizontalShinespark",
         {"canShineCharge": {
           "usedTiles": 15,
@@ -320,7 +308,6 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 180}
       ]
@@ -329,7 +316,6 @@
       "link": [3, 1],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 160}
       ],
@@ -338,13 +324,17 @@
           "length": 17,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 70}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 120}]}
+      ]
     },
     {
       "link": [3, 2],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Grapple",
         {"heatFrames": 500}
       ]
@@ -353,7 +343,6 @@
       "link": [3, 2],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 500}
       ]
@@ -362,7 +351,6 @@
       "link": [3, 2],
       "name": "Speedjump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "SpeedBooster",
         {"heatFrames": 500}
@@ -373,7 +361,6 @@
       "link": [3, 2],
       "name": "HiJump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "canWalljump",
         {"heatFrames": 600}
@@ -384,7 +371,6 @@
       "link": [3, 2],
       "name": "Morph",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 400}
       ]
@@ -393,7 +379,6 @@
       "link": [3, 2],
       "name": "Quick Lava Bath",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 350},
         {"or": [
           {"lavaFrames": 70},

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -400,6 +400,11 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 160}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 70}]}
       ]
     },
     {
@@ -416,19 +421,26 @@
         }
       },
       "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 70}]}
       ]
     },
     {
       "link": [5, 1],
       "name": "Right Side Climb",
       "requires": [
+        "canTrickyJump",
         {"or": [
           "HiJump",
           "canPreciseWalljump"
         ]},
         {"heatFrames": 140}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 70}]}
       ]
     },
     {
@@ -534,6 +546,11 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 50}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 70}]}
       ]
     },
     {
@@ -562,6 +579,11 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 50}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 70}]}
       ]
     },
     {

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -193,7 +193,6 @@
       "link": [1, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 130}
       ]
     },
@@ -207,7 +206,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 140}
       ],
       "exitCondition": {
@@ -215,6 +213,10 @@
           "framesRemaining": 70
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "devNote": "FIXME: Entering with too little run speed causes Samus to 'trip', so the runway cannot reliably be used for short shortcharges."
     },
     {
@@ -241,7 +243,6 @@
       "link": [2, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpeedBooster",
         {"heatFrames": 380}
       ],
@@ -257,7 +258,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovement",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 86, "excessFrames": 10}},
@@ -294,7 +294,6 @@
       "link": [3, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
       ]
     },
@@ -321,7 +320,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSpeedball",
         {"heatFrames": 570}
       ],
@@ -340,7 +338,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovement",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 84, "excessFrames": 10}},
@@ -362,7 +359,6 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 94, "excessFrames": 10}},
         {"heatFrames": 700}
       ],
@@ -396,7 +392,6 @@
       "link": [4, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
       ]
     },
@@ -404,7 +399,6 @@
       "link": [5, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 160}
       ]
     },
@@ -412,7 +406,6 @@
       "link": [5, 1],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 130}
       ],
       "exitCondition": {
@@ -421,13 +414,16 @@
           "openEnd": 1,
           "gentleUpTiles": 4
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [5, 1],
       "name": "Right Side Climb",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "HiJump",
           "canPreciseWalljump"
@@ -445,14 +441,17 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 160}
       ],
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": 30
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [5, 2],
@@ -465,7 +464,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canShinechargeMovementTricky",
         "canTrickyJump",
         "canMidairShinespark",
@@ -519,7 +517,6 @@
       "link": [5, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 215}
       ]
     },
@@ -527,7 +524,6 @@
       "link": [6, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"obstaclesCleared": ["A"]},
         "SpeedBooster",
         {"heatFrames": 500}
@@ -537,7 +533,6 @@
       "link": [6, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
       ]
     },
@@ -557,13 +552,15 @@
           "framesRemaining": 100
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": "Enabled by coming in from the left and breaking the speed blocks on the way, or coming in charged and opening the path to the left."
     },
     {
       "link": [6, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
       ]
     },
@@ -584,13 +581,15 @@
           "framesRemaining": 60
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": "Enabled by coming in from the left and breaking the speed blocks on the way, or coming in charged and opening the path to the left."
     },
     {
       "link": [6, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 300}
       ]
     },
@@ -610,6 +609,9 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
       "note": [
         "Move very quickly to bring a shinespark from the speedway up to the Save Room door.",
         "Preclear the Cacatacs, and it may help to not run while platforming if HiJump is not available."

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -105,7 +105,6 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 200}
       ]
     },
@@ -113,7 +112,6 @@
       "link": [1, 3],
       "name": "Crumble Shaft Top Item Crumble Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCrumbleJump",
         {"heatFrames": 150}
       ],
@@ -123,7 +121,6 @@
       "link": [1, 3],
       "name": "Crumble Shaft Top Item Crumble Spin Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCrumbleJump",
         "canTrickyJump",
         {"heatFrames": 150}
@@ -135,7 +132,6 @@
       "link": [1, 3],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 150}
       ],
@@ -150,7 +146,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 20}},
         {"heatFrames": 175}
@@ -161,7 +156,6 @@
       "name": "Crumble Shaft Top Item Precise Walljump",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canPreciseWalljump",
         "canCameraManip",
         {"heatFrames": 300}
@@ -177,7 +171,6 @@
       "name": "Crumble Shaft Top Item Frozen Sova",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         "canCameraManip",
         {"heatFrames": 350}
@@ -192,7 +185,6 @@
       "link": [1, 3],
       "name": "SpringBall",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canUseSpringBall",
         {"heatFrames": 200}
       ],
@@ -202,7 +194,6 @@
       "link": [2, 1],
       "name": "Crumble Shaft HiJump Climb",
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "canConsecutiveWalljump",
         {"heatFrames": 500}
@@ -213,7 +204,6 @@
       "link": [2, 1],
       "name": "Crumble Shaft HiJumpless Climb",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canPreciseWalljump",
         "canConsecutiveWalljump",
         {"heatFrames": 500}
@@ -224,7 +214,6 @@
       "link": [2, 1],
       "name": "Crumble Shaft Consecutive Crumble Climb",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCrumbleJump",
         "canTrickyJump",
         {"heatFrames": 800}
@@ -236,7 +225,6 @@
       "link": [2, 1],
       "name": "Crumble Shaft Wall/Crumble Climb",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCrumbleJump",
         "canConsecutiveWalljump",
         {"heatFrames": 600}
@@ -247,7 +235,6 @@
       "link": [2, 1],
       "name": "SpringBall",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canUseSpringBall",
         {"heatFrames": 800}
       ],
@@ -257,7 +244,6 @@
       "link": [2, 1],
       "name": "Wall Jump with Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         "canConsecutiveWalljump",
         {"heatFrames": 500}
@@ -268,7 +254,6 @@
       "link": [2, 1],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 1000}
       ],
@@ -278,7 +263,6 @@
       "link": [2, 1],
       "name": "Crumble Shaft IBJ (Right)",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         "h_canStaggeredIBJ",
         {"heatFrames": 4000}
@@ -306,7 +290,6 @@
       "link": [2, 1],
       "name": "Crumble Shaft Springwall",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canSpringwall",
         "canConsecutiveWalljump",
         {"heatFrames": 500}
@@ -322,7 +305,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 59}},
         {"heatFrames": 250}
       ],
@@ -332,7 +314,6 @@
       "link": [2, 1],
       "name": "Crumble Shaft Frozen Climb",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         "canConsecutiveWalljump",
         {"heatFrames": 800}
@@ -346,7 +327,6 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canXRayClimb",
         {"heatFrames": 4000},
         "canBePatient"
@@ -378,7 +358,6 @@
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 20}
       ],
       "exitCondition": {
@@ -417,7 +396,6 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canConsecutiveWalljump",
         {"heatFrames": 550}
       ]
@@ -426,7 +404,6 @@
       "link": [2, 3],
       "name": "Crumble Shaft IBJ (Left)",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canIBJ",
         "h_canStaggeredIBJ",
         {"heatFrames": 4000}
@@ -451,7 +428,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 59}},
         {"heatFrames": 250}
       ],
@@ -461,7 +437,6 @@
       "link": [3, 1],
       "name": "Crumble Shaft Top Door Crumble Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCrumbleJump",
         {"heatFrames": 200}
       ]
@@ -470,7 +445,6 @@
       "link": [3, 1],
       "name": "Frozen Sova",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 400}
       ],
@@ -483,7 +457,6 @@
       "link": [3, 1],
       "name": "SpringBall",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canUseSpringBall",
         {"heatFrames": 250}
       ]
@@ -492,7 +465,6 @@
       "link": [3, 1],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         {"obstaclesCleared": ["A"]},
         {"heatFrames": 175}
@@ -503,7 +475,6 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 250}
       ]
     }

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -92,7 +92,6 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 190}
       ]
     },
@@ -100,7 +99,6 @@
       "link": [1, 2],
       "name": "Platforming and Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 170}
       ],
       "exitCondition": {
@@ -108,13 +106,17 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
+      ]
     },
     {
       "link": [1, 2],
       "name": "Platforming and Leave with Frozen Tripper Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyUseFrozenEnemies",
         {"heatFrames": 240}
       ],
@@ -123,7 +125,12 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -135,7 +142,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         "canCarefulJump",
         {"heatFrames": 135}
@@ -145,7 +151,6 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 210}
       ]
     },
@@ -153,7 +158,6 @@
       "link": [2, 1],
       "name": "Platforming and Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 190}
       ],
       "exitCondition": {
@@ -161,13 +165,17 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
+      ]
     },
     {
       "link": [2, 1],
       "name": "Platforming and Leave with Frozen Tripper Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canTrickyUseFrozenEnemies",
         {"heatFrames": 330}
       ],
@@ -176,7 +184,12 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -188,7 +201,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "SpaceJump",
         "canCarefulJump",
         {"heatFrames": 135}

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -455,6 +455,10 @@
           "framesRemaining": 130
         }
       },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Store the Shinespark after the second shutter to avoid breaking the Bomb Blocks in the floor."
     },
     {

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -137,7 +137,6 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 750}
       ]
     },
@@ -145,7 +144,6 @@
       "link": [1, 3],
       "name": "Screw Attack",
       "requires": [
-        "h_canNavigateHeatRooms",
         "ScrewAttack",
         {"heatFrames": 525}
       ],
@@ -155,7 +153,6 @@
       "link": [1, 3],
       "name": "Pseudo Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canPseudoScrew",
         {"heatFrames": 560}
       ]
@@ -164,7 +161,6 @@
       "link": [1, 3],
       "name": "Frozen Funes",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Wave",
         "Ice",
         {"heatFrames": 550}
@@ -174,7 +170,6 @@
       "link": [1, 3],
       "name": "Frozen Funes Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Wave",
         "Ice",
         {"heatFrames": 540}
@@ -184,13 +179,17 @@
           "length": 12,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 3],
       "name": "Frozen Funes Leave with Runway - Kill Fune",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Wave",
         "Ice",
         {"ammo": {"type": "Super", "count": 1}},
@@ -201,13 +200,17 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
+      ]
     },
     {
       "link": [1, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 100}
       ]
     },
@@ -245,7 +248,6 @@
       "link": [2, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 200}
       ]
@@ -254,7 +256,6 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 500}
       ]
     },
@@ -302,7 +303,6 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 80}
       ]
@@ -327,7 +327,6 @@
       "link": [4, 2],
       "name": "Tank Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"or": [
           "HiJump",
@@ -364,7 +363,6 @@
       "link": [4, 2],
       "name": "Kill Sovas",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"or": [
           "HiJump",
@@ -407,7 +405,6 @@
       "link": [4, 2],
       "name": "Speedrun Ice Beam Entry",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "canTrickyJump",
         {"or": [
@@ -436,7 +433,6 @@
       "link": [4, 2],
       "name": "Damage Boost",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCrouchJump",
         "Morph",
         "canNeutralDamageBoost",
@@ -453,7 +449,6 @@
       "link": [4, 2],
       "name": "Sova Freeze",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "canUseFrozenEnemies",
         {"heatFrames": 840}
@@ -464,7 +459,6 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 100}
       ]
@@ -473,7 +467,6 @@
       "link": [4, 3],
       "name": "Leave with Runway",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 140}
       ],
@@ -482,13 +475,17 @@
           "length": 12,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [4, 3],
       "name": "Leave with Runway - Dead Fune",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"or": [
           {"and": [
@@ -506,7 +503,13 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": []}
+      ],
+      "devNote": "FIXME: unlocksDoors: powerbomb would not have an ammo cost as one is used as part of the strat."
     },
     {
       "link": [4, 4],
@@ -519,7 +522,6 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             "canWalljump",
@@ -547,7 +549,6 @@
       "link": [5, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 150}
       ]
     },
@@ -555,7 +556,6 @@
       "link": [5, 2],
       "name": "Tank Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 150},
         {"or": [
@@ -573,7 +573,6 @@
       "link": [5, 2],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",
         {"heatFrames": 200}
       ]
@@ -582,7 +581,6 @@
       "link": [5, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
       ]
     }

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -138,6 +138,9 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 750}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": []}
       ]
     },
     {
@@ -147,6 +150,9 @@
         "ScrewAttack",
         {"heatFrames": 525}
       ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": []}
+      ],
       "devNote": "The bottom Fune shoots a fireball which wastes all of the time save of a Leave with Runway strat."
     },
     {
@@ -154,7 +160,10 @@
       "name": "Pseudo Screw",
       "requires": [
         "canPseudoScrew",
-        {"heatFrames": 560}
+        {"heatFrames": 540}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": []}
       ]
     },
     {
@@ -163,7 +172,10 @@
       "requires": [
         "Wave",
         "Ice",
-        {"heatFrames": 550}
+        {"heatFrames": 530}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": []}
       ]
     },
     {
@@ -172,7 +184,7 @@
       "requires": [
         "Wave",
         "Ice",
-        {"heatFrames": 540}
+        {"heatFrames": 525}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -203,8 +215,7 @@
       },
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
-        {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
+        {"types": ["super", "powerbomb"], "requires": []}
       ]
     },
     {
@@ -256,7 +267,12 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        {"heatFrames": 500}
+        {"heatFrames": 330}
+      ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 25}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 40}]}
       ]
     },
     {
@@ -461,6 +477,9 @@
       "requires": [
         "Morph",
         {"heatFrames": 100}
+      ],
+      "unlocksDoors": [
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 50}]}
       ]
     },
     {
@@ -479,7 +498,7 @@
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
         {"types": ["super"], "requires": []},
-        {"types": ["powerbomb"], "requires": ["never"]}
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 30}]}
       ]
     },
     {

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -83,7 +83,6 @@
       "link": [1, 2],
       "name": "Gravity",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "Gravity",
         {"heatFrames": 330},
@@ -95,7 +94,6 @@
       "link": [1, 2],
       "name": "Speedy Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "SpeedBooster",
         "canCarefulJump",
@@ -107,7 +105,6 @@
       "link": [1, 2],
       "name": "Boyon PB Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "canWalljump",
         "canCarefulJump",
@@ -123,7 +120,6 @@
       "link": [1, 2],
       "name": "Boyon Super Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "canWalljump",
         "canCarefulJump",
@@ -142,7 +138,6 @@
       "link": [1, 2],
       "name": "Frozen Boyon",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "canUseFrozenEnemies",
         {"heatFrames": 350}
@@ -152,7 +147,6 @@
       "link": [1, 2],
       "name": "Boyon Hit",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "canNeutralDamageBoost",
         {"enemyDamage": {
@@ -171,7 +165,6 @@
       "link": [1, 2],
       "name": "Lateral Mid-Air Morph",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canLateralMidAirMorph",
         {"heatFrames": 350}
       ],
@@ -181,7 +174,6 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         {"heatFrames": 270},
         {"or": [
@@ -205,7 +197,6 @@
       "link": [2, 1],
       "name": "Ice",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Morph",
         "canUseFrozenEnemies",
         {"heatFrames": 300}

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -212,7 +212,17 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": [
+          {"enemyDamage": {
+            "enemy": "Blue Sidehopper",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ]
     },
     {
       "link": [1, 2],
@@ -233,7 +243,17 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": [
+          {"enemyDamage": {
+            "enemy": "Blue Sidehopper",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ]
     },
     {
       "link": [1, 2],

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -475,7 +475,8 @@
         "leaveShinecharged": {
           "framesRemaining": 60
         }
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 3],

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -247,7 +247,8 @@
           "length": 45,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 1],
@@ -263,7 +264,8 @@
           "length": 45,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 1],

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -113,7 +113,7 @@
     },
     {
       "link": [1, 2],
-      "name": "Come in Shinecharging, Leave Shineharged",
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -126,6 +126,7 @@
           "framesRemaining": 160
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "devNote": "FIXME: Requires the item to have been collected."
     },
     {
@@ -213,7 +214,7 @@
     },
     {
       "link": [2, 1],
-      "name": "Come in Shinecharging, Leave Shineharged",
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -226,6 +227,7 @@
           "framesRemaining": 160
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "devNote": "FIXME: Requires the item to have been collected."
     },
     {

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -126,7 +126,10 @@
           "framesRemaining": 160
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "devNote": "FIXME: Requires the item to have been collected."
     },
     {
@@ -227,7 +230,10 @@
           "framesRemaining": 160
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "devNote": "FIXME: Requires the item to have been collected."
     },
     {

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -165,7 +165,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -186,7 +189,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -343,7 +349,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -364,7 +373,10 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -164,7 +164,8 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 2],
@@ -184,7 +185,8 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 2],
@@ -340,7 +342,8 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],
@@ -360,7 +363,8 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 2],

--- a/region/wreckedship/main/Wrecked Ship Entrance.json
+++ b/region/wreckedship/main/Wrecked Ship Entrance.json
@@ -71,6 +71,7 @@
           "openEnd": 1
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "devNote": [
         "With Phantoon defeated, entering from the same door will have the conveyors on and lengthening the runway.",
         "Without Phantoon defeated, the runway is still 45+ tiles."
@@ -135,6 +136,7 @@
           "openEnd": 1
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "devNote": [
         "With Phantoon defeated, entering from the same door will have the conveyors on and lengthening the runway.",
         "Without Phantoon defeated, the runway is still 45+ tiles."

--- a/strats.md
+++ b/strats.md
@@ -953,7 +953,7 @@ By default every door node has an implicit strat from the node to itself, for un
   "link": [1, 1],
   "name": "Unlock Door",
   "requires": [],
-  "unlocksDoors": [{"type": "ammo", "requires": []}]
+  "unlocksDoors": [{"types": ["ammo"], "requires": []}]
 }
 ```
 
@@ -965,9 +965,9 @@ In a heated room, it instead has the form:
   "name": "Unlock Door",
   "requires": [],
   "unlocksDoors": [
-    {"type": "missiles", "requires": [{"heatFrames": 50}]},
-    {"type": "super", "requires": []},
-    {"type": "powerbomb", "requires": [{"heatFrames": 110}]}
+    {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+    {"types": ["super"], "requires": []},
+    {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
   ]
 }
 ```

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -82,7 +82,7 @@ def process_keyvalue(k, v, metadata):
         "leaveWithSpark", # validated by schema
         "speedBooster", # validated by schema
         "framesRemaining",  # validated by schema
-        "types",  # validated by schema in 'unlockDoors', manually in 'enemyDamage'
+        "types",  # validated by schema in 'unlocksDoors', manually in 'enemyDamage'
     ]
 
     # check if it's a key we want to check


### PR DESCRIPTION
- unlocksDoors heat frame counts for precathedral and double chamber are estimates
- Hoping `doorUnlockedAtNode` is still ok to leave inside of an `or`
- Removed h_canNavigateHeatRooms while going through UN
- Opening doors with missiles could still remove from remainingShinesparkFrames, if it were to become a resource.