### PR TITLE
Plasma spark bomb boost

### DIFF
--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -720,11 +720,12 @@
     },
     {
       "link": [3, 4],
-      "name": "Frozen Choot Tricky Dash Jump Spring Ball Jump",
+      "name": "Frozen Choot Speedy Spring Ball Jump",
       "requires": [
         "canTrickyUseFrozenEnemies",
         "HiJump",
-        "canTrickyDashJump",
+        "SpeedBooster",
+        "canTrickyJump",
         "canSpringBallJumpMidAir"
       ]
     },

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -711,17 +711,31 @@
     },
     {
       "link": [3, 4],
-      "name": "Frozen Choot",
+      "name": "Frozen Choot Wall Jump",
       "requires": [
         "canTrickyUseFrozenEnemies",
         "HiJump",
-        {"or": [
-          "canWalljump",
-          {"and": [
-            "canTrickyDashJump",
-            "canSpringBallJumpMidAir"
-          ]}
-        ]}
+        "canWalljump"
+      ]
+    },
+    {
+      "link": [3, 4],
+      "name": "Frozen Choot Tricky Dash Jump Spring Ball Jump",
+      "requires": [
+        "canTrickyUseFrozenEnemies",
+        "HiJump",
+        "canTrickyDashJump",
+        "canSpringBallJumpMidAir"
+      ]
+    },
+    {
+      "link": [3, 4],
+      "name": "Frozen Choot Spring Ball Jump Unmorph Bomb Boost",
+      "requires": [
+        "canTrickyUseFrozenEnemies",
+        "HiJump",
+        "canSpringBallJumpMidAir",
+        "canUnmorphBombBoost"
       ]
     },
     {


### PR DESCRIPTION
This adds a new unmorph bomb boost strat that I just noticed is possible here. Also splits the existing "Frozen Choot" strat into two separate strats, one for the walljump (Basic) and one for the speedy spring ball jump (Very Hard). The latter had a "canTrickyDashJump" requirement, but this seems unnecessary since essentially any speedy jump off the Choot works (as long as it's frozen reasonably high); so I replaced that "canTrickyDashJump" requirement with a "canTrickyJump".