### PR TITLE
Some grapple teleports from Halfie Climb

### DIFF
--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -87,6 +87,7 @@
       "from": 3,
       "to": [
         {"id": 1},
+        {"id": 2},
         {"id": 3},
         {"id": 4}
       ]
@@ -158,6 +159,20 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "devNote": [
+        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
       ]
     },
     {
@@ -288,6 +303,20 @@
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "devNote": [
+        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
       ]
     },
     {

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -119,6 +119,7 @@
         {"id": 1},
         {"id": 2},
         {"id": 3},
+        {"id": 4},
         {"id": 5}
       ]
     },
@@ -487,6 +488,16 @@
         "While holding down, let it hit Samus, then Freeze it immediately."
       ],
       "devNote": "This setup takes damage, but you can farm before and after."
+    },
+    {
+      "link": [1, 4],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": []
     },
     {
       "link": [1, 5],

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -542,6 +542,16 @@
       ]
     },
     {
+      "link": [3, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [3, 3],
       "name": "Leave With Runway",
       "requires": [],

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -474,6 +474,20 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "devNote": [
+        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Kill the Beetoms",
       "requires": [

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -209,8 +209,8 @@
         }
       },
       "note": [
-        "Exit the door transition while grappled, in order to initiate a teleport in the next room.",
-        "This is done by moonwalking into the transition on the same frame that the Grapple Beam reaches the Grapple block."
+        "Moonwalk into the transition on the same frame that the Grapple Beam reaches the Grapple block.",
+        "Continue holding Grapple through the door transition to initiate a teleport in the next room."
       ],
       "devNote": [
         "FIXME: Strats could be added which come in shinecharging or shinecharged, and leave with both a grapple teleport and a shinecharge.",

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -126,7 +126,6 @@
           "id": 3,
           "devNote": "No strat for getting through the Boyons with a dboost, since it's redundant with the bluesuit jump."
         },
-        {"id": 4},
         {"id": 5}
       ]
     },
@@ -651,8 +650,10 @@
           "blockPositions": [[12, 13]]
         }
       },
-      "requires": [
-        {"spikeHits": 1}
+      "requires": [],
+      "note": [
+        "Samus will enter the room grappled to a spike block below.",
+        "Release Grapple quickly after entering, then aim up and grapple onto a Grapple block on the ceiling to avoid taking spike damage."
       ]
     },
     {
@@ -871,20 +872,6 @@
         "Note that the boyons can be killed with bombs."
       ],
       "devNote": "This is technically doable without canBePatient, but would require double bomb jump, morph, a way to bypass Boyons, and never falling."
-    },
-    {
-      "link": [2, 4],
-      "name": "Grapple Teleport",
-      "entranceCondition": {
-        "comeInWithGrappleTeleport": {
-          "blockPositions": [[12, 13]]
-        }
-      },
-      "requires": [
-        {"spikeHits": 1},
-        "canIframeSpikeJump",
-        "canOffScreenMovement"
-      ]
     },
     {
       "link": [2, 5],

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -126,6 +126,7 @@
           "id": 3,
           "devNote": "No strat for getting through the Boyons with a dboost, since it's redundant with the bluesuit jump."
         },
+        {"id": 4},
         {"id": 5}
       ]
     },
@@ -643,6 +644,18 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [
+        {"spikeHits": 1}
+      ]
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],
@@ -858,6 +871,20 @@
         "Note that the boyons can be killed with bombs."
       ],
       "devNote": "This is technically doable without canBePatient, but would require double bomb jump, morph, a way to bypass Boyons, and never falling."
+    },
+    {
+      "link": [2, 4],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [
+        {"spikeHits": 1},
+        "canIframeSpikeJump",
+        "canOffScreenMovement"
+      ]
     },
     {
       "link": [2, 5],

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -178,6 +178,36 @@
       }
     },
     {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },    
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -563,6 +563,16 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [],
@@ -714,6 +724,21 @@
       "note": [
         "There are scroll PLMs throughout the room, which will overload PLMs when going through them.",
         "The bomb blocks then become air and can be passed through."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "note": [
+        "If entering the transition too deeply, Samus may end up stuck slightly inside the Bomb blocks and the floor.",
+        "This can be avoided by tapping up to retract Grapple (pulling Samus left and down), quickly releasing Grapple, and then jumping to clip up through the floor.",
+        "If Morph is available, rolling out to the left is also an option."
       ]
     },
     {

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -107,7 +107,8 @@
       },
       "note": [
         "Hold angle-up, jump, bonk the ceiling, and use Grapple just before landing.",
-        "Moonwalk into the transition on the same frame that the Grapple Beam reaches the Grapple block."
+        "Moonwalk into the transition on the same frame that the Grapple Beam reaches the Grapple block.",
+        "Continue holding Grapple through the door transition to initiate a teleport in the next room."
       ]
     },
     {

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -130,6 +130,7 @@
     {
       "from": 3,
       "to": [
+        {"id": 1},
         {"id": 3},
         {"id": 4},
         {"id": 9},
@@ -427,6 +428,20 @@
         }
       },
       "requires": []
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "devNote": [
+        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
+      ]
     },
     {
       "link": [3, 3],

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -229,6 +229,20 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "devNote": [
+        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1359,6 +1359,58 @@
           "knockback": false
         }
       }
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Grapple Teleport (Bottom Position)",
+      "requires": [
+        "Gravity",
+        "canGrappleBombHang",
+        "h_canUseMorphBombs"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "note": [
+        "Get a boost from a Bomb or Power Bomb on the same frame as grappling to the second Grapple block below the door.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "Pressing right while inside the transition tiles will trigger the transition.",
+        "Continue holding Grapple through the transition to initiate a teleport in the next room.",
+        "The game may lag heavily: if lag persists, it can typically be alleviated by pressing or releasing right;",
+        "avoid pressing left as it will cause the Grapple to detach."
+      ],
+      "devNote": [
+        "FIXME: Using a Power Bomb can also work, but we would need to define leniency in order for this to be reasonable."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Grapple Teleport (Top Position)",
+      "requires": [
+        "Gravity",
+        "canGrappleBombHang",
+        "h_canUseMorphBombs"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "note": [
+        "Get a boost from a Bomb or Power Bomb on the same frame as grappling to the top Grapple block below the door.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "While swinging up, briefly tap up to retract Grapple to avoid the ceiling, then immediately press down to extend it again while approaching the door.",
+        "Continue holding Grapple through the door transition to initiate a teleport in the next room.",
+        "The game may lag heavily: if lag persists, it can typically be alleviated by pressing or releasing right;",
+        "avoid pressing left as it will cause the Grapple to detach."
+      ],
+      "devNote": [
+        "FIXME: Using a Power Bomb can also work, but we would need to define leniency in order for this to be reasonable."
+      ]
     }
   ]
 }

--- a/tech.json
+++ b/tech.json
@@ -493,6 +493,17 @@
                 "The corresponding position in the destination room (counting tiles from the top-left corner of the room) must have a block to which Samus can remain grappled (e.g. a solid block would work but air would not);",
                 "otherwise the teleport will not occur."
               ]
+            },
+            {
+              "name": "canGrappleBombHang",
+              "requires": [
+                "canUseGrapple"
+              ],
+              "note": [
+                "Attach to a Grapple block on the same frame as receiving a boost from a Bomb or Power Bomb, to enter a 'glitched grapple hanging' state.",
+                "Among other things, this state gives a way to trigger a door transition while still grappled.",
+                "The game may lag heavily in this state: if lag persists, it can typically be alleviated by changing the inputs held."
+              ]
             }
           ]
         }


### PR DESCRIPTION
This introduces a new tech "canGrappleBombHang", with a grapple teleport setup from the top right of Halfie Climb using it. It wasn't as bad as I was expecting. It's different but seems not necessarily harder than the Moat setup.

I'm planning on going through the rest of the rooms to add all the applications (from this door) but figured it could make sense to start with a smaller PR to get feedback.

This setup has a little more nuance because it looks like that there are multiple ways to enter the transition (e.g. by varying your momentum) which can slightly affect your position in the next room, so we'll have to be careful with that. Also this setup has the ability to bypass door shells and even chain the grapple teleport into subsequent rooms.