### PR TITLE
Add collectsItems and setsFlags

### DIFF
--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -905,6 +905,25 @@
             "pattern": "^(.*)$"
           }
         },
+        "collectsItems": {
+          "$id": "#/definitions/strat/properties/collectsItems",
+          "type": "array",
+          "title": "Collects Items",
+          "description": "A list of node IDs of items that become collected (if not already collected) by executing this strat.",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "setsFlags": {
+          "$id": "#/definitions/strat/properties/setsFlags",
+          "type": "array",
+          "title": "Sets Flags",
+          "description": "A list of flag names of flags that are set by executing this strat.",
+          "items": {
+            "type": "string",
+            "pattern": "^(.*)$"
+          }
+        },
         "failures": {
           "$id": "#/definitions/strat/properties/failures",
           "type": "array",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -918,7 +918,7 @@
           "$id": "#/definitions/strat/properties/setsFlags",
           "type": "array",
           "title": "Sets Flags",
-          "description": "A list of flag names of flags that are set by executing this strat.",
+          "description": "A list of names of game flags that are set by executing this strat.",
           "items": {
             "type": "string",
             "pattern": "^(.*)$"

--- a/strats.md
+++ b/strats.md
@@ -1140,7 +1140,6 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
   "link": [5, 6],
   "name": "Break the Tube",
   "requires": [
-    {"not": "f_MaridiaTubeBroken"},
     "h_canUsePowerBombs"
   ],
   "setsFlags": ["f_MaridiaTubeBroken"]

--- a/strats.md
+++ b/strats.md
@@ -18,7 +18,8 @@ A `strat` can have the following properties:
   * _gModeRegainMobility_: Indicates that this strat allows regaining mobility when entering with G-mode immobile.
   * _bypassesDoorShell_: Indicates that this strat allows exiting without opening the door.
   * _unlocksDoors_: An array describing possible doors that can be unlocked as part of this strat.
-  
+  * _collectsItems_: An array listing items that are collected as part of this strat (e.g. for G-mode remote item acquire).
+  * _setsFlags_: An array listing game flags that are set as part of this strat.
 These properties are described below in more detail.
 ### Example
 
@@ -1114,3 +1115,34 @@ In a heated room, it instead has the form:
 ```
 
 The implicit unlock strats can be disabled by setting the node property `useImplicitDoorUnlocks` to false.
+
+## Collects Items
+
+An `collectsItems` array lists the node IDs (within the room) of items that become collected (if not already collected) as part of executing this strat. This can be useful, for example, for strats that use G-mode to "remote acquire" items at a location different from the item node.
+
+For items collected in this way, the `locks` property of the item node plays no role, so the strat `requires` must include any necessary requirements to ensure the item has spawned.
+
+```json
+{
+  "link": [1, 2],
+  "name": "G-Mode Remote Acquire Item",
+  "requires": [],
+  "collectsItems": [3]
+}
+```
+
+## Sets Flags
+
+A `setsFlags` array lists the names of game flags that become set (if not already set) as part of executing this strat.
+
+```json
+{
+  "link": [5, 6],
+  "name": "Break the Tube",
+  "requires": [
+    {"not": "f_MaridiaTubeBroken"},
+    "h_canUsePowerBombs"
+  ],
+  "setsFlags": ["f_MaridiaTubeBroken"]
+}
+```

--- a/strats.md
+++ b/strats.md
@@ -1118,7 +1118,7 @@ The implicit unlock strats can be disabled by setting the node property `useImpl
 
 ## Collects Items
 
-An `collectsItems` array lists the node IDs (within the room) of items that become collected (if not already collected) as part of executing this strat. This can be useful, for example, for strats that use G-mode to "remote acquire" items at a location different from the item node.
+A `collectsItems` array lists the node IDs (within the room) of items that become collected (if not already collected) as part of executing this strat. This can be useful, for example, for strats that use G-mode to "remote acquire" items at a location different from the item node.
 
 For items collected in this way, the `locks` property of the item node plays no role, so the strat `requires` must include any necessary requirements to ensure the item has spawned.
 

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -743,6 +743,20 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 messages["reds"].append(msg)
                                 messages["counts"]["reds"] += 1
 
+                        if "collectsItems" in strat:
+                            for item_node_id in strat["collectsItems"]:
+                                if item_node_id not in node_lookup or node_lookup[item_node_id]["nodeType"] != "item":
+                                    msg = f"🔴ERROR: collectsItems references node {item_node_id} which is not an item node:{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
+
+                        if "setsFlags" in strat:
+                            for flag in strat["setsFlags"]:
+                                if flag not in keywords["flags"]:
+                                    msg = f"🔴ERROR: setsFlags references flag '{flag}' which does not exist:{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
+
                     # Validate Nodes
                     showNodes = paramData["showNodes"]
                     bail = paramData["bail"]


### PR DESCRIPTION
This will resolve #1086.

Earlier I was resistant to add these because it requires adding extra nodes on the randomizer side to deal with them. But we're going to have to do that kind of thing anyway in order to handle door locks properly, so I no longer see a reason not to do this. Given that we have `unlocksDoors` on strats (and `clearsObstacles`, etc.), it only seems natural to have `collectsItems` and `setsFlags`. Eventually I would like if all the flags could be set using `setsFlags` in this way, and then we could remove flag nodes and their associated locks/yields (the way that flags are currently getting set), as part of the long-term goal of migrating strats away from being embedded inside "node" properties and into the room "strats" list instead.