### PR TITLE
Add missing cross-room jump up Main Street

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -327,13 +327,16 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "h_canCrouchJumpDownGrab"
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          "canUseFrozenEnemies"
+        ]}
       ],
       "note": [
         "Spin jump to the left through the transition.",
         "Bonking the left side of the door frame works but is not required.",
         "Hold left through the transition to avoid the fish and land on the platform to the left.",
-        "Then crouch-jump down-grab to reach the higher platforms."
+        "Then reach the platform above either using a crouch-jump down-grab or by freezing the fish."
       ]
     },
     {
@@ -502,8 +505,8 @@
       "entranceCondition": {
         "comeInWithPlatformBelow": {
           "maxHeight": 7,
-          "maxLeftPosition": -2,
-          "minRightPosition": -1
+          "maxLeftPosition": 2,
+          "minRightPosition": -2
         }
       },
       "requires": [
@@ -520,6 +523,10 @@
         "Align with the left side of the door frame and crouch jump straight up through the door.",
         "Angle up and shoot the fish twice on the way up, then aim down and shoot three more times as needed until it is frozen.",
         "Land on the fish, wait until it is flashing, then jump and freeze it again further to left as needed, until you can spin jump to the left to reach the platforms."
+      ],
+      "devNote": [
+        "It is not actually required to align with the left side of the door.",
+        "Starting further to the right and moving left through the jump can also work, but there does not appear to be an application where this would be needed."
       ]
     },
     {

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -317,6 +317,27 @@
     },
     {
       "link": [1, 3],
+      "name": "Cross Room Jump - Spin Jump",
+      "entranceCondition": {
+        "comeInWithPlatformBelow": {
+          "maxHeight": 6,
+          "maxLeftPosition": 2,
+          "minRightPosition": -2
+        }
+      },
+      "requires": [
+        "canCrossRoomJumpIntoWater",
+        "h_canCrouchJumpDownGrab"
+      ],
+      "note": [
+        "Spin jump to the left through the transition.",
+        "Bonking the left side of the door frame works but is not required.",
+        "Hold left through the transition to avoid the fish and land on the platform to the left.",
+        "Then crouch-jump down-grab to reach the higher platforms."
+      ]
+    },
+    {
+      "link": [1, 3],
       "name": "Cross Room Jump - Space Jump",
       "entranceCondition": {
         "comeInWithSpaceJumpBelow": {}
@@ -477,35 +498,10 @@
     },
     {
       "link": [1, 3],
-      "name": "Cross Room Jump - Frozen Fish",
-      "entranceCondition": {
-        "comeInWithPlatformBelow": {
-          "maxHeight": 7,
-          "maxLeftPosition": -2,
-          "minRightPosition": -1
-        }
-      },
-      "requires": [
-        "canCrossRoomJumpIntoWater",
-        "canTrickyUseFrozenEnemies",
-        {"or": [
-          "Wave",
-          "Spazer",
-          "Plasma"
-        ]}
-      ],
-      "note": [
-        "Align with the left side of the door frame and jump (or crouch jump) straight up through the door.",
-        "Angle up and shoot the fish twice on the way up, then aim down and shoot three more times as needed until it is frozen.",
-        "Land on the fish, wait until it is flashing, then jump and freeze it again further to left as needed, until you can spin jump to the left to reach the platforms."
-      ]
-    },
-    {
-      "link": [1, 3],
       "name": "Cross Room Jump - Frozen Fish (Crouch Jump)",
       "entranceCondition": {
         "comeInWithPlatformBelow": {
-          "maxHeight": 6,
+          "maxHeight": 7,
           "maxLeftPosition": -2,
           "minRightPosition": -1
         }

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -520,13 +520,9 @@
         ]}
       ],
       "note": [
-        "Align with the left side of the door frame and crouch jump straight up through the door.",
+        "Crouch jump up through the left side of the door transition.",
         "Angle up and shoot the fish twice on the way up, then aim down and shoot three more times as needed until it is frozen.",
         "Land on the fish, wait until it is flashing, then jump and freeze it again further to left as needed, until you can spin jump to the left to reach the platforms."
-      ],
-      "devNote": [
-        "It is not actually required to align with the left side of the door.",
-        "Starting further to the right and moving left through the jump can also work, but there does not appear to be an application where this would be needed."
       ]
     },
     {


### PR DESCRIPTION
This adds a simple strat that was missing: For height-6 platforms (like in Basement, Crab Maze, etc.), you can just spin-jump to make it up onto the ledge on the left at the bottom of Main Street.

The Frozen Fish strats here were a little messed up: their "height" requirements were swapped between the crouch-jump vs. no-crouch-jump versions. One of them (the height 6, no-crouch-jump one) gets obsoleted by the new strat. The other one (height 7) I fixed up a bit, relaxing its position requirements so that it now also applies to jumping from the PCJR Power Bomb blocks (in addition to Tourian Escape Room 2).