### PR TITLE
East Sand Hall Spring Ball jump right-to-left

### DIFF
--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -847,9 +847,7 @@
         "alternatively, jump slightly to the left and freeze the Evir, then return back to the center pillar before jumping across the sand.",
         "Freeze the right Evir and jump onto it.",
         "Quickly move left and fire an angle-down shot to freeze the left Evir before it descends too far.",
-        "Jump onto the left Evir.",
-        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
-        "Break spin before landing on the sand, then spin jump onto the ledge.",
+        "Jump onto the left Evir, back up to the right side of it to maximize space to build momentum, and jump to the left onto the sand and then onto the ledge.",
         "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
         "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
       ]

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -676,7 +676,7 @@
       "name": "Spring Ball Jump",
       "requires": [
         "canTrickyUseFrozenEnemies",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ],
       "note": [
         "Freeze the Evir soon after entering the room.",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -821,7 +821,7 @@
     },
     {
       "link": [4, 1],
-      "name": "East Sand Hall Suitless Bootless Evir Freeze (Right to Left)",
+      "name": "East Sand Hall Suitless Bootless Evir Freeze (Center to Left)",
       "notable": true,
       "requires": [
         "canSuitlessMaridia",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -838,6 +838,7 @@
           ]},
           {"and": [
             "canCameraManip",
+            "canMoonwalk",
             "canInsaneJump"
           ]}  
         ]}
@@ -846,7 +847,9 @@
         "From the left pillar, jump and place a Power Bomb (if available) to make the Evirs rise again, while being careful not to kill the close Evir.",
         "Freeze the first Evir such that its bottom is only slightly lower than the top of the pillar.",
         "Crouch jump onto the Evir, then freeze the second about 1.5 to 2.5 tiles lower. Jump off of the sand to get to the left door.",
-        "The Power Bomb use can be avoided by manipulating the camera to avoid bringing the left Evir on screen too early."
+        "The Power Bomb use can be avoided by manipulating the camera to avoid bringing the left Evir on screen too early:",
+        "If coming from the sandfall above, this can be done by freezing the first Evir on the way down, but not moving left enough to bring the left Evir on screen until after landing.",
+        "If coming from the right, this can be done by using moonwalk on the center pillar to shift the camera to the right before jumping onto the sand."
       ]
     },
     {

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -710,17 +710,24 @@
         "canTrickyJump",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
-        "canCameraManip",
-        "canInsaneJump"
+        {"or": [
+          "canCameraManip",
+          {"and": [
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"enemyDamage": {
+              "enemy": "Evir",
+              "type": "particle",
+              "hits": 2
+            }}
+          ]}
+        ]}
       ],
       "note": [
         "Enter the room at the far left of the transition, with either a spin-jump or i-frames, to avoid the Evir shot.",
         "Land on the right side of the pillar to the left, being careful to not bring left Evir on camera.",
         "Freeze the right Evir and jump onto it.",
         "Quickly move left and fire an angle-down shot to freeze the left Evir before it descends too far.",
-        "Jump onto the left Evir.",
-        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
-        "Break spin before landing on the sand, then spin jump onto the ledge.",
+        "Jump onto the left Evir, back up to the right side of it to maximize space to build momentum, and jump to the left onto the sand and then onto the ledge.",
         "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
         "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
       ]
@@ -871,17 +878,24 @@
         "canTrickyJump",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
-        "canCameraManip",
-        "canMoonwalk",
-        "canInsaneJump"
+        {"or": [
+          "canCameraManip",
+          {"and": [
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"enemyDamage": {
+              "enemy": "Evir",
+              "type": "particle",
+              "hits": 2
+            }}
+          ]}
+        ]}
       ],
       "note": [
-        "From the center pillar, moonwalk to scroll the camera as far right as possible, to avoid getting hit by an Evir shot.",
-        "Jump to the left onto the sand (breaking spin before landing), then quickly jump onto the left pillar.",
+        "From the center pillar, moonwalk to scroll the camera as far right as possible, to avoid getting hit by an Evir shot;",
+        "alternatively, jump slightly to the left and freeze the Evir, then return back to the center pillar.",
+        "Jump to the left onto the sand, then quickly jump onto the left pillar.",
         "Quickly freeze the first Evir, jump on top of it, and freeze the left Evir before it descends too far.",
-        "Jump onto the left Evir.",
-        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
-        "Break spin before landing on the sand, then spin jump onto the ledge.",
+        "Jump onto the left Evir, back up to the right side of it to maximize space to build momentum, then jump to the left onto the sand and then onto the ledge.",
         "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
         "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
       ]

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -672,6 +672,18 @@
       "devNote": "It is assumed that getting to the third pillar is free relative to getting to the left door."
     },
     {
+      "link": [2, 4],
+      "name": "Spring Ball Jump",
+      "requires": [
+        "canTrickyUseFrozenEnemies",
+        "canSpringBallJumpMidAir"
+      ],
+      "note": [
+        "Freeze the Evir soon after entering the room.",
+        "Use a Spring Ball jump to reach the first pillar, then continue across using the Evir as a platform."
+      ]
+    },
+    {
       "link": [3, 1],
       "name": "G-Mode",
       "entranceCondition": {
@@ -815,17 +827,26 @@
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
         "canCrouchJump",
-        {"ammo": {"type": "PowerBomb", "count": 1}},
-        {"enemyDamage": {
-          "enemy": "Evir",
-          "type": "particle",
-          "hits": 1
-        }}
+        {"or": [
+          {"and": [
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"enemyDamage": {
+              "enemy": "Evir",
+              "type": "particle",
+              "hits": 1
+            }}
+          ]},
+          {"and": [
+            "canCameraManip",
+            "canInsaneJump"
+          ]}  
+        ]}
       ],
       "note": [
-        "From the left pillar, jump and place a PB to make the Evirs rise again, while being careful not to kill the close Evir.",
+        "From the left pillar, jump and place a Power Bomb (if available) to make the Evirs rise again, while being careful not to kill the close Evir.",
         "Freeze the first Evir such that its bottom is only slightly lower than the top of the pillar.",
-        "Crouch jump onto the Evir, then freeze the second about 1.5 to 2.5 tiles lower. Jump off of the sand to get to the left door."
+        "Crouch jump onto the Evir, then freeze the second about 1.5 to 2.5 tiles lower. Jump off of the sand to get to the left door.",
+        "The Power Bomb use can be avoided by manipulating the camera to avoid bringing the left Evir on screen too early."
       ]
     },
     {

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -62,23 +62,6 @@
         "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
         "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
       ]
-    },
-    {
-      "name": "East Sand Hall Suitless Bootless Evir Freeze",
-      "note": [
-        "Safely cross from the center of the room to the left with only Ice beam.",
-        "If entering from the sandfall above, come in at the far left of the transition, with either a spin-jump or i-frames, to avoid the Evir shot;",
-        "land on the right side of the pillar to the left, being careful to not bring left Evir on camera.",
-        "If coming from the right side of the room, then moonwalk on the center pillar to scroll the camera as far right as possible, to avoid getting hit by an Evir shot.",
-        "Freeze the right Evir and jump onto it.",
-        "Quickly move left and fire an angle-down shot to freeze the left Evir before it descends too far.",
-        "Jump onto the left Evir.",
-        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
-        "Break spin before landing on the sand, then spin jump onto the ledge.",
-        "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
-        "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
-      ]
-
     }
   ],
   "links": [
@@ -702,38 +685,6 @@
     },
     {
       "link": [3, 1],
-      "name": "East Sand Hall Suitless Bootless Evir Freeze (Above to Left)",
-      "notable": true,
-      "reusableRoomwideNotable": "East Sand Hall Suitless Bootless Evir Freeze",
-      "requires": [
-        "canSuitlessMaridia",
-        "canTrickyJump",
-        "canTrickyUseFrozenEnemies",
-        "canPlayInSand",
-        {"or": [
-          "canCameraManip",
-          {"and": [
-            {"ammo": {"type": "PowerBomb", "count": 1}},
-            {"enemyDamage": {
-              "enemy": "Evir",
-              "type": "particle",
-              "hits": 2
-            }}
-          ]}
-        ]}
-      ],
-      "note": [
-        "Enter the room at the far left of the transition, with either a spin-jump or i-frames, to avoid the Evir shot.",
-        "Land on the right side of the pillar to the left, being careful to not bring left Evir on camera.",
-        "Freeze the right Evir and jump onto it.",
-        "Quickly move left and fire an angle-down shot to freeze the left Evir before it descends too far.",
-        "Jump onto the left Evir, back up to the right side of it to maximize space to build momentum, and jump to the left onto the sand and then onto the ledge.",
-        "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
-        "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
-      ]
-    },
-    {
-      "link": [3, 1],
       "name": "G-Mode",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -872,7 +823,6 @@
       "link": [4, 1],
       "name": "East Sand Hall Suitless Bootless Evir Freeze (Right to Left)",
       "notable": true,
-      "reusableRoomwideNotable": "East Sand Hall Suitless Bootless Evir Freeze",
       "requires": [
         "canSuitlessMaridia",
         "canTrickyJump",
@@ -891,11 +841,15 @@
         ]}
       ],
       "note": [
-        "From the center pillar, moonwalk to scroll the camera as far right as possible, to avoid getting hit by an Evir shot;",
-        "alternatively, jump slightly to the left and freeze the Evir, then return back to the center pillar.",
-        "Jump to the left onto the sand, then quickly jump onto the left pillar.",
-        "Quickly freeze the first Evir, jump on top of it, and freeze the left Evir before it descends too far.",
-        "Jump onto the left Evir, back up to the right side of it to maximize space to build momentum, then jump to the left onto the sand and then onto the ledge.",
+        "If entering from the sandfall above, come in at the far left of the transition, with either a spin-jump or i-frames, to avoid the Evir shot;",
+        "land on the right side of the pillar to the left, being careful to not bring left Evir on camera.",
+        "If coming from the right side of the room, then moonwalk on the center pillar to scroll the camera as far right as possible, to avoid getting hit by an Evir shot;",
+        "alternatively, jump slightly to the left and freeze the Evir, then return back to the center pillar before jumping across the sand.",
+        "Freeze the right Evir and jump onto it.",
+        "Quickly move left and fire an angle-down shot to freeze the left Evir before it descends too far.",
+        "Jump onto the left Evir.",
+        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
+        "Break spin before landing on the sand, then spin jump onto the ledge.",
         "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
         "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
       ]

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -62,6 +62,23 @@
         "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
         "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
       ]
+    },
+    {
+      "name": "East Sand Hall Suitless Bootless Evir Freeze",
+      "note": [
+        "Safely cross from the center of the room to the left with only Ice beam.",
+        "If entering from the sandfall above, come in at the far left of the transition, with either a spin-jump or i-frames, to avoid the Evir shot;",
+        "land on the right side of the pillar to the left, being careful to not bring left Evir on camera.",
+        "If coming from the right side of the room, then moonwalk on the center pillar to scroll the camera as far right as possible, to avoid getting hit by an Evir shot.",
+        "Freeze the right Evir and jump onto it.",
+        "Quickly move left and fire an angle-down shot to freeze the left Evir before it descends too far.",
+        "Jump onto the left Evir.",
+        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
+        "Break spin before landing on the sand, then spin jump onto the ledge.",
+        "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
+        "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
+      ]
+
     }
   ],
   "links": [
@@ -685,6 +702,31 @@
     },
     {
       "link": [3, 1],
+      "name": "East Sand Hall Suitless Bootless Evir Freeze (Above to Left)",
+      "notable": true,
+      "reusableRoomwideNotable": "East Sand Hall Suitless Bootless Evir Freeze",
+      "requires": [
+        "canSuitlessMaridia",
+        "canTrickyJump",
+        "canTrickyUseFrozenEnemies",
+        "canPlayInSand",
+        "canCameraManip",
+        "canInsaneJump"
+      ],
+      "note": [
+        "Enter the room at the far left of the transition, with either a spin-jump or i-frames, to avoid the Evir shot.",
+        "Land on the right side of the pillar to the left, being careful to not bring left Evir on camera.",
+        "Freeze the right Evir and jump onto it.",
+        "Quickly move left and fire an angle-down shot to freeze the left Evir before it descends too far.",
+        "Jump onto the left Evir.",
+        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
+        "Break spin before landing on the sand, then spin jump onto the ledge.",
+        "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
+        "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
+      ]
+    },
+    {
+      "link": [3, 1],
       "name": "G-Mode",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -751,7 +793,9 @@
           "canSandfallBounce"
         ]}
       ],
-      "note": "Enter on the right side of the transition to prevent the Evirs from firing."
+      "note": [
+        "To safely avoid the Evir shot, enter in a spin jump from either the far left or far right side of the transition."
+      ]
     },
     {
       "link": [4, 1],
@@ -819,37 +863,27 @@
     },
     {
       "link": [4, 1],
-      "name": "East Sand Hall Suitless Bootless Evir Freeze (Center to Left)",
+      "name": "East Sand Hall Suitless Bootless Evir Freeze (Right to Left)",
       "notable": true,
+      "reusableRoomwideNotable": "East Sand Hall Suitless Bootless Evir Freeze",
       "requires": [
         "canSuitlessMaridia",
         "canTrickyJump",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
-        "canCrouchJump",
-        {"or": [
-          {"and": [
-            {"ammo": {"type": "PowerBomb", "count": 1}},
-            {"enemyDamage": {
-              "enemy": "Evir",
-              "type": "particle",
-              "hits": 1
-            }}
-          ]},
-          {"and": [
-            "canCameraManip",
-            "canMoonwalk",
-            "canInsaneJump"
-          ]}  
-        ]}
+        "canCameraManip",
+        "canMoonwalk",
+        "canInsaneJump"
       ],
       "note": [
-        "From the left pillar, jump and place a Power Bomb (if available) to make the Evirs rise again, while being careful not to kill the close Evir.",
-        "Freeze the first Evir such that its bottom is only slightly lower than the top of the pillar.",
-        "Crouch jump onto the Evir, then freeze the second about 1.5 to 2.5 tiles lower. Jump off of the sand to get to the left door.",
-        "The Power Bomb use can be avoided by manipulating the camera to avoid bringing the left Evir on screen too early:",
-        "If coming from the sandfall above, this can be done by freezing the first Evir on the way down, but not moving left enough to bring the left Evir on screen until after landing.",
-        "If coming from the right, this can be done by using moonwalk on the center pillar to shift the camera to the right before jumping onto the sand."
+        "From the center pillar, moonwalk to scroll the camera as far right as possible, to avoid getting hit by an Evir shot.",
+        "Jump to the left onto the sand (breaking spin before landing), then quickly jump onto the left pillar.",
+        "Quickly freeze the first Evir, jump on top of it, and freeze the left Evir before it descends too far.",
+        "Jump onto the left Evir.",
+        "Back up to the right side of it, to maximize space to build momentum, and jump to the left.",
+        "Break spin before landing on the sand, then spin jump onto the ledge.",
+        "If Samus does not quite get enough height to make it onto the ledge, then break spin, turn around to the right, land on the sand again, and do a turnaround spin-jump to the left.",
+        "If the Evirs descend too far, it is possible to use a Power Bomb to bring them back up again, but caution is needed to avoid killing the first Evir, and it is difficult to avoid getting shot."
       ]
     },
     {


### PR DESCRIPTION
This adds a spring ball jump option (in combination with Ice) to get from right to left. Also adds an option to avoid Evir damage and Power Bomb usage going from the center to left. See insomniaspeed's video: https://discord.com/channels/1053421401354285129/1053436236628496454/1189600996469514340. I also tested that avoiding Evir damage and PB usage is possible when entering from the sandfall above, by entering the room with a jump, freezing the first Evir on the way down, and avoiding bringing the second Evir on camera until after landing.

Similar to how other 2->4 strats are done in this room, the new Spring Ball strat mainly only includes the requirements to get to the first pillar, since getting from there to the center is considered to be free relative to the requirements to get from the center to the left.