### PR TITLE
Crateria temporary blue strats

### DIFF
--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -282,7 +282,8 @@
       "requires": [
         "canLongChainTemporaryBlue",
         "canXRayTurnaround"
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 2],

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -272,6 +272,20 @@
     },
     {
       "link": [1, 2],
+      "name": "Temporary Blue Chain",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {
+          "direction": "any"
+        },
+        "comesThroughToilet": "any"        
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ]
+    },
+    {
+      "link": [1, 2],
       "name": "G-Mode through Bomb Blocks",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -333,6 +347,33 @@
     },
     {
       "link": [1, 3],
+      "name": "Temporary Blue Chain",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {
+          "direction": "right"
+        },
+        "comesThroughToilet": "any"        
+      },
+      "requires": [
+        "canChainTemporaryBlue"
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Temporary Blue Chain With X-Ray",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {
+          "direction": "left"
+        },
+        "comesThroughToilet": "any"        
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canXRayTurnaround"
+      ]
+    },
+    {
+      "link": [1, 3],
       "name": "G-Mode Morph through Bomb Blocks",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -346,6 +387,33 @@
       ],
       "note": "Overload PLMs using the scroll block next to the bomb blocks.",
       "devNote": "PBs cannot be used, as they will solidify the bomb blocks."
+    },
+    {
+      "link": [1, 4],
+      "name": "Temporary Blue Chain",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {
+          "direction": "right"
+        },
+        "comesThroughToilet": "any"        
+      },
+      "requires": [
+        "canLongChainTemporaryBlue"
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Temporary Blue Chain With X-Ray",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {
+          "direction": "left"
+        },
+        "comesThroughToilet": "any"        
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ]
     },
     {
       "link": [1, 4],
@@ -778,6 +846,36 @@
     },
     {
       "link": [3, 6],
+      "name": "Temporary Blue Spring Ball (Come in Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canLongChainTemporaryBlue",
+        "can4HighMidAirMorph",
+        "canSpringBallBounce"
+      ],
+      "devNote": "There is 1 unusable tile in this runway."
+    },
+    {
+      "link": [3, 6],
+      "name": "Temporary Blue Spring Ball (Come in With Temporary Blue)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canInsaneJump",
+        "canLongChainTemporaryBlue",
+        "can4HighMidAirMorph",
+        "canSpringBallBounce"
+      ]
+    },
+    {
+      "link": [3, 6],
       "name": "G-Mode Morph through Bomb Blocks",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -959,6 +1057,36 @@
     },
     {
       "link": [4, 6],
+      "name": "Temporary Blue Spring Ball (Come in Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canLongChainTemporaryBlue",
+        "canSpringBallBounce",
+        "can4HighMidAirMorph"        
+      ],
+      "devNote": "There is 1 unusable tile in this runway."
+    },
+    {
+      "link": [4, 6],
+      "name": "Temporary Blue Spring Ball (Come in With Temporary Blue)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canInsaneJump",
+        "canLongChainTemporaryBlue",
+        "canSpringBallBounce",
+        "can4HighMidAirMorph"        
+      ]
+    },
+    {
+      "link": [4, 6],
       "name": "G-Mode Morph through Bomb Blocks",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1020,6 +1148,17 @@
             {"doorUnlockedAtNode": 5}
           ]}
         ]}
+      ],
+      "clearsObstacles": ["A"]
+    },
+    {
+      "link": [5, 2],
+      "name": "Temporary Blue",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue"
       ],
       "clearsObstacles": ["A"]
     },
@@ -1221,7 +1360,6 @@
         "Overload the PLMs at the bottom, if the top bomb block is hit with a PB before PLMs are overloaded, they will remain solid."
       ]
     },
-    
     {
       "link": [5, 4],
       "name": "Behemoth Spark Bottom, Come in Shinecharging",

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -478,6 +478,22 @@
     },
     {
       "link": [1, 6],
+      "name": "Temporary Blue Springball",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canSpringBallBounce",
+        {"spikeHits": 3}
+      ],
+      "note": [
+        "Use Springball on the spikes to cross the room while retaining temporary blue.",
+        "Then use Spring Ball to bounce all of the way through the Morph tunnel."
+      ]
+    },
+    {
+      "link": [1, 6],
       "name": "X-Mode BlueSuit",
       "entranceCondition": {
         "comeInShinecharging": {
@@ -523,6 +539,24 @@
       ],
       "note": "Use X-Mode to store a spikesuit, and then convert that to a blue suit with more X-Mode.",
       "devNote": "One leniency spikehit given."
+    },
+    {
+      "link": [1, 6],
+      "name": "Speedkeep (Come in With Temporary Blue)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "can4HighMidAirMorph",
+        "canSpeedKeep",
+        {"spikeHits": 1},
+        "canSpeedball"
+      ],
+      "note": [
+        "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
+        "Bouncing on the platform near the door saves a spike hit."
+      ]
     },
     {
       "link": [1, 6],

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -115,6 +115,20 @@
     },
     {
       "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 2],
       "name": "Transition with Stored Fall Speed",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
@@ -270,6 +284,20 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
+      }
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
       }
     },
     {

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -117,7 +117,7 @@
     },
     {
       "link": [2, 1],
-      "name": "Temporary Blue Bounce",
+      "name": "Temporary Blue Bounce (Come in Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 2,
@@ -129,6 +129,17 @@
         "canSpringBallBounce"
       ],
       "devNote": "There is 1 unusable tile in this runway."
+    },
+    {
+      "link": [2, 1],
+      "name": "Temporary Blue Bounce (Come in With Temporary Blue)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canSpringBallBounce"
+      ]
     },
     {
       "link": [2, 1],

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -100,6 +100,20 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Mellow Farm",
       "requires": [
         {"resetRoom": {
@@ -203,6 +217,21 @@
         "leaveShinecharged": {
           "framesRemaining": 140
         }
+      }
+    },
+
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
       }
     },
     {

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -553,6 +553,30 @@
     },
     {
       "link": [3, 1],
+      "name": "Landing Site Big Jump Leave With Temporary Blue",
+      "notable": true,
+      "requires": [
+        "canCarefulJump",
+        "Morph",
+        "canSpeedball",
+        {"canShineCharge": {
+          "usedTiles": 30,
+          "openEnd": 2
+        }},
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "note": [
+        "Use the runway near the Power Bomb room door to jump towards the Gauntlet Entrance room Bomb blocks and break them with a speedball;",
+        "then chain temporary blue through the door.",
+        "The jump into speedball can be set up by using the full runway with a one-tap shortcharge, with the tap being at the top of the lowest slope."
+      ],
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [3, 1],
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -558,7 +558,7 @@
       "requires": [
         "canCarefulJump",
         "Morph",
-        "canSpeedball",
+        "canLateralMidAirMorph",
         {"canShineCharge": {
           "usedTiles": 30,
           "openEnd": 2
@@ -569,9 +569,9 @@
         "leaveWithTemporaryBlue": {}
       },
       "note": [
-        "Use the runway near the Power Bomb room door to jump towards the Gauntlet Entrance room Bomb blocks and break them with a speedball;",
-        "then chain temporary blue through the door.",
-        "The jump into speedball can be set up by using the full runway with a one-tap shortcharge, with the tap being at the top of the lowest slope."
+        "Use the runway near the Power Bomb room door to jump to the left, morphing as Samus begins descending, to bounce through the Bomb blocks.",
+        "Any time while bouncing, hold an angle button and unmorph to gain temporary blue; then chain it to reach the door with temporary blue.",
+        "The jump can be set up by using the full runway with a one-tap shortcharge, with the tap being at the top of the lowest slope."
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -2070,6 +2070,24 @@
       "requires": []
     },
     {
+      "link": [8, 3],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "openEnd": 1,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [8, 4],
       "name": "Base",
       "requires": []
@@ -2112,6 +2130,23 @@
       "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
+      "link": [8, 4],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "openEnd": 1,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3
+        }},
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [8, 5],
       "name": "Base",
       "requires": [
@@ -2124,9 +2159,47 @@
       "requires": []
     },
     {
+      "link": [8, 6],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "openEnd": 1,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [8, 7],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [8, 7],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "openEnd": 1,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "any"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [8, 8],

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -2065,6 +2065,26 @@
       ]
     },
     {
+      "link": [8, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "openEnd": 1,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        "can4HighMidAirMorph",
+        "canSpringBallBounce"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [8, 3],
       "name": "Base",
       "requires": []
@@ -2080,7 +2100,8 @@
           "steepDownTiles": 3
         }},
         "canLongChainTemporaryBlue",
-        "canXRayTurnaround"
+        "canXRayTurnaround",
+        "can4HighMidAirMorph"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
@@ -2169,7 +2190,8 @@
           "steepDownTiles": 3
         }},
         "canLongChainTemporaryBlue",
-        "canXRayTurnaround"
+        "canXRayTurnaround",
+        "can4HighMidAirMorph"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
@@ -2192,7 +2214,8 @@
           "steepDownTiles": 3
         }},
         "canLongChainTemporaryBlue",
-        "canXRayTurnaround"
+        "canXRayTurnaround",
+        "can4HighMidAirMorph"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -192,6 +192,23 @@
       "requires": []
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
       "link": [1, 3],
       "name": "Base",
       "requires": [
@@ -299,6 +316,23 @@
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     },
     {
       "link": [2, 1],

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -204,7 +204,7 @@
     },
     {
       "link": [1, 3],
-      "name": "Temporary Blue",
+      "name": "Temporary Blue (Come In Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -217,6 +217,34 @@
       "clearsObstacles": ["A"],
       "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks.",
       "devNote": "FIXME: Add chain strat with x-ray turnaround and a 7 tile runway."
+    },
+    {
+      "link": [1, 3],
+      "name": "Temporary Blue With X-Ray (Come In Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "clearsObstacles": ["A"],
+      "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks.",
+      "devNote": "FIXME: Add chain strat with x-ray turnaround and a 7 tile runway."
+    },
+    {
+      "link": [1, 3],
+      "name": "Temporary Blue (Come In With Temporary Blue)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 3],
@@ -356,7 +384,7 @@
     },
     {
       "link": [2, 3],
-      "name": "Full Room Temporary Blue",
+      "name": "Full Room Temporary Blue (Come in Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 1,
@@ -367,7 +395,7 @@
         "canTemporaryBlue",
         "canInsaneJump",
         {"or": [
-          "canChainTemporaryBlue",
+          "canLongChainTemporaryBlue",
           {"and": [
             "canSpeedball",
             "canSpringBallBounce",
@@ -382,6 +410,17 @@
       ],
       "note": "Bring temporary blue from the right side door all the way to the missile location using Springball, SpaceJump, or Morph-UnMorphs.",
       "devNote": "There is 1 unusable tile in this runway."
+    },
+    {
+      "link": [2, 3],
+      "name": "Full Room Temporary Blue (Come in With Temporary Blue)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canInsaneJump"
+      ]
     },
     {
       "link": [2, 3],

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -233,8 +233,7 @@
         "canTemporaryBlue"
       ],
       "clearsObstacles": ["A"],
-      "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks.",
-      "devNote": "FIXME: Add chain strat with x-ray turnaround and a 7 tile runway."
+      "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks."
     },
     {
       "link": [1, 3],
@@ -250,8 +249,7 @@
         "canXRayTurnaround"
       ],
       "clearsObstacles": ["A"],
-      "note": "Breaking the side blocks can be done by moving into them once past the solid blocks.",
-      "devNote": "FIXME: Add chain strat with x-ray turnaround and a 7 tile runway."
+      "note": "Breaking the side blocks can be done by moving into them once past the solid blocks."
     },
     {
       "link": [1, 3],

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -206,7 +206,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 3],
@@ -332,7 +333,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -250,7 +250,7 @@
         "canXRayTurnaround"
       ],
       "clearsObstacles": ["A"],
-      "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks.",
+      "note": "Breaking the side blocks can be done by moving into them once past the solid blocks.",
       "devNote": "FIXME: Add chain strat with x-ray turnaround and a 7 tile runway."
     },
     {

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -102,9 +102,41 @@
       "requires": []
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     },
     {
       "link": [2, 1],

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -115,7 +115,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],
@@ -136,7 +137,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -909,5 +909,8 @@
       ],
       "gModeRegainMobility": {}
     }
+  ],
+  "devNote": [
+    "FIXME: Add comeInShinecharging+leaveWithTemporaryBlue strats; avoiding enemies is difficult but possible."
   ]
 }

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -254,6 +254,46 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave with Spark (Water Shinecharge)",
+      "requires": [
+        "canWaterShineCharge",
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 1
+        }},
+        {"or": [
+          {"shinespark": {"frames": 53}},
+          {"and": [
+            "canShinechargeMovementComplex",
+            {"shinespark": {"frames": 30}}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "canWaterShineCharge",
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 1
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        "can4HighMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [2, 2],
       "name": "Sciser Farm",
       "requires": [
         {"resetRoom": {

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -240,6 +240,22 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 0,
+          "steepUpTiles": 2,
+          "steepDownTiles": 5
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [2, 2],
       "name": "Sciser Farm",
       "requires": [
         {"resetRoom": {
@@ -301,6 +317,25 @@
         "leaveNormally": {}
       },
       "requires": []
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 0,
+          "steepUpTiles": 2,
+          "steepDownTiles": 5
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "any"
+        }
+      }
     },
     {
       "link": [3, 3],

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -449,28 +449,6 @@
     },
     {
       "link": [2, 2],
-      "name": "Leave With Temporary Blue (Spring Ball Jump)",
-      "requires": [
-        "Gravity",
-        {"and": [
-          {"canShineCharge": {
-            "usedTiles": 15,
-            "openEnd": 0,
-            "steepUpTiles": 2,
-            "steepDownTiles": 3,
-            "startingDownTiles": 1
-          }},
-          "HiJump",
-          "canSpringBallJumpMidAir"
-        ]},
-        "canChainTemporaryBlue"
-      ],
-      "exitCondition": {
-        "leaveWithTemporaryBlue": {}
-      }
-    },
-    {
-      "link": [2, 2],
       "name": "Leave With Temporary Blue (Gravity Jump)",
       "requires": [
         "Gravity",
@@ -546,38 +524,6 @@
           "steepDownTiles": 2,
           "startingDownTiles": 1
         }},
-        "canChainTemporaryBlue"
-      ],
-      "exitCondition": {
-        "leaveWithTemporaryBlue": {}
-      }
-    },
-    {
-      "link": [2, 2],
-      "name": "Leave With Temporary Blue With X-Ray",
-      "requires": [
-        "Gravity",
-        "HiJump",
-        {"or": [
-          {"and": [
-            {"canShineCharge": {
-              "usedTiles": 21,
-              "openEnd": 0,
-              "steepUpTiles": 3,
-              "steepDownTiles": 3,
-              "startingDownTiles": 1
-            }},
-            "canXRayTurnaround"  
-          ]},
-          {"canShineCharge": {
-            "usedTiles": 15,
-            "openEnd": 0,
-            "steepUpTiles": 2,
-            "steepDownTiles": 3,
-            "startingDownTiles": 1
-          }}
-        ]},
-        "canSpringBallJumpMidAir",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -148,6 +148,7 @@
           "startingDownTiles": 1
         }},
         "canShinechargeMovementTricky",
+        "canMidairShinespark",
         {"shinespark": {"frames": 18}}
       ],
       "exitCondition": {
@@ -173,9 +174,7 @@
         "can4HighMidAirMorph"
       ],
       "exitCondition": {
-        "leaveWithSpark": {
-          "position": "bottom"
-        }
+        "leaveWithTemporaryBlue": {}
       }
     },
     {
@@ -450,7 +449,112 @@
     },
     {
       "link": [2, 2],
-      "name": "Leave With Temporary Blue",
+      "name": "Leave With Temporary Blue (Spring Ball Jump)",
+      "requires": [
+        "Gravity",
+        {"and": [
+          {"canShineCharge": {
+            "usedTiles": 15,
+            "openEnd": 0,
+            "steepUpTiles": 2,
+            "steepDownTiles": 3,
+            "startingDownTiles": 1
+          }},
+          "HiJump",
+          "canSpringBallJumpMidAir"
+        ]},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue (Gravity Jump)",
+      "requires": [
+        "Gravity",
+        "HiJump",
+        {"or": [
+          {"and": [
+            {"canShineCharge": {
+              "usedTiles": 21,
+              "openEnd": 0,
+              "steepUpTiles": 3,
+              "steepDownTiles": 3,
+              "startingDownTiles": 1
+            }},
+            "canXRayTurnaround"  
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 18,
+            "openEnd": 0,
+            "steepUpTiles": 2,
+            "steepDownTiles": 3,
+            "startingDownTiles": 1
+          }}
+        ]},
+        "canGravityJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue (Spring Ball Jump)",
+      "requires": [
+        "Gravity",
+        "HiJump",
+        {"or": [
+          {"and": [
+            {"canShineCharge": {
+              "usedTiles": 21,
+              "openEnd": 0,
+              "steepUpTiles": 3,
+              "steepDownTiles": 3,
+              "startingDownTiles": 1
+            }},
+            "canXRayTurnaround"  
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 15,
+            "openEnd": 0,
+            "steepUpTiles": 2,
+            "steepDownTiles": 3,
+            "startingDownTiles": 1
+          }}
+        ]},
+        "canSpringBallJumpMidAir",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue (Blue Space Jump)",
+      "requires": [
+        "Gravity",
+        "canBlueSpaceJump",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 0,
+          "steepUpTiles": 2,
+          "steepDownTiles": 2,
+          "startingDownTiles": 1
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue With X-Ray",
       "requires": [
         "Gravity",
         "HiJump",
@@ -586,29 +690,6 @@
         "canSuitlessMaridia",
         "canBombJumpWaterEscape"
       ]
-    },
-    {
-      "link": [3, 1],
-      "name": "East Ocean Floor Shinespark Left",
-      "notable": true,
-      "requires": [
-        "canShinechargeMovementComplex",
-        "canMidairShinespark",
-        "Gravity",
-        {"canShineCharge": {
-          "usedTiles": 20,
-          "openEnd": 0,
-          "steepUpTiles": 2,
-          "steepDownTiles": 4,
-          "startingDownTiles": 1
-        }},
-        {"shinespark": {"frames": 23}}
-      ],
-      "exitCondition": {
-        "leaveWithSpark": {}
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "note": "Quickly climb the submerged structures. Not dashing may make platforming easier."
     },
     {
       "link": [3, 2],

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -137,6 +137,49 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Spark",
+      "requires": [
+        "Gravity",
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 0,
+          "steepUpTiles": 4,
+          "steepDownTiles": 2,
+          "startingDownTiles": 1
+        }},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 18}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "Gravity",
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 0,
+          "steepUpTiles": 4,
+          "steepDownTiles": 2,
+          "startingDownTiles": 1
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        "can4HighMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"
@@ -403,6 +446,38 @@
           "openEnd": 1,
           "steepUpTiles": 1
         }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "Gravity",
+        "HiJump",
+        {"or": [
+          {"and": [
+            {"canShineCharge": {
+              "usedTiles": 21,
+              "openEnd": 0,
+              "steepUpTiles": 3,
+              "steepDownTiles": 3,
+              "startingDownTiles": 1
+            }},
+            "canXRayTurnaround"  
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 15,
+            "openEnd": 0,
+            "steepUpTiles": 2,
+            "steepDownTiles": 3,
+            "startingDownTiles": 1
+          }}
+        ]},
+        "canSpringBallJumpMidAir",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
       }
     },
     {

--- a/region/crateria/east/Forgotten Highway Elbow.json
+++ b/region/crateria/east/Forgotten Highway Elbow.json
@@ -103,6 +103,23 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "left"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []

--- a/region/crateria/east/Forgotten Highway Kago Room.json
+++ b/region/crateria/east/Forgotten Highway Kago Room.json
@@ -88,6 +88,28 @@
       "requires": []
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 10,
+          "openEnd": 1,
+          "steepUpTiles": 2,
+          "steepDownTiles": 1
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "any"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []

--- a/region/crateria/east/Homing Geemer Room.json
+++ b/region/crateria/east/Homing Geemer Room.json
@@ -142,6 +142,21 @@
     },
     {
       "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
       "name": "Transition with Stored Fall Speed",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
@@ -242,6 +257,21 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -124,6 +124,57 @@
     },
     {
       "link": [1, 2],
+      "name": "Speedy Jump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 26,
+          "speedBooster": true
+        }
+      },
+      "requires": []
+    },
+    {
+      "link": [1, 2],
+      "name": "Insane Speedy Jump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 21,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Speedy Airball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 18,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canLateralMidAirMorph"
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Insane Speedy Airball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 10,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canLateralMidAirMorph"
+      ]
+    },
+    {
+      "link": [1, 2],
       "name": "Moat SpringBall Bounce, Run Through the Door",
       "notable": true,
       "entranceCondition": {
@@ -306,15 +357,75 @@
         }
       },
       "requires": [
-        "Gravity",
-        "HiJump",
         "canLongChainTemporaryBlue",
-        "canSpringBallJumpMidAir"
+        {"or": [
+          {"and": [
+            "Gravity",
+            "HiJump",
+            "canSpringBallJumpMidAir"
+          ]},
+          {"and": [
+            "canGravityJump",
+            {"or": [
+              "HiJump",
+              "canSpringBallJumpMidAir"
+            ]}
+          ]},
+          "canBlueSpaceJump"
+        ]}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Speedy Jump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "steepDownTiles": 1,
+          "openEnd": 0,
+          "minTiles": 21
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canLateralMidAirMorph",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Enter with enough speed to jump over all the water, morphing mid-air and then unmorphing into temporary blue."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Insane Speedy Jump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "steepDownTiles": 1,
+          "openEnd": 0,
+          "minTiles": 16
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canLateralMidAirMorph",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Enter with enough speed to jump over all the water, morphing mid-air and then unmorphing into temporary blue."
+      ]
     },
     {
       "link": [1, 3],
@@ -431,23 +542,23 @@
     },
     {
       "link": [2, 1],
-      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Speedy Jump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
-          "openEnd": 0
+          "openEnd": 0,
+          "minTiles": 9
         }
       },
       "requires": [
-        "canLongChainTemporaryBlue",
-        "canSpringBallBounce"
+        "canLongChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
-        "Use Spring Ball to bounce through the underwater bomb block."
+        "Enter with enough speed to jump over all the water, morphing mid-air and then unmorphing into temporary blue."
       ]
     },
     {

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -296,6 +296,27 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "steepDownTiles": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        "HiJump",
+        "canLongChainTemporaryBlue",
+        "canSpringBallJumpMidAir"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [1, 3],
       "name": "Base",
       "requires": [
@@ -406,6 +427,27 @@
         "Sparking too late will cause the shot to despawn before reaching the door.",
         "Sparking too early will cause Samus to bonk the door as it will not yet be open.",
         "A beam shot, Missile, or Super can be used."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canSpringBallBounce"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Use Spring Ball to bounce through the underwater bomb block."
       ]
     },
     {

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -653,7 +653,35 @@
     },
     {
       "link": [4, 4],
-      "name": "Leave With Temporary Blue",
+      "name": "Leave With Temporary Blue (Blue Space Jump)",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 23,
+          "openEnd": 1,
+          "steepDownTiles": 5,
+          "steepUpTiles": 1
+        }},
+        "canBlueSpaceJump",
+        "canSlowShortCharge",
+        "canTrickyJump",
+        {"or": [
+          "HiJump",
+          {"canShineCharge": {
+            "usedTiles": 13,
+            "openEnd": 1
+          }}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "devNote": [
+        "HiJump is needed unless horizontal speed is minimized by performing near-perfect shortcharge taps."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Temporary Blue (Spring Ball Jumps)",
       "requires": [
         "Gravity",
         "HiJump",
@@ -674,6 +702,27 @@
         ]},
         "canSpringBallJumpMidAir",
         "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Temporary Blue (Spring Ball Bounce)",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 1,
+          "steepDownTiles": 4,
+          "steepUpTiles": 1
+        }},
+        "canSpeedball",
+        "canSpringBallBounce",
+        "canTrickyJump",
+        "HiJump",
+        "canSpringBallJumpMidAir",
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
@@ -1105,15 +1154,42 @@
     },
     {
       "link": [5, 5],
-      "name": "Leave With Temporary Blue",
+      "name": "Leave With Temporary Blue (Gravity)",
       "requires": [
         "Gravity",
         {"canShineCharge": {
           "usedTiles": 33,
           "openEnd": 2
         }},
-        "canSpringBallJumpMidAir",
-        "canLongChainTemporaryBlue"
+        {"or": [
+          {"and": [
+            "canSpringBallJumpMidAir",
+            "canLongChainTemporaryBlue"
+          ]},
+          {"and": [
+            "canBlueSpaceJump",
+            "canChainTemporaryBlue"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [5, 5],
+      "name": "Leave With Temporary Blue (Spring Ball Bounce)",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 1,
+          "steepDownTiles": 4,
+          "steepUpTiles": 1
+        }},
+        "canSpeedball",
+        "canSpringBallBounce",
+        "canTrickyJump",
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -551,6 +551,20 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
       "link": [2, 12],
       "name": "Base",
       "requires": []
@@ -635,6 +649,34 @@
           "length": 1,
           "openEnd": 1
         }
+      }
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "Gravity",
+        "HiJump",
+        {"or": [
+          {"and": [
+            {"canShineCharge": {
+              "usedTiles": 33,
+              "openEnd": 2
+            }},
+            "canXRayTurnaround"
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 18,
+            "openEnd": 2,
+            "steepUpTiles": 3,
+            "steepDownTiles": 4
+          }}
+        ]},
+        "canSpringBallJumpMidAir",
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
       }
     },
     {
@@ -1059,6 +1101,22 @@
           "openEnd": 1,
           "steepUpTiles": 2
         }
+      }
+    },
+    {
+      "link": [5, 5],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "Gravity",
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        "canSpringBallJumpMidAir",
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
       }
     },
     {

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -937,5 +937,8 @@
       ],
       "devNote": "Damageless is possible without SpringBall but it is very likely you end up taking more damage by attempting it."
     }
+  ],
+  "devNote": [
+    "FIXME: Add canLongChainTemporaryBlue left-to-right strats."
   ]
 }

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -725,5 +725,8 @@
         "Most of these strats kill the Wavers or set up situations where they can't reach the door."
       ]
     }
+  ],
+  "devNote": [
+    "FIXME: add canLongChainTemporaryBlue strats."
   ]
 }

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -564,6 +564,21 @@
     },
     {
       "link": [3, 4],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [3, 4],
       "name": "Transition with Stored Fall Speed",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
@@ -843,6 +858,21 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
+    },
+    {
+      "link": [4, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [4, 3],

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -72,6 +72,20 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"
@@ -155,6 +169,20 @@
         "leaveShinecharged": {
           "framesRemaining": 140
         }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
       }
     }
   ]

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -249,6 +249,37 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"or": [
+          {"canShineCharge": {
+            "usedTiles": 18,
+            "openEnd": 1,
+            "gentleUpTiles": 2,
+            "gentleDownTiles": 4
+          }},
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"canShineCharge": {
+              "usedTiles": 19,
+              "openEnd": 1,
+              "gentleUpTiles": 2,
+              "gentleDownTiles": 4
+            }}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "left"
+        }
+      },
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []}
+      ]
+    },
+    {
+      "link": [2, 2],
       "name": "Gamet Ice Moonfall Door Lock Skip",
       "requires": [
         "canEnemyStuckMoonfall",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -249,7 +249,13 @@
                   "type": "integer",
                   "title": "Steep Down Tiles",
                   "description": "Number of tiles in the runway that steeply slope (one vertical tile) downwards (when running away from the door)"
-                }    
+                },
+                "minTiles": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInShinecharging/properties/minTiles",
+                  "type": "integer",
+                  "title": "Minimum Tiles",
+                  "description": "Minimum number of tiles of runway in the other room required to be used (in order to gain enough momentum)."
+                }
               }
             },
             "comeInShinecharged": {

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -364,7 +364,14 @@
               "description": "Represents that Samus must come in by jumping through this door with temporary blue.",
               "required": [],
               "additionalProperties": false,
-              "properties": {}
+              "properties": {
+                "direction": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithTemporaryBlue/properties/direction",
+                  "type": "string",
+                  "description": "Direction that Samus must be facing through the transition (applicable only to vertical transitions).",
+                  "enum": ["left", "right", "any"]
+                }
+              }
             },
             "comeInWithStoredFallSpeed": {
               "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithStoredFallSpeed",
@@ -655,6 +662,22 @@
                   "title": "Frames Remaining",
                   "minimum": 1,
                   "description": "The number of frames remaining in the shinespark charge when leaving the room."
+                }
+              }
+            },
+            "leaveWithTemporaryBlue": {
+              "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithTemporaryBlue",
+              "type": "object",
+              "title": "Leave With Temporary Blue",
+              "description": "Represents that Samus may jump through this door with temporary blue.",
+              "required": [],
+              "additionalProperties": false,
+              "properties": {
+                "direction": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithTemporaryBlue/properties/direction",
+                  "type": "string",
+                  "description": "Direction that Samus is facing through the transition (applicable only to vertical transitions).",
+                  "enum": ["left", "right", "any"]
                 }
               }
             },

--- a/strats.md
+++ b/strats.md
@@ -526,7 +526,9 @@ A `comeInShinecharging` entrance condition represents the need for Samus to run 
 
 * _length_, _openEnd_, _gentleUpTiles_, _gentleDownTiles_, _steepUpTiles_, _steepDownTiles_
 
-The length should not include any tiles that Samus skips over through the transition (e.g. door transition tiles and door shell tiles).
+The length should not include any tiles that Samus skips over through the transition (e.g. door transition tiles and door shell tiles). It also has the following property:
+
+* _minTiles_: If specified, this is the minimum number of tiles of runway in the other room required to be used, in order to gain enough momentum.
 
 A `comeInShinecharging` must match with a corresponding `leaveWithRunway` condition on the other side of the door. 
 
@@ -540,7 +542,7 @@ The way to calculate minimally required heat frames depends on the type of `leav
 
 - If the `from` node of the `leaveWithRunway` is the same as the `to` node, then this represents that the runway in the other room is used starting from the door. In this case Samus will need to run in both directions. The way to calculate heat frames then depends on which rooms are heated:
   - If both rooms are heated, then it is best to use smallest amount of runway possible in the other room. If the required shinecharge tiles
-  (based on the desired difficulty) is no more than the effective runway length in the current room (based on the `comeInShinecharging` properties), then there is no need to add heat frames for running in the other room. Otherwise, the amount of runway to use in the other room is the difference between the required shinecharge tiles and the effective runway length in the current room. The run in the other room to get positioned on the runway can be done at full speed, so the [table](#come-in-running) can be used to determine the required heat frames for this run, including heat frames for turning around and positioning. For the run back to charge the spark, there are two cases:
+  (based on the desired difficulty) is no more than the effective runway length in the current room (based on the `comeInShinecharging` properties), then there is no need to add heat frames for running in the other room. Otherwise, the amount of runway to use in the other room is the difference between the required shinecharge tiles and the effective runway length in the current room (but at least `minTiles`, if specified). The run in the other room to get positioned on the runway can be done at full speed, so the [table](#come-in-running) can be used to determine the required heat frames for this run, including heat frames for turning around and positioning. For the run back to charge the spark, there are two cases:
      - If the combined effective runway length is at least 31.3 tiles, then dash can be held through the entire run, so the [table](#come-in-running) can be used to get the total heat frames. 
      - If the combined effective runway length is less than 31.3 tiles, then run back to charge the spark requires a constant 85 frames (essentially independent of shortcharging technique).
 

--- a/strats.md
+++ b/strats.md
@@ -85,6 +85,7 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveNormally_: This indicates that can Samus leave through this door in a "normal" way, by walking, falling, or jumping.
 - _leaveWithRunway_: This indicates that a runway of a certain length is connected to the door, with which Samus can gain speed and run or jump through the door, among other possible actions. 
 - _leaveShinecharged_: This indicates that it is possible to charge a shinespark and leave the room with a certain amount of time remaining on the shinecharge timer (e.g., so that a shinespark can be activated in the next room). 
+- _leaveWithTemporaryBlue_: This indicates that Samus may leave through this door by jumping with temporary blue.
 - _leaveWithSpark_: This indicates that it is possible to shinespark through the door transition.
 - _leaveWithStoredFallSpeed_: This indicates that is is possible to walk through the door with the stored velocity to clip through floor tiles using a Moonfall.
 - _leaveWithGModeSetup_: This indicates that Samus can take enemy damage through the door transition, to set up R-mode or direct G-mode in the next room.
@@ -178,6 +179,32 @@ A `leaveShinecharged` object does not provide any way to specify Samus' position
     "leaveShinecharged": {
       "framesRemaining": 90
     }
+  }
+}
+```
+
+### Leave With Temporary Blue
+
+A `leaveWithTemporaryBlue` exit condition represents that Samus can leave through this door by jumping with temporary blue. It has no properties.
+
+The `leaveWithTemporaryBlue` object has the following property:
+- _direction_: This takes two possible values "left" and "right", indicating the direction that Samus is facing through the transition. It should be specified for all vertical transitions but not horizontal ones.
+
+*Note*: Using a runway connected to a door to leave the room with temporary blue is already covered by `leaveWithRunway`.
+
+#### Example
+```json
+{
+  "name": "Leave With Temporary Blue",
+  "notable": false,
+  "requires": [
+    {"canShinecharge": {
+      "usedTiles": 20,
+      "openEnd": 0
+    }}
+  ],
+  "exitCondition": {
+    "leaveWithTemporaryBlue": {}
   }
 }
 ```
@@ -741,7 +768,16 @@ A `comeInSpeedballing` entrance condition must match with a `leaveWithRunway` co
 
 A `comeInWithTemporaryBlue` entrance condition indicates that Samus must come in by jumping through this door with temporary blue. It has no properties.
 
-A `comeInWithTemporaryBlue` entrance condition must match with a `leaveWithRunway` condition on the other side of the door. This comes with implicit requirements for actions to be performed in the previous room:
+The `comeInWithTemporaryBlue` object has the following property:
+- _direction_: This takes two possible values "left" and "right", indicating the direction that Samus must be facing through the transition. It should be specified for all vertical transitions but not horizontal ones.
+
+A `comeInWithTemporaryBlue` entrance condition must match with either a `leaveWithTemporaryBlue` or `leaveWithRunway` condition on the other side of the door. 
+
+For a `comeInWithTemporaryBlue` to match with a `leaveWithTemporaryBlue`, their `direction` properties must be equal, if they are both specified and not "any".
+
+A match with `leaveWithTemporaryBlue` comes only with an implicit requirement of the tech `canTemporaryBlue`.
+
+A match with `leaveWithRunway` comes with implicit requirements for actions to be performed in the previous room:
   - The tech `canTemporaryBlue` is required.
   - A `canShinecharge` requirement is included based on the runway length. This includes a `SpeedBooster` item requirement as well as a check that the effective runway length is enough that gaining a shinecharge is possible.
   - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as in `comeInShinecharging`, except here with `comeInShinecharged` there is no second runway to combine with. An extra 200 heat frames are assumed for gaining temporary blue and leaving the room after the shinecharge is obtained.

--- a/tech.json
+++ b/tech.json
@@ -1321,6 +1321,17 @@
                 "Afterwards, hold angle again while soft unmorphing and continue to hold angle after landing.",
                 "Hold forward the entire time while morphed after the mockball inputs to prevent losing Temporary Blue.",
                 "It is possible to use this alongside canXRayTurnaround to change directions during a Temporary Blue chain."
+              ],
+              "extensionTechs": [
+                {
+                  "name": "canLongChainTemporaryBlue",
+                  "requires": [
+                    "canChainTemporaryBlue"
+                  ],
+                  "note": [
+                    "The ability to move across large distances while maintaining Temporary Blue."
+                  ]
+                }    
               ]
             }
           ]

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -84,6 +84,7 @@ def process_keyvalue(k, v, metadata):
         "speedBooster", # validated by schema
         "framesRemaining",  # validated by schema
         "comesThroughToilet",  # validated by schema
+        "direction",  # validated by schema
         "types",  # validated by schema in 'unlocksDoors', manually in 'enemyDamage'
     ]
 
@@ -693,6 +694,15 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 msg = f"🔴ERROR: Strat has 'comesThroughToilet' but is not a vertical connection:{stratRef}"
                                 messages["reds"].append(msg)
                                 messages["counts"]["reds"] += 1
+                            if "comeInWithTemporaryBlue" in strat["entranceCondition"]:
+                                if (room["id"], fromNode) in vertical_door_nodes and "direction" not in strat["entranceCondition"]["comeInWithTemporaryBlue"]:
+                                    msg = f"🔴ERROR: Strat has vertical comeInWithTemporaryBlue entranceCondition without 'direction':{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
+                                if (room["id"], fromNode) not in vertical_door_nodes and "direction" in strat["entranceCondition"]["comeInWithTemporaryBlue"]:
+                                    msg = f"🔴ERROR: Strat has non-vertical comeInWithTemporaryBlue entranceCondition with 'direction':{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
                         if "exitCondition" in strat:
                             if node_lookup[toNode]["nodeType"] not in ["door", "exit"]:
                                 msg = f"🔴ERROR: Strat has exitCondition but To Node is not door or exit:{stratRef}"
@@ -704,6 +714,16 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                         msg = f"🔴ERROR: Strat has leaveShinecharged exitCondition with framesRemaining 'auto' but no comeInShinecharged entranceCondition:{stratRef}"
                                         messages["reds"].append(msg)
                                         messages["counts"]["reds"] += 1
+                            if "leaveWithTemporaryBlue" in strat["exitCondition"]:
+                                if (room["id"], toNode) in vertical_door_nodes and "direction" not in strat["exitCondition"]["leaveWithTemporaryBlue"]:
+                                    msg = f"🔴ERROR: Strat has vertical leaveWithTemporaryBlue exitCondition without 'direction':{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
+                                if (room["id"], toNode) not in vertical_door_nodes and "direction" in strat["exitCondition"]["leaveWithTemporaryBlue"]:
+                                    msg = f"🔴ERROR: Strat has non-vertical leaveWithTemporaryBlue exitCondition with 'direction':{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
+
                         node_subtype = node_lookup[toNode]["nodeSubType"]
                         door_unlocked_nodes = find_door_unlocked_nodes(strat, node_subtype)                                
                         for node in door_unlocked_nodes:


### PR DESCRIPTION
This adds some new stuff relating to cross-room temporary blue strats:
- A new exit condition `leaveWithTemporaryBlue`, in order to represent strats that leave a room with temporary blue using methods other than using a runway connected to the door (e.g. by chaining temporary blue from a runway elsewhere in the room).
- A new tech `canLongChainTemporaryBlue`.
- A new `direction` property in the `comeInWithTemporaryBlue` entrance condition, since for vertical transitions the direction that Samus is facing can be important (e.g. if X-Ray is not available to turn around).
- Applications in Crateria (and one random instance in Post Croc Farm Room).

Currently I'm not adding `comeInWithTemporaryBlue` + `leaveWithTemporaryBlue` strats, because that would allow arbitrarily long chains, which could create a difficulty problem. We could add those later if we come up with some way to deal with that.