### PR TITLE
Add tricky crouch jump down-grab in Everest

### DIFF
--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -782,6 +782,19 @@
     },
     {
       "link": [2, 7],
+      "name": "Tricky Crouch Jump Down Grab",
+      "requires": [
+        "Gravity",
+        "h_canCrouchJumpDownGrab",
+        "canTrickyJump"
+      ],
+      "note": [
+        "Stand on higher ground on the right side and face left.",
+        "Crouch jump and immediately press left (almost simultaneously) to avoid bonking the ceiling."
+      ]
+    },
+    {
+      "link": [2, 7],
       "name": "Suitless Jump Assists",
       "requires": [
         "canSuitlessMaridia",


### PR DESCRIPTION
Getting up with a Gravity jump is already in logic, so this strat doesn't add a lot. But in some applications Gravity jump might not be possible (e.g. if using vanilla equipment screen). This crouch jump down-grab is also faster than a Gravity jump, so it doesn't hurt to have it documented.