### PR TITLE
Springball Review + SpringFling

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -652,7 +652,17 @@
           "name": "h_canMaxHeightSpringBallJump",
           "requires": [
             "canCrouchJump",
-            "canTrickySpringBallJump"
+            "canTrickySpringBallJump",
+            "canTrickyJump"
+          ]
+        },
+        {
+          "name": "h_canTrickySpringwall",
+          "requires": [
+            "canTrickySpringBallJump",
+            "canSpringwall",
+            "canSpringFling",
+            "canTrickyJump"
           ]
         },
         {

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -197,7 +197,32 @@
       "requires": [
         "canSuitlessMaridia",
         "canTrickySpringBallJump"
+      ],
+      "note": "It helps to begin jumping when the water level is high."
+    },
+    {
+      "link": [2, 1],
+      "name": "WallJump Bomb Boost",
+      "requires": [
+        "canWallJumpBombBoost"
       ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Spring Ball Bomb Jump",
+      "requires": [
+        {"doorUnlockedAtNode": 2},
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          "canWalljump"
+        ]},
+        "canSpringBallBombJump",
+        "h_canBombThings"
+      ],
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["ammo"], "requires": []}
+      ],
+      "note": "Requires waiting until the last moment before SpringBall jumping."
     },
     {
       "link": [2, 1],

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -579,6 +579,18 @@
       ]
     },
     {
+      "link": [3, 1],
+      "name": "Ice Clip",
+      "requires": [
+        "h_canXRayCeilingClip",
+        "canTrickyUseFrozenEnemies"
+      ],
+      "note": [
+        "Prepare a pipe bug to Ice clip through the crumble blocks, using Morph and X-Ray.",
+        "It can be tested on the solid blocks directly above the pipe spawner."
+      ]
+    },
+    {
       "link": [3, 5],
       "name": "Base",
       "requires": [

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -3946,7 +3946,7 @@
       "name": "Speedy Spring Ball Jump",
       "requires": [
         "canTrickyDashJump",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ]
     },
     {

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -509,7 +509,7 @@
           "h_canFly",
           "canWalljump",
           "canUseFrozenEnemies",
-          "canTrickySpringBallJump"
+          "canSpringBallJumpMidAir"
         ]}
       ]
     },

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -513,6 +513,7 @@
       "requires": [
         "Morph",
         "canNeutralDamageBoost",
+        "canTrickyJump",
         "canCrouchJump",
         {"enemyDamage": {
           "enemy": "Zero",

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -510,7 +510,7 @@
         {"or": [
           "h_canTrickySpringwall",
           {"and": [
-            "h_canMaxHeightSpringballJump",
+            "h_canMaxHeightSpringBallJump",
             "canNeutralDamageBoost"
           ]}
         ]},
@@ -640,6 +640,7 @@
       "note": [
         "Jump from the safe spot on the spikey stairs and use the momentum change from equipping SpringBall to move closer to the door's platform.",
         "Then SpringBall jump to reach the door."
+      ]
     },
     {
       "link": [4, 1],

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -505,10 +505,15 @@
     },
     {
       "link": [2, 3],
-      "name": "Tricky Springwall",
+      "name": "Tricky Springball Jump",
       "requires": [
-        "canSpringwall",
-        "canTrickyJump",
+        {"or": [
+          "h_canTrickySpringwall",
+          {"and": [
+            "h_canMaxHeightSpringballJump",
+            "canNeutralDamageBoost"
+          ]}
+        ]},
         {"spikeHits": 1}
       ]
     },
@@ -626,6 +631,18 @@
     },
     {
       "link": [4, 1],
+      "name": "X-Ray Access Tricky SpringBall Jump",
+      "notable": true,
+      "requires": [
+        "canTrickySpringBallJump",
+        "canSpringFling"
+      ],
+      "note": [
+        "Jump from the safe spot on the spikey stairs and use the momentum change from equipping SpringBall to move closer to the door's platform.",
+        "Then SpringBall jump to reach the door."
+    },
+    {
+      "link": [4, 1],
       "name": "Speed HiJump",
       "requires": [
         "HiJump",
@@ -638,7 +655,7 @@
     },
     {
       "link": [4, 1],
-      "name": "Spring Ball Jump",
+      "name": "HiJump Spring Ball Jump",
       "requires": [
         "HiJump",
         "canSpringBallJumpMidAir",

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -831,7 +831,7 @@
       "requires": [
         "canTrickyDashJump",
         "HiJump",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ]
     },
     {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -166,6 +166,7 @@
         "canTrickyJump",
         "canSpaceJumpWaterBounce",
         "canSpringBallBounce",
+        "canSpringFling",
         "canMockball",
         {"or": [
           "canDownGrab",

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -675,7 +675,7 @@
         "canCarefulJump",
         "canSpringBallJumpMidAir",
         {"or": [
-          "canTrickyJump",
+          "canTrickySpringBallJump",
           "canResetFallSpeed",
           "canStationaryLateralMidAirMorph"
         ]},
@@ -683,7 +683,7 @@
         "canWalljump"
       ],
       "note": [
-        "Freeze the Choot at the top right of its jump. Quickly get on top of it by first getting onto the pillar to the left.",
+        "Freeze the Choot when it swings right on its jump. Quickly get on top of it by first getting onto the pillar to the left, or with a SpringBall Jump.",
         "Perform a precise spring ball jump to get to the far right ledge, while avoiding hitting the water surface.",
         "While on the ledge, stand on the raised ground to the right and jump to the surface, then space jump across the water to the left."
       ]

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1985,7 +1985,7 @@
           "h_canFly",
           {"and": [
             "canTrickyDashJump",
-            "canSpringBallJumpMidAir",
+            "canTrickySpringBallJump",
             "HiJump"
           ]}
         ]}

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -641,19 +641,17 @@
       "name": "Bootless Spring Ball Escape",
       "requires": [
         "h_canNavigateHeatRooms",
-        "canTrickyJump",
+        "canTrickySpringBallJump",
         {"heatFrames": 250},
         {"or": [
           {"and": [
-            "canSpringBallJumpMidAir",
-            {"or": [
-              "can3HighMidAirMorph",
-              "canLateralMidAirMorph",
-              "canCrumbleJump"
-            ]}
+            "can3HighMidAirMorph",
+            "canSpringFling"
           ]},
+          "canLateralMidAirMorph",
+          "canCrumbleJump",
           {"and": [
-            "canSpringwall",
+            "h_canTrickySpringwall",
             "canPreciseWalljump"
           ]}
         ]},

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -196,6 +196,22 @@
     },
     {
       "link": [1, 3],
+      "name": "SpringFling over the acid",
+      "requires": [
+        "canSpringFling",
+        "canDisableEquipment",
+        "SpeedBooster",
+        "canTrickyJump",
+        "canLateralMidAirMorph",
+        {"heatFrames": 210}
+      ],
+      "note": [
+        "Begin with SpeedBooster unequipped, and run&jump over the acid into an airball.",
+        "Once Samus begins falling, equip SpringBall and SpeedBooster to safely land on the other side near the statue."
+      ]
+    },
+    {
+      "link": [1, 3],
       "name": "Gravityless Acid Dive",
       "requires": [
         "h_canNavigateHeatRooms",

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -824,12 +824,12 @@
     },
     {
       "link": [5, 4],
-      "name": "Golden Torizo Supers Springwall with Bombs",
-      "notable": true,
+      "name": "Springwall with Bombs",
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUseMorphBombs",
         "canSpringwall",
+        "canTrickySpringBallJump",
         {"heatFrames": 900}
       ],
       "note": [

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -516,12 +516,12 @@
     },
     {
       "link": [2, 5],
-      "name": "Screw Attack Room Springwall with Bombs",
-      "notable": true,
+      "name": "Springwall with Bombs",
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUseMorphBombs",
         "canSpringwall",
+        "canTrickySpringBallJump",
         {"heatFrames": 300}
       ],
       "clearsObstacles": ["A"],

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -168,6 +168,14 @@
     },
     {
       "link": [1, 3],
+      "name": "Max Height SpringBall Jump",
+      "requires": [
+        "canSuitlessMaridia",
+        "h_canMaxHeightSpringBallJump"
+      ]
+    },
+    {
+      "link": [1, 3],
       "name": "Suitless Frozen Puyo",
       "requires": [
         "canSuitlessMaridia",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -55,6 +55,15 @@
       "betweenNodes": [2, 4]
     }
   ],
+  "reusableRoomwideNotable": [
+    {
+      "name": "East Sand Hall Cross-Room SpringBall Jump",
+      "note": [
+        "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
+        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
+      ]
+    }
+  ],
   "links": [
     {
       "from": 1,
@@ -192,6 +201,28 @@
       "devNote": [
         "If applicable, the heat frames in the adjacent room may be underrepresented, particularly on a longer runway,",
         "but it shouldn't be too bad because with a longer runway, Samus can just come in fully shinecharged."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "East Sand Hall Cross-Room SpringBall Jump (Left to Right)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 10,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canPlayInSand",
+        "canCrossRoomJumpIntoWater",
+        "canLateralMidAirMorph",
+        "canTrickySpringBallJump",
+        "canCarefulJump"
+      ],
+      "note": [
+        "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
+        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
       ]
     },
     {
@@ -420,6 +451,29 @@
         "Alternatively, with spring ball it is possible to use a bomb boost spring ball jump."
       ],
       "devNote": "It is assumed that getting to the second pillar is free relative to getting to the right door."
+    },
+    {
+      "link": [2, 1],
+      "name": "East Sand Hall Cross-Room SpringBall Jump (Right to Left)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 10,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canPlayInSand",
+        "canCrossRoomJumpIntoWater",
+        "canLateralMidAirMorph",
+        "canTrickySpringBallJump",
+        "canCarefulJump"
+      ],
+      "reusableRoomwideNotable": "East Sand Hall Cross-Room SpringBall Jump",
+      "note": [
+        "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
+        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
+      ]
     },
     {
       "link": [2, 1],

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -803,9 +803,11 @@
             "canWalljump",
             "HiJump",
             "canUseFrozenEnemies",
+            "canGravityJump",
             {"and": [
               "canTrickyJump",
-              "canSpringBallJumpMidAir"
+              "can3HighMidAirMorph",
+              "canTrickySpringBallJump"
             ]}
           ]}
         ]}
@@ -847,8 +849,9 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canStationaryLateralMidAirMorph",
+        "canSpringFling",
         "canPlayInSand",
         {"or": [
           {"enemyDamage": {
@@ -874,12 +877,10 @@
       "notable": true,
       "requires": [
         "canSuitlessMaridia",
-        "canTrickyJump",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
-        "canSpringBallJumpMidAir",
-        "canStationaryLateralMidAirMorph",
-        "canCrouchJump"
+        "h_canMaxHeightSpringBallJump",
+        "canStationaryLateralMidAirMorph"
       ],
       "note": [
         "From the sand fall, quickly get onto the left platform to prevent the right side Evir from lowering too far.",

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -448,8 +448,7 @@
       "requires": [
         "Gravity",
         "Grapple",
-        "canSpringBallJumpMidAir",
-        "canTrickyJump",
+        "canTrickySpringBallJump",
         "canPlayInSand"
       ],
       "note": "Break spin before touching the sand, and then spinjump to get a good jump off of the sand."
@@ -498,15 +497,14 @@
     },
     {
       "link": [4, 5],
-      "name": "Pants Room Suitless MidAir SpringBall Jump with HiJump",
-      "notable": true,
+      "name": "Suitless MidAir SpringBall Jump with HiJump",
       "requires": [
         "Grapple",
         "canSuitlessMaridia",
         "HiJump",
         "canSpringBallJumpMidAir",
         "canPlayInSand",
-        "canCarefulJump"
+        "canTrickyJump"
       ],
       "note": [
         "Requires a mid-air SpringBall jump off the sand.",

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -671,9 +671,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canPlayInSand",
-        "canTrickyJump",
-        "canCrouchJump",
-        "canTrickySpringBallJump",
+        "h_canMaxHeightSpringBallJump",
         "canStationaryLateralMidAirMorph",
         {"or": [
           {"enemyKill": {
@@ -773,10 +771,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canPlayInSand",
-        "canTrickyJump",
-        "canCrouchJump",
-        "canTrickySpringBallJump",
-        "canStationaryLateralMidAirMorph",
+        "h_canMaxHeightSpringBallJump",
         {"or": [
           {"enemyKill": {
             "enemies": [["Evir"]],
@@ -925,9 +920,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canPlayInSand",
-        "canTrickyJump",
-        "canCrouchJump",
-        "canTrickySpringBallJump",
+        "h_canMaxHeightSpringBallJump",
         "canStationaryLateralMidAirMorph"
       ],
       "reusableRoomwideNotable": "West Sand Hall Suitless Bootless Spring Ball",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1650,7 +1650,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canStationaryLateralMidAirMorph",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canResetFallSpeed"
       ]
     },

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -217,7 +217,15 @@
       "name": "Suitless CF Clip (Left to Right)",
       "requires": [
         "h_canJumpIntoCrystalFlashClip",
-        "canSuitlessMaridia"
+        "canSuitlessMaridia",
+        {"or": [
+          "HiJump",
+          "canSpringBallJumpMidAir",
+          {"and": [
+            "h_canCrouchJumpDownGrab",
+            "canCarefulJump"
+          ]}
+        ]}
       ],
       "note": [
         "Find the crumble blocks and crystal flash mid-air, just below them.",
@@ -294,7 +302,7 @@
         {"or": [
           {"and": [
             "h_canCrouchJumpDownGrab",
-            "canCarefulJump"
+            "canTrickyJump"
           ]},
           "HiJump",
           "Gravity",
@@ -380,7 +388,7 @@
         {"or": [
           {"and": [
             "h_canCrouchJumpDownGrab",
-            "canCarefulJump"
+            "canTrickyJump"
           ]},
           "HiJump",
           "Gravity",

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -253,7 +253,7 @@
         "Gravity",
         "HiJump",
         "canPlayInSand",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ]
     },
     {
@@ -288,7 +288,7 @@
             "canPlayInSand",
             "HiJump",
             "canNeutralDamageBoost",
-            "canSpringBallJumpMidAir",
+            "canTrickySpringBallJump",
             {"spikeHits": 2}
           ]}
         ]},
@@ -461,13 +461,19 @@
           {"and": [
             "HiJump",
             "canGravityJump"
-          ]},
-          {"and": [
-            "canSpringBallJumpMidAir",
-            "canGravityJump"
           ]}
         ]}
       ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Gravity Jump, SpringBall Jump",
+      "requires": [
+        "canTrickySpringBallJump",
+        "canGravityJump",
+        "canTrickyJump"
+      ],
+      "note": "Pause for the Gravity Jump as late as possible and then repause as soon as possible for the SpringBall Jump."
     },
     {
       "link": [2, 3],
@@ -563,7 +569,7 @@
         }
       },
       "requires": [
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround"
       ],
@@ -689,7 +695,7 @@
         "Gravity",
         "HiJump",
         "canPlayInSand",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ]
     },
     {

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -252,7 +252,7 @@
       "name": "Frozen SpringBall",
       "requires": [
         "canSuitlessMaridia",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canUseFrozenEnemies"
       ]
     },

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -440,8 +440,13 @@
       "name": "Draygon Springwall",
       "requires": [
         "Gravity",
-        "canSpringwall"
-      ]
+        "canSpringwall",
+        "canTrickySpringBallJump",
+        {"resetRoom": {
+          "nodes": [1]
+        }}
+      ],
+      "devNote": "The turret cannot be broken."
     },
     {
       "link": [3, 2],

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -388,7 +388,10 @@
         "canSpringBallJumpMidAir",
         {"or": [
           "HiJump",
-          "canTrickyJump"
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            "canSpringFling"
+          ]}
         ]}
       ],
       "note": "There is just enough distance for a MidAir SpringBall jump to reach without HiJump."
@@ -492,7 +495,7 @@
       "requires": [
         {"or": [
           "canWalljump",
-          "canSpringBallJumpMidAir",
+          "canTrickySpringBallJump",
           "SpaceJump"
         ]},
         "canCrossRoomJumpIntoWater"
@@ -747,7 +750,7 @@
         "HiJump",
         "canSuitlessMaridia",
         "canCarefulJump",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canLateralMidAirMorph",
         "canNeutralDamageBoost",
         {"enemyDamage": {

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -301,7 +301,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canSandfallBounce",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canTrickyJump"
       ],
       "note": [

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -664,7 +664,7 @@
         }
       },
       "requires": [
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "h_canJumpIntoIBJ",
         {"or": [
           "h_canDoubleBombJump",

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -158,7 +158,8 @@
       "requires": [
         "canSuitlessMaridia",
         "canUseFrozenEnemies",
-        "canSpringBallJumpMidAir"
+        "canSpringBallJumpMidAir",
+        "canCrouchJump"
       ]
     },
     {

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -549,7 +549,7 @@
       "name": "Spring Ball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canCarefulJump"
       ]
     },

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -124,7 +124,7 @@
             ]}
           ]},
           {"and": [
-            "canSpringBallJumpMidAir",
+            "canTrickySpringBallJump",
             "canCarefulJump",
             "canCrouchJump"
           ]}

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -328,7 +328,12 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "canTrickySpringBallJump"
+        "canSpringBallJumpMidAir",
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          "canTrickySpringBallJump",
+          "canWalljump"
+        ]}
       ]
     },
     {
@@ -337,6 +342,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
+        "canCarefulJump",
         "canUseFrozenEnemies",
         "h_canCrouchJumpDownGrab"
       ]

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -968,6 +968,22 @@
       ]
     },
     {
+      "link": [5, 4],
+      "name": "Plasma Spark Room SpringFling into Top Right Door",
+      "notable": true,
+      "requires": [
+        "Morph",
+        "canSpringFling",
+        "canResetFallSpeed",
+        "canDownBack"
+      ],
+      "note": [
+        "Roll off the above ledge and use both the vertical speed resets from first (un)equipping SpringBall and then by unmorphing in order to reach the door.",
+        "Pause shortly after rolling off the ledge, after falling for 1 tile.  The timing is very precise.",
+        "A downback helps by shrinking Samus' hitbox."
+      ]
+    },
+    {
       "link": [6, 2],
       "name": "Bottom Right Door Lock Skip",
       "requires": [],

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -554,7 +554,7 @@
         "SpeedBooster",
         {"or": [
           "HiJump",
-          "canSpringBallJumpMidAir",
+          "canTrickySpringBallJump",
           "canWalljump",
           {"and": [
             "canGravityJump",

--- a/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
@@ -628,7 +628,7 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": [
         "Standing on the platform in the room below, jump up (crouch jump makes it easier) and press right against the door frame through the transition.",
@@ -648,7 +648,7 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": [
         "Standing on the platform in the room below, perform a spring ball jump mid-air a few tiles below the transition.",

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -426,7 +426,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canTrickyJump",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canTrickyUseFrozenEnemies",
         "canStationaryLateralMidAirMorph"
       ],

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -530,7 +530,7 @@
           }},
           {"enemyKill": {
             "enemies": [["Pink Space Pirate (standing)"]],
-            "explicitWeapons": ["Plasma"]
+            "explicitWeapons": ["Plasma", "ScrewAttack"]
           }}
         ]}
       ]
@@ -551,7 +551,7 @@
           }},
           {"enemyKill": {
             "enemies": [["Pink Space Pirate (standing)"]],
-            "explicitWeapons": ["Plasma", "ScrewAttack"]
+            "explicitWeapons": ["Plasma"]
           }}
         ]}
       ]
@@ -561,11 +561,29 @@
       "name": "SpringBall Escape",
       "requires": [
         "canSuitlessMaridia",
-        "canStationaryLateralMidAirMorph",
-        "canTrickySpringBallJump"
+        "canTrickySpringBallJump",
+        {"or": [
+          "canStationaryLateralMidAirMorph",
+          "canSpringFling"
+        ]},
+        {"or": [
+          "canTrickyJump",
+          {"enemyDamage": {
+            "enemy": "Pink Space Pirate (standing)",
+            "type": "contact",
+            "hits": 1
+          }},
+          {"enemyKill": {
+            "enemies": [["Pink Space Pirate (standing)"]],
+            "explicitWeapons": ["Plasma"]
+          }}
+        ]}
       ],
-      "note": "The second jump is doable by combining a stationary mid-air mockball with a mid-air springball jump.",
-      "devNote": "The second jump is actually doable with just a regular SpringBall jump but is ridiculously tight."
+      "note": [
+        "The second jump is harder than a normal mid-air springball jump.",
+        "Use either a stationary lateral mid air morph, to gain enough horizontal momentum,",
+        "or a SpringFling to reduce Samus' fall speed as soon as it begins to build up."
+      ]
     },
     {
       "link": [2, 6],

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -319,7 +319,7 @@
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         "HiJump",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ]
     },
     {
@@ -373,7 +373,7 @@
         "HiJump",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": "Requires 3 tiles of run speed (with no open end) to make it past the overhang above the door."
     },
@@ -558,11 +558,11 @@
     },
     {
       "link": [2, 6],
-      "name": "Fish Tank SpringBall Escape",
+      "name": "SpringBall Escape",
       "requires": [
         "canSuitlessMaridia",
         "canStationaryLateralMidAirMorph",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": "The second jump is doable by combining a stationary mid-air mockball with a mid-air springball jump.",
       "devNote": "The second jump is actually doable with just a regular SpringBall jump but is ridiculously tight."
@@ -921,6 +921,7 @@
       "name": "Suitless",
       "requires": [
         "canSuitlessMaridia",
+        "canCarefulJump",
         {"or": [
           "HiJump",
           "canSpringBallJumpMidAir"

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -860,6 +860,124 @@
     },
     {
       "link": [2, 3],
+      "name": "Cross Room Jump with SpeedBooster",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 12.4375,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canCrossRoomJumpIntoWater",
+        "canCarefulJump"
+      ],
+      "note": "Run with enough speed to jump (after the transition) to reach the far left ledge."
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room Jump with HiJump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 7,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canTrickyJump",
+        "canDodgeWhileShooting",
+        {"or": [
+          {"ammo": {"type": "Super", "count": 1}},
+          {"and": [
+            "Charge",
+            "Plasma"
+          ]},
+          {"and": [
+            "Plasma",
+            "canHitBox"
+          ]},
+          {"and": [
+            "canKago",
+            "canLateralMidAirMorph",
+            {"enemyDamage": {
+              "enemy": "Skulterra",
+              "type": "contact",
+              "hits": 1
+            }}
+          ]}
+        ]}
+      ],
+      "note": [
+        "Run with enough speed to jump (after the transition) to reach the far left ledge.",
+        "Either kill or Kago through the Fish enemy.",
+        "At slightly higher run speeds, Samus can jump from the bottom of the slope and avoid the fish."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room TrickyDashJump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 6.4375,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canCrossRoomJumpIntoWater",
+        "canTrickyDashJump",
+        "canDodgeWhileShooting",
+        {"or": [
+          {"ammo": {"type": "Super", "count": 1}},
+          {"and": [
+            "Charge",
+            "Plasma"
+          ]},
+          {"and": [
+            "Plasma",
+            "canHitBox"
+          ]},
+          {"and": [
+            "canKago",
+            "canLateralMidAirMorph",
+            {"enemyDamage": {
+              "enemy": "Skulterra",
+              "type": "contact",
+              "hits": 1
+            }}
+          ]}
+        ]}
+      ],
+      "note": [
+        "Run with 7 tiles (no openend) of speed to jump (after the transition) to reach the far left ledge.",
+        "Either kill or Kago through the Fish enemy."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room TrickyDashJump with HiJump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 4,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canTrickyDashJump"
+      ],
+      "note": [
+        "Bring 4 full tiles of run speed from the adjacent room in order to jump (after the transition) up to the far left ledge.",
+        "Either kill the Fish enemy, or jump from the bottom of the slope to pass underneath it."
+      ]
+    },
+    {
+      "link": [2, 3],
       "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -537,7 +537,7 @@
       "requires": [
         "canCrossRoomJumpIntoWater",
         "canCrouchJump",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": [
         "Standing on the platform in the room below, crouch jump and perform a spring ball jump mid-air just before reaching the transition."
@@ -1623,15 +1623,9 @@
       "notable": true,
       "requires": [
         "canSuitlessMaridia",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canTrickyUseFrozenEnemies",
-        {"or": [
-          "canTrickyJump",
-          {"and": [
-            "h_canMaxHeightSpringBallJump",
-            "canStationaryLateralMidAirMorph"
-          ]}
-        ]}
+        "canTrickyJump"
       ],
       "note": [
         "The tricky part is getting to the ledge below the missiles. There are two ways to do this:",
@@ -2264,7 +2258,7 @@
         "canSuitlessMaridia",
         {"or": [
           "HiJump",
-          "canSpringBallJumpMidAir"
+          "canTrickySpringBallJump"
         ]},
         "canTrickyUseFrozenEnemies"
       ],

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -897,13 +897,13 @@
           ]},
           {"and": [
             "Plasma",
-            "canHitBox"
+            "canHitbox"
           ]},
           {"and": [
             "canKago",
             "canLateralMidAirMorph",
             {"enemyDamage": {
-              "enemy": "Skulterra",
+              "enemy": "Skultera",
               "type": "contact",
               "hits": 1
             }}
@@ -938,13 +938,13 @@
           ]},
           {"and": [
             "Plasma",
-            "canHitBox"
+            "canHitbox"
           ]},
           {"and": [
             "canKago",
             "canLateralMidAirMorph",
             {"enemyDamage": {
-              "enemy": "Skulterra",
+              "enemy": "Skultera",
               "type": "contact",
               "hits": 1
             }}

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -701,12 +701,30 @@
     },
     {
       "link": [5, 2],
-      "name": "Mama Turtle Springwall",
+      "name": "Springwall",
       "requires": [
         "canSpringwall",
         "canResetFallSpeed"
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Springwall onto Grapple Block",
+      "requires": [
+        "canSpringwall",
+        "canSpringFling"
       ],
-      "devNote": "FIXME: It is possible to do this without canResetFallSpeed, but with a spring fling. A spring ball jump midair could be added, which combined with a spring fling can get onto the platform."
+      "clearsObstacles": ["B"]
+    },
+    {
+      "link": [5, 2],
+      "name": "Walljumpless SpringFling",
+      "requires": [
+        "h_canMaxHeightSpringBallJump",
+        "canSpringFling"
+      ],
+      "clearsObstacles": ["B"],
+      "note": "Time a pause before jumping to give a significant momentum boost in order to reach the Grapple Block."
     },
     {
       "link": [5, 2],

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1456,7 +1456,7 @@
       "requires": [
         "canCrossRoomJumpIntoWater",
         "HiJump",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": "Wall jump off either side of the door frame in the room below and Springball Jump at the height of the jump."
     },
@@ -1474,7 +1474,7 @@
         "canCrossRoomJumpIntoWater",
         "HiJump",
         "SpeedBooster",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": "Run and jump up through the door using HiJump and SpeedBooster in the room below and Springball Jump at the top of the jump."
     },
@@ -2153,7 +2153,10 @@
         "canSuitlessMaridia",
         {"or": [
           "HiJump",
-          "canSpringBallJumpMidAir"
+          {"and": [
+            "canCrouchJump",
+            "canTrickySpringBallJump"
+          ]}
         ]}
       ]
     },
@@ -2253,7 +2256,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canTrickyUseFrozenEnemies"
       ],
       "clearsObstacles": ["A", "B"],
@@ -2298,7 +2301,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "clearsObstacles": ["A", "B"],
@@ -2382,7 +2385,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canTrickyJump",
         "canCameraManip"
       ],
@@ -2690,7 +2693,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canFlatleyJump"
       ],
       "note": "Start the jump from the higher ground to the left, specifically the right side of the second highest region."
@@ -2744,7 +2747,7 @@
       "name": "Mt. Everest Right Top Half Crab Climb with Supers and Spring Ball",
       "requires": [
         "canSuitlessMaridia",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canCrazyCrabClimb",
         {"ammo": {"type": "Super", "count": 1}},
         {"obstaclesCleared": ["A"]}
@@ -2823,7 +2826,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
-        "canSpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canTrickyJump",
         "canCameraManip",
         {"obstaclesCleared": ["B"]}

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -496,7 +496,7 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": [
         "Standing on the platform in the room below, perform a spring ball jump mid-air just before reaching the transition."

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -304,9 +304,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "canSpringBallJumpMidAir",
-        "canCrouchJump",
-        "canTrickyJump"
+        "h_canMaxHeightSpringBallJump"
       ],
       "note": "Wait for the water to be rising and perform a max height SpringBall Jump."
     },

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -488,6 +488,16 @@
     },
     {
       "link": [4, 3],
+      "name": "SpringFling",
+      "requires": [
+        "canCarefulJump",
+        "canLateralMidAirMorph",
+        "canSpringFling",
+        "SpeedBooster"
+      ]
+    },
+    {
+      "link": [4, 3],
       "name": "Suitless Double SpringBall Jump",
       "requires": [
         "canSuitlessMaridia",

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -635,7 +635,10 @@
         "SpeedBooster",
         {"or": [
           "HiJump",
-          "canSpringBallJumpMidAir"
+          {"and": [
+            "canLateralMidAirMorph",
+            "canSpringBallJumpMidAir"
+          ]}
         ]}
       ]
     },
@@ -753,7 +756,7 @@
       "requires": [
         "HiJump",
         "canTrickyDashJump",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -712,9 +712,9 @@
     },
     {
       "link": [5, 1],
-      "name": "PCJR Left Side Spring Wall",
+      "name": "Tricky Spring Wall",
       "requires": [
-        "canSpringwall"
+        "h_canTrickySpringwall"
       ]
     },
     {
@@ -762,7 +762,7 @@
       "notable": true,
       "requires": [
         "HiJump",
-        "canSpringwall",
+        "h_canTrickySpringwall",
         "canPreciseWalljump",
         "can2HighWallMidAirMorph"
       ],

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -666,9 +666,9 @@
         }
       },
       "requires": [
-        "canIframeSpikeJump",
         "canSpringFling",
         "canLateralMidAirMorph",
+        "canCarefulJump",
         {"heatFrames": 120}
       ]
     },

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -658,6 +658,22 @@
     },
     {
       "link": [3, 4],
+      "name": "SpringFling over the Spikes",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 4,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canIframeSpikeJump",
+        "canSpringFling",
+        "canLateralMidAirMorph",
+        {"heatFrames": 120}
+      ]
+    },
+    {
+      "link": [3, 4],
       "name": "Double Chamber Spike HiJump",
       "requires": [
         "h_canNavigateHeatRooms",

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -304,18 +304,18 @@
     },
     {
       "link": [2, 1],
-      "name": "Crumble Shaft Springwall",
+      "name": "WallJump and SpringBall",
       "requires": [
         "h_canNavigateHeatRooms",
-        "canSpringwall",
+        "h_canUseSpringBall",
         "canConsecutiveWalljump",
         {"heatFrames": 500}
       ],
-      "note": "Walljump up the right then do a springwall to get around the top right crumble platform."
+      "note": "Walljump up the right then SpringBall bounce on top of the highest Crumble Block platform to reach the door."
     },
     {
       "link": [2, 1],
-      "name": "Crumble Shaft Shinespark Climb",
+      "name": "Shinespark Climb",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 60

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -346,6 +346,28 @@
     },
     {
       "link": [2, 6],
+      "name": "SpringFling Bowling",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 12,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canSpringFling",
+        "h_canUseSpringBall",
+        "canLateralMidAirMorph",
+        "canDisableEquipment",
+        {"spikeHits": 1}
+      ],
+      "note": [
+        "Start with Springball disabled.  Jump over the spikes and midair morph.",
+        "SpringFling on the way down, SpringBall bounce through the spikes, then SpringFling again to reach the statue taking only one spike hit."
+      ]
+    },
+    {
+      "link": [2, 6],
       "name": "2-hit Bowling",
       "requires": [
         "canTrickyJump",

--- a/tech.json
+++ b/tech.json
@@ -558,7 +558,7 @@
             "note": [
               "The ability to gain extra distance meerly by turning Springball on or off.",
               "When equipping or unequipping Springball while Morphed, Samus' speed is reset.",
-              "If rising, the horizontal speed is set to full roll speed.",
+              "If rising (and not in liquid physics), the horizontal speed is set to full roll speed.",
               "If falling, the vertical speed is set to zero."
             ]
           }

--- a/tech.json
+++ b/tech.json
@@ -512,6 +512,30 @@
                 "This can also be used out of a Spring Wall or from a spin jump, in order to gain more horizontal distance before triggering the second jump.",
                 "This, along with a crouch jump, is also needed in order to perform a maximum height spring ball jump.",
                 "Maximum height jumps primarily have underwater applications, as it enables Samus to barely make it up 7 tiles vertically."
+              ],
+              "extensionTechs": [
+                {
+                  "name": "canDoubleSpringBallJumpMidAir",
+                  "requires": [ "canTrickySpringBallJump" ],
+                  "note": [
+                    "Using a mid-air Spring Ball jump twice during a single jump to gain even more height.",
+                    "This consists of a tight variant of mid-air Spring Ball jump, then turning off Spring Ball, then a second mid-air Spring Ball jump all while still climbing upwards.",
+                    "This is typically used underwater with HiJump, but it is technically possible in lava without HiJump or to perform more than two Spring Ball jumps in acid."
+                  ]
+                },
+                {
+                  "name": "canUnderwaterBombIntoSpringBallJump",
+                  "requires": [ 
+                    "canTrickySpringBallJump",
+                    "h_canJumpIntoIBJ"
+                  ],
+                  "note": [
+                    "Use the tiny amount of height gain from an underwater Bomb explosion to re-equip Springball and perform a Springball jump.",
+                    "This is most often used to get a second SpringBall jump when underwater without HiJump.",
+                    "Bombs are required since Power Bombs will prevent pausing."
+                  ],
+                  "devNote": "Similar to an underwater walljump into springballjump, but that has no applications yet since double springballjump is easier for similar requirements."
+                }
               ]
             },
             {
@@ -522,31 +546,22 @@
               ],
               "note": [
                 "A mid-air Spring Ball jump that starts with a wall jump to gain more height.",
-                "It often relies on the momentum change when equipping or unequipping Spring Ball while morphed and moving horizontally."
+                "It often relies on the momentum change when equipping Spring Ball while morphed and moving horizontally."
               ]
             },
-            {
-              "name": "canDoubleSpringBallJumpMidAir",
-              "requires": [ "canTrickySpringBallJump" ],
-              "note": [
-                "Using a mid-air Spring Ball jump twice during a single jump to gain even more height.",
-                "This consists of a tight variant of mid-air Spring Ball jump, then turning off Spring Ball, then a second mid-air Spring Ball jump all while still climbing upwards.",
-                "This is typically used underwater with HiJump, but it is technically possible in lava without HiJump or to perform more than two Spring Ball jumps in acid."
-              ]
-            },
-            {
-              "name": "canUnderwaterBombIntoSpringBallJump",
-              "requires": [ 
-                "canTrickySpringBallJump",
-                "h_canJumpIntoIBJ"
-              ],
-              "note": [
-                "Use the tiny amount of height gain from an underwater Bomb explosion to re-equip Springball and perform a Springball jump.",
-                "This is most often used to get a second SpringBall jump when underwater without HiJump.",
-                "Bombs are required since Power Bombs will prevent pausing."
-              ],
-              "devNote": "Similar to an underwater walljump into springballjump, but that has no applications yet since double springballjump is easier for similar requirements."
-            }
+          {
+            "name": "canSpringFling",
+            "requires": [
+              "canDisableEquipment",
+              "SpringBall"
+            ],
+            "note": [
+              "The ability to gain extra distance meerly by turning Springball on or off.",
+              "When equipping or unequipping Springball while Morphed, Samus' speed is reset.",
+              "If rising, the horizontal speed is set to full roll speed.",
+              "If falling, the vertical speed is set to zero."
+            ]
+          }
           ]
         },
         {

--- a/tech.json
+++ b/tech.json
@@ -546,7 +546,7 @@
               ],
               "note": [
                 "A mid-air Spring Ball jump that starts with a wall jump to gain more height.",
-                "It often relies on the momentum change when equipping Spring Ball while morphed and moving horizontally."
+                "It often benefits from the momentum change when equipping Spring Ball while morphed and moving horizontally after a WallJump."
               ]
             },
           {
@@ -559,7 +559,7 @@
               "The ability to gain extra distance meerly by turning Springball on or off.",
               "When equipping or unequipping Springball while Morphed, Samus' speed is reset.",
               "If rising (and not in liquid physics), the horizontal speed is set to full roll speed.",
-              "If falling, the vertical speed is set to zero."
+              "If falling, the vertical speed is set to zero and horizontal speed is reset unless SpeedBooster is equipped."
             ]
           }
           ]


### PR DESCRIPTION
- SpringFling applies to walljumps and jump morphs when they are central to the strat.  Descending SpringFlings are clearer in where they are needed, but the "only helpful" ones need to make a noticeable difference to add to a strat.
- I was looking through `#logic` for SpringFlings, so some unrelated strats were added too.
- Converted a bunch of `canSpringBallJumpMidAir` into `canTrickySpringBallJump`