### PR TITLE
Screw Attack Room spring ball jump

### DIFF
--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -869,7 +869,7 @@
     },
     {
       "link": [5, 3],
-      "name": "Space",
+      "name": "Space Jump",
       "requires": [
         "h_canNavigateHeatRooms",
         "SpaceJump",
@@ -878,7 +878,7 @@
     },
     {
       "link": [5, 3],
-      "name": "Screw Attack Room Springwall",
+      "name": "Springwall",
       "requires": [
         "h_canNavigateHeatRooms",
         "canSpringwall",
@@ -887,15 +887,14 @@
     },
     {
       "link": [5, 3],
-      "name": "Screw Attack Room Doorway Speedjump",
+      "name": "Doorway Speedjump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         "SpeedBooster",
         "canWalljump",
         "canCarefulJump",
         {"doorUnlockedAtNode": 2},
-        {"heatFrames": 400}
+        {"heatFrames": 240}
       ],
       "unlocksDoors": [
         {"nodeId": 2, "types": ["missiles"], "requires": [{"heatFrames": 50}]},
@@ -903,6 +902,21 @@
         {"nodeId": 2, "types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
       ],
       "note": "Position yourself in the door way, then run and jump. Makes it possible to walljump up."
+    },
+    {
+      "link": [5, 3],
+      "name": "Spring Ball Jump",
+      "requires": [
+        "HiJump",
+        {"doorUnlockedAtNode": 2},
+        "canTrickySpringBallJump",
+        {"heatFrames": 200}
+      ],
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"nodeId": 2, "types": ["super"], "requires": []},
+        {"nodeId": 2, "types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ]
     },
     {
       "link": [5, 3],

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -905,7 +905,7 @@
     },
     {
       "link": [5, 3],
-      "name": "Spring Ball Jump",
+      "name": "Doorway Spring Ball Jump",
       "requires": [
         "HiJump",
         {"doorUnlockedAtNode": 2},


### PR DESCRIPTION
This adds a strat for spring ball jumping from the doorway to the top of Screw Attack Room, with HiJump (where blocks are already broken). This was something that Kewlan recently noticed was missing. I also saw that the heat frames on the "Doorway Speedjump" strat were very lenient, so I tightened them up to some extent. 

Probably other strats in the room could also use another look at the heat frames; I also notice there's no canDoubleBombJump strat, but I'm not skilled enough to work that out.