### PR TITLE
Refine some Three Musketeers strats

### DIFF
--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -272,7 +272,10 @@
         {"heatFrames": 800},
         {"or": [
           "canDodgeWhileShooting",
-          {"heatFrames": 800}
+          {"and": [
+            "canCarefulJump",
+            {"heatFrames": 800}
+          ]}
         ]}
       ],
       "clearsObstacles": ["A"],

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -184,8 +184,7 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "canTrickyJump",
-        "Morph",
-        {"heatFrames": 540}
+        {"heatFrames": 500}
       ],
       "note": [
         "Wait for the top one to pass by.",
@@ -239,14 +238,9 @@
         "h_canNavigateHeatRooms",
         "Plasma",
         "Wave",
-        {"or": [
-          "canDodgeWhileShooting",
-          {"heatFrames": 30}
-        ]},
-        {"heatFrames": 790}
+        {"heatFrames": 720}
       ],
-      "clearsObstacles": ["A"],
-      "note": "The top KiHunter can be ignored."
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 4],
@@ -261,7 +255,7 @@
             {"heatFrames": 1800}
           ]}
         ]},
-        {"heatFrames": 1320}
+        {"heatFrames": 1200}
       ],
       "clearsObstacles": ["A"],
       "note": "Jump to the previous level when the enemy gets close, or fight entirely from safety."
@@ -272,28 +266,20 @@
       "requires": [
         "h_canNavigateHeatRooms",
         {"enemyKill": {
-          "enemies": [["Kihunter (red)", "Kihunter (red)"]],
+          "enemies": [["Kihunter (red)", "Kihunter (red)", "Kihunter (red)"]],
           "explicitWeapons": ["Super"]
         }},
+        {"heatFrames": 800},
         {"or": [
           "canDodgeWhileShooting",
-          {"and": [
-            "canCarefulJump",
-            {"enemyKill": {
-              "enemies": [["Kihunter (red)"]],
-              "explicitWeapons": ["Super"]
-            }},
-            {"heatFrames": 960}
-          ]}
-        ]},
-        {"heatFrames": 690}
+          {"heatFrames": 800}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "note": [
         "Jump to the previous level when the enemy gets close, or fight entirely from safety.",
-        "Two supers can hit per cycle when shooting from above."
-      ],
-      "devNote": "Without two supers per cycle, this requires heatproof."
+        "Two supers can hit per cycle when shooting from above."        
+      ]
     },
     {
       "link": [1, 4],


### PR DESCRIPTION
Some of the strats that killed Kihunters from top to bottom assumed the top would be left alive. This was a problem because these were clearing obstacle "A", which meant the strats going back from bottom to top would assume they were all three dead.

If we want to correctly model leaving the top one alive, we would probably need to add another obstacle and take it into account in the strats that go back up. But it wasn't clear if this would be useful. So I simplified the strats to assume you kill all 3 or none at all.

Also checked the heat frames for the top-to-bottom strats and tightened some of them. Removed an unnecessary "Morph" requirement from the dodging strat going down; Morph will be needed anyway to do anything at the bottom of the room but it's not used as part of this strat.

Also removed the "canCarefulJump" requirement from the safe version of the Super kill strat. I assume it was for firing 2 Supers per cycle, but with the heat frame leniency on low settings it wouldn't be expected to do this.