### PR TITLE
Refine WS ETank grapple fling

### DIFF
--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -275,9 +275,20 @@
       "link": [1, 2],
       "name": "Precise Grapple",
       "requires": [
-        "canPreciseGrapple"
+        "canPreciseGrapple",
+        "canTrickyJump",
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            "canLateralMidAirMorph",
+            {"thornHits": 5}
+          ]}
+        ]}
       ],
-      "note": "Fling Samus from the first set of grapple blocks to the second set without falling. Requires precise timing."
+      "note": [
+        "Fling Samus from the first set of grapple blocks to the second set without falling. Requires precise timing.",
+        "It can help to perform a lateral mid-air morph and unmorph."
+      ]
     },
     {
       "link": [1, 2],
@@ -387,7 +398,8 @@
       "link": [2, 1],
       "name": "Precise Grapple",
       "requires": [
-        "canPreciseGrapple"
+        "canPreciseGrapple",
+        "canTrickyJump"
       ],
       "note": "Fling Samus from the first set of grapple blocks to the second set without falling. Requires precise timing."
     },


### PR DESCRIPTION
This came up in Oats' seed tonight where you had to use Grapple to get this item and get out without taking a hit. It was an Extreme seed but it could have happened in Hard.

I'm not sure if I completely understand this strat. For some reason, to me going left-to-right seems way easier than going right-to-left, even though the geometry is symmetric so I would have expected them to be basically the same. A lateral mid-air morph seems to help a lot with going right-to-left but not really with going left-to-right.