### PR TITLE
Remove walljump req from Indy Jones Long Mella

### DIFF
--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -799,7 +799,6 @@
         "canUseFrozenEnemies",
         "canManipulateMellas",
         "canBeVeryPatient",
-        "canConsecutiveWalljump",
         {"or": [
           {"obstaclesCleared": ["B"]},
           "Morph"

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -806,7 +806,8 @@
       ],
       "note": [
         "Lure a Mella from the right by breaking the speed blocks or using Morph.",
-        "Then you need to manipulate it to go high enough to be used as a stepping stone once frozen."
+        "Then manipulate it to go high enough to be used as a stepping stone once frozen.",
+        "Without movement items it may be necessary to continue manipulating it from above, jumping and aiming down to freeze it."
       ]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -798,7 +798,13 @@
       "requires": [
         "canUseFrozenEnemies",
         "canManipulateMellas",
-        "canBeVeryPatient",
+        {"or": [
+          {"and": [
+            "canBePatient",
+            "canWalljump"
+          ]},
+          "canBeVeryPatient"
+        ]},
         {"or": [
           {"obstaclesCleared": ["B"]},
           "Morph"


### PR DESCRIPTION
The walljump requirement here isn't needed; somerando figured this out a while ago: https://youtu.be/9t2AWPOJNYQ?list=PLMfL5HDn1Tf6wtTlVNGcwCUMdUYDWUbLd&t=3818.