### PR TITLE
Add spark position constraint in Climb

### DIFF
--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -954,7 +954,9 @@
       "link": [5, 2],
       "name": "Shinespark",
       "entranceCondition": {
-        "comeInWithSpark": {}
+        "comeInWithSpark": {
+          "position": "bottom"
+        }
       },
       "requires": [
         {"shinespark": {"frames": 43, "excessFrames": 17}}


### PR DESCRIPTION
This is for a cross-room spark right-to-left to break the bomb blocks at the bottom of Climb. It needs to be done in bottom position since otherwise you would bonk a floating platform. This fixes a bug reported by Anozilla from a recent seed: https://discord.com/channels/1053421401354285129/1053434704180805744/1213965619452579931