### PR TITLE
Add Moat grapple teleport strats

### DIFF
--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -274,7 +274,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -597,6 +597,16 @@
       "clearsObstacles": ["A"]
     },
     {
+      "link": [2, 4],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [3, 1],
       "name": "Base",
       "requires": [

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -649,7 +649,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -692,7 +692,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []
@@ -737,7 +737,24 @@
     },
     {
       "link": [3, 2],
-      "name": "Green Hills Grapple Teleport into Grapple Jump",
+      "name": "Green Hills Grapple Teleport Fling to Right (from Moat)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "note": [
+        "After teleporting, extend the Grapple, and swing back and forth to fix the camera and then to gain momentum.",
+        "A precisely timed release of Grapple will allow Samus to fling onto the ledge on the right."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Green Hills Grapple Teleport into Grapple Jump (from Red Brinstar Firefleas)",
       "notable": true,
       "entranceCondition": {
         "comeInWithGrappleTeleport": {

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -341,7 +341,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -705,7 +705,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -1198,7 +1198,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -445,7 +445,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -31,6 +31,13 @@
       "nodeSubType": "junction"
     }
   ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Speed blocks",
+      "obstacleType": "inanimate"
+    }
+  ],
   "enemies": [
     {
       "id": "e1",
@@ -153,7 +160,8 @@
       "requires": [
         "Gravity",
         "SpeedBooster"
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 2],
@@ -169,7 +177,8 @@
           "frames": 155,
           "excessFrames": 10
         }}
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 2],
@@ -186,6 +195,23 @@
       "note": [
         "Roll through the whole room, breaking the speedblocks.",
         "The fish enemies will die but some puyos will remain."
+      ],
+      "clearsObstacles": ["A"]
+    },
+    {
+      "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3], [7, 2]]
+        }
+      },
+      "requires": [],
+      "devNote": [
+        "This strat has limited usefulness since you will be stuck behind the speed blocks.",
+        "Potentially it could be useful if you could use a flash suit to get out (though this is not yet logic);",
+        "for example, the item could be an Energy Tank and you could need its refill in order to spark out (rather than sparking in).",
+        "It also could be useful if the game were modified to allow retaining items after resetting."
       ]
     },
     {
@@ -244,8 +270,9 @@
     {
       "link": [2, 1],
       "name": "Base",
-      "requires": [],
-      "note": "Speed blocks are ignored here because it's impossible to reach node 2 without breaking them."
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ]
     },
     {
       "link": [3, 1],

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -213,7 +213,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -357,6 +357,16 @@
       ]
     },
     {
+      "link": [3, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [3, 2],
       "name": "Stored Moonfall Clip",
       "entranceCondition": {

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -302,6 +302,18 @@
       ]
     },
     {
+      "link": [2, 3],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "h_canBombThings"
+      ]
+    },
+    {
       "link": [3, 1],
       "name": "Base",
       "requires": [

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -482,7 +482,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -231,6 +231,7 @@
         {"id": 2},
         {"id": 3},
         {"id": 4},
+        {"id": 5},
         {
           "id": 6,
           "note": "This link is only for sparking. Other strats go 8 -> 7 -> 6."
@@ -1634,6 +1635,16 @@
           "requires": []
         }
       ]
+    },
+    {
+      "link": [4, 5],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
     },
     {
       "link": [4, 6],

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -95,6 +95,9 @@
       "note": [
         "This allows reaching the item without Morph.",
         "The item will need to be Morph in order to get out."
+      ],
+      "devNote": [
+        "FIXME: Once we have a way to represent grapple teleporting while carrying a shinecharge, a strat could be added that uses a spark to break the bomb block."
       ]
     },
     {

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -84,6 +84,20 @@
       "devNote": "There are additional requirements to get back out. It's a softlock if they aren't met."
     },
     {
+      "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3], [7, 2]]
+        }
+      },
+      "requires": [],
+      "note": [
+        "This allows reaching the item without Morph.",
+        "The item will need to be Morph in order to get out."
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": [

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -149,7 +149,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -889,7 +889,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []
@@ -1013,7 +1013,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []
@@ -1342,7 +1342,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -93,6 +93,24 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Moat Leave With Grapple Teleport",
+      "notable": true,
+      "requires": [
+        "canMoonwalk",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "note": [
+        "Hold angle-up, jump, bonk the ceiling, and use Grapple just before landing.",
+        "Moonwalk into the transition on the same frame that the Grapple Beam reaches the Grapple block."
+      ]
+    },
+    {
       "link": [1, 2],
       "name": "Shinespark",
       "entranceCondition": {

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -576,7 +576,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -513,7 +513,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -120,6 +120,7 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 4},
         {"id": 9},
@@ -138,6 +139,7 @@
     {
       "from": 4,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3},
         {"id": 4},
@@ -206,6 +208,44 @@
       "link": [1, 8],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport (from Red Brinstar Firefleas)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3]]
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "h_canCrystalFlash"
+      ],
+      "note": [
+        "In Red Brinstar Firefleas, instead of simply grappling and moonwalking into the transition, perform a setup like in the Moat:",
+        "Angle-up, jump, bonk the ceiling, then use Grapple just before landing and moonwalk back as it attaches.",
+        "This will put Samus into a lower position after the transition.",
+        "Samus will be stuck inside the wall.",
+        "Perform a Crystal Flash, then morph and roll out."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "Morph",
+        "canOffScreenMovement"
+      ],
+      "note": [
+        "After teleporting, press down while still grappling, to move Samus up and right by retracting the grapple.",
+        "Release Grapple, angle-down, and shoot the blocks to the left and right of Samus.",
+        "Morph and roll to the right; then Samus will be able to unmorph and stand."
+      ]
     },
     {
       "link": [2, 2],
@@ -582,6 +622,44 @@
         "It is also possible but tighter to get high enough from bouncing on a Power Bomb with a single jump, similar to jumping into an IBJ.",
         "This doesn't save anything if breaking the Power Bomb blocks above.",
         "With an extra Power Bomb to spare, simply Spring Ball Bomb Jump."
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Grapple Teleport (from Red Brinstar Firefleas)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3]]
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "h_canCrystalFlash"
+      ],
+      "note": [
+        "In Red Brinstar Firefleas, instead of simply grappling and moonwalking into the transition, perform a setup like in the Moat:",
+        "Angle-up, jump, bonk the ceiling, then use Grapple just before landing and moonwalk back as it attaches.",
+        "This will put Samus into a lower position after the transition.",
+        "Samus will be stuck inside the wall.",
+        "Perform a Crystal Flash, then morph and roll out."
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "Morph",
+        "canOffScreenMovement"
+      ],
+      "note": [
+        "After teleporting, press down while still grappling, to move Samus up and right by retracting the grapple.",
+        "Release Grapple, angle-down, and shoot the blocks to the left and right of Samus.",
+        "Morph and roll to the right; then Samus will be able to unmorph and stand."
       ]
     },
     {

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -558,7 +558,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [
@@ -609,7 +609,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -335,7 +335,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -277,11 +277,11 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [
-        {"heatFrames": 60}
+        {"heatFrames": 50}
       ]
     },
     {

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -604,6 +604,18 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 50}
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave With Runway",
       "entranceCondition": {

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -341,7 +341,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -349,7 +349,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -735,7 +735,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -375,7 +375,7 @@
     },
     {
       "link": [2, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Crystal Flash (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
@@ -387,10 +387,36 @@
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
+      "clearsObstacles": ["A"],
       "note": [
         "Grapple teleporting here will spawn Samus inside the wall behind the Acid Chozo statue.",
         "To escape, perform a Crystal Flash to stand up, then morph and roll out to the right.",
-        "Samus will be visible but off-camera, making the movement tricky."
+        "Samus will be visible but off-camera, making the movement tricky.",
+        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Grapple Teleport Power Bomb (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "h_canUsePowerBombs",
+        {"heatFrames": 220},
+        "canOffScreenMovement"
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "After teleporting, press down to retract Grapple.",
+        "Samus will be inside the Power Bomb blocks behind the Acid Chozo statue hand.",
+        "Use a Power Bomb, wait to begin falling, then hold right to roll out under the hand.",
+        "Samus will be visible but off-camera, making the movement tricky.",
+        "Holding right too early after laying the Power Bomb will cause Samus to get stuck inside the Chozo hand;",
+        "in this case, Samus can get out by unmorphing, remorphing, and rolling to the right on top of the hand.",
+        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
       ]
     },
     {

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -48,8 +48,8 @@
               "name": "Base",
               "notable": false,
               "requires": [
-                "h_canNavigateHeatRooms",
                 "h_canActivateAcidChozo",
+                {"obstaclesNotCleared": ["A"]},
                 "h_canUsePowerBombs",
                 {"heatFrames": 1000}
               ]
@@ -71,6 +71,14 @@
       "name": "Bottom Junction Right of Morph Tunnel",
       "nodeType": "junction",
       "nodeSubType": "junction"
+    }
+  ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Camera Broken",
+      "obstacleType": "abstract",
+      "note": "Represents being off-camera in the top part of the room."
     }
   ],
   "enemies": [
@@ -294,7 +302,7 @@
     },
     {
       "link": [1, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Crystal Flash (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
@@ -306,10 +314,36 @@
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
+      "clearsObstacles": ["A"],
       "note": [
         "Grapple teleporting here will spawn Samus inside the wall behind the Acid Chozo statue.",
         "To escape, perform a Crystal Flash to stand up, then morph and roll out to the right.",
-        "Samus will be visible but off-camera, making the movement tricky."
+        "Samus will be visible but off-camera, making the movement tricky.",
+        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Grapple Teleport Power Bomb (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "h_canUsePowerBombs",
+        {"heatFrames": 220},
+        "canOffScreenMovement"
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "After teleporting, press down to retract Grapple.",
+        "Samus will be inside the Power Bomb blocks behind the Acid Chozo statue hand.",
+        "Use a Power Bomb, wait to begin falling, then hold right to roll out under the hand.",
+        "Samus will be visible but off-camera, making the movement tricky.",
+        "Holding right too early after laying the Power Bomb will cause Samus to get stuck inside the Chozo hand;",
+        "in this case, Samus can get out by unmorphing, remorphing, and rolling to the right on top of the hand.",
+        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
       ]
     },
     {

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -160,7 +160,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -748,7 +748,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -387,7 +387,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -715,6 +715,21 @@
       "devNote": "This does not have collision oscillation"
     },
     {
+      "link": [2, 4],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "canOffScreenMovement"
+      ],
+      "note": [
+        "Immediately after teleporting, press down to retract Grapple to avoid getting stuck inside the wall (in case the top door is blue, causing it to open with Grapple on entry)."
+      ]
+    },
+    {
       "link": [2, 5],
       "name": "Base",
       "requires": []

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -187,7 +187,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -480,6 +480,16 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1392,7 +1392,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1177,7 +1177,7 @@
       "name": "Grapple Teleport Below Bomb Blocks",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [],
@@ -1389,13 +1389,24 @@
     },
     {
       "link": [5, 9],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3], [7, 2]]
+          "blockPositions": [[5, 3]]
         }
       },
       "requires": []
+    },
+    {
+      "link": [5, 9],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [],
+      "note": "Press down immediately after teleporting, in order to get above the bomb blocks."
     },
     {
       "link": [5, 10],

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -824,6 +824,16 @@
       ]
     },
     {
+      "link": [4, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [4, 2],
       "name": "G-Mode",
       "notable": false,

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -368,7 +368,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -352,7 +352,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -888,7 +888,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -446,7 +446,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -638,14 +638,10 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": [],
-      "devNote": [
-        "This strat is just to avoid the canCrouchJump requirement of the 2->3 strat.",
-        "This could be cleaned up if a spawnAt node were added below the door."
-      ]
+      "requires": []
     },
     {
       "link": [2, 2],
@@ -730,7 +726,7 @@
     },
     {
       "link": [2, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
@@ -742,6 +738,29 @@
       "devNote": [
         "The canCrouchJump is for getting up through the door.",
         "FIXME: It could be cleaner to add a node below the door and use a spawnAt."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"or": [
+          "canUseFrozenEnemies",
+          "HiJump",
+          "canSpringBallJumpMidAir"
+        ]}
+      ],
+      "note": [
+        "If the top door is blue, it will open immediately after the teleport, not allowing Samus to swing directly onto the platform."
+      ],
+      "devNote": [
+        "FIXME: It could be cleaner to add a node below the platform.",
+        "FIXME: Add a variation with canRiskPermanentLossOfAccess if the door is not blue."
       ]
     },
     {

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -297,7 +297,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1261,7 +1261,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -200,7 +200,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -460,6 +460,16 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [3, 3],
       "name": "Leave with Runway",
       "requires": [],
@@ -539,6 +549,16 @@
       },
       "requires": [],
       "note": "The gate will not spawn in indirect g-mode and is freely passable."
+    },
+    {
+      "link": [3, 4],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
     },
     {
       "link": [4, 1],

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -693,6 +693,16 @@
       ]
     },
     {
+      "link": [3, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [3, 2],
       "name": "Base",
       "requires": []

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -264,7 +264,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -157,6 +157,7 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 4},
         {"id": 5},
@@ -492,6 +493,23 @@
         "Gravity"
       ],
       "note": "Kill the first fish with bombs then dodge or kill the second one."
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [],
+      "note": [
+        "After teleporting, Grapple will open the door (if it is blue), making it not possible to swing over to the ledge."
+      ],
+      "devNote": [
+        "FIXME: Add canRiskPermanentLossOfAccess variations to get onto the ledge if the door is not blue;",
+        "also to get up through the door with a tricky grapple jump, if the door is pink or green (using a Super to open it)."
+      ]
     },
     {
       "link": [2, 2],

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -676,7 +676,8 @@
         "The grapple beam will need to be retracted while swinging to the right, to avoid bonking on the small platform."
       ],
       "devNote": [
-        "FIXME: Add a version of this with an exit condition for grapple jumping through the transition."
+        "FIXME: Add a version of this with an exit condition for grapple jumping through the transition.",
+        "FIXME: Add a canRiskPermanentLossOfAccess variation coming from Moat, which only works if door is not blue."
       ]
     },
     {
@@ -684,7 +685,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []
@@ -905,7 +906,8 @@
         "The grapple beam will need to be retracted while swinging to the right, to avoid bonking on the small platform."
       ],
       "devNote": [
-        "FIXME: Add a version of this with an exit condition for grapple jumping through the transition."
+        "FIXME: Add a version of this with an exit condition for grapple jumping through the transition.",
+        "FIXME: Add a canRiskPermanentLossOfAccess variation coming from Moat, which only works if door is not blue."
       ]
     },
     {
@@ -934,7 +936,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [2, 7]]
         }
       },
       "requires": []

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1716,7 +1716,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -268,7 +268,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [],

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -375,7 +375,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -348,6 +348,16 @@
       ]
     },
     {
+      "link": [3, 4],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [4, 1],
       "name": "Base",
       "requires": []

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -87,6 +87,7 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3},
         {"id": 4}
@@ -117,6 +118,16 @@
       "requires": [
         {"heatFrames": 70}
       ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
     },
     {
       "link": [2, 2],

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -90,6 +90,7 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3},
         {"id": 5}
@@ -220,6 +221,18 @@
         "FIXME: Find some way to properly express being above health bomb range, though it shouldn't be a serious problem here.",
         "Without heat protection, this is already accounted for by the heatFrames (though this is a bit hacky).",
         "With heat protection, it should be possible to farm a bit to get out of health bomb range."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 45}
       ]
     },
     {

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -258,7 +258,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -710,7 +710,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -171,7 +171,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -172,7 +172,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -128,6 +128,18 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 50}
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -193,6 +193,23 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 120}
+      ],
+      "note": [
+        "After teleporting, press down to retract Grapple and swing to the right.",
+        "Then swing to the left to the platform with the Chozo ball item.",
+        "The Sova should fall from the ceiling before Samus would hit it."
+      ]
+    },
+    {
       "link": [1, 3],
       "name": "Base",
       "requires": [

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -320,7 +320,10 @@
       },
       "requires": [
         {"heatFrames": 100},
-        "canOffScreenMovement"
+        {"or": [
+          "canOffScreenMovement"
+          {"heatFrames": 80}
+        ]}
       ],
       "note": [
         "After teleporting, briefly press down to extend Grapple, then press up to retract it again.",

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -312,14 +312,31 @@
     },
     {
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
         }
       },
       "requires": [
-        {"heatFrames": 100}
+        {"heatFrames": 100},
+        "canOffScreenMovement"
+      ],
+      "note": [
+        "After teleporting, briefly press down to extend Grapple, then press up to retract it again.",
+        "Release Grapple to fall onto the platform below the door."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 75}
       ]
     },
     {
@@ -433,14 +450,31 @@
     },
     {
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
         }
       },
       "requires": [
-        {"heatFrames": 100}
+        {"heatFrames": 100},
+        "canOffScreenMovement"
+      ],
+      "note": [
+        "After teleporting, briefly press down to extend Grapple, then press up to retract it again.",
+        "Release Grapple to fall onto the platform below the door."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 75}
       ]
     },
     {

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -321,7 +321,7 @@
       "requires": [
         {"heatFrames": 100},
         {"or": [
-          "canOffScreenMovement"
+          "canOffScreenMovement",
           {"heatFrames": 80}
         ]}
       ],

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -381,6 +381,18 @@
       "note": "Jump to the first long platform then use a the full platform to jump and mockball through the lava."
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 50}
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -236,7 +236,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [
@@ -376,7 +376,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [
@@ -641,7 +641,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [
@@ -762,7 +762,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -381,7 +381,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -589,7 +589,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -309,6 +309,18 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 45}
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -119,11 +119,11 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [
-        {"heatFrames": 50}
+        {"heatFrames": 45}
       ]
     },
     {

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -388,7 +388,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -525,7 +525,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -356,7 +356,7 @@
     },
     {
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
@@ -374,6 +374,24 @@
         "note that buffering the down input through the transition will not work.",
         "Then swing over to the door.",
         "Crumble jump in case the swing does not make it all the way to the door.",
+        "Samus will be visible but off-camera; swinging back and forth to fix the camera is possible, at the cost of additional heat damage."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport (from Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 80}
+      ],
+      "note": [
+        "After the teleport, immediately press down to extend Grapple to avoid bonking on the ceiling overhang;",
+        "note that buffering the down input through the transition will not work.",
+        "Then swing over to the door.",
         "Samus will be visible but off-camera; swinging back and forth to fix the camera is possible, at the cost of additional heat damage."
       ]
     },

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -180,7 +180,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []
@@ -217,7 +217,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -351,7 +351,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -251,7 +251,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": [

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -230,6 +230,18 @@
       "note": "Unmorph with the right timing to damage boost using the Boyon who is closest to the Morph tunnel in order to avoid taking any lava damage."
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        {"heatFrames": 50}
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -209,7 +209,7 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3]]
+          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -441,6 +441,16 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -6,7 +6,10 @@
   "subarea": "Main",
   "playable": true,
   "roomAddress": "0x7DD58",
-  "devNote": "FIXME Maybe we can split MB into several events to properly indicate the ammo requirements?",
+  "devNote": [
+    "FIXME: Maybe we can split MB into several events to properly indicate the ammo requirements?",
+    "FIXME: It is possible toGrapple teleport from Moat to the left of Mother Brain, through currently it has no known use."
+  ],
   "roomEnvironments": [{"heated": false}],
   "nodes": [
     {

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -204,6 +204,16 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3], [7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -94,6 +94,7 @@
     {
       "from": 3,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3}
       ]
@@ -430,6 +431,16 @@
         "Wait for the Workrobot to pass, then roll off to the right of it. Be careful not to hit any of the invisible, stationary lasers.",
         "Use the camera scroll blocks just left of the bomb blocks, in order to overload PLMs and go through them."
       ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": []
     },
     {
       "link": [3, 2],

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -348,6 +348,17 @@
       "clearsObstacles": ["A"]
     },
     {
+      "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [],
+      "note": "After teleporting, press down to retract Grapple, to prevent getting stuck inside the Chozo statue."
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": [


### PR DESCRIPTION
In addition to the strats for Moat, this also adds a few more strats from Red Brinstar Firefleas that were skipped earlier:
- into Waterway (end up stuck behind Speed blocks)
- into X-Ray Scope (basically needs the item to be Morph)
- into Green Pirates Shaft (needs a jump like from Moat, and then a Crystal Flash)

It also includes a couple fixes:
- in Acid Statue Room, the statue cannot be used while off-camera; so an obstacle is now used to track being off-camera.
- the teleport into Purple Shaft from Red Brinstar Firefleas requires some unintuitive off-camera movement (extending and then retracting Grapple), otherwise a much larger amount of heat damage would be required. So this is now reflected in the requirement of either `canOffScreenMovement` or extra `heatFrames`.