### PR TITLE
Remove some kihunter farms

### DIFF
--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -125,21 +125,6 @@
     },
     {
       "link": [1, 1],
-      "name": "Kihunter Farm",
-      "requires": [
-        {"resetRoom": {
-          "nodes": [1, 2],
-          "mustStayPut": false
-        }},
-        {"or": [
-          "ScrewAttack",
-          "h_hasBeamUpgrade"
-        ]},
-        {"refill": ["Energy", "Missile"]}
-      ]
-    },
-    {
-      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -179,13 +179,13 @@
     },
     {
       "link": [2, 2],
-      "name": "Kihunter and Sciser Farm",
+      "name": "Sciser Farm",
       "requires": [
         {"resetRoom": {
           "nodes": [1, 2, 3],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "PowerBomb"]}
+        {"refill": ["Energy", "PowerBomb"]}
       ]
     },
     {

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -335,7 +335,7 @@
           "nodes": [1, 3, 4],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"refill": ["Energy", "Super"]}
       ]
     },
     {

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -135,7 +135,7 @@
           "nodes": [1],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"refill": ["Energy", "Super"]}
       ]
     },
     {


### PR DESCRIPTION
- LN KiHunters didn't seem to get all drops rolled into missiles once everything else was full.  It was like 25% missile rate.
- Kraid Kis is a good good missile farm if your health stays full and with a strong weapon