### PR TITLE
Wrecked Ship Enemy Extend Runways

### DIFF
--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -158,6 +158,25 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Runway - Frozen Atomic",
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 4,
+          "openEnd": 0
+        }
+      },
+      "note": [
+        "Freeze the Atomic in position to extend the runway. Maintain a half-tile gap between the Atomic and the runway to extend it as far as possible.",
+        "One easy method to align the Atomic is to lure the it high then stand under it to freeze it."
+      ],
+      "devNote": "This should be possible with a frozen Covern, but it is annoying to set up."
+    },
+    {
+      "link": [1, 1],
       "name": "Leave Shinecharged, Second Closest Runway",
       "requires": [
         "canShinechargeMovement",

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -128,6 +128,25 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Runway - Frozen Atomic",
+      "requires": [
+        "h_canFrozenEnemyRunway"
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 5,
+          "openEnd": 0
+        }
+      },
+      "note": [
+        "One way to position the Atomic is to lure it to the right by standing on the ground,",
+        "then jump over it and freeze it while standing in the corner on the ground once it is just under 2 tiles away from the ledge.",
+        "Stand on the ledge and freeze it again once it is in position, maintaining a half-tile gap between the Atomic and the runway to extend it as much as possible."
+      ],
+      "devNote": "This does not require Phantoon to be killed, as the broken workrobot is there otherwise."
+    },
+    {
+      "link": [1, 1],
       "name": "Leave Charged",
       "requires": [
         "canShinechargeMovement",
@@ -482,6 +501,36 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Runway - Frozen Atomic",
+      "requires": [
+        "f_DefeatedPhantoon",
+        {"or": [
+          "h_canBombThings",
+          {"and": [
+            "Morph",
+            {"obstaclesCleared": ["A"]}
+          ]}
+        ]},
+        "h_canFrozenEnemyRunway",
+        {"enemyDamage": {
+          "enemy": "Atomic",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 4,
+          "openEnd": 0
+        }
+      },
+      "note": [
+        "Lure an Atomic from the left half of the room. Morph in the corner against the top stair and wait for the Atomic to approach.",
+        "Quickly unmorph just before and freeze the Atomic just after it hits Samus."
+      ]
     },
     {
       "link": [3, 3],

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -503,7 +503,7 @@
       }
     },
     {
-      "link": [1, 1],
+      "link": [3, 3],
       "name": "Leave With Runway - Frozen Atomic",
       "requires": [
         "f_DefeatedPhantoon",

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -112,7 +112,11 @@
           "openEnd": 1
         }
       },
-      "devNote": "Note that this room has a half-width runway tile."
+      "devNote": [
+        "Note that this room has a half-width runway tile.",
+        "It is possible to extend this runway with a Covern with canRiskPermanentLossOfAccess, but it is very difficult to position the Covern.",
+        "The Covern can easily be positioned 2 pixels above the runway with Morph, but that can't be used to extend short shinecharge strats."
+      ]
     },
     {
       "link": [1, 1],

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -335,6 +335,22 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave With Runway - Frozen Atomic",
+      "requires": [
+        "f_DefeatedPhantoon",
+        "h_canFrozenEnemyRunway"
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 8,
+          "openEnd": 0
+        }
+      },
+      "note": "Position and freeze an Atomic to extend the runway. Maintain a half-tile gap between the runway to extend it as far as possible.",
+      "devNote": "It could be possible to freeze a Covern in its place, but it seems very difficult to position."
+    },
+    {
+      "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Covern or Atomic",
       "notable": false,
       "requires": [],
@@ -502,7 +518,8 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "devNote": "FIXME: It may be possible to extend this runway with a frozen Atomic or Covern."
     },
     {
       "link": [3, 3],
@@ -744,6 +761,36 @@
       ]
     },
     {
+      "link": [3, 8],
+      "name": "Wrecked Ship Main Shaft Spooky Missiles Temporary Blue Bounce with Frozen Enemy Runway",
+      "notable": true,
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        {"or": [
+          "f_DefeatedPhantoon",
+          {"and": [
+            "SpaceJump",
+            "canInsaneJump"
+          ]}
+        ]},
+        "canSlowShortCharge",
+        {"canShineCharge": {
+          "usedTiles": 14,
+          "openEnd": 0,
+          "steepUpTiles": 3
+        }},
+        "canTemporaryBlue",
+        "canSpringBallBounce"
+      ],
+      "note": [
+        "Use a frozen Atomic or Covern to extend the runway in front of the Spooky Missiles bomb block, then use temporary blue into a Spring Ball bounce to break it.",
+        "Position the enemy horizontally centered in the hole to extend the runway all the way to the wall.",
+        "Positioning a Covern is tricky. One way to set this up is with Space Jump.",
+        "Perform Space Jumps half way between the desired Covern position and the ceiling until the Covern spawns in the correct position."
+      ],
+      "devNote": "FIXME: There may be other ways to set up the Covern positioning without Space Jump."
+    },
+    {
       "link": [4, 1],
       "name": "Base",
       "requires": []
@@ -852,6 +899,29 @@
           "steepUpTiles": 7
         }
       }
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Runway - Frozen Atomic or Covern",
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        {"or": [
+          "f_DefeatedPhantoon",
+          "canInsaneJump"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 14,
+          "openEnd": 0,
+          "steepUpTiles": 7
+        }
+      },
+      "note": [
+        "Lure an Atomic or get a Covern to spawn to slightly extend the runway.",
+        "Positioning a Covern is a bit tricky. Consecutive wall jump or Space Jump in place above the gap but not quite at the ceiling,",
+        "or perform full height jumps to sometimes get the Covern to spawn in position. A crouch shot may help freeze the Coven when it is in position."
+      ]
     },
     {
       "link": [4, 4],
@@ -1075,6 +1145,35 @@
           "steepUpTiles": 6
         }
       }
+    },
+    {
+      "link": [5, 5],
+      "name": "Leave With Runway - Frozen Atomic or Covern",
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        {"or": [
+          "f_DefeatedPhantoon",
+          {"and": [
+            "SpaceJump",
+            "canInsaneJump"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 14,
+          "openEnd": 0,
+          "steepUpTiles": 6
+        }
+      },
+      "note": [
+        "Lure an Atomic or get a Covern to spawn to extend the runway.",
+        "Position the enemy horizontally centered in the hole to extend the runway all the way to the wall.",
+        "Positioning a Covern is tricky. One way to set this up is with Space Jump.",
+        "Align Samus left against the tile in the ceiling to align the Covern horizontally, then perform short Space Jumps half way between",
+        "the desired Covern position and the ceiling until the Covern spawns in the correct position."
+      ],
+      "devNote": "FIXME: There may be other ways to set up the Covern positioning without Space Jump."
     },
     {
       "link": [5, 5],

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -762,7 +762,7 @@
     },
     {
       "link": [3, 8],
-      "name": "Wrecked Ship Main Shaft Spooky Missiles Temporary Blue Bounce with Frozen Enemy Runway",
+      "name": "Wrecked Ship Main Shaft Spooky Missiles Temporary Blue with Frozen Enemy Runway",
       "notable": true,
       "requires": [
         "h_canFrozenEnemyRunway",

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -779,8 +779,7 @@
           "openEnd": 0,
           "steepUpTiles": 3
         }},
-        "canTemporaryBlue",
-        "canSpringBallBounce"
+        "canTemporaryBlue"
       ],
       "note": [
         "Use a frozen Atomic or Covern to extend the runway in front of the Spooky Missiles bomb block, then use temporary blue into a Spring Ball bounce to break it.",

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -86,11 +86,11 @@
       ],
       "exitCondition": {
         "leaveWithRunway": {
-          "length": 6,
-          "openEnd": 1
+          "length": 7,
+          "openEnd": 0
         }
       },
-      "note": "Stand at the bottom of the stairs to easily position the Covern."
+      "note": "Stand a few pixels away from the bottom of the stairs to easily position the Covern and extend the runway as far as possible."
     },
     {
       "link": [1, 1],

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -78,6 +78,22 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Runway - Frozen Covern",
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        {"not": "f_DefeatedPhantoon"},
+        "canRiskPermanentLossOfAccess"
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "openEnd": 1
+        }
+      },
+      "note": "Stand at the bottom of the stairs to easily position the Covern."
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -76,6 +76,23 @@
         }
       }
     },
+    
+    {
+      "link": [1, 1],
+      "name": "Leave With Runway - Frozen Covern",
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        {"not": "f_DefeatedPhantoon"},
+        "canRiskPermanentLossOfAccess"
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "openEnd": 0
+        }
+      },
+      "note": "Stand half way between the ledge and the save station to position the Covern and extend the runway as far as possible."
+    },
     {
       "link": [1, 1],
       "name": "Crystal Flash",


### PR DESCRIPTION
I was using `canInsaneJump` as a proxy for annoying positioning of Coverns. I wonder if we should instead have a second tech `canTrickyEnemyExtendRunway`?