### PR TITLE
Fix Botwoon ETank sand transition addresses which were swapped

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -22,16 +22,14 @@
       "name": "Left Sand Pit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a858",
-      "devNote": "FIXME Add leaveWithGMode strats. These can't currently be represented in the logic."
+      "nodeAddress": "0x001a864"
     },
     {
       "id": 3,
       "name": "Right Sand Pit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a864",
-      "devNote": "FIXME Add leaveWithGMode strats. These can't currently be represented in the logic."
+      "nodeAddress": "0x001a858"
     },
     {
       "id": 4,


### PR DESCRIPTION
Funny that this one went uncaught for so long. It didn't affect Map Rando before, because of how both exits went to the same room (Botwoon Quicksand Room), but that will no longer be the case with the new upcoming map pools.