### PR TITLE
Add resourceAvailable to schema

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -291,10 +291,30 @@ A `resourceCapacity` object represents the need for Samus to be capable of holdi
 __Example:__
 ```json
 {"resourceCapacity": [
-    { "type": "Missile", "count": 10},
-    { "type": "Super", "count":10},
-    { "type": "PowerBomb", "count": 11},
-    { "type": "RegularEnergy", "count":899}
+    {"type": "Missile", "count": 10},
+    {"type": "Super", "count": 10},
+    {"type": "PowerBomb", "count": 11},
+    {"type": "RegularEnergy", "count": 899}
+]}
+```
+
+#### resourceAvailable object
+A `resourceAvailable` object represents the need for Samus to be holding at least a set amount of a specific resource. It can have the following properties:
+* _type:_ The type of resource. Can have the following values:
+  * Missile
+  * Super
+  * PowerBomb
+  * RegularEnergy
+  * ReserveEnergy
+  * Energy (total of RegularEnergy + ReserveEnergy)
+* _count:_ The amount of the resource that Samus must have.
+
+This requirement does not consume the resource.
+
+__Example:__
+```json
+{"resourceAvailable": [
+    {"type": "Energy", "count": 99}
 ]}
 ```
 

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -396,6 +396,45 @@
               }
             }
           },
+          "resourceAvailable": {
+            "$id": "#/definitions/logicalRequirement/items/properties/resourceAvailable",
+            "type": "array",
+            "title": "Resource Available",
+            "description": "Fulfilled by having at least the amount available for all given resource types",
+            "items": {
+              "$id": "#/definitions/logicalRequirement/items/properties/resourceAvailable/items",
+              "type": "object",
+              "required": [
+                "type",
+                "count"
+              ],
+              "minItems": 1,
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/resourceAvailable/properties/items/type",
+                  "type": "string",
+                  "enum": [
+                    "Missile",
+                    "Super",
+                    "PowerBomb",
+                    "RegularEnergy",
+                    "ReserveEnergy",
+                    "Energy"
+                  ],
+                  "title": "Resource Type",
+                  "description": "The type of resource held."
+                },
+                "count": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/resourceAvailable/properties/items/count",
+                  "type": "integer",
+                  "minimum": 0,
+                  "title": "Resource Count",
+                  "description": "The amount of the resource that Samus must have."
+                }
+              }
+            }
+          },
           "canShineCharge": {
             "$id": "#/definitions/logicalRequirement/items/properties/canShineCharge",
             "type": "object",


### PR DESCRIPTION
This adds a new logical requirement `resourceAvailable` analagous to `resourceCapacity` but based on the current amount of resources not capacity.

I was thinking this could be useful to refine the logic in Metal Pirates Room, i.e. to add strats for killing both pirates with only 5 Supers, based on the assumption that you get at least one Super dropped (given enough energy to be out of health bomb range), or tankless with shinespark echoes, based on the assumption that you will get enough health drops to survive. I don't think I'm experienced enough with the room to be able to add the strats, but @osse101 maybe sometime you could? It seems like this room is currently one of the most common sources of "easy" sequence breaks on Challenge seeds.