### PR TITLE
Add spring ball jump and IBJ options for Tourian Escape 4 L->R

### DIFF
--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -154,6 +154,9 @@
         }
       },
       "requires": [
+        "canPrepareForNextRoom",
+        "canShinechargeMovement",
+        "canMidairShinespark",
         {"shinespark": {"frames": 53, "excessFrames": 13}}
       ]
     },

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -139,7 +139,8 @@
           "HiJump",
           "SpaceJump",
           "canWalljump",
-          "h_canIBJ"
+          "h_canIBJ",
+          "canSpringBallJumpMidAir"
         ]}
       ],
       "note": "The pirates are free to kill, although they take some time."
@@ -460,7 +461,8 @@
           "HiJump",
           "SpaceJump",
           "canWalljump",
-          "h_canCrouchJumpDownGrab"
+          "h_canCrouchJumpDownGrab",
+          "canSpringBallJumpMidAir"
         ]},
         {"or": [
           "canCarefulJump",

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -147,6 +147,18 @@
     },
     {
       "link": [1, 3],
+      "name": "Shinespark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 15
+        }
+      },
+      "requires": [
+        {"shinespark": {"frames": 53, "excessFrames": 13}}
+      ]
+    },
+    {
+      "link": [1, 3],
       "name": "G-Mode Morph Power Bomb Pirate Kill",
       "entranceCondition": {
         "comeInWithGMode": {

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -157,7 +157,7 @@
         "canPrepareForNextRoom",
         "canShinechargeMovement",
         "canMidairShinespark",
-        {"shinespark": {"frames": 53, "excessFrames": 13}}
+        {"shinespark": {"frames": 57, "excessFrames": 13}}
       ]
     },
     {

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -441,7 +441,7 @@
       "notable": true,
       "requires": [
         "canSuitlessLavaDive",
-        "canJumpIntoIBJ",
+        "h_canJumpIntoIBJ",
         "canDoubleBombJump",
         {"or": [
           {"and": [
@@ -462,6 +462,7 @@
           "SpaceJump",
           "canWalljump",
           "h_canCrouchJumpDownGrab",
+          "h_canJumpIntoIBJ",
           "canSpringBallJumpMidAir"
         ]},
         {"or": [

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -475,8 +475,7 @@
           }}
         ]}
       ],
-      "clearsObstacles": ["A"],
-      "devNote": "IBJ can be used to avoid wall jumps before the acid starts rising, but a crouch jump down grab is needed near the right door."
+      "clearsObstacles": ["A"]
     },
     {
       "link": [3, 3],

--- a/strats.md
+++ b/strats.md
@@ -507,7 +507,7 @@ The way to calculate minimally required heat frames depends on the type of `leav
 
 ### Come In Shinecharged
 
-A `comeInShinecharged` entrance condition represents the need for Samus to run into the room with a shinecharge with a certain amount of time remaining before it would expire. It has the following property:
+A `comeInShinecharged` entrance condition represents the need for Samus to run or jump into the room with a shinecharge with a certain amount of time remaining before it would expire. It has the following property:
 
 - _framesRequired_: The number of frames that must be left on the shinespark charge when coming in. This must be a value between 1 and 179. Note that the shinecharge timer begins at 180 frames, and at least one frame must elapse between obtaining the shinecharge in the other room and crossing the door transition.
 
@@ -526,7 +526,7 @@ A `comeInShinecharged` must match with either a `leaveShinecharged` condition or
 
 A `comeInShinecharged` object does not provide any way to specify Samus' position or momentum through the door transition, but these details can affect the execution of the strat. As a way of normalizing the requirements, we make the following assumptions:
 
-- For a horizontal door transition, the `framesRequired` (and any other strat requirements such as heat frames) should be based on an assumption that Samus enters the room while running, with an unspecified amount of horizontal momentum. So the requirements should be based on the worst-case scenario, which in most cases means entering the room on the ground but with no momentum.
+- For a horizontal door transition, the `framesRequired` (and any other strat requirements such as heat frames) should be based on an assumption that Samus enters the room either while running or spin-jumping just before the transition, with an unspecified amount of momentum. So the requirements should be based on the worst-case scenario, which in most cases means entering the room with no momentum. If entering with a spin jump is required, keep in mind that a `comeInShinecharged` condition does not require air physics in the previous room, so the jump may be low; if a spin jump with more momentum is required then the `comeInShinechargedJumping` condition should be used.
 
 - For an vertical door transition, the `framesRemaining` (and other strat requirements) should be based on an assumption that Samus can enter through any horizontal position of the doorway (whichever is most favorable), in a jumping or falling pose, but with an unspecified amount of horizontal and vertical momentum. The requirements should be based on the worst-case momentum scenario, which generally means entering the room with no momentum, since any unwanted vertical momentum can be cancelled by releasing jump through the transition.
 


### PR DESCRIPTION
This also adds item requirements (Morph + Bombs) that appear to have been missing in the right-to-left strat "Tourian Escape Room 4 IBJ and Acid Bath".

Also adds a shinespark strat (coming in shinecharged) for getting up left->right walljumpless.
