### PR TITLE
Tricky Heated Power Bombs with Reserves Only

### DIFF
--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -232,13 +232,19 @@
             {"heatFrames": 240},
             {"acidFrames": 96}
           ]}
+        ]},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
         ]}
       ],
       "reusableRoomwideNotable": "Lower Norfair Pillar Room with Two Power Bombs",
       "note": [
         "Place the PBs next to the pillars in order to only use 2.",
         "Minimize acid by unmorphing high to land back on the jump spot or walljumping before placing the bomb."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [1, 2],
@@ -269,12 +275,18 @@
             {"heatFrames": 240},
             {"acidFrames": 96}
           ]}
+        ]},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
         ]}
       ],
       "note": [
         "The power bombs can be placed pretty far from the next pillar in line.",
         "PB1 - Above the mound of dirt on the ground.  PB2 - On pillar 2 (not on the Puromi Fire Snake).  PB3 - Near pillar 5."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [1, 2],
@@ -487,6 +499,11 @@
             {"heatFrames": 50},
             {"acidFrames": 50}
           ]}
+        ]},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
         ]}
       ],
       "reusableRoomwideNotable": "Lower Norfair Pillar Room with Two Power Bombs",
@@ -494,7 +511,8 @@
         "Place the PBs next to the pillars in order to only use 2.",
         "Avoid acid during the first Power Bomb by walljumping before placing the bomb.",
         "Avoiding acid damage at the last jump is tricky but possible."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [2, 1],
@@ -514,13 +532,19 @@
             {"heatFrames": 810},
             {"acidFrames": 55}
           ]}
+        ]},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
         ]}
       ],
       "note": [
         "The power bombs can be placed far from the next pillar in line.",
         "PB1 - Near the broken pillar.  PB2 - On the 2nd full pillar.  PB3 - On the 4th full pillar.",
         "Wait for the Puromis to avoid damage but wait too long and the acid will cover the door."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [2, 1],

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -268,7 +268,7 @@
     },
     {
       "link": [2, 4],
-      "name": "SpaceJump ScrewAttack",
+      "name": "Space Jump Screw Attack",
       "requires": [
         "h_canNavigateHeatRooms",
         "SpaceJump",
@@ -313,13 +313,19 @@
         "canCarefulJump",
         "h_canUsePowerBombs",
         "canHitbox",
-        {"heatFrames": 420}
+        {"heatFrames": 420},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
         "Jump with some run speed to place the power bomb high enough to break the bomb blocks.",
         "During the explosion, jump through the left wall pirate and precisely walljump to reach the upper area."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [2, 4],
@@ -331,13 +337,19 @@
         "canConsecutiveWalljump",
         "HiJump",
         "ScrewAttack",
-        {"heatFrames": 330}
+        {"heatFrames": 330},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
         "Use ScrewAttack to remove the left wall pirate and walljump high enough to place a power bomb to destroy the bomb blocks",
         "Then walljump up again to reach the upper region."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [2, 4],
@@ -354,13 +366,19 @@
           "HiJump",
           "SpaceJump"
         ]},
-        {"heatFrames": 530}
+        {"heatFrames": 530},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
         "Avoid the bottom pirates and jump high enough to break the bomb blocks with a power bomb.",
         "During the explosion, climb the right wall passing through any pirates and use a movement item to reach the top."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [2, 4],
@@ -395,7 +413,12 @@
         {"ammo": {"type": "Missile", "count": 1}},
         {"ammo": {"type": "Super", "count": 1}},
         {"ammo": {"type": "PowerBomb", "count": 1}},
-        {"heatFrames": 870}
+        {"heatFrames": 870},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -405,7 +428,8 @@
         "Jump and shoot the top pirate with a charge+ice shot.",
         "Hold a charge and walljump up the left wall and freeze the top pirate when it jumps across.",
         "Use the pirate to jump to the higher area."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [2, 4],
@@ -421,7 +445,12 @@
         "h_canUseMorphBombs",
         {"ammo": {"type": "Missile", "count": 4}},
         {"ammo": {"type": "PowerBomb", "count": 1}},
-        {"heatFrames": 900}
+        {"heatFrames": 900},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -431,7 +460,8 @@
         "Place a Bomb on the left wall to hit the top pirate when it jumps over, followed by a power bomb.",
         "Unmorph precisely below the middle pirate so both top pirates will jump back to the right, and begin charging Ice.",
         "Walljump up the left wall with charge held and freeze the top pirate when it jumps over and use it to reach the upper region."
-      ]
+      ],
+      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
     },
     {
       "link": [2, 4],
@@ -443,7 +473,12 @@
         "canWallJumpBombBoost",
         "canDiagonalBombJump",
         "h_canUsePowerBombs",
-        {"heatFrames": 930}
+        {"heatFrames": 930},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -451,7 +486,10 @@
         "Two quick walljumps upon entering the room can position Samus to get the left pirate to jump to the right and jump over the right pirate's lazer attack.",
         "Jump up the left wall and begin bomb jumping starting with a power bomb."
       ],
-      "devNote": "There is a very similar strat using an HBJ that is a little faster but more precise and overall harder."
+      "devNote": [
+        "There is a very similar strat using an HBJ that is a little faster but more precise and overall harder.",
+        "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
+      ]
     },
     {
       "link": [2, 4],
@@ -627,7 +665,12 @@
           ],
           "explicitWeapons": ["PowerBombPeriphery"]
         }},
-        {"heatFrames": 790}
+        {"heatFrames": 790},
+        {"or": [
+          "h_heatResistant",
+          "canPauseAbuse",
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -639,7 +682,8 @@
         "It's not really possible to hit all enemies with double-PB hits while not taking damage.",
         "Using Power Bomb Periphery is based on a strat that allows killing them and taking out the blocks with 4 PBs.",
         "This calculation ends up taking 5, leaving a spare PB.",
-        "The movement item used does not increase heat frames except for IBJ in which case the PB can be used while IBJing."
+        "The movement item used does not increase heat frames except for IBJ in which case the PB can be used while IBJing.",
+        "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
       ]
     },
     {

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -416,7 +416,10 @@
         {"heatFrames": 870},
         {"or": [
           "h_heatResistant",
-          "canPauseAbuse",
+          {"and": [
+            "canInsaneJump",
+            "canPauseAbuse"
+          ]},
           {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
         ]}
       ],
@@ -429,7 +432,7 @@
         "Hold a charge and walljump up the left wall and freeze the top pirate when it jumps across.",
         "Use the pirate to jump to the higher area."
       ],
-      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
+      "devNote": "With Reserves only, this strat requires much more precise movement and either pause abuse or optimal reserve management."
     },
     {
       "link": [2, 4],
@@ -448,7 +451,10 @@
         {"heatFrames": 900},
         {"or": [
           "h_heatResistant",
-          "canPauseAbuse",
+          {"and": [
+            "canInsaneJump",
+            "canPauseAbuse"
+          ]},
           {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
         ]}
       ],
@@ -461,7 +467,7 @@
         "Unmorph precisely below the middle pirate so both top pirates will jump back to the right, and begin charging Ice.",
         "Walljump up the left wall with charge held and freeze the top pirate when it jumps over and use it to reach the upper region."
       ],
-      "devNote": "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
+      "devNote": "With Reserves only, this strat requires much more precise movement and either pause abuse or optimal reserve management."
     },
     {
       "link": [2, 4],
@@ -476,7 +482,10 @@
         {"heatFrames": 930},
         {"or": [
           "h_heatResistant",
-          "canPauseAbuse",
+          {"and": [
+            "canInsaneJump",
+            "canPauseAbuse"
+          ]},
           {"resourceCapacity": [{"type": "RegularEnergy", "count": 149}]}
         ]}
       ],
@@ -488,7 +497,7 @@
       ],
       "devNote": [
         "There is a very similar strat using an HBJ that is a little faster but more precise and overall harder.",
-        "With Reserves only, canPauseAbuse is used as a proxy for pause abuse or optimal reserve management and character movement."
+        "With Reserves only, this strat requires much more precise movement and either pause abuse or optimal reserve management."
       ]
     },
     {


### PR DESCRIPTION
This is just a quick attempt to address some of the hardest uses of Power Bombs in heated rooms with tight Reserve management. This would move these strats from `VH` to `Expert` in Map Rando if the player has no E-Tanks.

There are other heated rooms that require using Power Bombs, but I don't think they are on the same level of difficulty with precise movement while placing the PBs and triggering reserves:
Right side of Single Chamber, LN Springball Maze, Three Musketeers, Screw Attack, Mickey Mouse, LN Kihunter, Wasteland, Pillar Setup, GT right item

@osse101, what are your thoughts on something like this: is it useful, should it be included in more rooms, should there be a `canInsaneJump` alternative?