### PR TITLE
Frozen Enemy Runways in Lower Norfair

### DIFF
--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -391,6 +391,28 @@
       ]
     },
     {
+      "link": [3, 1],
+      "name": "Leave With Runway - Frozen Zebbo",
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        {"heatFrames": 1000}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "openEnd": 0
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
+      "note": [
+        "The Zebbo needs to be 2 pixels higher than where it would be if Samus was standing.",
+        "One setup is to peform a tiny hop just before the right Zebbo starts moving to the left then freeze it after it starts moving left.",
+        "Lure the Zebbo to the left and freeze it to extend the runway while maintaining a half-tile gap between it and the runway to extend the runway as much as possible."
+      ]
+    },
+    {
       "link": [3, 3],
       "name": "Heat-proof Zebbo Farm",
       "requires": [
@@ -450,6 +472,28 @@
       "requires": [
         "h_canNavigateHeatRooms",
         {"heatFrames": 60}
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Leave With Runway - Frozen Zebbo",
+      "requires": [
+        "h_canFrozenEnemyRunway",
+        {"heatFrames": 600}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "openEnd": 0
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
+      "note": [
+        "The Zebbo needs to be 2 pixels higher than where it would be if Samus was standing.",
+        "One setup is to peform a tiny hop just before the left Zebbo starts moving to the right then freeze it after it starts moving right.",
+        "Get onto the runway and freeze the Zebbo while maintaining a half-tile gap between it and the runway to extend it as much as possible."
       ]
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -409,7 +409,8 @@
       "note": [
         "The Zebbo needs to be 2 pixels higher than where it would be if Samus was standing.",
         "One setup is to peform a tiny hop just before the right Zebbo starts moving to the left then freeze it after it starts moving left.",
-        "Lure the Zebbo to the left and freeze it to extend the runway while maintaining a half-tile gap between it and the runway to extend the runway as much as possible."
+        "Lure the Zebbo to the left and freeze it again to extend the runway while maintaining a half-tile gap between it and the runway to extend the runway as much as possible.",
+        "With more Energy, it is possible to morph on one of the medium-height pillars to align the Zebbo."
       ]
     },
     {
@@ -479,7 +480,11 @@
       "name": "Leave With Runway - Frozen Zebbo",
       "requires": [
         "h_canFrozenEnemyRunway",
-        {"heatFrames": 600}
+        {"heatFrames": 300},
+        {"or": [
+          "canInsaneJump",
+          {"heatFrames": 300}
+        ]}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -493,7 +498,10 @@
       "note": [
         "The Zebbo needs to be 2 pixels higher than where it would be if Samus was standing.",
         "One setup is to peform a tiny hop just before the left Zebbo starts moving to the right then freeze it after it starts moving right.",
-        "Get onto the runway and freeze the Zebbo while maintaining a half-tile gap between it and the runway to extend it as much as possible."
+        "Get onto the runway and freeze the Zebbo again while maintaining a half-tile gap between it and the runway to extend it as much as possible.",
+        "With more Energy, it is possible to morph on one of the medium-height pillars to align the Zebbo.",
+        "With less Energy, it is possible to get the Zebbo into position by only freezing it once -",
+        "after the small hop, jump towards the door and shoot downwards to freeze it in place."
       ]
     },
     {

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -534,6 +534,7 @@
       "requires": [
         "h_heatResistant",
         "h_canFrozenEnemyRunway",
+        "Morph",
         {"heatFrames": 500}
       ],
       "exitCondition": {
@@ -596,6 +597,7 @@
       "requires": [
         "h_heatResistant",
         "h_canFrozenEnemyRunway",
+        "Morph",
         {"heatFrames": 500}
       ],
       "exitCondition": {

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -494,7 +494,68 @@
     },
     {
       "link": [3, 1],
-      "name": "Farm to Full",
+      "name": "Farm then Leave",
+      "requires": [
+        "h_heatResistant",
+        {"heatFrames": 100}
+      ],
+      "note": [
+        "Leaving from the farm node assumes killing all the Holtzes and farming to full before exiting.",
+        "Gaining Energy from the farm requires some sort of heat reduction."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Farm then Leave With Runway - Frozen Holtz",
+      "requires": [
+        "h_heatResistant",
+        "h_canTrickyFrozenEnemyRunway",
+        {"heatFrames": 300},
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
+      "note": [
+        "Assumes killing all the Holtzes except for one that can be frozen to extend the runway.",
+        "Get the Holtz stuck under the platform then farming to full before freezing it to extend the runway.",
+        "Gaining Energy from the farm requires some sort of heat reduction."
+      ],
+      "devNote": "FIXME: Another strat could be added without the farm or heat resistance."
+    },
+    {
+      "link": [3, 1],
+      "name": "Farm then Leave With Runway - Frozen Zebbo",
+      "requires": [
+        "h_heatResistant",
+        "h_canFrozenEnemyRunway",
+        {"heatFrames": 500},
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "openEnd": 0
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
+      "note": [
+        "Assumes killing all the Holtzes then farming to full.",
+        "Morph on the ground near the Zebbo spawner then quickly unmorph and shoot as it starts to move horizontally.",
+        "While on the runway near the door, freeze the Zebbo again while maintaining a half-tile gap between it and the runway to extend it as much as possible.",
+        "Gaining Energy from the farm requires some sort of heat reduction."
+      ],
+      "devNote": "FIXME: Another strat could be added without the farm or heat resistance."
+    },
+    {
+      "link": [3, 2],
+      "name": "Farm then Leave",
       "requires": [
         "h_canNavigateHeatRooms",
         "h_heatResistant",
@@ -502,21 +563,57 @@
       ],
       "note": [
         "Leaving from the farm node assumes killing all the Holtzes and farming to full before exiting.",
-        "Gaining energy from the farm requires some sort of heat reduction."
+        "Gaining Energy from the farm requires some sort of heat reduction."
       ]
     },
     {
       "link": [3, 2],
-      "name": "Farm to Full",
+      "name": "Farm then Leave With Runway - Frozen Holtz",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_heatResistant",
-        {"heatFrames": 100}
+        "h_canTrickyFrozenEnemyRunway",
+        {"heatFrames": 300},
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
       ],
       "note": [
-        "Leaving from the farm node assumes killing all the Holtzes and farming to full before exiting.",
-        "Gaining energy from the farm requires some sort of heat reduction."
-      ]
+        "Assumes killing all the Holtzes except for one that can be frozen to extend the runway.",
+        "Get the Holtz stuck under the platform then farming to full before freezing it to extend the runway.",
+        "Gaining Energy from the farm requires some sort of heat reduction."
+      ],
+      "devNote": "FIXME: Another strat could be added without the farm or heat resistance."
+    },
+    {
+      "link": [3, 2],
+      "name": "Farm then Leave With Runway - Frozen Zebbo",
+      "requires": [
+        "h_heatResistant",
+        "h_canFrozenEnemyRunway",
+        {"heatFrames": 500},
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "openEnd": 0
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": []}
+      ],
+      "note": [
+        "Assumes killing all the Holtzes then farming to full.",
+        "Morph on the ground near the Zebbo spawner then quickly unmorph and shoot as it starts to move horizontally.",
+        "While on the runway near the door, freeze the Zebbo again while maintaining a half-tile gap between it and the runway to extend it as much as possible.",
+        "Gaining Energy from the farm requires some sort of heat reduction."
+      ],
+      "devNote": "FIXME: Another strat could be added without the farm or heat resistance."
     },
     {
       "link": [3, 3],

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -361,6 +361,36 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave With Runway - Frozen Holtz",
+      "requires": [
+        "h_canTrickyFrozenEnemyRunway",
+        {"heatFrames": 800},
+        {"or": [
+          {"and": [
+            "Wave",
+            {"heatFrames": 500}
+          ]},
+          {"and": [
+            "Spazer",
+            {"heatFrames": 500}
+          ]},
+          {"and": [
+            "Plasma",
+            {"heatFrames": 200}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "note": "On entry lure both Holtz. Kill one and freeze the other in position.",
+      "devNote": "FIXME: These heatFrames can likely be tightened."
+    },
+    {
+      "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
         "h_canHeatedCrystalFlash"

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -510,7 +510,7 @@
       "requires": [
         "h_heatResistant",
         "h_canTrickyFrozenEnemyRunway",
-        {"heatFrames": 300},
+        {"heatFrames": 300}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -534,7 +534,7 @@
       "requires": [
         "h_heatResistant",
         "h_canFrozenEnemyRunway",
-        {"heatFrames": 500},
+        {"heatFrames": 500}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -572,7 +572,7 @@
       "requires": [
         "h_heatResistant",
         "h_canTrickyFrozenEnemyRunway",
-        {"heatFrames": 300},
+        {"heatFrames": 300}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -596,7 +596,7 @@
       "requires": [
         "h_heatResistant",
         "h_canFrozenEnemyRunway",
-        {"heatFrames": 500},
+        {"heatFrames": 500}
       ],
       "exitCondition": {
         "leaveWithRunway": {


### PR DESCRIPTION
There are very few here. 

I skipped only a couple:
- Left door of Plowerhouse is kind of a pain and it has so many different entrance behaviors. Generally it looks like you need to kill the first two and bring the third Holtz.
- ~~Bottom door of Acid Statue room can have a +4 pixel freeze, which could be useful for a cross room jump but not a shinecharge.~~ +4 is never useful