### PR TITLE
Add comesThroughToilet strat property

### DIFF
--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1163,6 +1163,25 @@
     },
     {
       "link": [2, 11],
+      "name": "Cross Room Jump - Toilet HiJump Wall Jump",
+      "entranceCondition": {
+        "comeInWithWallJumpBelow": {
+          "minHeight": 2
+        }
+      },
+      "comesThroughToilet": "yes",
+      "requires": [
+        "canCrossRoomJumpIntoWater",
+        "HiJump",
+        "canDownGrab"
+      ],
+      "note": [
+        "Wall jump from a high position on either side of the door frame, pass through the Toilet, and down-grab onto the ledge.",
+        "The Toilet affects Samus' vertical spawn position, making this jump possible."
+      ]
+    },
+    {
+      "link": [2, 11],
       "name": "Cross Room Jump - Tricky Dash Jump",
       "entranceCondition": {
         "comeInWithPlatformBelow": {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1167,9 +1167,9 @@
       "entranceCondition": {
         "comeInWithWallJumpBelow": {
           "minHeight": 2
-        }
+        },
+        "comesThroughToilet": "yes"
       },
-      "comesThroughToilet": "yes",
       "requires": [
         "canCrossRoomJumpIntoWater",
         "HiJump",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -515,6 +515,17 @@
             }
           }
         },
+        "comesThroughToilet": {
+          "$id": "#/definitions/strat/properties/comesThroughToilet",
+          "type": "string",
+          "description": "For a strat having an entranceCondition through a vertical transition, indicates whether the strat is applicable if the Toilet comes between this room and the room with the exitCondition.",
+          "default": "no",
+          "enum": [
+            "no",
+            "yes",
+            "any"
+          ]
+        },
         "requires": {
           "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
           "$id": "#/definitions/strat/properties/requires",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -118,17 +118,6 @@
           "title": "Entrance Condition",
           "additionalProperties": false,
           "properties": {
-            "comesThroughToilet": {
-              "$id": "#/definitions/strat/properties/entranceCondition/comesThroughToilet",
-              "type": "string",
-              "description": "For a strat having an entranceCondition through a vertical transition, indicates whether the strat is applicable if the Toilet comes between this room and the room with the exitCondition.",
-              "default": "no",
-              "enum": [
-                "no",
-                "yes",
-                "any"
-              ]
-            },
             "comeInNormally": {
               "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInNormally",
               "type": "object",
@@ -521,6 +510,17 @@
                   }
                 }
               }              
+            },
+            "comesThroughToilet": {
+              "$id": "#/definitions/strat/properties/entranceCondition/comesThroughToilet",
+              "type": "string",
+              "description": "For a strat having an entranceCondition through a vertical transition, indicates whether the strat is applicable if the Toilet comes between this room and the room with the exitCondition.",
+              "default": "no",
+              "enum": [
+                "no",
+                "yes",
+                "any"
+              ]
             }
           },
           "oneOf": [

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -117,9 +117,18 @@
           "type": "object",
           "title": "Entrance Condition",
           "additionalProperties": false,
-          "minProperties": 1,
-          "maxProperties": 1,
           "properties": {
+            "comesThroughToilet": {
+              "$id": "#/definitions/strat/properties/entranceCondition/comesThroughToilet",
+              "type": "string",
+              "description": "For a strat having an entranceCondition through a vertical transition, indicates whether the strat is applicable if the Toilet comes between this room and the room with the exitCondition.",
+              "default": "no",
+              "enum": [
+                "no",
+                "yes",
+                "any"
+              ]
+            },
             "comeInNormally": {
               "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInNormally",
               "type": "object",
@@ -513,17 +522,27 @@
                 }
               }              
             }
-          }
-        },
-        "comesThroughToilet": {
-          "$id": "#/definitions/strat/properties/comesThroughToilet",
-          "type": "string",
-          "description": "For a strat having an entranceCondition through a vertical transition, indicates whether the strat is applicable if the Toilet comes between this room and the room with the exitCondition.",
-          "default": "no",
-          "enum": [
-            "no",
-            "yes",
-            "any"
+          },
+          "oneOf": [
+            {"required": ["comeInNormally"]},
+            {"required": ["comeInRunning"]},
+            {"required": ["comeInJumping"]},
+            {"required": ["comeInShinecharging"]},
+            {"required": ["comeInShinecharged"]},
+            {"required": ["comeInShinechargedJumping"]},
+            {"required": ["comeInWithSpark"]},
+            {"required": ["comeInWithBombBoost"]},
+            {"required": ["comeInStutterShinecharging"]},
+            {"required": ["comeInWithDoorStuckSetup"]},
+            {"required": ["comeInSpeedballing"]},
+            {"required": ["comeInWithTemporaryBlue"]},
+            {"required": ["comeInWithStoredFallSpeed"]},
+            {"required": ["comeInWithRMode"]},
+            {"required": ["comeInWithGMode"]},
+            {"required": ["comeInWithWallJumpBelow"]},
+            {"required": ["comeInWithSpaceJumpBelow"]},
+            {"required": ["comeInWithPlatformBelow"]},
+            {"required": ["comeInWithGrappleTeleport"]}
           ]
         },
         "requires": {

--- a/strats.md
+++ b/strats.md
@@ -354,13 +354,14 @@ A `leaveWithGrappleTeleport` comes with an implicit tech requirement `canGrapple
 
 ## Entrance conditions
 
-In all strats with an `entranceCondition`, the `from` node of the strat must be a door node or entrance node. An `entranceCondition` object must contain exactly one property:
+In all strats with an `entranceCondition`, the `from` node of the strat must be a door node or entrance node. An `entranceCondition` object must contain exactly one of the following properties:
 
 - _comeInNormally_: This indicates that Samus must come into the room through the specified door, with no other particular requirements.
 - _comeInRunning_: This indicates that Samus must run into the room, with speed in a certain range.
 - _comeInJumping_: This indicates that Samus must run and jump just before hitting the transition, with speed in a certain range.
 - _comeInShinecharging_: This indicates that Samus must run into the room with enough space to complete a shinecharge.
 - _comeInShinecharged_: This indicates that Samus must enter the room with a shinecharge with a certain amount of frames remaining.
+- _comeInShinechargedJumping_: This indicates that Samus must jump into the the room with a shinecharge with a certain amount of frames remaining.
 - _comeInWithSpark_: This indicates that Samus must shinespark into the room.
 - _comeInWithBombBoost_: This indicates that Samus must come into the room with a horizontal bomb boost.
 - _comeInStutterShinecharging_: This indicates that Samus must run into the room with a stutter immediately before the transition.
@@ -374,6 +375,10 @@ In all strats with an `entranceCondition`, the `from` node of the strat must be 
 - _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below.
 - _comeInWithPlatformBelow_: This indicates that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.
 - _comeInWithGrappleTeleport_: This indicates that Samus must come into the room while grappling, teleporting Samus to a position in this room corresponding to the location of the (grapple) block in the other room.
+
+In addition it may contain the following property:
+
+- _comesThroughToilet_: This indicates whether the strat is applicable if the Toilet comes between this room and the other room.
 
 Each of these properties is described in more detail below.
 
@@ -930,9 +935,9 @@ A `comeInWithGrappleTeleport` comes with an implicit tech requirement `canGrappl
 }
 ```
 
-## Comes Through Toilet
+### Comes Through Toilet
 
-A `comesThroughToilet` property indicates if the strat is applicable when the Toilet comes between this room (which should have an `entranceCondition`) and the other room (one with a matching `exitCondition`). This property should be specified on every strat having an `entranceCondition` through a vertical transition. It has three possible values:
+Inside an `entranceCondition` object, a `comesThroughToilet` property indicates if the strat is applicable when the Toilet comes between this room and the other room (one with a matching `exitCondition`). This property should be specified on every strat having an `entranceCondition` through a vertical transition. It has three possible values:
 
 - "yes": The strat is applicable only if the Toilet comes between this room and the other room.
 - "no": The strat is applicable only if the Toilet *does not* come between this room and the other room.
@@ -945,9 +950,9 @@ A `comesThroughToilet` property indicates if the strat is applicable when the To
   "entranceCondition": {
     "comeInWithWallJumpBelow": {
       "minHeight": 2
-    }
+    },
+    "comesThroughToilet": "yes"
   },
-  "comesThroughToilet": "yes",
   "requires": [
     "canCrossRoomJumpIntoWater",
     "HiJump",

--- a/strats.md
+++ b/strats.md
@@ -14,6 +14,7 @@ A `strat` can have the following properties:
   * _exitCondition_: Indicates that this strat leaves through the door transition in a special way that combines with a strat in the next room. 
   * _clearsObstacles_: An array containing the ID of obstacles that will be cleared by executing this strat (if they are not already cleared).
   * _resetsObstacles_: An array containing the ID of obstacles that will be reset (i.e. returned to their original state) by executing this strat.
+  * _comesThroughToilet_: Indicates whether this strat is applicable if the Toilet comes between this room and the other room.
   * _gModeRegainMobility_: Indicates that this strat allows regaining mobility when entering with G-mode immobile.
   * _bypassesDoorShell_: Indicates that this strat allows exiting without opening the door.
   * _unlocksDoors_: An array describing possible doors that can be unlocked as part of this strat.
@@ -926,6 +927,32 @@ A `comeInWithGrappleTeleport` comes with an implicit tech requirement `canGrappl
       "blockPositions": [[5, 3]]
     }
   }
+}
+```
+
+## Comes Through Toilet
+
+A `comesThroughToilet` property indicates if the strat is applicable when the Toilet comes between this room (which should have an `entranceCondition`) and the other room (one with a matching `exitCondition`). This property should be specified on every strat having an `entranceCondition` through a vertical transition. It has three possible values:
+
+- "yes": The strat is applicable only if the Toilet comes between this room and the other room.
+- "no": The strat is applicable only if the Toilet *does not* come between this room and the other room.
+- "any": The strat is applicable regardless of whether the Toilet comes between this room and the other room.
+
+### Example
+```json
+{
+  "name": "Cross Room Jump - Toilet HiJump Wall Jump",
+  "entranceCondition": {
+    "comeInWithWallJumpBelow": {
+      "minHeight": 2
+    }
+  },
+  "comesThroughToilet": "yes",
+  "requires": [
+    "canCrossRoomJumpIntoWater",
+    "HiJump",
+    "canDownGrab"
+  ]
 }
 ```
 

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -82,6 +82,7 @@ def process_keyvalue(k, v, metadata):
         "leaveWithSpark", # validated by schema
         "speedBooster", # validated by schema
         "framesRemaining",  # validated by schema
+        "comesThroughToilet",  # validated by schema
         "types",  # validated by schema in 'unlocksDoors', manually in 'enemyDamage'
     ]
 


### PR DESCRIPTION
This PR sets up the schema to represent vertical cross-room strats (e.g. jumps, G-mode setups, etc.) that pass through the Toilet. For now it just adds one example strat, the Mt. Everest one that was discovered/shared this morning by 123456789you123456789 on the Discord (https://discord.com/channels/1053421401354285129/1053436236628496454/1220378509046841468).