### PR TITLE
Add/refine Alcatraz Escape strats

### DIFF
--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1097,8 +1097,27 @@
     },
     {
       "link": [5, 8],
+      "name": "Tricky Spring Ball Jump",
+      "requires": [
+        "canTrickySpringBallJump",
+        "canTrickyJump"
+      ],
+      "note": [
+        "Run and spin jump into a spring ball jump, starting from the floating platform."
+      ]
+    },
+    {
+      "link": [5, 8],
+      "name": "Tricky Dash Jump",
+      "requires": [
+        "canTrickyDashJump"
+      ]
+    },
+    {
+      "link": [5, 8],
       "name": "Frozen Geemer Alcatraz Escape",
       "requires": [
+        "h_ZebesIsAwake",
         "Morph",
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -1122,24 +1141,97 @@
     },
     {
       "link": [5, 8],
-      "name": "Ceiling Clip Alcatraz Escape",
+      "name": "Grapple X-Ray Ceiling Clip Alcatraz Escape",
+      "notable": true,
       "requires": [
-        "canBeVeryPatient",
+        "h_ZebesIsAwake",
+        "canBePatient",
+        {"or": [
+          "canBeVeryPatient",
+          {"ammo": {"type": "Super", "count": 1}}
+        ]},
         "canPreciseCeilingClip",
         "canTrickyUseFrozenEnemies",
-        {"or": [
-          "Morph",
-          "canUseGrapple"
-        ]},
+        "canUseGrapple",
         "canXRayStandUp"
       ],
       "note": [
-        "Wait for a global geemer to make the long trip along the map.",
+        "Wait for a global Geemer to make the long trip along the map, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
         "Freeze it just after it starts climbing the bomb blocks.",
-        "Then use Xray to standup before jumping through the ceiling.",
-        "A second Gemmer can be killed using Grapple to enable use of Xray, if Morph is not available."
+        "Spin-jump above it, which will put Samus into a forced crouch where X-Ray cannot be used.",
+        "Use Grapple to kill a a second Geemer, restoring the ability to use X-Ray.",
+        "Use X-Ray to stand up, then jump up through the ceiling."
       ],
-      "devNote": "FIXME: An RMode forced standup can be used for this strat but it requires reserves > etanks to farm the ripper, or a GMode Crystal Flash plus a way to damage down again."
+      "devNote": [
+        "Morph could also be used instead of Grapple, but with Morph there is an easier strat that goes up through the tunnel to the left."
+      ]
+    },
+    {
+      "link": [5, 8],
+      "name": "HiJump Ceiling Clip Alcatraz Escape",
+      "notable": true,
+      "requires": [
+        "HiJump",
+        "h_ZebesIsAwake",
+        {"or": [
+          "canBeVeryPatient",
+          {"ammo": {"type": "Super", "count": 1}}
+        ]},
+        "canPreciseCeilingClip",
+        "canTrickyUseFrozenEnemies",
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }},
+        "canInsaneJump"
+      ],
+      "note": [
+        "Wait for a global Geemer to make the long trip along the map, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
+        "Hold right against the bomb blocks, take damage from the Geemer, jump, aim-down, and shoot the Geemer shortly before landing.",
+        "Samus should end up standing on the ground with the Geemer frozen on the wall slightly above the ground (overlapping Samus' hitbox).",
+        "Facing the bomb blocks and pressed against them, jump while holding down (but not crouched) and then press forward at a precise time to break the aim-down pose.",
+        "If successful, Samus will clip up through the ceiling.",
+        "This can be attempted several times before the Geemer thaws."
+      ]
+    },
+    {
+      "link": [5, 8],
+      "name": "G-Mode Forced Standup Alcatraz Escape",
+      "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_ZebesIsAwake",
+        "canBeVeryPatient",
+        {"ammo": {"type": "Super", "count": 3}},
+        "h_canArtificialMorphCrystalFlash",
+        {"autoReserveTrigger": {}},
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "note": [
+        "Enter with direct G-Mode artificial morph, and perform a Crystal Flash to refill reserve energy.",
+        "Do this all the way to the left, to prevent the Geemer from being destroyed by the lingering light orb.",
+        "Wait for a global Geemer to make the long trip along the map, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
+        "Either way, after the Geemer comes down into Alcatraz, shoot a Super to knock it off the ledge to make it bypass the light orb.",
+        "Damage down until one Geemer hit away from running out of energy.",
+        "If Samus has an ETank, it will take longer to damage down, in which case an additional Super can be used to knock the Geemer onto the floating platform, to allow unlimited time for damaging down.",
+        "A final Super can be used to knock the Geemer off the floating platform.",
+        "Set reserves to manual, stand next to the bomb blocks, and wait for the Geemer to approach.",
+        "Just before taking a hit, press pause.",
+        "During the fade-out, hold forward to land quickly after knockback.",
+        "At a precise moment just before the pause hits, jump and aim down; the aim-down can be buffered before jumpng, e.g. by rolling from forward to down through a diagonal input.",
+        "Set reserves to auto, then unpause while continuing to hold jump.",
+        "If successful, the forced stand-up will occur close to the ceiling and while Samus still has upward momentum, allowing Samus to clip through."
+      ]
     },
     {
       "link": [5, 8],
@@ -1157,6 +1249,37 @@
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing.",
         "There are scroll PLMs next to the bomb blocks and on the ledge below the Alcatraz exit, which will overload PLMs when going through them.",
         "The bomb blocks then become air and can be passed through."
+      ]
+    },
+    {
+      "link": [5, 8],
+      "name": "Double Damage Boost Alcatraz Escape",
+      "notable": true,
+      "requires": [
+        "h_ZebesIsAwake",
+        "HiJump",
+        "Morph",
+        {"or": [
+          "canBeVeryPatient",
+          {"ammo": {"type": "Super", "count": 1}}
+        ]},
+        "canInsaneJump",
+        "canPauseAbuse",
+        "canNeutralDamageBoost",
+        {"autoReserveTrigger": {"minReserveEnergy": 85}},
+        {"enemyDamage": {
+          "enemy": "Geemer (blue)",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "note": [
+        "Wait 3 minutes for a global Geemer to waddle over, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
+        "Damage down so until one Geemer hit away from running out of energy, and set reserves to manual.",
+        "Jump at a very precise time and mid-air morph to contact the Geemer at the peak of the jump, pressing pause to be in the fade-out while getting hit and reaching 0 energy.",
+        "Set reserves to auto, unpause, and hold left.",
+        "While reserves are auto-refilling, Samus' i-frames will run out, allowing Samus to be hit by the Geemer again and be boosted high enough to reach the ledge.",
+        "The screen will be black, which can be fixed by pausing and unpausing again."
       ]
     },
     {

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1110,7 +1110,8 @@
       "link": [5, 8],
       "name": "Tricky Dash Jump",
       "requires": [
-        "canTrickyDashJump"
+        "canTrickyDashJump",
+        "Morph"
       ]
     },
     {

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1110,8 +1110,12 @@
       "link": [5, 8],
       "name": "Tricky Dash Jump",
       "requires": [
-        "canTrickyDashJump",
-        "Morph"
+        "HiJump",
+        "Morph",
+        "canTrickyDashJump"
+      ],
+      "note": [
+        "The wall above can be used to align to a good starting position for the running jump."
       ]
     },
     {

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1210,6 +1210,7 @@
         "canBeVeryPatient",
         {"ammo": {"type": "Super", "count": 3}},
         "h_canArtificialMorphCrystalFlash",
+        "canPauseAbuse",
         {"autoReserveTrigger": {}},
         {"enemyDamage": {
           "enemy": "Geemer (blue)",

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1230,7 +1230,7 @@
         "Set reserves to manual, stand next to the bomb blocks, and wait for the Geemer to approach.",
         "Just before taking a hit, press pause.",
         "During the fade-out, hold forward to land quickly after knockback.",
-        "At a precise moment just before the pause hits, jump and aim down; the aim-down can be buffered before jumpng, e.g. by rolling from forward to down through a diagonal input.",
+        "At a precise moment just before the pause hits, jump and aim down; the aim-down can be buffered before jumping, e.g. by rolling from forward to down through a diagonal input.",
         "Set reserves to auto, then unpause while continuing to hold jump.",
         "If successful, the forced stand-up will occur close to the ceiling and while Samus still has upward momentum, allowing Samus to clip through."
       ]

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1146,7 +1146,7 @@
     },
     {
       "link": [5, 8],
-      "name": "Grapple X-Ray Ceiling Clip Alcatraz Escape",
+      "name": "Alcatraz Escape with Grapple X-Ray Ceiling Clip",
       "notable": true,
       "requires": [
         "h_ZebesIsAwake",
@@ -1173,7 +1173,7 @@
     },
     {
       "link": [5, 8],
-      "name": "HiJump Ceiling Clip Alcatraz Escape",
+      "name": "Alcatraz Escape with HiJump Ceiling Clip",
       "notable": true,
       "requires": [
         "HiJump",
@@ -1202,7 +1202,7 @@
     },
     {
       "link": [5, 8],
-      "name": "G-Mode Forced Standup Alcatraz Escape",
+      "name": "Alcatraz Escape G-Mode Crystal Flash Then Forced Standup",
       "notable": true,
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1229,7 +1229,7 @@
         "Wait for a global Geemer to make the long trip along the map, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
         "Either way, after the Geemer comes down into Alcatraz, shoot a Super to knock it off the ledge to make it bypass the light orb.",
         "Damage down until one Geemer hit away from running out of energy.",
-        "If Samus has an ETank, it will take longer to damage down, in which case an additional Super can be used to knock the Geemer onto the floating platform, to allow unlimited time for damaging down.",
+        "If Samus has at least one Energy Tank, it will take longer to damage down, in which case an additional Super can be used to knock the Geemer onto the floating platform, to allow unlimited time for damaging down.",
         "A final Super can be used to knock the Geemer off the floating platform.",
         "Set reserves to manual, stand next to the bomb blocks, and wait for the Geemer to approach.",
         "Just before taking a hit, press pause.",
@@ -1237,7 +1237,8 @@
         "At a precise moment just before the pause hits, jump and aim down; the aim-down can be buffered before jumping, e.g. by rolling from forward to down through a diagonal input.",
         "Set reserves to auto, then unpause while continuing to hold jump.",
         "If successful, the forced stand-up will occur close to the ceiling and while Samus still has upward momentum, allowing Samus to clip through."
-      ]
+      ],
+      "devNote": "FIXME: A version of this strat could be added with canRiskPermanentLossOfAccess requiring fewer Supers and time, if Samus has no tanks."
     },
     {
       "link": [5, 8],
@@ -1259,7 +1260,7 @@
     },
     {
       "link": [5, 8],
-      "name": "Double Damage Boost Alcatraz Escape",
+      "name": "Alcatraz Escape Double Damage Boost",
       "notable": true,
       "requires": [
         "h_ZebesIsAwake",
@@ -1281,7 +1282,7 @@
       ],
       "note": [
         "Wait 3 minutes for a global Geemer to waddle over, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
-        "Damage down so until one Geemer hit away from running out of energy, and set reserves to manual.",
+        "Damage down until Samus is one Geemer hit away from running out of energy, and set reserves to manual.",
         "Jump at a very precise time and mid-air morph to contact the Geemer at the peak of the jump, pressing pause to be in the fade-out while getting hit and reaching 0 energy.",
         "Set reserves to auto, unpause, and hold left.",
         "While reserves are auto-refilling, Samus' i-frames will run out, allowing Samus to be hit by the Geemer again and be boosted high enough to reach the ledge.",


### PR DESCRIPTION
This is based on bobbob's recent set of videos: https://www.youtube.com/playlist?list=PLUMF22jq7du3IWFXDwoBa3Tdw10kFUjQ2.

I tested all of these to figure out tech requirements. The G-mode forced stand-up clip seemed particularly tough, given the potentially lengthy setup required for a single attempt (which requires a frame perfect jump?), though it could just be I'm not practiced at it.

The HiJump ceiling clip was interesting; it's different from a normal frozen enemy ceiling clip, and it turned out to be more forgiving than I was expecting.