### PR TITLE
Add helper for Bomb Torizo activation

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -55,6 +55,14 @@
           ]
         },
         {
+          "name": "h_canActivateBombTorizo",
+          "requires": [ "Bombs" ],
+          "devNote": [
+            "In the vanilla game, Bomb Torizo is activated by having collected Bombs.",
+            "This may be changed in randomizers, e.g. to make it activate when collecting the (randomized) item in Bomb Torizo Room."
+          ]
+        },
+        {
           "name": "h_canActivateAcidChozo",
           "requires": [ "SpaceJump" ],
           "devNote": "In Vanilla, the Acid Chozo Statue requires Space Jump to activate. This may be unintuitive in a randomizer, as many players will have never been there without Space Jump."

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -69,7 +69,7 @@
               "name": "Base",
               "notable": false,
               "requires": [
-                "Bombs",
+                "h_canActivateBombTorizo",
                 {"or": [
                   "canDodgeWhileShooting",
                   {"ammo": {"type": "Super", "count": 2}},
@@ -79,8 +79,7 @@
                     "hits": 3
                   }}
                 ]}
-              ],
-              "note": "Killing Bomb Torizo requires only Power Beam, but Bombs are needed for it to activate."
+              ]
             }
           ]
         }


### PR DESCRIPTION
By overriding this helper, we can make Chozos objective work more precisely in Map Rando, e.g. when using "Stop item placement early". Currently the logic would require placing Bombs.