### PR TITLE
 Remove Diagonal IBJ from Crateria Supers

### DIFF
--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -200,7 +200,7 @@
     },
     {
       "link": [1, 3],
-      "name": "Direct G-Mode Morph",
+      "name": "Direct G-Mode Morph Ceiling Bomb Jump",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -208,10 +208,7 @@
         }
       },
       "requires": [
-        {"or": [
-          "h_canArtificialMorphDiagonalBombJump",
-          "h_canArtificialMorphCeilingBombJump"
-        ]}
+        "h_canArtificialMorphCeilingBombJump"
       ],
       "clearsObstacles": ["C"]
     },
@@ -226,7 +223,6 @@
       },
       "requires": [
         {"or": [
-          "h_canArtificialMorphDiagonalBombJump",
           "h_canArtificialMorphCeilingBombJump",
           {"and": [
             "h_canArtificialMorphSpringBall",
@@ -305,12 +301,9 @@
     },
     {
       "link": [1, 4],
-      "name": "Bomb Jump Over Spikes",
+      "name": "Ceiling Bomb Jump Over Spikes",
       "requires": [
-        {"or": [
-          "h_canDiagonalBombJump",
-          "h_canCeilingBombJump"
-        ]}
+        "h_canCeilingBombJump"
       ]
     },
     {
@@ -354,11 +347,10 @@
               {"spikeHits": 2}
             ]}
           ]},
-          "h_canArtificialMorphDiagonalBombJump",
           "h_canArtificialMorphCeilingBombJump"
         ]}
       ],
-      "devNote": "The IBJ strat has 2 extra spike hits added as a leniency."
+      "devNote": "The IBJ from spikes has 2 extra spike hits added as a leniency."
     },
     {
       "link": [1, 5],
@@ -1029,27 +1021,13 @@
     },
     {
       "link": [4, 1],
-      "name": "Bomb Jump Over Spikes",
+      "name": "Jump into Ceiling Bomb Jump Over Spikes",
       "requires": [
-        {"or": [
-          "h_canDiagonalBombJump",
-          {"and": [
-            "h_canCeilingBombJump",
-            "canPreciseWalljump",
-            "canWallJumpInstantMorph",
-            "canJumpIntoIBJ"
-          ]}
-        ]}
+        "h_canCeilingBombJump",
+        "canPreciseWalljump",
+        "canWallJumpInstantMorph",
+        "canJumpIntoIBJ"
       ]
-    },
-    {
-      "link": [4, 1],
-      "name": "G-Mode Artificial Morph Diagonal Bomb Jump",
-      "requires": [
-        {"obstaclesCleared": ["C"]},
-        "h_canArtificialMorphDiagonalBombJump"
-      ],
-      "devNote": "Returning from the item in GMode needs to avoid any spike damage, or Crystal Flash."
     },
     {
       "link": [4, 3],

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -208,6 +208,7 @@
         }
       },
       "requires": [
+        "canLongCeilingBombJump",
         "h_canArtificialMorphCeilingBombJump"
       ],
       "clearsObstacles": ["C"]
@@ -223,7 +224,10 @@
       },
       "requires": [
         {"or": [
-          "h_canArtificialMorphCeilingBombJump",
+          {"and": [
+            "canLongCeilingBombJump",
+            "h_canArtificialMorphCeilingBombJump"
+          ]},
           {"and": [
             "h_canArtificialMorphSpringBall",
             {"spikeHits": 3},
@@ -303,6 +307,7 @@
       "link": [1, 4],
       "name": "Ceiling Bomb Jump Over Spikes",
       "requires": [
+        "canLongCeilingBombJump",
         "h_canCeilingBombJump"
       ]
     },
@@ -347,7 +352,10 @@
               {"spikeHits": 2}
             ]}
           ]},
-          "h_canArtificialMorphCeilingBombJump"
+          {"and": [
+            "canLongCeilingBombJump",
+            "h_canArtificialMorphCeilingBombJump"
+          ]}
         ]}
       ],
       "devNote": "The IBJ from spikes has 2 extra spike hits added as a leniency."
@@ -1023,6 +1031,7 @@
       "link": [4, 1],
       "name": "Jump into Ceiling Bomb Jump Over Spikes",
       "requires": [
+        "canLongCeilingBombJump",
         "h_canCeilingBombJump",
         "canPreciseWalljump",
         "canWallJumpInstantMorph",


### PR DESCRIPTION
I believe this is too long too low of an angle for `canDiagonalBombJump`. This was expected on Spiffy's recent seed, which caused some confusion. 

I also checked all other uses of `canDiagonalBombJump`, which looked fine. And added `canLongCeilingBombJump` here, as it is 2 screens wide.