### PR TITLE
Refine Base strat for getting out of Watering Hole

### DIFF
--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -145,14 +145,28 @@
           "canWalljump",
           "HiJump",
           "h_canFly",
-          "canSpringBallJumpMidAir",
-          {"and": [
-            "canCarefulJump",
-            "h_canCrouchJumpDownGrab"
-          ]}
+          "canSpringBallJumpMidAir"
         ]}
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Frozen Choot",
+      "requires": [
+        "Gravity",
+        "canTrickyUseFrozenEnemies"
       ],
-      "note": "Getting out with only Gravity and no wall jump requires a tight Crouch Jump and Down Grab while above the water."
+      "devNote": "The only thing tricky about this is realizing to leave the Choot alive before going down."
+    },
+    {
+      "link": [4, 1],
+      "name": "Crouch Jump Down Grab",
+      "requires": [
+        "Gravity",
+        "canTrickyJump",
+        "h_canCrouchJumpDownGrab"
+      ],
+      "note": "Getting out with only Gravity and no wall jump requires a tight crouch jump and down grab while above the water."
     },
     {
       "link": [4, 1],

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -166,7 +166,10 @@
         "canTrickyJump",
         "h_canCrouchJumpDownGrab"
       ],
-      "note": "Getting out with only Gravity and no wall jump requires a tight crouch jump and down grab while above the water."
+      "note": [
+        "Getting out with only Gravity and no wall jump requires a tight crouch jump and down grab while above the water:",
+        "Position very close to the edge, and press forward immediately after crouch jumping (almost simultaneously)."
+      ]
     },
     {
       "link": [4, 1],


### PR DESCRIPTION
- Added a frozen Choot strat.
- Split off crouch-jump down-grab into its own strat, and upgraded the "canCarefulJump" requirement to "canTrickyJump". The positioning has a few pixels of leniency, but the required precision in timing the forward press and down grab seems more difficult than "Medium". It could maybe be "Hard" if there were a suitable tech for it.