### PR TITLE
Add 'Carry Grapple Teleport' strats

### DIFF
--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -170,10 +170,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 3],
@@ -314,10 +343,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [3, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [3, 3],

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -482,10 +482,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [2, 1],

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -1050,10 +1050,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 5],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 5],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 6],
@@ -1198,10 +1227,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [2, 5],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [2, 5],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [3, 2],
@@ -1420,10 +1478,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [3, 5],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [3, 5],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [3, 6],

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -179,6 +179,17 @@
     },
     {
       "link": [1, 2],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
       "name": "Carry Grapple Teleport (Top Position)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
@@ -186,6 +197,7 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true,
       "exitCondition": {
         "leaveWithGrappleTeleport": {
           "blockPositions": [[12, 12]]
@@ -201,6 +213,7 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true,
       "exitCondition": {
         "leaveWithGrappleTeleport": {
           "blockPositions": [[12, 13]]

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -438,10 +438,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [3, 1],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [3, 1],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [3, 3],

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -264,10 +264,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 4],

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -225,14 +225,43 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12]]
         }
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 3],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 4],

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -237,10 +237,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 2],

--- a/region/maridia/inner-pink/Draygon Save Room.json
+++ b/region/maridia/inner-pink/Draygon Save Room.json
@@ -106,10 +106,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 3],

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -495,10 +495,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [2, 1],
@@ -1045,10 +1074,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [2, 4],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [2, 4],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [3, 1],

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -245,14 +245,43 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12]]
         }
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [2, 1],

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -327,14 +327,43 @@
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12], [12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 3],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 13]]
         }
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 4],

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -296,10 +296,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [2, 1],

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -213,10 +213,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 2],

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -347,9 +347,39 @@
         }
       },
       "requires": [],
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [2, 1],
@@ -634,9 +664,39 @@
         }
       },
       "requires": [],
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [2, 4],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [2, 4],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [2, 5],

--- a/region/maridia/outer/West Glass Tube Tunnel.json
+++ b/region/maridia/outer/West Glass Tube Tunnel.json
@@ -130,10 +130,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 2],      

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -187,10 +187,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 3],

--- a/region/norfair/east/Frog Savestation.json
+++ b/region/norfair/east/Frog Savestation.json
@@ -149,10 +149,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 3],

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -193,10 +193,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 2],

--- a/region/norfair/east/Nutella Refill.json
+++ b/region/norfair/east/Nutella Refill.json
@@ -176,10 +176,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 3],

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -219,10 +219,39 @@
         }
       },
       "requires": [],
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Top Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "requires": [],
       "bypassesDoorShell": true,
-      "devNote": [
-        "FIXME: Add a 'Carry Grapple Teleport' variation, with comeInWithGrappleTeleport+leaveWithGrappleTeleport."
-      ]
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Grapple Teleport (Bottom Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      }
     },
     {
       "link": [1, 3],


### PR DESCRIPTION
This adds strats for chaining grapple teleports across multiple rooms, starting from Halfie Climb Room top right door.

For Crab Hole and Crateria Tube, I put `bypassesDoorShell: true` because even though there is no door shell, these strats would bypass a door shell if one were there (e.g. in case a randomizer were to add one). 