### PR TITLE
G-Mode Bottom of Vertical Doors

### DIFF
--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -265,7 +265,7 @@
             "type": "contact",
             "hits": 1
           }}
-        ]}
+        ]},
         {"or": [
           "h_canArtificialMorphSpringBallBombJump",
           {"and": [

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -227,6 +227,69 @@
         }}
       ],
       "gModeRegainMobility": {}
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Back Up",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "bypassesDoorShell": true,
+      "note": "Quickly jump back through the door to avoid a Kihunter hit."
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Morph Back Up",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        {"or": [
+          "canTrickyJump",
+          {"enemyDamage": {
+            "enemy": "Kihunter (green)",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+        {"or": [
+          "h_canArtificialMorphSpringBallBombJump",
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "HiJump"
+          ]},
+          {"and": [
+            "h_canArtificialMorphIBJ",
+            "h_canArtificialMorphPowerBomb"
+          ]},
+          "Morph"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "bypassesDoorShell": true,
+      "note": [
+        "With Spring Ball alone, quickly jump over the Kihunter and wait for it to move away, then Spring Ball Bomb Jump through the door.",
+        "Alternatively, place a Power Bomb and roll to the left on entry to kill the Kihunter, then quickly IBJ through the door before more arrive."
+      ],
+      "devNote": "It is possible to do this with Bombs alone, but it is pretty chaotic."
     }
   ]
 }

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -540,7 +540,7 @@
       }
     },
     {
-      "link": [1, 1],
+      "link": [3, 3],
       "name": "Carry G-Mode Back Up",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -558,7 +558,7 @@
       "bypassesDoorShell": true
     },
     {
-      "link": [1, 1],
+      "link": [3, 3],
       "name": "Carry G-Mode Morph Back Up",
       "entranceCondition": {
         "comeInWithGMode": {

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -538,6 +538,52 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       }
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Up",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "bypassesDoorShell": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Up",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        {"or": [
+          "h_canArtificialMorphSpringBallBombJump",
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "HiJump"
+          ]},
+          "h_canArtificialMorphIBJ",
+          "Morph"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "bypassesDoorShell": true
     }
   ]
 }

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -271,6 +271,42 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
+    },
+    {
       "link": [1, 2],
       "name": "Temporary Blue Chain",
       "entranceCondition": {

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -273,10 +273,9 @@
     {
       "link": [1, 1],
       "name": "Carry G-Mode Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": false
         }
       },
@@ -285,15 +284,15 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 1],
       "name": "Carry G-Mode Morph Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": true
         }
       },
@@ -304,7 +303,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 2],

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -277,7 +277,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": false
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [],
       "exitCondition": {
@@ -294,7 +295,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": true
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [
         "h_canArtificialMorphMovement"

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -174,7 +174,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": false
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [],
       "exitCondition": {
@@ -191,7 +192,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": true
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [
         "h_canArtificialMorphMovement"

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -168,6 +168,42 @@
       "gModeRegainMobility": {}
     },
     {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
+    },
+    {
       "link": [1, 3],
       "name": "Base",
       "requires": [

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -170,10 +170,9 @@
     {
       "link": [1, 1],
       "name": "Carry G-Mode Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": false
         }
       },
@@ -182,15 +181,15 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 1],
       "name": "Carry G-Mode Morph Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": true
         }
       },
@@ -201,7 +200,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 3],

--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -78,7 +78,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": false
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [],
       "exitCondition": {
@@ -95,7 +96,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": true
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [
         "h_canArtificialMorphMovement"

--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -74,10 +74,9 @@
     {
       "link": [1, 1],
       "name": "Carry G-Mode Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": false
         }
       },
@@ -86,15 +85,15 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 1],
       "name": "Carry G-Mode Morph Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": true
         }
       },
@@ -105,7 +104,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 2],

--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -72,6 +72,42 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -93,7 +93,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": false
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [],
       "exitCondition": {
@@ -110,7 +111,8 @@
         "comeInWithGMode": {
           "mode": "direct",
           "morphed": true
-        }
+        },
+        "comesThroughToilet": "any"
       },
       "requires": [
         "h_canArtificialMorphMovement"

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -89,10 +89,9 @@
     {
       "link": [1, 1],
       "name": "Carry G-Mode Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": false
         }
       },
@@ -101,15 +100,15 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 1],
       "name": "Carry G-Mode Morph Back Up",
-      "notable": false,
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "direct",
           "morphed": true
         }
       },
@@ -120,7 +119,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "bypassesDoorShell": true
     },
     {
       "link": [1, 2],

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -87,6 +87,42 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Up",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []

--- a/strats.md
+++ b/strats.md
@@ -297,7 +297,7 @@ A `leaveWithGMode` exit condition represents that Samus can leave through this d
 A `leaveWithGMode` object has the following property:
 - _morphed_: If true, then this strat results in leaving the room in a morphed state, either by maintaining artificial morph or by having the Morph item.
 
-For most doors in the game, it is possible to enter the room with a G-mode setup and then immediately exit back through the same door. This is because in direct G-mode the door does not close behind Samus. To avoid the need to write out tedious boilerplate, these strats are understood to be included implicitly. Specifically, for every door node without a `spawnAt` property, there are two implicit strats, with `leaveWithGMode` exit conditions, one of the form
+For most doors in the game, it is possible to enter the room with a G-mode setup and then immediately exit back through the same door. This is because in direct G-mode the door does not close behind Samus. To avoid the need to write out tedious boilerplate, these strats are understood to be included implicitly. The implicit strats are included for every door node excluding vertical doors with `"position": "bottom"` as well as any with a `spawnAt` property. There are two implicit strats, with `leaveWithGMode` exit conditions, one of the form
 
 ```json
 {


### PR DESCRIPTION
Currently it is always assumed that you can return through a door in g-mode unless there is a spawn-at. After this, I want it to not implicitly assume that for the bottom of a vertical door.

This is for Crateria and Brinstar.