### PR TITLE
Refine top of Mickey Mouse

### DIFF
--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -601,7 +601,7 @@
     },
     {
       "link": [4, 2],
-      "name": "HiJump",
+      "name": "Crumble Jump with HiJump",
       "requires": [
         {"obstaclesCleared": ["A"]},
         "HiJump",
@@ -612,7 +612,7 @@
     },
     {
       "link": [4, 2],
-      "name": "HiJump Springball",
+      "name": "Springball Bounce on Crumble Blocks with HiJump",
       "requires": [
         {"obstaclesCleared": ["A"]},
         "HiJump",
@@ -623,7 +623,7 @@
     },
     {
       "link": [4, 2],
-      "name": "Bootless Spring Ball Escape",
+      "name": "Mid-Air Spring Ball Jump Over Crumble Blocks",
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canTrickySpringBallJump",
@@ -727,7 +727,7 @@
         {"obstaclesNotCleared": ["A"]},
         "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",
-        {"heatFrames": 80}
+        {"heatFrames": 95}
       ],
       "clearsObstacles": ["B"],
       "note": "Position the Power Bomb far enough left to only partially clear the bomb blocks.",

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -76,13 +76,6 @@
       "note": "Represents being below the bomb blocks, regardless of whether they are broken"
     },
     {
-      "id": 5,
-      "name": "Junction Below Bomb Blocks with Some Blocks Broken",
-      "nodeType": "junction",
-      "nodeSubType": "junction",
-      "note": "Represents being below the bomb blocks with some bomb blocks broken, but not all"
-    },
-    {
       "id": 6,
       "name": "Bottom Right Corner Junction",
       "nodeType": "junction",
@@ -211,8 +204,7 @@
       "from": 2,
       "to": [
         {"id": 2},
-        {"id": 4},
-        {"id": 5}
+        {"id": 4}
       ]
     },
     {
@@ -228,18 +220,10 @@
         {"id": 2},
         {"id": 3},
         {"id": 4},
-        {"id": 5},
         {
           "id": 6,
           "note": "Options are to tank the damage or kill the Multiviolas. This is one-way because the way back requires setting up the ice clip."
         }
-      ]
-    },
-    {
-      "from": 5,
-      "to": [
-        {"id": 2},
-        {"id": 4}
       ]
     },
     {
@@ -281,8 +265,7 @@
       "from": 9,
       "to": [
         {"id": 2},
-        {"id": 4},
-        {"id": 5}
+        {"id": 4}
       ]
     }
   ],
@@ -493,27 +476,27 @@
         {"obstaclesNotCleared": ["A"]},
         "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",
-        {"heatFrames": 250}
+        {"heatFrames": 180}
       ],
       "clearsObstacles": ["A"],
-      "note": "Place the power bomb while passing through the shot block gap to save some time.",
+      "note": "Place the power bomb while passing through the shot block gap (or before) to save some time.",
       "devNote": [
         "We don't want the blocks to already be cleared (e.g. from Crystal Flash at node 2) because then we may need to crumble jump.",
         "FIXME: We could add a separate strat for the case where the blocks are already broken."
       ]
     },
     {
-      "link": [2, 5],
-      "name": "Only Left Blocks Broken",
+      "link": [2, 4],
+      "name": "Break Left Blocks Only",
       "requires": [
         "h_canNavigateHeatRooms",
-        {"heatFrames": 200},
+        {"heatFrames": 160},
         {"obstaclesNotCleared": ["A"]},
         {"or": [
           "ScrewAttack",
           {"and": [
             "h_canUseMorphBombs",
-            {"heatFrames": 50}
+            {"heatFrames": 60}
           ]},
           {"obstaclesCleared": ["B"]}
         ]}
@@ -521,7 +504,7 @@
       "clearsObstacles": ["B"]
     },
     {
-      "link": [2, 5],
+      "link": [2, 4],
       "name": "Temporary Blue Bounce onto Crumbles with SpringBall",
       "entranceCondition": {
         "comeInWithTemporaryBlue": {}
@@ -543,7 +526,7 @@
       "devNote": "You could jump into the room for the initial Temporary Blue and turn around with XRay twice, but this room is heated so that would be costly."
     },
     {
-      "link": [2, 5],
+      "link": [2, 4],
       "name": "Mickey Mouse Temporary Blue Crumble Jump without SpringBall",
       "notable": true,
       "entranceCondition": {
@@ -578,69 +561,71 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "Morph",
-        {"heatFrames": 200}
+        {"heatFrames": 120}
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Base",
+      "requires": [
+        {"obstaclesCleared": ["B"]},
+        {"heatFrames": 160},
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          "canWalljump",
+          "canSpringBallJumpMidAir",
+          "HiJump",
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 20}
+          ]},
+          {"and": [
+            "h_canSpringBallBombJump",
+            {"heatFrames": 50}
+          ]},
+          {"and": [
+            "h_canJumpIntoIBJ",
+            {"heatFrames": 60}
+          ]}
+        ]}
       ]
     },
     {
       "link": [4, 2],
       "name": "SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
-        {"heatFrames": 200},
+        {"obstaclesCleared": ["A"]},
         "SpaceJump",
-        {"or": [
-          {"and": [
-            "h_canUsePowerBombs",
-            {"heatFrames": 120}
-          ]},
-          {"obstaclesCleared": ["A"]}
-        ]}
-      ],
-      "clearsObstacles": ["A"]
+        {"heatFrames": 180}
+      ]
     },
     {
       "link": [4, 2],
       "name": "HiJump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "HiJump",
         "canCrumbleJump",
-        {"heatFrames": 200},
-        {"or": [
-          {"and": [
-            "h_canUsePowerBombs",
-            {"heatFrames": 120}
-          ]},
-          {"obstaclesCleared": ["A"]}
-        ]}
+        {"heatFrames": 180}
       ],
-      "clearsObstacles": ["A"],
       "note": "Requires one jump off a crumble block"
     },
     {
       "link": [4, 2],
       "name": "HiJump Springball",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "HiJump",
         "h_canUseSpringBall",
-        {"heatFrames": 150},
-        {"or": [
-          {"and": [
-            "h_canUsePowerBombs",
-            {"heatFrames": 120}
-          ]},
-          {"obstaclesCleared": ["A"]}
-        ]}
+        {"heatFrames": 130}
       ],
-      "clearsObstacles": ["A"],
       "note": "Use SpringBall to just bounce on the crumble blocks."
     },
     {
       "link": [4, 2],
       "name": "Bootless Spring Ball Escape",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "canTrickySpringBallJump",
         {"heatFrames": 250},
         {"or": [
@@ -654,16 +639,8 @@
             "h_canTrickySpringwall",
             "canPreciseWalljump"
           ]}
-        ]},
-        {"or": [
-          {"and": [
-            "h_canUsePowerBombs",
-            {"heatFrames": 120}
-          ]},
-          {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"],
       "note": [
         "This is possible by jumping on the crumble blocks into a mid-air spring ball jump, or by avoiding them.",
         "The crumbles can be avoided by starting with either an air ball, a 3 tile high mid-air morph, or a low spring wall.",
@@ -675,21 +652,13 @@
       "name": "Mickey Mouse Crumble Speedjump",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "canCrumbleJump",
         "canTrickyDashJump",
         "canPreciseWalljump",
         "canInsaneJump",
-        {"heatFrames": 250},
-        {"or": [
-          {"and": [
-            "h_canUsePowerBombs",
-            {"heatFrames": 120}
-          ]},
-          {"obstaclesCleared": ["A"]}
-        ]}
+        {"heatFrames": 180}
       ],
-      "clearsObstacles": ["A"],
       "note": [
         "Spinjump off a crumble block with just a tiny amount of run speed.",
         "That gives just enough height to be able to walljump out."
@@ -700,36 +669,22 @@
       "name": "Mickey Mouse Crumble Jump IBJ",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canJumpIntoIBJ",
+        {"obstaclesCleared": ["A"]},
         "canCrumbleJump",
-        {"or": [
-          "canTrickyJump",
-          "canDoubleBombJump",
-          "canBombAboveIBJ",
-          {"ammo": {"type": "PowerBomb", "count": 1}}
-        ]},
-        {"heatFrames": 500},
-        {"or": [
-          {"and": [
-            "h_canUsePowerBombs",
-            {"heatFrames": 120}
-          ]},
-          {"obstaclesCleared": ["A"]}
-        ]}
+        "h_canJumpIntoIBJ",
+        "canDoubleBombJump",
+        {"heatFrames": 360}
       ],
-      "clearsObstacles": ["A"],
       "note": [
-        "Jump and Mid-air morph off a crumble block to begin the IBJ.",
-        "The shot block respawns quickly so it's pretty unforgiving on the IBJ executions.",
-        "Conservatively placing bombs for the IBJ will not make it up in time, unless the block is broken while IBJing."
+        "Jump and mid-air morph off a crumble block to begin the IBJ.",
+        "Use double bomb jumps to make it up quickly before the shot block respawns."
       ]
     },
     {
       "link": [4, 2],
       "name": "Mickey Mouse Spring Ball IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "h_canJumpIntoIBJ",
         "h_canUseSpringBall",
         {"or": [
@@ -738,16 +693,8 @@
           "canBombAboveIBJ",
           {"ammo": {"type": "PowerBomb", "count": 1}}
         ]},
-        {"heatFrames": 500},
-        {"or": [
-          {"and": [
-            "h_canUsePowerBombs",
-            {"heatFrames": 120}
-          ]},
-          {"obstaclesCleared": ["A"]}
-        ]}
+        {"heatFrames": 500}
       ],
-      "clearsObstacles": ["A"],
       "note": [
         "Shoot the block before starting or in mid-air, then use spring ball to bounce on the crumb blocks and start an IBJ.",
         "The shot block respawns quickly so it's pretty unforgiving on the IBJ executions.",
@@ -760,7 +707,7 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "Morph",
-        {"heatFrames": 150}
+        {"heatFrames": 80}
       ]
     },
     {
@@ -769,7 +716,7 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",
-        {"heatFrames": 150}
+        {"heatFrames": 80}
       ],
       "clearsObstacles": ["A"]
     },
@@ -780,7 +727,7 @@
         {"obstaclesNotCleared": ["A"]},
         "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",
-        {"heatFrames": 150}
+        {"heatFrames": 80}
       ],
       "clearsObstacles": ["B"],
       "note": "Position the Power Bomb far enough left to only partially clear the bomb blocks.",
@@ -792,7 +739,7 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUseMorphBombs",
-        {"heatFrames": 150}
+        {"heatFrames": 80}
       ],
       "clearsObstacles": ["B"]
     },
@@ -805,15 +752,16 @@
       "clearsObstacles": ["A"]
     },
     {
-      "link": [4, 5],
-      "name": "Some Blocks Already Broken",
+      "link": [4, 4],
+      "name": "Power Bomb",
       "requires": [
-        {"obstaclesCleared": ["B"]},
-        {"obstaclesNotCleared": ["A"]}
-      ]
+        "h_canUsePowerBombs",
+        {"heatFrames": 120}
+      ],
+      "clearsObstacles": ["A"]
     },
     {
-      "link": [4, 5],
+      "link": [4, 4],
       "name": "Bombs",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
@@ -910,34 +858,6 @@
         {"heatFrames": 500}
       ],
       "clearsObstacles": ["D"]
-    },
-    {
-      "link": [5, 2],
-      "name": "Base",
-      "requires": [
-        "h_canNavigateHeatRooms",
-        {"or": [
-          "h_canCrouchJumpDownGrab",
-          "canWalljump",
-          "canSpringBallJumpMidAir",
-          "HiJump",
-          "SpaceJump",
-          {"and": [
-            "h_canSpringBallBombJump",
-            {"heatFrames": 50}
-          ]},
-          {"and": [
-            "h_canJumpIntoIBJ",
-            {"heatFrames": 60}
-          ]}
-        ]},
-        {"heatFrames": 250}
-      ]
-    },
-    {
-      "link": [5, 4],
-      "name": "Base",
-      "requires": []
     },
     {
       "link": [6, 4],
@@ -1671,7 +1591,7 @@
       ]
     },
     {
-      "link": [9, 5],
+      "link": [9, 4],
       "name": "Mickey Mouse Multiviola Clip (Screw Attack)",
       "notable": true,
       "requires": [
@@ -1696,7 +1616,7 @@
       ]
     },
     {
-      "link": [9, 5],
+      "link": [9, 4],
       "name": "Mickey Mouse Multiviola Clip (Bombs)",
       "notable": true,
       "requires": [


### PR DESCRIPTION
This tightens the heat frames at the top of the room (between the top door and the item), some of which were pretty loose before.

Also removes node 5, which is no longer needed since obstacles "A" and "B" were added.

This needs a room diagram update, which @kjbranch mentioned he can do.