### PR TITLE
Use errors in tests for missing unlocksDoors

### DIFF
--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -3627,6 +3627,7 @@
       "requires": [
         "h_EtecoonDoorSpawnFix"
       ],
+      "bypassesDoorShell": true,
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": false
@@ -3646,6 +3647,7 @@
       "requires": [
         "h_EtecoonDoorSpawnFix"
       ],
+      "bypassesDoorShell": true,
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": true

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -678,14 +678,14 @@ for r,d,f in os.walk(os.path.join(".","region")):
                         for node in door_unlocked_nodes:
                             missing_types = check_node_covered_in_unlocks_doors(strat, node)
                             if len(missing_types) == 3:
-                                msg = f"🟡WARNING: Door unlocked requirement for node {node} is not covered in `unlocksDoors`:{stratRef}"
-                                messages["yellows"].append(msg)
-                                messages["counts"]["yellows"] += 1
+                                msg = f"🔴ERROR: Door unlocked requirement for node {node} is not covered in `unlocksDoors`:{stratRef}"
+                                messages["reds"].append(msg)
+                                messages["counts"]["reds"] += 1
                             else:
                                 for t in missing_types:
-                                    msg = f"🟡WARNING: Door unlocked requirement for node {node}, type {t}, is not covered in `unlocksDoors`:{stratRef}"
-                                    messages["yellows"].append(msg)
-                                    messages["counts"]["yellows"] += 1
+                                    msg = f"🔴ERROR: Door unlocked requirement for node {node}, type {t}, is not covered in `unlocksDoors`:{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
                         if strat.get("bypassesDoorShell") == True:
                             if node_lookup[toNode]["nodeType"] != "door":
                                 msg = f"🔴ERROR: Strat has bypassesDoorShell but To Node is not door:{stratRef}"


### PR DESCRIPTION
This cleans up the remaining two "missing unlocksDoors" warnings, and upgrades the warnings to errors going forward.

Using a "bypassesDoorShell" in the these "Carry G-mode Back through the Door" strats is a little awkward, since this comes with an implicit "canSkipDoorLock" tech requirement which doesn't make sense, since the door not closing means the lock simply does not come into play. But putting an "unlocksDoors" here wouldn't be valid since in fact there is no opportunity to unlock the door while passing through the room. Possibly the solution could be to remove "canSkipDoorLock" from being an implicit tech on "bypassesDoorShell" strats, and instead add it explicitly in the cases where it makes sense; alternatively, we could provide some way to override it in strats like these to make it not generate the tech requirement.