### PR TITLE
Add Artificial Morph Helpers - A Step Towards Reducing Errors

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -349,6 +349,15 @@
           ]
         },
         {
+          "name": "h_additionalBomb",
+          "requires": [
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ]
+        },
+        {
           "name": "h_canIBJ",
           "requires": [
             "canIBJ",
@@ -854,6 +863,33 @@
       "description": "Helpers used in G-Mode Artificial Morph Strats.",
       "helpers": [
         {
+          "name": "h_canArtificialMorphSpringBall",
+          "requires": [
+            "SpringBall"
+          ]
+        },
+        {
+          "name": "h_canArtificialMorphBombThings",
+          "requires": [
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ]
+        },
+        {
+          "name": "h_canArtificialMorphBombs",
+          "requires": [
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_canArtificialMorphPowerBomb",
+          "requires": [
+            {"ammo": { "type": "PowerBomb", "count": 1}}
+          ]
+        },
+        {
           "name": "h_canArtificialMorphIBJ",
           "requires": [
             "canIBJ",
@@ -961,7 +997,7 @@
           "name": "h_canArtificialMorphMovement",
           "requires": [
             {"or": [
-              "SpringBall",
+              "h_canArtificialMorphSpringBall",
               "h_canArtificialMorphIBJ",
               "Morph"
             ]}

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -309,7 +309,7 @@
       },
       "requires": [
         "h_canArtificialMorphJumpIntoIBJ",
-        "canBombHorizontally"
+        "h_canArtificialMorphBombHorizontally"
       ],
       "note": "Starting an IBJ from spring ball with no other items is not very precise, it just takes a bit of an odd timing."
     },

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -406,9 +406,8 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "SpringBall",
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombThings",
           {"enemyDamage": {
             "enemy": "Geemer (blue)",
             "hits": 1,
@@ -434,9 +433,8 @@
       "requires": [
         {"or": [
           "h_ZebesNotAwake",
-          "SpringBall",
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombThings",
           {"enemyDamage": {
             "enemy": "Geemer (blue)",
             "hits": 1,
@@ -466,9 +464,8 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "SpringBall",
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombThings",
           {"enemyDamage": {
             "enemy": "Geemer (blue)",
             "hits": 1,
@@ -506,9 +503,8 @@
       "requires": [
         {"or": [
           "h_ZebesNotAwake",
-          "SpringBall",
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombThings",
           {"enemyDamage": {
             "enemy": "Geemer (blue)",
             "hits": 1,

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -587,7 +587,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphMovement"
       ],
       "clearsObstacles": ["B"],

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -126,7 +126,7 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "h_canArtificialMorphIBJ",
             "canOffScreenMovement"

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -310,8 +310,8 @@
       "requires": [
         "canOffScreenMovement",
         {"or": [
-          "Bombs",
-          "SpringBall",
+          "h_canArtificialMorphBombs",
+          "h_canArtificialMorphSpringBall",
           {"ammo": {"type": "PowerBomb", "count": 6}}
         ]}
       ],
@@ -458,8 +458,8 @@
       "requires": [
         "canOffScreenMovement",
         {"or": [
-          "Bombs",
-          "SpringBall",
+          "h_canArtificialMorphBombs",
+          "h_canArtificialMorphSpringBall",
           {"ammo": {"type": "PowerBomb", "count": 6}}
         ]}
       ],

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -438,7 +438,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
@@ -806,7 +806,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
@@ -1193,7 +1193,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
@@ -2066,7 +2066,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
@@ -2637,7 +2637,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
@@ -3155,7 +3155,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
@@ -3364,7 +3364,7 @@
       },
       "requires": [
         "h_canArtificialMorphMovement",
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb while on the top single tile platform, then exit g-mode before the Power Bomb explodes in order to break the blocks above."
@@ -3541,15 +3541,15 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           "h_canArtificialMorphIBJ",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "canSpringBallBombJump",
             {"ammo": {"type": "PowerBomb", "count": 6}}
           ]}
@@ -3717,7 +3717,7 @@
         {"itemNotCollectedAtNode": 11},
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphIBJ",
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         "canBePatient",
         "canOffScreenMovement"
       ],
@@ -3824,7 +3824,7 @@
         {"itemNotCollectedAtNode": 11},
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphIBJ",
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         "canBePatient",
         "canOffScreenMovement"
       ],

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -475,7 +475,7 @@
           "h_canArtificialMorphSpringBallBombJump",
           {"and": [
             "HiJump",
-            "SpringBall"
+            "h_canArtificialMorphSpringBall"
           ]}
         ]}
       ],
@@ -642,7 +642,7 @@
           "h_canArtificialMorphSpringBallBombJump",
           {"and": [
             "HiJump",
-            "SpringBall"
+            "h_canArtificialMorphSpringBall"
           ]}
         ]}
       ],
@@ -710,19 +710,16 @@
         {"or": [
           "canTrickyJump",
           {"and": [
-            "Bombs",
-            {"ammo": {"type": "PowerBomb", "count": 1}}
+            "h_canArtificialMorphBombs",
+            "h_canArtificialMorphPowerBomb"
           ]},
           {"ammo": {"type": "PowerBomb", "count": 3}}
         ]},
         {"or": [
           "h_canArtificialMorphIBJ",
           {"and": [
-            "canSpringBallBombJump",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 2}}
-            ]}
+            "h_canArtificialMorphSpringBallBombJump",
+            "h_additionalBomb"
           ]}
         ]}
       ],
@@ -826,8 +823,8 @@
         {"or": [
           "canTrickyJump",
           {"and": [
-            "Bombs",
-            {"ammo": {"type": "PowerBomb", "count": 1}}
+            "h_canArtificialMorphBombs",
+            "h_canArtificialMorphPowerBomb"
           ]},
           {"ammo": {"type": "PowerBomb", "count": 3}}
         ]},
@@ -836,7 +833,7 @@
           "h_canArtificialMorphSpringBallBombJump",
           {"and": [
             "HiJump",
-            "SpringBall"
+            "h_canArtificialMorphSpringBall"
           ]}
         ]}
       ],

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -291,10 +291,7 @@
         }
       },
       "requires": [
-        {"or": [
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 1}}
-        ]}
+        "h_canArtificialMorphBombThings"
       ],
       "note": [
         "Wait for the pirates to move as far right as possible in order to kill them all with a single Power Bomb.",
@@ -398,14 +395,14 @@
         }
       },
       "requires": [
-        "Bombs",
+        "h_canArtificialMorphBombs",
         {"enemyDamage": {
           "enemy": "Mini-Kraid",
           "type": "spike",
           "hits": 1
         }}
       ],
-      "note": "Kill all of the enemies with bombs. Samus will take a Baby Kraid spike hit while rolling through the invisible projectiles."
+      "note": "Kill all of the enemies with Bombs. Samus will take a Baby Kraid spike hit while rolling through the invisible projectiles."
     },
     {
       "link": [2, 2],

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -259,9 +259,9 @@
       },
       "requires": [
         {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"and": [
-            "Bombs",
+            "h_canArtificialMorphBombs",
             {"or": [
               "canTrickyJump",
               {"enemyDamage": {

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -201,7 +201,7 @@
       },
       "requires": [
         {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Kihunter (green)",
             "type": "contact",

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -484,15 +484,15 @@
       "requires": [
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Sm. Sidehopper",
             "hits": 1,
             "type": "contact"
           }}
         ]},
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["C"],
       "note": [
@@ -514,15 +514,16 @@
       "requires": [
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Sm. Sidehopper",
             "hits": 1,
             "type": "contact"
           }}
         ]},
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
       "note": [
@@ -545,14 +546,15 @@
       "requires": [
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Sm. Sidehopper",
             "hits": 1,
             "type": "contact"
           }}
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "note": [
         "Roll through the camera scroll blocks and then through the bomb block.",
@@ -626,7 +628,7 @@
         {"or": [
           "Morph",
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Sm. Sidehopper",
             "hits": 1,
@@ -635,7 +637,10 @@
         ]},
         {"or": [
           "h_canArtificialMorphMovement",
-          {"ammo": {"type": "PowerBomb", "count": 2}}
+          {"and": [
+            "h_canArtificialMorphPowerBomb",
+            "h_canArtificialMorphPowerBomb"
+          ]}
         ]}
       ],
       "note": [
@@ -655,7 +660,10 @@
       "requires": [
         {"or": [
           "h_canArtificialMorphMovement",
-          {"ammo": {"type": "PowerBomb", "count": 2}}
+          {"and": [
+            "h_canArtificialMorphPowerBomb",
+            "h_canArtificialMorphPowerBomb"
+          ]}
         ]}
       ],
       "note": "Roll through the camera scroll blocks and then through the bomb block."
@@ -731,15 +739,15 @@
       "requires": [
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Sm. Sidehopper",
             "hits": 1,
             "type": "contact"
           }}
         ]},
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["C"],
       "note": [
@@ -761,15 +769,16 @@
       "requires": [
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Sm. Sidehopper",
             "hits": 1,
             "type": "contact"
           }}
         ]},
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
       "note": [
@@ -825,15 +834,18 @@
               }}
             ]},
             {"or": [
-              "SpringBall",
+              "h_canArtificialMorphSpringBall",
               "h_canArtificialMorphIBJ"
             ]}
           ]},
-          {"ammo": {"type": "PowerBomb", "count": 1}}
+          "h_canArtificialMorphPowerBomb"
         ]},
         {"or": [
           "h_canArtificialMorphMovement",
-          {"ammo": {"type": "PowerBomb", "count": 2}}
+          {"and": [
+            "h_canArtificialMorphPowerBomb",
+            "h_canArtificialMorphPowerBomb"
+          ]}
         ]}
       ],
       "note": "Avoiding the hoppers can be tricky."
@@ -956,7 +968,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
       "note": "Use a Power Bomb, then exit G-Mode."
@@ -1350,11 +1362,11 @@
         {"ammo": {"type": "PowerBomb", "count": 3}},
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}}
+          "h_canArtificialMorphPowerBomb"
         ]},
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Sm. Sidehopper",
             "hits": 1,
@@ -1400,7 +1412,8 @@
       },
       "requires": [
         "h_canArtificialMorphSpringBallBombJump",
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_additionalBomb",
+        "h_additionalBomb"
       ],
       "clearsObstacles": ["C"],
       "note": [
@@ -1423,7 +1436,9 @@
       },
       "requires": [
         "h_canArtificialMorphSpringBallBombJump",
-        {"ammo": {"type": "PowerBomb", "count": 3}}
+        "h_additionalBomb",
+        "h_additionalBomb",
+        "h_additionalBomb"
       ],
       "clearsObstacles": ["B", "C"],
       "note": [
@@ -1499,7 +1514,7 @@
           "Morph",
           "h_canArtificialMorphIBJ",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]}
         ]}
@@ -1519,7 +1534,7 @@
       "requires": [
         {"itemNotCollectedAtNode": 11},
         "canRiskPermanentLossOfAccess",
-        "SpringBall"
+        "h_canArtificialMorphSpringBall"
       ],
       "note": "Roll through it until PLMs are overloaded, then roll through the bomb blocks and down below.",
       "devNote": "With more items, the strat with camera scroll blocks will be used."
@@ -1549,12 +1564,12 @@
           "h_canArtificialMorphIBJ",
           "Morph",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]},
           {"and": [
             "h_canArtificialMorphSpringBallBombJump",
-            {"ammo": {"type": "PowerBomb", "count": 1}}
+            "h_additionalBomb"
           ]}
         ]}
       ]
@@ -1604,12 +1619,14 @@
           "h_canArtificialMorphIBJ",
           "Morph",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "HiJump",
               {"and": [
                 "h_canArtificialMorphSpringBallBombJump",
-                {"ammo": {"type": "PowerBomb", "count": 3}}
+                "h_additionalBomb",
+                "h_additionalBomb",
+                "h_additionalBomb"
               ]}
             ]}
           ]}

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -396,11 +396,10 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
-          "Bombs",
-          "SpringBall",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphBombThings",
+          "h_canArtificialMorphSpringBall",
           {"enemyDamage": {
             "enemy": "Zeela",
             "hits": 1,

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -434,7 +434,7 @@
           "type": "contact",
           "hits": 1
         }},
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": "Kill the Sidehoppers with a Power Bomb upon entry."
@@ -547,7 +547,7 @@
             "type": "contact",
             "hits": 3
           }},
-          {"ammo": {"type": "PowerBomb", "count": 1}}
+          "h_canArtificialMorphPowerBomb"
         ]}
       ],
       "clearsObstacles": ["A", "B"],
@@ -754,7 +754,7 @@
             "type": "contact",
             "hits": 3
           }},
-          {"ammo": {"type": "PowerBomb", "count": 1}}
+          "h_canArtificialMorphPowerBomb"
         ]}
       ],
       "clearsObstacles": ["A"],
@@ -1188,7 +1188,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
       "note": "Using a power bomb against the left wall will kill the enemies and trigger the elevator."

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -392,13 +392,13 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           {"and": [
-            {"ammo": {"type": "PowerBomb", "count": 1}},
+            "h_canArtificialMorphPowerBomb",
             {"or": [
               "h_canArtificialMorphBombHorizontally",
-              "SpringBall"
+              "h_canArtificialMorphSpringBall"
             ]}
           ]},
           {"enemyDamage": {
@@ -490,9 +490,9 @@
         }
       },
       "requires": [
-        "Bombs"
+        "h_canArtificialMorphBombs"
       ],
-      "note": "Place Power Bombs against the side of the crumble block until PLMs are overloaded, then go through."
+      "note": "Place Bombs against the side of the crumble block until PLMs are overloaded, then go through."
     },
     {
       "link": [2, 3],
@@ -505,9 +505,10 @@
       },
       "requires": [
         {"itemNotCollectedAtNode": 3},
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"ammo": {"type": "PowerBomb", "count": 4}},
           {"and": [
             "Morph",

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -664,8 +664,8 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
-          "Bombs",
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
             "h_canFourTileJumpMorph"
@@ -707,8 +707,8 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
-          "Bombs",
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
             "h_canFourTileJumpMorph"
@@ -759,8 +759,8 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
-          "Bombs",
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
             "h_canFourTileJumpMorph"
@@ -781,8 +781,8 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
-          "Bombs",
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
             "h_canFourTileJumpMorph"
@@ -837,7 +837,7 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "Morph"
         ]}
       ],
@@ -940,8 +940,8 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
-          "Bombs",
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
             "h_canFourTileJumpMorph"
@@ -1145,7 +1145,7 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "Morph"
         ]}
       ],
@@ -1245,7 +1245,7 @@
         {"or": [
           "Morph",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "HiJump",
               "canCarefulJump"
@@ -1257,7 +1257,7 @@
           ]},
           {"and": [
             "h_canArtificialMorphMovement",
-            {"ammo": {"type": "PowerBomb", "count": 1}}
+            "h_canArtificialMorphPowerBomb"
           ]}
         ]}
       ],

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -229,7 +229,7 @@
           "h_canArtificialMorphDiagonalBombJump",
           "h_canArtificialMorphCeilingBombJump",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"spikeHits": 3},
             {"or": [
               "h_canArtificialMorphBombHorizontally",
@@ -323,10 +323,10 @@
         }
       },
       "requires": [
-        "Bombs",
+        "h_canArtificialMorphBombs",
         {"or": [
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"spikeHits": 3},
             {"or": [
               "h_canArtificialMorphBombHorizontally",
@@ -402,10 +402,11 @@
       "requires": [
         {"itemNotCollectedAtNode": 3},
         "canRiskPermanentLossOfAccess",
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"spikeHits": 3},
             {"or": [
               "h_canArtificialMorphBombHorizontally",

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -140,7 +140,7 @@
         }
       },
       "requires": [
-        "Bombs"
+        "h_canArtificialMorphBombs"
       ],
       "note": "Repeatedly bomb the crumble blocks until the PLMs are overloaded."
     },

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -352,7 +352,7 @@
         }
       },
       "requires": [
-        "Bombs"
+        "h_canArtificialMorphBombs"
       ],
       "note": [
         "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -965,7 +965,7 @@
       "requires": [
         {"or": [
           "h_canArtificialMorphMovement",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Geemer (blue)",
             "type": "contact",

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -228,7 +228,7 @@
         }
       },
       "requires": [
-        "Bombs"
+        "h_canArtificialMorphBombs"
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -247,7 +247,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Lay a Power Bomb to break the bomb blocks leading down to the item, then use X-ray to cancel G-mode, to clear the blocks."
@@ -387,9 +387,11 @@
       },
       "requires": [
         "h_canArtificialMorphBombHorizontally",
-        {"ammo": {"type": "PowerBomb", "count": 3}},
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
         {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           "canTrickyJump"
         ]}
       ],
@@ -411,8 +413,8 @@
         }
       },
       "requires": [
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": [

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -186,12 +186,9 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]},
+            "h_canArtificialMorphBombThings",
             "Gravity"
           ]},
           "h_canArtificialMorphIBJ"
@@ -218,9 +215,9 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump",
-            "Bombs"
+            "h_canArtificialMorphBombs"
           ]}
         ]}
       ],

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -697,8 +697,8 @@
             "h_canIBJ",
             {"or": [
               "Gravity",
-              "canJumpIntoIBJ",
-              "canBombHorizontally"
+              "h_canJumpIntoIBJ",
+              "h_canBombHorizontally"
             ]}
           ]},
           {"and": [
@@ -749,8 +749,8 @@
             "h_canIBJ",
             {"or": [
               "Gravity",
-              "canJumpIntoIBJ",
-              "canBombHorizontally"
+              "h_canJumpIntoIBJ",
+              "h_canBombHorizontally"
             ]}
           ]},
           {"and": [
@@ -786,8 +786,8 @@
             "h_canIBJ",
             {"or": [
               "Gravity",
-              "canJumpIntoIBJ",
-              "canBombHorizontally"
+              "h_canJumpIntoIBJ",
+              "h_canBombHorizontally"
             ]}
           ]},
           {"and": [
@@ -832,7 +832,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump",
@@ -861,7 +861,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump",
@@ -1083,7 +1083,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump",
@@ -1112,7 +1112,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump",
@@ -1339,9 +1339,9 @@
         "canPartialFloorClip",
         "canDownGrab",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
-            "Bombs",
+            "h_canArtificialMorphBombs",
             {"or": [
               "canTrickyJump",
               {"enemyDamage": {
@@ -1356,7 +1356,7 @@
             {"or": [
               {"and": [
                 "canTrickyJump",
-                {"ammo": {"type": "PowerBomb", "count": 1}}
+                "h_canArtificialMorphPowerBomb"
               ]},
               {"and": [
                 "canNeutralDamageBoost",

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -293,7 +293,7 @@
         }
       },
       "requires": [
-        "Bombs"
+        "h_canArtificialMorphBombs"
       ],
       "clearsObstacles": ["B"],
       "note": "Place a Power Bomb to the left of the Zebbo, then exit G-Mode, to break the bomb wall to the right."
@@ -308,7 +308,7 @@
         }
       },
       "requires": [
-        "Bombs"
+        "h_canArtificialMorphBombs"
       ],
       "clearsObstacles": ["C"],
       "note": "Carefully kill the Zebbo, then place two bombs against the right wall to break the left half of the wall to slightly increase the length of the runway."

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -570,15 +570,18 @@
             "h_additionalBomb",
             {"or": [
               "HiJump",
-              "h_additionalBomb",
+              "h_canArtificialMorphSpringBallBombJump",
               "canJumpIntoIBJ"
             ]}
           ]}
         ]}
       ],
       "note": [
-        "With Spring Ball, it is possible to save a Power Bomb by placing it high on the first jump and bouncing on it on the second,",
-        "but this doesn't save anything if breaking the Power Bomb blocks."
+        "With Spring Ball, it is possible to save a Power Bomb by placing it on the descent of the first jump by the bottom corner of the overhang,",
+        "then bouncing on it on the ascent of the second.",
+        "It is also possible but tighter to get high enough from bouncing on a Power Bomb with a single jump, similar to jumping into an IBJ.",
+        "This doesn't save anything if breaking the Power Bomb blocks above.",
+        "With an extra Power Bomb to spare, simply Spring Ball Bomb Jump."
       ]
     },
     {
@@ -836,15 +839,18 @@
             "h_additionalBomb",
             {"or": [
               "HiJump",
-              "h_additionalBomb",
+              "h_canArtificialMorphSpringBallBombJump",
               "canJumpIntoIBJ"
             ]}
           ]}
         ]}
       ],
       "note": [
-        "With Spring Ball, it is possible to save a Power Bomb by placing it high on the first jump and bouncing on it on the second,",
-        "but this doesn't save anything if breaking the Power Bomb blocks."
+        "With Spring Ball, it is possible to save a Power Bomb by placing it on the descent of the first jump by the bottom corner of the overhang,",
+        "then bouncing on it on the ascent of the second.",
+        "It is also possible but tighter to get high enough from bouncing on a Power Bomb with a single jump, similar to jumping into an IBJ.",
+        "This doesn't save anything if breaking the Power Bomb blocks above.",
+        "With an extra Power Bomb to spare, simply Spring Ball Bomb Jump."
       ]
     },
     {

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -565,11 +565,12 @@
         {"or": [
           "h_canArtificialMorphIBJ",
           {"and": [
-            "SpringBall",
-            {"ammo": { "type": "PowerBomb", "count": 2}},
+            "h_canArtificialMorphSpringBall",
+            "h_canArtificialMorphPowerBomb",
+            "h_additionalBomb",
             {"or": [
               "HiJump",
-              {"ammo": { "type": "PowerBomb", "count": 1}},
+              "h_additionalBomb",
               "canJumpIntoIBJ"
             ]}
           ]}
@@ -830,11 +831,12 @@
         {"or": [
           "h_canArtificialMorphIBJ",
           {"and": [
-            "SpringBall",
-            {"ammo": { "type": "PowerBomb", "count": 2}},
+            "h_canArtificialMorphSpringBall",
+            "h_canArtificialMorphPowerBomb",
+            "h_additionalBomb",
             {"or": [
               "HiJump",
-              {"ammo": { "type": "PowerBomb", "count": 1}},
+              "h_additionalBomb",
               "canJumpIntoIBJ"
             ]}
           ]}

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -491,7 +491,7 @@
       },
       "requires": [
         {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"and": [
             "h_canArtificialMorphIBJ",
             "Gravity"
@@ -842,7 +842,7 @@
       },
       "requires": [
         {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"and": [
             "h_canArtificialMorphIBJ",
             "Gravity"
@@ -866,10 +866,7 @@
         }
       },
       "requires": [
-        {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
-          "Bombs"
-        ]}
+        "h_canArtificialMorphBombThings"
       ]
     },
     {

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -171,7 +171,7 @@
     },
     {
       "link": [1, 3],
-      "name": "G-Mode PB",
+      "name": "G-Mode Morph Power Bomb",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -179,7 +179,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ]
     },
     {
@@ -343,9 +343,9 @@
             "Gravity",
             "h_canArtificialMorphIBJ"
           ]},
-          "SpringBall"
+          "h_canArtificialMorphSpringBall"
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "note": [
         "The Snails will dig through the sand without showing any visual difference. Each block they pass through gets closer to overloading PLMs.",

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -108,13 +108,15 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 2}}
-            ]}
+            "h_canArtificialMorphBombs"
+          ]},
+          {"and": [
+            "Gravity",
+            "h_canArtificialMorphPowerBombBombs",
+            "h_additionalBomb"
           ]}
         ]}
       ],

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -115,7 +115,7 @@
           ]},
           {"and": [
             "Gravity",
-            "h_canArtificialMorphPowerBombBombs",
+            "h_canArtificialMorphPowerBomb",
             "h_additionalBomb"
           ]}
         ]}

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -315,7 +315,7 @@
         }
       },
       "requires": [
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "Place a Power Bomb then exit G-Mode."
@@ -358,7 +358,7 @@
         }
       },
       "requires": [
-        "Bombs",
+        "h_canArtificialMorphBombs",
         "h_canNavigateUnderwater",
         {"or": [
           {"and": [
@@ -376,11 +376,11 @@
           ]}
         ]}
       ],
-      "note": "Bomb the PB blocks below to overload PLMs, then go up through the crumble blocks to escape."
+      "note": "Bomb the Power Bomb blocks below to overload PLMs, then go up through the crumble blocks to escape."
     },
     {
       "link": [1, 10],
-      "name": "G-Mode Morph Overload PLMs - Bomb the PB Blocks",
+      "name": "G-Mode Morph Overload PLMs - Bomb the Power Bomb Blocks",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -388,11 +388,10 @@
         }
       },
       "requires": [
-        "Bombs",
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
-      "note": "Bomb the PB blocks below to overload PLMs, then IBJ up through the crumble blocks to escape."
+      "note": "Bomb the Power Bomb blocks below to overload PLMs, then IBJ up through the crumble blocks to escape."
     },
     {
       "link": [1, 11],
@@ -404,7 +403,7 @@
         }
       },
       "requires": [
-        "Bombs",
+        "h_canArtificialMorphBombs",
         "h_canNavigateUnderwater",
         {"or": [
           {"and": [
@@ -901,8 +900,8 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "Morph",
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canUsePowerBombs",
+        "h_canUsePowerBombs",
         "h_canNavigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -940,8 +939,9 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
         "h_canNavigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -1296,8 +1296,8 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "Morph",
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canUsePowerBombs",
+        "h_canUsePowerBombs",
         "h_canNavigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -1335,8 +1335,9 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
         "h_canNavigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -1390,7 +1391,7 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "Morph",
           {"and": [
             "Gravity",
@@ -1409,9 +1410,9 @@
         }
       },
       "requires": [
-        "Bombs",
+        "h_canArtificialMorphBombs",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "Morph",
           {"and": [
             "Gravity",
@@ -1446,12 +1447,12 @@
       },
       "requires": [
         {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"and": [
-            "Bombs",
+            "h_canArtificialMorphBombs",
             {"or": [
               "Gravity",
-              "SpringBall"
+              "h_canArtificialMorphSpringBall"
             ]}
           ]}
         ]}
@@ -1530,8 +1531,8 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "Morph",
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canUsePowerBombs",
+        "h_canUsePowerBombs",
         "h_canNavigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -1569,8 +1570,9 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 2}},
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
         "h_canNavigateUnderwater",
         "canSnailClimb",
         {"or": [

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -250,14 +250,15 @@
       },
       "requires": [
         {"or": [
-          "Bombs",
+          "h_canArtificialMorphBombs",
           {"and": [
-            {"ammo": {"type": "PowerBomb", "count": 2}},
+            "h_canArtificialMorphPowerBomb",
+            "h_additionalBomb",
             {"or": [
               "canTrickyJump",
-              "SpringBall",
+              "h_canArtificialMorphSpringBall",
               "Gravity",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
+              "h_additionalBomb"
             ]}
           ]},
           {"and": [
@@ -269,7 +270,7 @@
             }}
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"enemyDamage": {
               "enemy": "Puyo",
               "type": "contact",
@@ -325,18 +326,20 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
             "h_canArtificialMorphBombHorizontally"
           ]}
         ]},
         {"or": [
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 2}},
+          {"and": [
+            "h_canArtificialMorphBombs",
+            "h_additionalBomb"
+          ]},
           {"and": [
             "Gravity",
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"enemyDamage": {
               "enemy": "Puyo",
               "type": "contact",
@@ -344,7 +347,7 @@
             }}
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"enemyDamage": {
               "enemy": "Puyo",
               "type": "contact",
@@ -353,7 +356,7 @@
           ]},
           {"and": [
             "Gravity",
-            {"ammo": {"type": "PowerBomb", "count": 1}},
+            "h_canArtificialMorphPowerBomb",
             {"enemyDamage": {
               "enemy": "Puyo",
               "type": "contact",
@@ -593,14 +596,14 @@
             "canDodgeWhileShooting"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
             ]},
             {"or": [
               "canTrickyJump",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
+              "h_canArtificialMorphPowerBomb"
             ]}
           ]}
         ]}
@@ -624,14 +627,14 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
             ]},
             {"or": [
               "canTrickyJump",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
+              "h_canArtificialMorphPowerBomb"
             ]}
           ]}
         ]}
@@ -845,7 +848,7 @@
       "requires": [
         {"or": [
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
@@ -856,11 +859,10 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "canTrickyJump",
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
+              "h_canArtificialMorphBombThings"
             ]}
           ]}
         ]}
@@ -910,7 +912,7 @@
       "requires": [
         {"or": [
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
@@ -921,11 +923,10 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "canTrickyJump",
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
+              "h_canArtificialMorphBombThings"
             ]}
           ]}
         ]}
@@ -1016,7 +1017,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
@@ -1046,7 +1047,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -334,7 +334,7 @@
         ]},
         {"or": [
           {"and": [
-            "h_canArtificialMorphBombs",
+            "h_canArtificialMorphBombThings",
             "h_additionalBomb"
           ]},
           {"and": [

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -247,18 +247,18 @@
       "requires": [
         "h_canNavigateUnderwater",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "h_canArtificialMorphBombHorizontally"
         ]},
         {"or": [
           {"and": [
-            "Bombs",
+            "h_canArtificialMorphBombs",
             {"or": [
               "Gravity",
-              "SpringBall"
+              "h_canArtificialMorphSpringBall"
             ]}
           ]},
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Cacatac",
             "hits": 1,
@@ -266,13 +266,10 @@
           }}
         ]},
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
+            "h_canArtificialMorphBombThings"
           ]}
         ]}
       ],

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -423,7 +423,7 @@
           "h_canArtificialMorphIBJ",
           {"and": [
             "h_canArtificialMorphSpringBallBombJump",
-            "h_canArtificialMorphSpringBallBombJump"
+            "h_additionalBomb"
           ]}
         ]}
       ],

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -239,7 +239,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
@@ -820,7 +820,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
@@ -1167,7 +1167,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"
@@ -1287,7 +1287,7 @@
             "h_canArtificialMorphIBJ"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "Gravity",
               "HiJump"

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -220,8 +220,11 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         {"or": [
-          "SpringBall",
-          {"ammo": {"type": "PowerBomb", "count": 2}},
+          "h_canArtificialMorphSpringBall",
+          {"and": [
+            "h_canArtificialMorphPowerBomb",
+            "h_canArtificialMorphPowerBomb"
+          ]},
           {"and": [
             "h_canArtificialMorphStaggeredIBJ",
             "canBeVeryPatient"

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -210,8 +210,8 @@
             "h_canArtificialMorphIBJ",
             {"or": [
               "Gravity",
-              "SpringBall",
-              {"ammo": {"type": "PowerBomb", "count": 1}},
+              "h_canArtificialMorphSpringBall",
+              "h_canArtificialMorphPowerBomb",
               {"enemyDamage": {
                 "enemy": "Ripper",
                 "type": "contact",
@@ -299,9 +299,9 @@
           ]},
           {"and": [
             "h_canIBJ",
-            {"ammo": { "type": "PowerBomb", "count": 1}},
+            "h_canUsePowerBombs",
             {"or": [
-              {"ammo": { "type": "PowerBomb", "count": 1}},
+              "h_canUsePowerBombs",
               "canStaggeredIBJ"
             ]}
           ]}
@@ -321,10 +321,10 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphSpringBallBombJump",
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           "h_canArtificialMorphStaggeredIBJ",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Ripper",
             "type": "contact",
@@ -352,17 +352,17 @@
         "h_canArtificialMorphIBJ",
         {"or": [
           "Gravity",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Ripper",
             "type": "contact",
             "hits": 1
           }}
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           "h_canArtificialMorphStaggeredIBJ",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Ripper",
             "type": "contact",
@@ -592,9 +592,9 @@
           ]},
           {"and": [
             "h_canIBJ",
-            {"ammo": { "type": "PowerBomb", "count": 1}},
+            "h_canUsePowerBombs",
             {"or": [
-              {"ammo": { "type": "PowerBomb", "count": 1}},
+              "h_canUsePowerBombs",
               "canStaggeredIBJ"
             ]}
           ]}
@@ -613,10 +613,10 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ",
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           "h_canArtificialMorphStaggeredIBJ",
-          {"ammo": {"type": "PowerBomb", "count": 1}},
+          "h_canArtificialMorphPowerBomb",
           {"enemyDamage": {
             "enemy": "Ripper",
             "type": "contact",

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -139,7 +139,7 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "h_canArtificialMorphIBJ",
             "Gravity"
@@ -160,10 +160,8 @@
       "requires": [
         "canOffScreenMovement",
         "h_canArtificialMorphBombHorizontally",
-        {"or": [
-          "Bombs",
-          {"ammo": {"type": "PowerBomb", "count": 2}}
-        ]}
+        "h_canArtificialMorphBombThings",
+        "h_additionalBomb"
       ],
       "note": [
         "Use one bomb to get to the off-screen region. After going a full screen to the right, when Samus is partially visible in the left wall, bomb to the middle platform on the right.",
@@ -188,7 +186,7 @@
         "canOffScreenMovement",
         "h_canArtificialMorphIBJ",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "Gravity"
         ]}
       ],
@@ -370,14 +368,12 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
+            "h_canArtificialMorphBombThings",
+            "h_additionalBomb",
             {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 3}}
-            ]},
-            {"or": [
-              "canBombHorizontally",
+              "h_canArtificialMorphBombHorizontally",
               "Gravity"
             ]}
           ]}

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -374,7 +374,10 @@
             "h_additionalBomb",
             {"or": [
               "h_canArtificialMorphBombHorizontally",
-              "Gravity"
+              {"and": [
+                "h_additionalBomb",
+                "Gravity"
+              ]}
             ]}
           ]}
         ]}

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -304,7 +304,9 @@
           ]},
           {"and": [
             "h_canArtificialMorphSpringBallBombJump",
-            {"ammo": {"type": "PowerBomb", "count": 3}}
+            "h_additionalBomb",
+            "h_additionalBomb",
+            "h_additionalBomb"
           ]}
         ]}
       ]
@@ -600,7 +602,7 @@
           {"and": [
             "canSuitlessMaridia",
             "HiJump",
-            "SpringBall"
+            "h_canArtificialMorphSpringBall"
           ]}
         ]},
         "h_canArtificialMorphIBJ"
@@ -621,7 +623,7 @@
           {"and": [
             "canSuitlessMaridia",
             "HiJump",
-            "SpringBall"
+            "h_canArtificialMorphSpringBall"
           ]}
         ]},
         "h_canArtificialMorphIBJ"

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -214,11 +214,11 @@
       },
       "requires": [
         {"or": [
-          {"ammo": {"type": "PowerBomb", "count": 1}},
-          "SpringBall",
+          "h_canArtificialMorphPowerBomb",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
-            "Bombs"
+            "h_canArtificialMorphBombs"
           ]},
           "canTrickyJump",
           {"enemyDamage": {
@@ -307,7 +307,7 @@
       "requires": [
         {"or": [
           "Morph",
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
             "h_canArtificialMorphIBJ"
@@ -316,8 +316,7 @@
             "Gravity",
             "h_canArtificialMorphBombHorizontally",
             {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}},
+              "h_canArtificialMorphBombThings",
               "canTrickyJump",
               {"enemyDamage": {
                 "enemy": "Sciser",
@@ -686,7 +685,7 @@
       },
       "requires": [
         "canGravityJump",
-        "SpringBall"
+        "h_canArtificialMorphSpringBall"
       ],
       "note": [
         "The shaft will be clear of crabs on room entry. Quickly gravity jump before the bottom crab enters the shaft and exit the left morph tunnel to be safe.",
@@ -870,7 +869,7 @@
       },
       "requires": [
         "canGravityJump",
-        "SpringBall"
+        "h_canArtificialMorphSpringBall"
       ],
       "note": [
         "The shaft will be clear of crabs on room entry. Quickly gravity jump before the bottom crab enters the shaft and exit the left morph tunnel to be safe.",
@@ -950,7 +949,7 @@
       "requires": [
         {"or": [
           "Morph",
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
             "h_canArtificialMorphIBJ"

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -355,7 +355,7 @@
       "requires": [
         {"or": [
           "Morph",
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
             "h_canArtificialMorphIBJ"
@@ -363,10 +363,7 @@
           {"and": [
             "Gravity",
             "h_canArtificialMorphBombHorizontally",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
+            "h_canArtificialMorphBombThings"
           ]},
           {"and": [
             {"not": "f_MaridiaTubeBroken"},
@@ -436,7 +433,7 @@
       },
       "requires": [
         {"not": "f_MaridiaTubeBroken"},
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
@@ -479,7 +476,7 @@
           ]},
           {"and": [
             "canSuitlessMaridia",
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]}
         ]}
@@ -583,7 +580,7 @@
           ]},
           {"and": [
             "canSuitlessMaridia",
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]}
         ]}
@@ -708,7 +705,7 @@
       },
       "requires": [
         {"not": "f_MaridiaTubeBroken"},
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphMovement"
       ],
       "clearsObstacles": ["A"],
@@ -787,7 +784,7 @@
       "requires": [
         {"or": [
           "Morph",
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
             "h_canArtificialMorphIBJ"
@@ -795,10 +792,7 @@
           {"and": [
             "Gravity",
             "h_canArtificialMorphBombHorizontally",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
+            "h_additionalBomb"
           ]},
           {"and": [
             {"not": "f_MaridiaTubeBroken"},
@@ -930,7 +924,7 @@
       },
       "requires": [
         {"not": "f_MaridiaTubeBroken"},
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
@@ -1037,7 +1031,7 @@
       },
       "requires": [
         {"not": "f_MaridiaTubeBroken"},
-        {"ammo": {"type": "PowerBomb", "count": 1}}
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": [

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -611,11 +611,11 @@
         {"or": [
           "h_canArtificialMorphJumpIntoIBJ",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "canGravityJump"
           ]},
           "canDoubleBombJump",
@@ -627,7 +627,7 @@
           }}
         ]},
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "h_canArtificialMorphCeilingBombJump",
           "canBeVeryPatient"
         ]}
@@ -661,7 +661,7 @@
           ]}
         ]},
         {"or": [
-          "SpringBall",
+          "h_canUseSpringBall",
           "canBeVeryPatient",
           {"and": [
             "Gravity",
@@ -732,7 +732,8 @@
             "HiJump"
           ]}
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canUsePowerBombs",
+        "h_canUsePowerBombs"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
       "note": [
@@ -1088,11 +1089,11 @@
         {"or": [
           "h_canArtificialMorphJumpIntoIBJ",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "canGravityJump"
           ]},
           "canDoubleBombJump",
@@ -1104,7 +1105,7 @@
           }}
         ]},
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "h_canArtificialMorphCeilingBombJump",
           "canBeVeryPatient"
         ]}
@@ -1138,7 +1139,7 @@
           ]}
         ]},
         {"or": [
-          "SpringBall",
+          "h_canUseSpringBall",
           "canBeVeryPatient",
           {"and": [
             "Gravity",
@@ -1170,15 +1171,16 @@
         "Wave",
         {"or": [
           "h_canArtificialMorphJumpIntoIBJ",
-          "canDoubleBombJump",
-          "canStaggeredIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
           "canBeVeryPatient",
           {"enemyKill": {
             "enemies": [["Skultera"]],
             "explicitWeapons": ["PowerBomb"]
           }}
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
       "note": [
@@ -1209,7 +1211,8 @@
             "HiJump"
           ]}
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canUsePowerBombs",
+        "h_canUsePowerBombs"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
       "note": [
@@ -1557,8 +1560,8 @@
         "Gravity",
         {"or": [
           "h_canArtificialMorphJumpIntoIBJ",
-          "canDoubleBombJump",
-          "canStaggeredIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
           "canBeVeryPatient"
         ]}
       ],
@@ -1699,15 +1702,15 @@
         {"or": [
           "h_canArtificialMorphJumpIntoIBJ",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]},
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "canGravityJump"
           ]},
-          "canDoubleBombJump",
-          "canStaggeredIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
           "canBeVeryPatient",
           {"enemyKill": {
             "enemies": [["Skultera"]],
@@ -1715,7 +1718,7 @@
           }}
         ]},
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           "h_canArtificialMorphCeilingBombJump",
           "canBeVeryPatient"
         ]}
@@ -1749,7 +1752,7 @@
           ]}
         ]},
         {"or": [
-          "SpringBall",
+          "h_canUseSpringBall",
           "canBeVeryPatient",
           {"and": [
             "Gravity",
@@ -1781,15 +1784,16 @@
         "Wave",
         {"or": [
           "h_canArtificialMorphJumpIntoIBJ",
-          "canDoubleBombJump",
-          "canStaggeredIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
           "canBeVeryPatient",
           {"enemyKill": {
             "enemies": [["Skultera"]],
             "explicitWeapons": ["PowerBomb"]
           }}
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
       "note": [
@@ -1820,7 +1824,8 @@
             "HiJump"
           ]}
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canUsePowerBombs",
+        "h_canUsePowerBombs"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
       "note": [
@@ -2218,9 +2223,9 @@
         ]},
         "canTrickyUseFrozenEnemies",
         "Wave",
-        "Bombs",
+        "h_canArtificialMorphBombs",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Morph",
             "canBeVeryPatient"
@@ -2263,7 +2268,8 @@
         ]},
         "canTrickyUseFrozenEnemies",
         "Wave",
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
       "note": [
@@ -2355,10 +2361,10 @@
       "requires": [
         "h_EverestMorphTunnelExpanded",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
-            "Bombs"
+            "h_canArtificialMorphBombs"
           ]}
         ]}
       ],
@@ -2381,13 +2387,10 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
+            "h_canArtificialMorphBombThings"
           ]}
         ]}
       ],
@@ -2405,13 +2408,10 @@
       "requires": [
         "h_EverestMorphTunnelExpanded",
         {"or": [
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
+            "h_canArtificialMorphBombThings"
           ]}
         ]}
       ],

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -326,7 +326,7 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ",
-        "canBombHorizontally"
+        "h_canArtificialMorphBombHorizontally"
       ],
       "clearsObstacles": ["B"],
       "note": [
@@ -345,7 +345,7 @@
       },
       "requires": [
         "canSuitlessMaridia",
-        "SpringBall",
+        "h_canArtificialMorphSpringBall",
         "h_canArtificialMorphIBJ"
       ],
       "clearsObstacles": ["A", "B"],
@@ -519,7 +519,7 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ",
-        "canBombHorizontally"
+        "h_canArtificialMorphBombHorizontally"
       ],
       "note": "IBJ up a bit, then bomb over Mama Turtle and her babies to prevent her from waking. Then IBJ to the high right ledge before exiting g-mode."
     },

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -627,7 +627,7 @@
       "requires": [
         {"or": [
           "Morph",
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
             "h_canArtificialMorphIBJ"
@@ -1222,7 +1222,7 @@
         {"or": [
           "h_canArtificialMorphIBJ",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "canGravityJump",
               "HiJump"
@@ -1230,10 +1230,7 @@
           ]},
           {"and": [
             "h_canArtificialMorphSpringBallBombJump",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
+            "h_additionalBomb"
           ]}
         ]}
       ],
@@ -1823,7 +1820,7 @@
         {"or": [
           "Morph",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             {"or": [
               "canGravityJump",
               "HiJump"
@@ -1994,7 +1991,7 @@
       "requires": [
         {"or": [
           "Morph",
-          "SpringBall",
+          "h_canArtificialMorphSpringBall",
           {"and": [
             "Gravity",
             "h_canArtificialMorphIBJ"
@@ -2178,7 +2175,7 @@
       "requires": [
         "h_EverestMorphTunnelExpanded",
         "canInsaneJump",
-        "SpringBall"
+        "h_canArtificialMorphSpringBall"
       ],
       "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
     },
@@ -2193,7 +2190,7 @@
       },
       "requires": [
         "canInsaneJump",
-        "SpringBall"
+        "h_canArtificialMorphSpringBall"
       ],
       "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
     },

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -158,11 +158,12 @@
       },
       "requires": [
         {"or": [
-          "SpringBall",
-          "Bombs",
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphBombs",
           {"and": [
-            "canBombHorizontally",
-            {"ammo": {"type": "PowerBomb", "count": 3}}
+            "h_canArtificialMorphBombHorizontally",
+            "h_additionalBomb",
+            "h_additionalBomb"
           ]}
         ]}
       ],
@@ -202,7 +203,7 @@
         {"or": [
           "h_canArtificialMorphIBJ",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]}
         ]}

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -231,7 +231,7 @@
       },
       "requires": [
         "canMetroidAvoid",
-        "SpringBall",
+        "h_canArtificialMorphSpringBall",
         {"ammo": {"type": "PowerBomb", "count": 4}}
       ],
       "clearsObstacles": ["A"],
@@ -553,7 +553,7 @@
       },
       "requires": [
         "canMetroidAvoid",
-        "SpringBall",
+        "h_canArtificialMorphSpringBall",
         {"ammo": {"type": "PowerBomb", "count": 4}}
       ],
       "clearsObstacles": ["A"],

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -143,7 +143,9 @@
       },
       "requires": [
         "canMetroidAvoid",
-        {"ammo": {"type": "PowerBomb", "count": 3}}
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -703,8 +705,10 @@
       },
       "requires": [
         "canMetroidAvoid",
-        "SpringBall",
-        {"ammo": {"type": "PowerBomb", "count": 3}}
+        "h_canArtificialMorphSpringBall",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
       "note": [

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -165,7 +165,7 @@
       },
       "requires": [
         "canMetroidAvoid",
-        "SpringBall",
+        "h_canArtificialMorphSpringBall",
         {"ammo": {"type": "PowerBomb", "count": 4}}
       ],
       "clearsObstacles": ["A"],
@@ -496,7 +496,7 @@
       },
       "requires": [
         "canMetroidAvoid",
-        "SpringBall",
+        "h_canArtificialMorphSpringBall",
         "h_canArtificialMorphBombHorizontally",
         {"ammo": {"type": "PowerBomb", "count": 3}}
       ],

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -269,7 +269,9 @@
           "h_canArtificialMorphIBJ",
           "h_canArtificialMorphSpringBallBombJump"
         ]},
-        {"ammo": {"type": "PowerBomb", "count": 3}},
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb",
         "canHitbox"
       ],
       "note": "IBJ or spring ball bomb jump to avoid the wall jump. Using a total of 3 PBs will allow Samus to roll through the bottom 4 pirates."

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -225,10 +225,10 @@
       "requires": [
         "f_DefeatedPhantoon",
         "canBePatient",
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}}
+          "h_canArtificialMorphPowerBomb"
         ]}
       ],
       "note": [
@@ -416,10 +416,10 @@
       },
       "requires": [
         "f_DefeatedPhantoon",
-        {"ammo": {"type": "PowerBomb", "count": 1}},
+        "h_canArtificialMorphPowerBomb",
         {"or": [
           "canTrickyJump",
-          {"ammo": {"type": "PowerBomb", "count": 1}}
+          "h_canArtificialMorphPowerBomb"
         ]}
       ],
       "note": [

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -749,7 +749,7 @@
           "h_canArtificialMorphIBJ",
           "h_canArtificialMorphSpringBallBombJump",
           {"and": [
-            "SpringBall",
+            "h_canArtificialMorphSpringBall",
             "HiJump"
           ]}
         ]},


### PR DESCRIPTION
Many of our errors are accidentally using items or tech that don't have item requirements instead of their helpers that do. This PR is designed to be a first step towards addressing these problems by creating and utilizing more artificial morph helpers to help reduce the total number of items/tech in the project that are common offenders. With this we can more easily search for and eventually prevent the use of error prone tech and items such as `canIBJ` and `SpringBall`. 

This also fixes a few small errors found in the project in Maridia where `Power Bombs` were accidentally used without `Morph`. It looks like there is also the reverse problem in several places in Main Street, where `enemyKill: Skultera` is used with `Power Bombs` that shouldn't require `Morph`; this will be addressed in a future PR.