### PR TITLE
Add canBeExtremelyPatient, canLongCeilingBombJump, G-Mode in Red Firefleas

### DIFF
--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -326,7 +326,8 @@
       "notable": true,
       "requires": [
         "h_canCeilingBombJump",
-        "canBeExtremelyPatient"
+        "canLongCeilingBombJump",
+        "canBeVeryPatient"
       ],
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
       "note": [
@@ -346,7 +347,8 @@
       },
       "requires": [
         "h_canArtificialMorphCeilingBombJump",
-        "canBeExtremelyPatient",
+        "canLongCeilingBombJump",
+        "canBeVeryPatient",
         "canInsaneJump"
       ],
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
@@ -534,7 +536,8 @@
       "notable": true,
       "requires": [
         "h_canCeilingBombJump",
-        "canBeExtremelyPatient"
+        "canLongCeilingBombJump",
+        "canBeVeryPatient"
       ],
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
       "note": "This is a very long ceiling bomb jump. Kill the Wavers before crossing the room."
@@ -553,7 +556,8 @@
         "h_canArtificialMorphBombHorizontally",
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphCeilingBombJump",
-        "canBeExtremelyPatient",
+        "canLongCeilingBombJump",
+        "canBeVeryPatient",
         "canInsaneJump"
       ],
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -352,7 +352,7 @@
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
       "note": [
         "This is a very long ceiling bomb jump.",
-        "Crossing the room with artificial morph is particularly diffuclt without a good way to kill the Wavers."
+        "Crossing the room with artificial morph is particularly difficult without a good way to kill the Wavers."
       ]
     },
     {
@@ -559,7 +559,7 @@
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
       "note": [
         "This is a very long ceiling bomb jump.",
-        "Crossing the room with artificial morph is particularly diffuclt without a good way to kill the Wavers.",
+        "Crossing the room with artificial morph is particularly difficult without a good way to kill the Wavers.",
         "It is recommended to avoid killing the Firefleas, as the room gets dark fast."
       ]
     },

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -90,6 +90,12 @@
       "obstacleType": "inanimate"
     }
   ],
+  "reusableRoomwideNotable": [
+    {
+      "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "note": "This is a very long ceiling bomb jump."
+    }
+  ],
   "links": [
     {
       "from": 1,
@@ -315,6 +321,41 @@
       "note": "This strat is simply running and jumping across the spikes."
     },
     {
+      "link": [1, 2],
+      "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "notable": true,
+      "requires": [
+        "h_canCeilingBombJump",
+        "canBeExtremelyPatient"
+      ],
+      "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "note": [
+        "This is a very long ceiling bomb jump.",
+        "Wait for the Wavers to come and kill them before crossing the room."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Red Brinstar Firefleas Ceiling Bomb Jump (Artificial Morph)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphCeilingBombJump",
+        "canBeExtremelyPatient",
+        "canInsaneJump"
+      ],
+      "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "note": [
+        "This is a very long ceiling bomb jump.",
+        "Crossing the room with artificial morph is particularly diffuclt without a good way to kill the Wavers."
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": [
@@ -486,6 +527,41 @@
         }
       },
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "notable": true,
+      "requires": [
+        "h_canCeilingBombJump",
+        "canBeExtremelyPatient"
+      ],
+      "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "note": "This is a very long ceiling bomb jump. Kill the Wavers before crossing the room."
+    },
+    {
+      "link": [2, 1],
+      "name": "Red Brinstar Firefleas Ceiling Bomb Jump (Artificial Morph)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphBombHorizontally",
+        "h_canArtificialMorphIBJ",
+        "h_canArtificialMorphCeilingBombJump",
+        "canBeExtremelyPatient",
+        "canInsaneJump"
+      ],
+      "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "note": [
+        "This is a very long ceiling bomb jump.",
+        "Crossing the room with artificial morph is particularly diffuclt without a good way to kill the Wavers.",
+        "It is recommended to avoid killing the Firefleas, as the room gets dark fast."
+      ]
     },
     {
       "link": [2, 2],

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -886,7 +886,7 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ",
-        "canBeVeryPatient"
+        "canBeExtremelyPatient"
       ],
       "reusableRoomwideNotable": "Climb G-Mode Morph Insane IBJ to Top",
       "note": [
@@ -1194,7 +1194,7 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ",
-        "canBeVeryPatient"
+        "canBeExtremelyPatient"
       ],
       "reusableRoomwideNotable": "Climb G-Mode Morph Insane IBJ to Top",
       "note": [

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -174,7 +174,7 @@
               "notable": true,
               "requires": [
                 "h_canNavigateUnderwater",
-                "canBeVeryPatient",
+                "canBeExtremelyPatient",
                 {"enemyKill": {
                   "enemies": [
                     ["Reverse Botwoon 1"],

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2864,7 +2864,7 @@
       "name": "Main Street Ice Only Top Crab Climb",
       "notable": true,
       "requires": [
-        "canBeVeryPatient",
+        "canBeExtremelyPatient",
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canTrickyJump",

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -281,7 +281,8 @@
       },
       "requires": [
         "f_KilledMetroidRoom1",
-        "h_canArtificialMorphCeilingBombJump"
+        "h_canArtificialMorphCeilingBombJump",
+        "canLongCeilingBombJump"
       ]
     },
     {

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -282,7 +282,8 @@
       "requires": [
         "f_KilledMetroidRoom1",
         "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump"
+        "canLongCeilingBombJump",
+        "canBePatient"
       ]
     },
     {

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -126,12 +126,6 @@
       "spawn": ["f_DefeatedPhantoon"]
     }
   ],
-  "reusableRoomwideNotable": [
-    {
-      "name": "Bowling Alley Ceiling Bomb Jump",
-      "note": "This is a very long ceiling bomb jump."
-    }
-  ],
   "links": [
     {
       "from": 1,
@@ -428,9 +422,8 @@
       "notable": true,
       "requires": [
         "h_canCeilingBombJump",
-        "canBeVeryPatient"
+        "canBeExtremelyPatient"
       ],
-      "reusableRoomwideNotable": "Bowling Alley Ceiling Bomb Jump",
       "note": "This is a very long ceiling bomb jump."
     },
     {

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -422,7 +422,8 @@
       "notable": true,
       "requires": [
         "h_canCeilingBombJump",
-        "canBeExtremelyPatient"
+        "canLongCeilingBombJump",
+        "canBeVeryPatient"
       ],
       "note": "This is a very long ceiling bomb jump."
     },

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -284,7 +284,8 @@
       "name": "Ceiling Bomb Jump",
       "requires": [
         "h_canCeilingBombJump",
-        "canLongCeilingBombJump"
+        "canLongCeilingBombJump",
+        "canBePatient"
       ]
     },
     {
@@ -345,7 +346,8 @@
       },
       "requires": [
         "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump"
+        "canLongCeilingBombJump",
+        "canBePatient"
       ],
       "clearsObstacles": ["A"]
     },
@@ -383,7 +385,8 @@
       "name": "Ceiling Bomb Jump",
       "requires": [
         "h_canCeilingBombJump",
-        "canLongCeilingBombJump"
+        "canLongCeilingBombJump",
+        "canBePatient"
       ]
     },
     {
@@ -392,9 +395,11 @@
       "requires": [
         "h_canArtificialMorphCeilingBombJump",
         "canLongCeilingBombJump",
+        "canBeVeryPatient",
         {"obstaclesCleared": ["A"]}
       ],
-      "note": "Touch the item while remaining in artificial morph. Ceiling bomb jump back to the right, then use x-ray to cancel g-mode and obtain the item."
+      "note": "Touch the item while remaining in artificial morph. Ceiling bomb jump back to the right, then use x-ray to cancel g-mode and obtain the item.",
+      "devNote": "This strat alone would only require canBePatient, but it is only possible after Ceiling Bomb Jumping there, so it would be a combined 4 minues."
     }
   ]
 }

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -283,7 +283,8 @@
       "link": [1, 2],
       "name": "Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump"
+        "h_canCeilingBombJump",
+        "canLongCeilingBombJump"
       ]
     },
     {
@@ -343,7 +344,8 @@
         }
       },
       "requires": [
-        "h_canArtificialMorphCeilingBombJump"
+        "h_canArtificialMorphCeilingBombJump",
+        "canLongCeilingBombJump"
       ],
       "clearsObstacles": ["A"]
     },
@@ -380,7 +382,8 @@
       "link": [2, 1],
       "name": "Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump"
+        "h_canCeilingBombJump",
+        "canLongCeilingBombJump"
       ]
     },
     {
@@ -388,6 +391,7 @@
       "name": "G-mode Morph Ceiling Bomb Jump",
       "requires": [
         "h_canArtificialMorphCeilingBombJump",
+        "canLongCeilingBombJump",
         {"obstaclesCleared": ["A"]}
       ],
       "note": "Touch the item while remaining in artificial morph. Ceiling bomb jump back to the right, then use x-ray to cancel g-mode and obtain the item."

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -399,7 +399,7 @@
         {"obstaclesCleared": ["A"]}
       ],
       "note": "Touch the item while remaining in artificial morph. Ceiling bomb jump back to the right, then use x-ray to cancel g-mode and obtain the item.",
-      "devNote": "This strat alone would only require canBePatient, but it is only possible after Ceiling Bomb Jumping there, so it would be a combined 4 minues."
+      "devNote": "This strat alone would only require canBePatient, but it is only possible after Ceiling Bomb Jumping there, so it would be a combined 4 minutes."
     }
   ]
 }

--- a/tech.json
+++ b/tech.json
@@ -18,7 +18,7 @@
                 {
                   "name": "canBeExtremelyPatient",
                   "requires": ["canBeVeryPatient"],
-                  "note": "Executing a strat that requires waiting or doing the same thing over and over again for a very long time, potentially more than 5 minutes, even with good execution."
+                  "note": "Executing a strat that requires waiting or doing the same thing over and over again for a very long time, potentially more than 6 minutes, even with good execution."
                 }
               ]
             }
@@ -816,7 +816,14 @@
             {
               "name": "canCeilingBombJump",
               "requires": [ "canBombAboveIBJ" ],
-              "note": "The ability to IBJ at the ceiling and place bombs at a steady rhythm while slowly moving horizontally."
+              "note": "The ability to IBJ at the ceiling and place bombs at a steady rhythm while slowly moving horizontally.",
+              "extensionTechs": [
+                {
+                  "name": "canLongCeilingBombJump",
+                  "requires": [ "canCeilingBombJump" ],
+                  "note": "The ability to ceiling bomb jump over a distance of two screens or more."
+                },
+              ]
             },
             {
               "name": "canDiagonalBombJump",

--- a/tech.json
+++ b/tech.json
@@ -822,7 +822,7 @@
                   "name": "canLongCeilingBombJump",
                   "requires": [ "canCeilingBombJump" ],
                   "note": "The ability to ceiling bomb jump over a distance of two screens or more."
-                },
+                }
               ]
             },
             {

--- a/tech.json
+++ b/tech.json
@@ -11,9 +11,16 @@
           "note": "Executing a strat that requires waiting or doing the same thing over and over again for a substantial amount of time, potentially more than 1.5 minutes, even with good execution.",
           "extensionTechs": [
             {
-                "name": "canBeVeryPatient",
-                "requires": ["canBePatient"],
-                "note": "Executing a strat that requires waiting or doing the same thing over and over again for a long time, potentially more than 3 minutes, even with good execution."
+              "name": "canBeVeryPatient",
+              "requires": ["canBePatient"],
+              "note": "Executing a strat that requires waiting or doing the same thing over and over again for a long time, potentially more than 3 minutes, even with good execution.",
+              "extensionTechs": [
+                {
+                  "name": "canBeExtremelyPatient",
+                  "requires": ["canBeVeryPatient"],
+                  "note": "Executing a strat that requires waiting or doing the same thing over and over again for a very long time, potentially more than 5 minutes, even with good execution."
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
I'm adding this in hopes that it will be used as a `Beyond` tech in Map Rando. 

Alternatively/additionally, I wouldnt be opposed to a `canLongCeilingBombJump`, which could be `Beyond` and have a lower threshold (i.e. 2 screens instead of 4).