### PR TITLE
Waterway spark fix

### DIFF
--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -360,6 +360,7 @@
         "canHorizontalShinespark",
         {"shinespark": {"frames": 72, "excessFrames": 10}}
       ],
+      "clearsObstacles": ["A"],
       "note": [
         "Run from left to right on the dry platform to gain a shinecharge.",
         "Then fall off and spark to the left to break the speed blocks."


### PR DESCRIPTION
Recently added obstacle "A" to this room but forgot to put "clearsObstacle" on the shinespark strat from the platform. So this has been making the logic think the item would only be one-way reachable that way.

Noticed it from the spoiler map on Andy's seed today. 