### PR TITLE
Colosseum bomb jump water escape by Spiffy

### DIFF
--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1060,6 +1060,30 @@
     },
     {
       "link": [3, 1],
+      "name": "Colosseum Bomb Jump Water Escape",
+      "notable": true,
+      "requires": [
+        "HiJump",
+        "canPreciseWalljump",
+        "canIframeSpikeJump",
+        {"spikeHits": 2},
+        "canNeutralDamageBoost",
+        {"or": [
+          "canHorizontalDamageBoost",
+          {"spikeHits": 1}
+        ]},
+        "h_canMaxHeightSpringBallJump",
+        "canBombJumpWaterEscape",
+        "h_canJumpIntoIBJ"
+      ],
+      "note": [
+        "Stay out of the water, and by extension the sand, of Colosseum by using the spikes as platforms.",
+        "Morphing before landing on the spikes helps to be able to control the knockback.",
+        "The final spike jump (which would be the most difficult) is avoided by doing a mid-air spring ball jump into an IBJ."
+      ]
+    },
+    {
+      "link": [3, 1],
       "name": "Colosseum with no Equipment (Right to Left)",
       "notable": true,
       "requires": [
@@ -1076,7 +1100,7 @@
       "reusableRoomwideNotable": "Colosseum with no Equipment",
       "note": [
         "Stay out of the water, and by extension the sand, of Colosseum by using the spikes as platforms.",
-        "Landing on spikes aiming down with no other direction pressed can help contol the knockback.",
+        "Landing on spikes aiming down with no other direction pressed can help control the knockback.",
         "Requires knowing the position of every spike in the room.",
         "The final spike jump is very difficult."
       ]

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1073,13 +1073,16 @@
           {"spikeHits": 1}
         ]},
         "h_canMaxHeightSpringBallJump",
+        "canInsaneJump",
         "canBombJumpWaterEscape",
         "h_canJumpIntoIBJ"
       ],
       "note": [
         "Stay out of the water, and by extension the sand, of Colosseum by using the spikes as platforms.",
         "Morphing before landing on the spikes helps to be able to control the knockback.",
-        "The final spike jump (which would be the most difficult) is avoided by doing a mid-air spring ball jump into an IBJ."
+        "The final spike jump (which would be the most difficult) is avoided by doing a crouch jump into spring ball jump into IBJ to reach the left door.",
+        "The spring ball jump should be performed just before max height, during the 4-frame window between 2 and 5 frames before the last possible frame to jump (there are also 1-frame windows at 0 and 8 frames before the last frame).",
+        "In every case the first bomb must be placed exactly two frames before the spring ball jump."
       ]
     },
     {


### PR DESCRIPTION
Spiffy came up with this strat the other day in one of his seeds:
https://clips.twitch.tv/RepleteGeniusRabbitHassanChop-ng1dgYjhS-MVH-Il

Compared to the Insane "Colosseum with no Equipment" strat, this version uses one less spike hit, and it avoids the final spike jump which was the insanely difficult part. Escaping the water with the spring ball jump into IBJ is precise but can be retried as many times as needed. I put "canInsaneJump" on it since the frame-perfect bomb placement (2 frames before the spring ball jump) makes it probably take a while to get, given that you have to pause/unpause twice with every attempt.