### PR TITLE
resourceMissingAtMost requirement

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -299,7 +299,7 @@ __Example:__
 ```
 
 #### resourceAvailable object
-A `resourceAvailable` object represents the need for Samus to be holding at least a set amount of a specific resource. It can have the following properties:
+A `resourceAvailable` object represents the need for Samus to be holding at least a set amount of a specific resource. It has the following properties:
 * _type:_ The type of resource. Can have the following values:
   * Missile
   * Super
@@ -315,6 +315,26 @@ __Example:__
 ```json
 {"resourceAvailable": [
     {"type": "Energy", "count": 99}
+]}
+```
+
+#### resourceMissingAtMost object
+A `resourceMissingAtMost` object represents the need for Samus to be missing at most a certain amount of a specific resource, relative to being full capacity. It has the following properties:
+* _type:_ The type of resource. Can have the following values:
+  * Missile
+  * Super
+  * PowerBomb
+  * RegularEnergy
+  * ReserveEnergy
+  * Energy (total of RegularEnergy + ReserveEnergy)
+* _count:_ The amount of the resource that Samus must have.
+
+For example, a count of zero would indicate that Samus must be full on that resource type.
+
+__Example:__
+```json
+{"resourceMissingAtMost": [
+    {"type": "Energy", "count": 0}
 ]}
 ```
 

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -469,7 +469,7 @@
                   "type": "integer",
                   "minimum": 0,
                   "title": "Resource Count",
-                  "description": "The amount of the resource that Samus must not be missing too much of, relative to being full."
+                  "description": "The amount of the resource that Samus must not be missing, relative to being full."
                 }
               }
             }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -435,6 +435,45 @@
               }
             }
           },
+          "resourceMissingAtMost": {
+            "$id": "#/definitions/logicalRequirement/items/properties/resourceMissingAtMost",
+            "type": "array",
+            "title": "Resource Missing At Most",
+            "description": "Fulfilled by only missing at most the given amount from being full on a given resource type.",
+            "items": {
+              "$id": "#/definitions/logicalRequirement/items/properties/resourceMissingAtMost/items",
+              "type": "object",
+              "required": [
+                "type",
+                "count"
+              ],
+              "minItems": 1,
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/resourceMissingAtMost/properties/items/type",
+                  "type": "string",
+                  "enum": [
+                    "Missile",
+                    "Super",
+                    "PowerBomb",
+                    "RegularEnergy",
+                    "ReserveEnergy",
+                    "Energy"
+                  ],
+                  "title": "Resource Type",
+                  "description": "The type of resource held."
+                },
+                "count": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/resourceMissingAtMost/properties/items/count",
+                  "type": "integer",
+                  "minimum": 0,
+                  "title": "Resource Count",
+                  "description": "The amount of the resource that Samus must not be missing too much of, relative to being full."
+                }
+              }
+            }
+          },
           "canShineCharge": {
             "$id": "#/definitions/logicalRequirement/items/properties/canShineCharge",
             "type": "object",


### PR DESCRIPTION
This is following up on your idea @osse101 about a `resourceFull` requirement. I think this generalization `resourceMissingAtMost` can be useful in a other situations too. For example we could use it to refine some of the farming strats, e.g. their patience requirements based on how long the refill would take. It's still limited by the fact that we're still only representing full refills, but it could allow quite a bit of improvement by putting limits on it, e.g. so you don't end up needing to spend 10 minutes refilling energy in LN Firefleas on vanilla map.