### PR TITLE
Add position constraints to a few shinesparks

### DIFF
--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -480,7 +480,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "devNote": [
@@ -632,7 +634,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "devNote": [
@@ -687,7 +691,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -359,7 +359,9 @@
       "name": "Croc Speedway Reverse Spark Through Door",
       "notable": true,
       "entranceCondition": {
-        "comeInWithSpark": {}
+        "comeInWithSpark": {
+          "position": "bottom"
+        }
       },
       "requires": [
         "h_canNavigateHeatRooms",


### PR DESCRIPTION
This came up in a seed today that Eddie and others raced: the logic thought sparking from Landing Site into Reverse Croc Speedway was possible, when it's not. Probably we need to take a close look at all the cross-room shinespark strats to see if there are others that need position constraints.