### PR TITLE
Business Center shinecharges

### DIFF
--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -151,6 +151,7 @@
         {"id": 1},
         {"id": 2},
         {"id": 3},
+        {"id": 4},
         {"id": 5},
         {"id": 6},
         {"id": 7},
@@ -247,10 +248,19 @@
         }
       },
       "requires": [
-        {"enemyKill": {
-          "enemies": [["Sova"]],
-          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
-        }},
+        {"or": [
+          {"enemyKill": {
+            "enemies": [["Sova"]],
+            "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+          }},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Sova"]],
+              "explicitWeapons": ["PowerBeam"]
+            }},
+            "canDownBack"
+          ]}
+        ]},
         "canShinechargeMovementComplex"
       ],
       "exitCondition": {
@@ -393,7 +403,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "note": "Shoot the door open while entering, land near the door, then run and jump under the platform above to get to the right side quickly."
+      "note": "Shoot the door open while entering, then run and jump under the platform above to get to the right side quickly."
     },
     {
       "link": [1, 6],
@@ -424,15 +434,12 @@
       "name": "Come In Shinecharged, Leave Sparking (Bottom)",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 25
+          "framesRequired": 30
         }
       },
       "requires": [
-        {"or": [
-          "canMoonwalk",
-          "canMidairShinespark"
-        ]},
-        {"shinespark": {"frames": 22}}
+        "canMidairShinespark",
+        {"shinespark": {"frames": 18}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -444,8 +451,8 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "note": [
-        "Moonwalk back against the left door to get high enough to spark without bonking the platform on the right.",
-        "Alternatively, do a small jump and spark mid-air."
+        "After landing, do a small jump and spark mid-air.",
+        "Alternatively, if you can avoid tripping while entering the room, another option is to moonwalk back against the left door to get high enough to spark without bonking the platform on the right."
       ]
     },
     {
@@ -491,7 +498,7 @@
       "name": "Carry Shinecharge (Wall Jump)",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 120
+          "framesRequired": 110
         }
       },
       "requires": [
@@ -598,6 +605,10 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
         {"enemyKill": {
           "enemies": [["Sova"]],
           "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
@@ -611,7 +622,31 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "note": "Spin-jump up and kill the Sova from the left just before landing on its platform."
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry Shinecharge (Sova Evade, Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 125
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canPreciseWalljump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Wall jump off the side of the platform and weave around the Sova to get onto the ledge above."
     },
     {
       "link": [2, 1],
@@ -669,6 +704,10 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
         {"enemyKill": {
           "enemies": [["Sova"]],
           "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
@@ -682,7 +721,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "note": "Carefully avoid hitting the Sova."
+      "note": "Spin-jump up and kill the Sova from the left just before landing on its platform."
     },
     {
       "link": [2, 1],
@@ -694,6 +733,10 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
         {"enemyKill": {
           "enemies": [["Sova"]],
           "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
@@ -709,7 +752,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "note": "Carefully avoid hitting the Sova."
+      "note": "Spin-jump up and kill the Sova from the left just before landing on its platform."
     },
     {
       "link": [2, 1],
@@ -722,6 +765,10 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
         {"enemyKill": {
           "enemies": [["Sova"]],
           "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
@@ -735,7 +782,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "note": "Spin-jump up and kill the Sova from the left just before landing on its platform."
     },
     {
       "link": [2, 1],
@@ -837,6 +885,29 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Come in Shinecharging, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 12, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
       "link": [2, 5],
       "name": "Carry Shinecharge",
       "entranceCondition": {
@@ -877,23 +948,15 @@
     },
     {
       "link": [2, 6],
-      "name": "Carry Shinecharge (Sova Kill, HiJump)",
+      "name": "Carry Shinecharge (HiJump)",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 120
+          "framesRequired": 110
         }
       },
       "requires": [
         "HiJump",
-        "canShinechargeMovementComplex",
-        {"or": [
-          "ScrewAttack",
-          "canTrickyJump"
-        ]},
-        {"enemyKill": {
-          "enemies": [["Sova"]],
-          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
-        }}
+        "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -903,7 +966,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "note": "Jump over the platform with the Sova that would otherwise be in the way."
     },
     {
       "link": [2, 6],
@@ -932,11 +996,12 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "note": "Spin-jump up and kill the Sova from the left just before landing on its platform."
     },
     {
       "link": [2, 6],
-      "name": "Come in Shinecharged, Leave With Spark (Sova Kill, HiJump, Bottom)",
+      "name": "Come in Shinecharged, Leave With Spark (HiJump, Bottom)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 80
@@ -945,15 +1010,7 @@
       "requires": [
         "HiJump",
         "canShinechargeMovementComplex",
-        {"or": [
-          "ScrewAttack",
-          "canTrickyJump"
-        ]},
-        {"enemyKill": {
-          "enemies": [["Sova"]],
-          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
-        }},
-        {"shinespark": {"frames": 12, "excessFrames": 0}}
+        {"shinespark": {"frames": 10, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -967,24 +1024,16 @@
     },
     {
       "link": [2, 6],
-      "name": "Come in Shinecharged, Leave With Spark (Sova Kill, HiJump)",
+      "name": "Come in Shinecharged, Leave With Spark (HiJump)",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 110
+          "framesRequired": 100
         }
       },
       "requires": [
         "HiJump",
         "canShinechargeMovementComplex",
-        {"or": [
-          "ScrewAttack",
-          "canTrickyJump"
-        ]},
-        {"enemyKill": {
-          "enemies": [["Sova"]],
-          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
-        }},
-        {"shinespark": {"frames": 5, "excessFrames": 0}}
+        {"shinespark": {"frames": 7, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -1052,7 +1101,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "note": "Spin-jump up and kill the Sova from the left just before landing on its platform."
     },
     {
       "link": [2, 6],
@@ -1082,7 +1132,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "note": "Spin-jump up and kill the Sova from the left just before landing on its platform."
     },
     {
       "link": [2, 7],
@@ -1107,7 +1158,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "note": "Requires very effecient movement.",
+      "note": "Requires very efficient movement.",
       "devNote": "1 unusable tile."
     },
     {
@@ -1970,7 +2021,7 @@
     },
     {
       "link": [5, 2],
-      "name": "Come in Shinecharging, Leave Shinecharged",
+      "name": "Come in Shinecharging, Leave Shinecharged (Ledge Grabs)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -1982,7 +2033,53 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 40
+          "framesRemaining": 30
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 45
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "HiJump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 60
         }
       },
       "unlocksDoors": [
@@ -2637,7 +2734,10 @@
         "leaveShinecharged": {
           "framesRemaining": "auto"
         }
-      }
+      },
+      "devNote": [
+        "FIXME: With some run speed from the other room, it's possible to jump onto and off of the right side of the platform before the Sova reaches Samus."
+      ]
     },
     {
       "link": [6, 7],

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -2507,37 +2507,11 @@
     },
     {
       "link": [6, 2],
-      "name": "Come in Shinecharging, Leave Shinecharged (Slide Off)",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 4,
-          "openEnd": 1
-        }
-      },
-      "requires": [
-        "canShinechargeMovementTricky",
-        "canTemporaryBlue"
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 85
-        }
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "note": [
-        "Slide off the ledge while gaining a shinecharge, and hold forward to clear both platforms, killing the Sova with temporary blue."
-      ]
-    },
-    {
-      "link": [6, 2],
       "name": "Come in Shinecharging, Leave Shinecharged (Sova Kill)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
-          "openEnd": 1
+          "openEnd": 0
         }
       },
       "requires": [
@@ -2558,6 +2532,31 @@
       ],
       "note": "Shoot the top Sova while falling.",
       "devNote": "1 unusable tile, since you need space to gain a little speed before falling."
+    },
+    {
+      "link": [6, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (Sova Evade)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canDownBack"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 70
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Shoot the top Sova while falling to delay its movement.",
+      "devNote": "Closed end because this strat might not work if sliding off, depending on the run speed."
     },
     {
       "link": [6, 2],

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -854,9 +854,7 @@
         {"shinespark": {"frames": 2, "excessFrames": 0}}
       ],
       "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": "auto"
-        }
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1302,9 +1300,7 @@
 
       ],
       "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": "auto"
-        }
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1663,9 +1659,7 @@
         {"shinespark": {"frames": 8, "excessFrames": 0}}
       ],
       "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": "auto"
-        }
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1686,9 +1680,7 @@
         {"shinespark": {"frames": 9, "excessFrames": 0}}
       ],
       "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": "auto"
-        }
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1785,9 +1777,7 @@
         {"shinespark": {"frames": 8, "excessFrames": 0}}
       ],
       "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": "auto"
-        }
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1808,9 +1798,7 @@
         {"shinespark": {"frames": 9, "excessFrames": 0}}
       ],
       "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": "auto"
-        }
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -238,7 +238,58 @@
     },
     {
       "link": [1, 2],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 125
+        }
+      },
+      "requires": [
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Shinecharge (Sova Damage)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 145
+        }
+      },
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Sova",
+          "type": "contact",
+          "hits": 1
+        }},
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -247,7 +298,7 @@
         }
       },
       "requires": [
-        "canShinechargeMovement",
+        "canShinechargeMovementComplex",
         {"or": [
           "canDownBack",
           {"enemyDamage": {
@@ -259,7 +310,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 70
+          "framesRemaining": 85
         }
       },
       "unlocksDoors": [
@@ -322,7 +373,29 @@
     },
     {
       "link": [1, 6],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 85
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Shoot the door open while entering, land near the door, then run and jump under the platform above to get to the right side quickly."
+    },
+    {
+      "link": [1, 6],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -331,16 +404,46 @@
         }
       },
       "requires": [
-        "canShinechargeMovement"
+        "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 70
+          "framesRemaining": 85
         }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": "There is a possibility of slipping on this runway when entering the room."
+    },
+    {
+      "link": [1, 6],
+      "name": "Come In Shinecharged, Leave Sparking (Bottom)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 25
+        }
+      },
+      "requires": [
+        {"or": [
+          "canMoonwalk",
+          "canMidairShinespark"
+        ]},
+        {"shinespark": {"frames": 22}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "Moonwalk back against the left door to get high enough to spark without bonking the platform on the right.",
+        "Alternatively, do a small jump and spark mid-air."
       ]
     },
     {
@@ -348,29 +451,78 @@
       "name": "Come In Shinecharged, Leave Sparking",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 70
+          "framesRequired": 75
         }
       },
       "requires": [
-        {"or": [
-          {"doorUnlockedAtNode": 1},
-          "canMidairShinespark"
-        ]},
-        {"shinespark": {"frames": 23}}
+        {"shinespark": {"frames": 6, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
       },
       "unlocksDoors": [
-        {"nodeId": 1, "types": ["super"], "requires": []},
-        {"nodeId": 1, "types": ["missiles", "powerbomb"], "requires": ["never"]},
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "note": "Shoot the door open while entering, land near the door, then run and jump under the platform above to get to the right side quickly."
     },
     {
       "link": [1, 7],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      }
+    },
+    {
+      "link": [1, 7],
+      "name": "Carry Shinecharge (Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 120
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      }
+    },
+    {
+      "link": [1, 7],
+      "name": "Carry Shinecharge (Ledge Grabs)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      }
+    },
+    {
+      "link": [1, 7],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -383,13 +535,10 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 50
+          "framesRemaining": 55
         }
       },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      "devNote": "There is a possibility of slipping on this runway when entering the room."
     },
     {
       "link": [1, 8],
@@ -1228,19 +1377,18 @@
     },
     {
       "link": [6, 1],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge",
       "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 5,
-          "openEnd": 1
+        "comeInShinecharged": {
+          "framesRequired": 70
         }
       },
       "requires": [
-        "canShinechargeMovement"
+        "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 70
+          "framesRemaining": "auto"
         }
       },
       "unlocksDoors": [
@@ -1250,14 +1398,57 @@
     },
     {
       "link": [6, 1],
-      "name": "Come In Shinecharged, Leave Sparking",
+      "name": "Come in Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 80
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [6, 1],
+      "name": "Come In Shinecharged, Leave With Spark (Bottom)",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 12
+          "framesRequired": 10
         }
       },
       "requires": [
         {"shinespark": {"frames": 21}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [6, 1],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 65
+        }
+      },
+      "requires": [
+        {"shinespark": {"frames": 5}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -1269,62 +1460,123 @@
     },
     {
       "link": [6, 2],
-      "name": "Leave Shinecharged Downback",
+      "name": "Carry Shinecharge (Sova Evade or Kill)",
       "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 5,
-          "openEnd": 1
+        "comeInShinecharged": {
+          "framesRequired": 115
         }
       },
       "requires": [
-        "canDownBack"
+        {"or": [
+          "canShinechargeMovementTricky",
+          {"and": [
+            "canShinechargeMovementComplex",
+            "ScrewAttack"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 75
+          "framesRemaining": "auto"
         }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "note": "Shoot the top Sova while falling to delay its movement."
+      "note": "If Screw Attack is unavailable, do a low spin jump to make it over the Sova without taking a hit."
     },
     {
       "link": [6, 2],
-      "name": "Leave Shinecharged Kill Sova",
+      "name": "Carry Shinecharge (Sova Damage)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Sova",
+          "type": "contact",
+          "hits": 1
+        }},
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [6, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (Slide Off)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
+          "length": 4,
           "openEnd": 1
         }
       },
       "requires": [
+        "canShinechargeMovementTricky",
+        "canTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 85
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "Slide off the ledge while gaining a shinecharge, and hold forward to clear both platforms, killing the Sova with temporary blue."
+      ]
+    },
+    {
+      "link": [6, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
         {"enemyKill": {
-          "enemies": [["Sova"]]
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
         }}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 75
+          "framesRemaining": 70
         }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "note": "Shoot the top Sova while falling."
+      "note": "Shoot the top Sova while falling.",
+      "devNote": "1 unusable tile, since you need space to gain a little speed before falling."
     },
     {
       "link": [6, 2],
-      "name": "Leave Shinecharged Fall Through Sova",
+      "name": "Come in Shinecharging, Leave Shinecharged (Sova Damage)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
+          "length": 4,
           "openEnd": 1
         }
       },
       "requires": [
+        "canShinechargeMovementComplex",
         {"enemyDamage": {
           "enemy": "Sova",
           "type": "contact",
@@ -1333,7 +1585,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 45
+          "framesRemaining": 50
         }
       },
       "unlocksDoors": [
@@ -1343,20 +1595,20 @@
     },
     {
       "link": [6, 3],
-      "name": "Leave Shinecharged Left Side Weave",
+      "name": "Come in Shinecharging, Leave Shinecharged (Left Side Weave)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
+          "length": 4,
           "openEnd": 1
         }
       },
       "requires": [
         "canShinechargeMovementTricky",
-        "canDownBack"
+        "canTemporaryBlue"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 20
+          "framesRemaining": 30
         }
       },
       "unlocksDoors": [
@@ -1364,22 +1616,22 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "note": [
-        "Weave down the left side of the room by first DownBacking left and then moving to the right to avoid landing on any platforms.",
-        "Shoot the first Sova to delay its movements."
+        "Slide off the ledge while gaining a shinecharge, and hold forward to clear both platforms, killing the Sova with temporary blue.",
+        "Weave down the left side of the room, avoiding landing on any platforms."
       ]
     },
     {
       "link": [6, 3],
-      "name": "Leave Sparking",
+      "name": "Come in Shinecharging, Leave With Spark (Right Side Weave)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
+          "length": 4,
           "openEnd": 1
         }
       },
       "requires": [
-        "canShinechargeMovement",
-        {"shinespark": {"frames": 10}}
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 15}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -1391,19 +1643,19 @@
     },
     {
       "link": [6, 5],
-      "name": "Leave Shinecharged",
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
+          "length": 4,
           "openEnd": 1
         }
       },
       "requires": [
-        "canShinechargeMovement"
+        "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 15
+          "framesRemaining": 30
         }
       },
       "unlocksDoors": [
@@ -1424,10 +1676,118 @@
     },
     {
       "link": [6, 7],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      }
+    },
+    {
+      "link": [6, 7],
+      "name": "Carry Shinecharge (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 115
+        }
+      },
+      "requires": [
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      }
+    },
+    {
+      "link": [6, 7],
+      "name": "Carry Shinecharge (Sova Evade)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      }
+    },
+    {
+      "link": [6, 7],
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 90
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": "1 unusable tile, otherwise it is too slow."
+    },
+    {
+      "link": [6, 7],
+      "name": "Come in Shinecharging, Leave Shinecharged (Sova Kill, Short Runway)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 60
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Kill the Sova.",
+      "devNote": "1 unusable tile, to avoid needing to turn around."
+    },
+    {
+      "link": [6, 7],
+      "name": "Come in Shinecharging, Leave Shinecharged (Sova Evade)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
           "openEnd": 0
         }
       },
@@ -1436,19 +1796,62 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 30
+          "framesRemaining": 40
         }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "note": "Jump over or kill the Sova."
+      "note": "Jump over the Sova."
     },
     {
       "link": [6, 8],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [7, 1],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 125
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [7, 6],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canDownBack"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [7, 8],

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -206,6 +206,8 @@
     {
       "from": 7,
       "to": [
+        {"id": 1},
+        {"id": 6},
         {"id": 8}
       ]
     },
@@ -565,26 +567,45 @@
     },
     {
       "link": [2, 1],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge (HiJump)",
       "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 3,
-          "openEnd": 0
+        "comeInShinecharged": {
+          "framesRequired": 105
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Carefully avoid hitting the Sova."
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry Shinecharge (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
         }
       },
       "requires": [
         "canShinechargeMovementComplex",
-        {"or": [
-          "ScrewAttack",
-          {"and": [
-            "canWalljump",
-            "canTrickyJump"
-          ]}
-        ]}
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 30
+          "framesRemaining": "auto"
         }
       },
       "unlocksDoors": [
@@ -594,7 +615,131 @@
     },
     {
       "link": [2, 1],
-      "name": "Leave Shinecharged with HiJump",
+      "name": "Come in Shinecharged, Leave With Spark (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 90
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 6, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Carefully avoid hitting the Sova."
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharged, Leave With Spark (HiJump, Bottom)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 75
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 10, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Carefully avoid hitting the Sova."
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharged, Leave With Spark (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 115
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        {"shinespark": {"frames": 7, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Carefully avoid hitting the Sova."
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharged, Leave With Spark (Sova Kill, Bottom)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 105
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        {"shinespark": {"frames": 10, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Carefully avoid hitting the Sova."
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave Shinecharged (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 35
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -611,7 +756,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 50
+          "framesRemaining": 55
         }
       },
       "unlocksDoors": [
@@ -632,7 +777,48 @@
     },
     {
       "link": [2, 3],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 105
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 90
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 2, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -642,7 +828,7 @@
       "requires": [],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 70
+          "framesRemaining": 85
         }
       },
       "unlocksDoors": [
@@ -652,7 +838,26 @@
     },
     {
       "link": [2, 5],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 110
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 5],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -662,7 +867,7 @@
       "requires": [],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 45
+          "framesRemaining": 55
         }
       },
       "unlocksDoors": [
@@ -672,20 +877,56 @@
     },
     {
       "link": [2, 6],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge (Sova Kill, HiJump)",
       "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 3,
-          "openEnd": 0
+        "comeInShinecharged": {
+          "framesRequired": 120
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 6],
+      "name": "Carry Shinecharge (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
         }
       },
       "requires": [
         "canShinechargeMovementComplex",
-        "canTrickyJump"
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 10
+          "framesRemaining": "auto"
         }
       },
       "unlocksDoors": [
@@ -695,7 +936,127 @@
     },
     {
       "link": [2, 6],
-      "name": "Leave Shinecharged with HiJump or Screw Attack",
+      "name": "Come in Shinecharged, Leave With Spark (Sova Kill, HiJump, Bottom)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 80
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        {"shinespark": {"frames": 12, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 6],
+      "name": "Come in Shinecharged, Leave With Spark (Sova Kill, HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 110
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 6],
+      "name": "Come in Shinecharged, Leave With Spark (Sova Kill, Bottom)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        {"shinespark": {"frames": 10, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 6],
+      "name": "Come in Shinecharged, Leave With Spark (Sova Kill)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 125
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          "canTrickyJump"
+        ]},
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }},
+        {"shinespark": {"frames": 7, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 6],
+      "name": "Come in Shinecharging, Leave Shinecharged (Sova Kill)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -706,15 +1067,16 @@
         "canShinechargeMovementComplex",
         {"or": [
           "ScrewAttack",
-          {"and": [
-            "HiJump",
-            "canTrickyJump"
-          ]}
-        ]}
+          "canTrickyJump"
+        ]},
+        {"enemyKill": {
+          "enemies": [["Sova"]],
+          "explicitWeapons": ["ScrewAttack", "Wave", "Spazer", "Plasma", "Missile", "Super"]
+        }}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 30
+          "framesRemaining": 35
         }
       },
       "unlocksDoors": [
@@ -773,7 +1135,7 @@
     },
     {
       "link": [3, 1],
-      "name": "Leave Sparking",
+      "name": "Come in Shinecharging, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -782,7 +1144,7 @@
       },
       "requires": [
         "HiJump",
-        "canShinechargeMovementComplex",
+        "canShinechargeMovementTricky",
         {"shinespark": {"frames": 10}}
       ],
       "exitCondition": {
@@ -813,7 +1175,95 @@
     },
     {
       "link": [3, 2],
-      "name": "Leave Shinecharged Short Runway",
+      "name": "Carry Shinecharge (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 105
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 130
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharged, Leave With Spark (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 85
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 8, "excessFrames": 0}}
+
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 105
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 8, "excessFrames": 0}}
+
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (Short Runway)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -835,7 +1285,7 @@
     },
     {
       "link": [3, 2],
-      "name": "Leave Shinecharged with Walljump",
+      "name": "Come in Shinecharging, Leave Shinecharged (Walljump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -858,7 +1308,7 @@
     },
     {
       "link": [3, 2],
-      "name": "Leave Shinecharged with HiJump",
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -908,7 +1358,52 @@
     },
     {
       "link": [3, 4],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
+    },
+    {
+      "link": [3, 4],
+      "name": "Come in Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 11, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
+    },
+    {
+      "link": [3, 4],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -932,7 +1427,7 @@
     },
     {
       "link": [3, 4],
-      "name": "Leave Shinecharged with Half Runway",
+      "name": "Come in Shinecharging, Leave Shinecharged (Half Runway)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 6,
@@ -945,7 +1440,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 50
+          "framesRemaining": 60
         }
       },
       "unlocksDoors": [
@@ -956,17 +1451,17 @@
     },
     {
       "link": [3, 5],
-      "name": "Leave Shinecharged",
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 12,
+          "length": 13,
           "openEnd": 0
         }
       },
       "requires": [],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 150
+          "framesRemaining": 160
         }
       },
       "unlocksDoors": [
@@ -976,14 +1471,16 @@
     },
     {
       "link": [3, 5],
-      "name": "Come In Shinecharged, Leave Sparking",
+      "name": "Come In Shinecharged, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 12
+          "framesRequired": 10
         }
       },
       "requires": [
-        {"shinespark": {"frames": 21}}
+        {"shinespark": {
+          "frames": 21
+        }}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -994,8 +1491,65 @@
       ]
     },
     {
+      "link": [3, 5],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 55
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 5],
+      "name": "Transition with Stored Fall Speed",
+      "entranceCondition": {
+        "comeInWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 5],
+      "name": "Transition with Stored Fall Speed (more speed)",
+      "entranceCondition": {
+        "comeInWithStoredFallSpeed": {
+          "fallSpeedInTiles": 2
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 2
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
       "link": [3, 6],
-      "name": "Leave Sparking",
+      "name": "Come in Shinecharging, Leave With Spark (Bottom)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -1004,8 +1558,33 @@
       },
       "requires": [
         "HiJump",
-        "canShinechargeMovementComplex",
+        "canShinechargeMovementTricky",
         {"shinespark": {"frames": 10}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 6],
+      "name": "Come in Shinecharging, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shinespark": {"frames": 6}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -1013,7 +1592,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "devNote": "Sparking out in top position is very tight, hence the canInsaneJump requirement."
     },
     {
       "link": [3, 8],
@@ -1022,7 +1602,52 @@
     },
     {
       "link": [4, 3],
-      "name": "Leave Shinecharged",
+      "name": "Come in Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 8, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 3],
+      "name": "Come in Shinecharged, Leave With Spark (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 120
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 9, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 3],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 8,
@@ -1045,7 +1670,7 @@
     },
     {
       "link": [4, 3],
-      "name": "Leave Shinecharged with HiJump",
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 8,
@@ -1059,7 +1684,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 35
+          "framesRemaining": 40
         }
       },
       "unlocksDoors": [
@@ -1099,7 +1724,52 @@
     },
     {
       "link": [4, 5],
-      "name": "Leave Shinecharged",
+      "name": "Come in Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 8, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 5],
+      "name": "Come in Shinecharged, Leave With Spark (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 115
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 9, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 5],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 8,
@@ -1122,7 +1792,7 @@
     },
     {
       "link": [4, 5],
-      "name": "Leave Shinecharged with HiJump",
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 8,
@@ -1136,7 +1806,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 35
+          "framesRemaining": 40
         }
       },
       "unlocksDoors": [
@@ -1170,10 +1840,10 @@
     },
     {
       "link": [5, 1],
-      "name": "Leave Sparking",
+      "name": "Come in Shinecharging, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
+          "length": 4,
           "openEnd": 1
         }
       },
@@ -1181,7 +1851,7 @@
         "HiJump",
         "canMidairShinespark",
         "canShinechargeMovementTricky",
-        {"shinespark": {"frames": 10}}
+        {"shinespark": {"frames": 6}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -1194,7 +1864,113 @@
     },
     {
       "link": [5, 2],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 110
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Carry Shinecharge (Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Come in Shinecharged, Leave With Spark (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 75
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 11, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Come in Shinecharged, Leave With Spark (Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        {"shinespark": {"frames": 11, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Come in Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 7, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -1216,10 +1992,10 @@
     },
     {
       "link": [5, 3],
-      "name": "Leave Shinecharged",
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 12,
+          "length": 13,
           "openEnd": 0
         }
       },
@@ -1236,14 +2012,16 @@
     },
     {
       "link": [5, 3],
-      "name": "Come In Shinecharged, Leave Sparking",
+      "name": "Come In Shinecharged, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 12
+          "framesRequired": 10
         }
       },
       "requires": [
-        {"shinespark": {"frames": 21}}
+        {"shinespark": {
+          "frames": 21
+        }}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -1254,8 +2032,111 @@
       ]
     },
     {
+      "link": [5, 3],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 55
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 3],
+      "name": "Transition with Stored Fall Speed",
+      "entranceCondition": {
+        "comeInWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [5, 3],
+      "name": "Transition with Stored Fall Speed (more speed)",
+      "entranceCondition": {
+        "comeInWithStoredFallSpeed": {
+          "fallSpeedInTiles": 2
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 2
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
       "link": [5, 4],
-      "name": "Leave Shinecharged",
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canDownBack"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
+    },
+    {
+      "link": [5, 4],
+      "name": "Come in Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 11, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
+    },
+    {
+      "link": [5, 4],
+      "name": "Come In Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -1279,11 +2160,11 @@
     },
     {
       "link": [5, 4],
-      "name": "Leave Shinecharged with Half Runway",
+      "name": "Come in Shinecharging, Leave Shinecharged (Short Runway)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 5,
-          "openEnd": 0
+          "length": 4,
+          "openEnd": 1
         }
       },
       "requires": [
@@ -1292,7 +2173,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 50
+          "framesRemaining": 60
         }
       },
       "unlocksDoors": [
@@ -1348,7 +2229,7 @@
     },
     {
       "link": [5, 6],
-      "name": "Leave Sparking",
+      "name": "Come in Shinecharging, Leave With Spark (Bottom)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 5,
@@ -1362,13 +2243,41 @@
         {"shinespark": {"frames": 10}}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "note": "Quickly climb the right side of the room to just have enough time to shinespark out the door."
+    },
+    {
+      "link": [5, 6],
+      "name": "Come in Shinecharging, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canMidairShinespark",
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shinespark": {"frames": 6}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "Quickly climb the right side of the room to just have enough time to shinespark out the door.",
+      "devNote": "Sparking out in top position is very tight, hence the canInsaneJump requirement."
     },
     {
       "link": [5, 8],
@@ -1864,9 +2773,134 @@
       "requires": []
     },
     {
+      "link": [8, 1],
+      "name": "Leave With Spark",
+      "requires": [
+        "HiJump",
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 5},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 5}
+            ]},
+            {"canShineCharge": {
+              "usedTiles": 13,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 12,
+            "openEnd": 0
+          }}
+        ]},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 10}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"nodeId": 1, "types": ["ammo"], "requires": []},
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 5, "types": ["ammo"], "requires": []}
+      ]
+    },
+    {
       "link": [8, 2],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [8, 2],
+      "name": "Leave Shinecharged (Walljump)",
+      "requires": [
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 5},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 5}
+            ]},
+            {"canShineCharge": {
+              "usedTiles": 13,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 12,
+            "openEnd": 0
+          }}
+        ]},
+        "canShinechargeMovementComplex",
+        "canWalljump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 30
+        }
+      },
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["ammo"], "requires": []},
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 5, "types": ["ammo"], "requires": []}
+      ]
+    },
+    {
+      "link": [8, 2],
+      "name": "Leave Shinecharged (HiJump)",
+      "requires": [
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 5},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 5}
+            ]},
+            {"canShineCharge": {
+              "usedTiles": 13,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 12,
+            "openEnd": 0
+          }}
+        ]},
+        "canShinechargeMovementComplex",
+        "HiJump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 50
+        }
+      },
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["ammo"], "requires": []},
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 5, "types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [8, 3],
@@ -1879,6 +2913,49 @@
       "requires": []
     },
     {
+      "link": [8, 4],
+      "name": "Leave Shinecharged",
+      "requires": [
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 5},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 5}
+            ]},
+            {"canShineCharge": {
+              "usedTiles": 13,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 12,
+            "openEnd": 0
+          }}
+        ]},
+        "canShinechargeMovementComplex",
+        "canDownBack"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 30
+        }
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 4, "types": ["ammo"], "requires": []},
+        {"nodeId": 5, "types": ["ammo"], "requires": []}
+      ],
+      "note": "Fall around the floating platform with either a Downback or by jumping down with a Spinjump."
+    },
+    {
       "link": [8, 5],
       "name": "Base",
       "requires": []
@@ -1887,6 +2964,92 @@
       "link": [8, 6],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [8, 6],
+      "name": "Leave With Spark (Bottom)",
+      "requires": [
+        "HiJump",
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 5},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 5}
+            ]},
+            {"canShineCharge": {
+              "usedTiles": 13,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 12,
+            "openEnd": 0
+          }}
+        ]},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 10}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 5, "types": ["ammo"], "requires": []},
+        {"nodeId": 6, "types": ["ammo"], "requires": []}
+      ]
+    },
+    {
+      "link": [8, 6],
+      "name": "Leave With Spark",
+      "requires": [
+        "HiJump",
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 5},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 5}
+            ]},
+            {"canShineCharge": {
+              "usedTiles": 13,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 12,
+            "openEnd": 0
+          }}
+        ]},
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shinespark": {"frames": 6}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 5, "types": ["ammo"], "requires": []},
+        {"nodeId": 6, "types": ["ammo"], "requires": []}
+      ],
+      "devNote": "Sparking out in top position is very tight, hence the canInsaneJump requirement."
     },
     {
       "link": [8, 7],


### PR DESCRIPTION
This was already a complicated room for cross-room shinecharge strats, but there was quite a bit of opportunity to add more strats:
- Carry Shinecharge strats (i.e. comeInShinecharged/leaveShinecharged), which couldn't be represented before
- More variations based on different movement options (HiJump/walljump)
- Some more options which spark out rather than leave shinecharged
- In-room shortcharge strats (which are basically variations of the the full-runway comeInShinecharging strats from node 3; the strats and their requirements correspond exactly, aside from how unlocked doors affect the runway length).

I had trouble with the [6, 2] strats where the note said to down-back and shoot the Sova to delay its movement. Sometimes I could manage to down-back to squeeze past the Sova (with or without shooting it) but almost always I would get hit. I found sliding off with temporary blue to be more consistent (though still difficult), and it gets down faster as well. Shooting the Sova with a weapon that kills it (e.g. a Missile) also worked as an easier, slower alternative. I'm guessing I may have been doing something wrong though, so feel free to help fix this up if you see how.