### PR TITLE
Add doorOrientation node property

### DIFF
--- a/region/brinstar/blue/Billy Mays Room.json
+++ b/region/brinstar/blue/Billy Mays Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018ffa",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018fee",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018fe2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018ee6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "viewableNodes": [
         {
@@ -34,6 +35,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018ef2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018ec2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018ece",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018eda",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/blue/First Missile Room.json
+++ b/region/brinstar/blue/First Missile Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018fa6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018e9e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -39,7 +40,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0018eb6"
+      "nodeAddress": "0x0018eb6",
+      "doorOrientation": "up"
     },
     {
       "id": 3,
@@ -47,6 +49,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018eaa",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Brinstar Map Room.json
+++ b/region/brinstar/green/Brinstar Map Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d72",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d36",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018d42",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d66",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d4e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018d5a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0018f3a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f2e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f52",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -53,6 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f46",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Etecoon Save Room.json
+++ b/region/brinstar/green/Etecoon Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019012",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Etecoon Super Room.json
+++ b/region/brinstar/green/Etecoon Super Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f5e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f22",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f16",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d7e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d8a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/green/Green Brinstar Main Shaft Save Room.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019006",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -13,7 +13,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0018ca6"
+      "nodeAddress": "0x0018ca6",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
@@ -21,6 +22,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018cb2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -44,6 +46,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018cd6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -67,6 +70,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018d12",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -90,6 +94,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018cca",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -113,6 +118,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018ce2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -136,6 +142,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018cee",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -159,6 +166,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018cbe",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -167,6 +175,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d06",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "spawnAt": 9,
       "devNote": [
@@ -180,6 +189,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018cfa",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Green Brinstar Missile Refill.json
+++ b/region/brinstar/green/Green Brinstar Missile Refill.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d96",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018e7a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0018e86",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018e92",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018efe",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0018f0a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018e32",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018e3e",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/green/Spore Spawn Room.json
+++ b/region/brinstar/green/Spore Spawn Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018e4a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0018e56",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0019192",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -39,6 +40,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001919e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00191aa",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x00191c2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "eye",
       "nodeAddress": "0x00191b6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/kraid/Kraid Recharge Station.json
+++ b/region/brinstar/kraid/Kraid Recharge Station.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001920a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x00191ce",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x00191da",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/kraid/Kraid Save Room.json
+++ b/region/brinstar/kraid/Kraid Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001925e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/kraid/Varia Suit Room.json
+++ b/region/brinstar/kraid/Varia Suit Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019252",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0019162",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001922e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -21,7 +22,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0019246"
+      "nodeAddress": "0x0019246",
+      "doorOrientation": "down"
     },
     {
       "id": 3,
@@ -29,6 +31,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001923a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001916e",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001917a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019186",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001913e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001914a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019156",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/pink/Big Pink Save Room.json
+++ b/region/brinstar/pink/Big Pink Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018fd6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018df6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018dc6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018dd2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -53,6 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x0018e02",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -61,6 +65,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018dde",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "spawnAt": 14,
       "note": "Samus is considered to spawn at 14 because of the crumble blocks. This can be negated by performing a stationary spin jump when entering, allowing her to 'get back to 5'"
@@ -71,6 +76,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0018e1a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -94,6 +100,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018e26",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -102,6 +109,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0018dea",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -125,6 +133,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018e0e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/pink/Dachora Energy Refill.json
+++ b/region/brinstar/pink/Dachora Energy Refill.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f6a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018da2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018dba",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018dae",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/pink/Hopper Energy Tank Room.json
+++ b/region/brinstar/pink/Hopper Energy Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018fca",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018fb2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018fbe",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018e62",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -39,6 +40,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018e6e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0018f82",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f76",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d2a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018d1e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018f8e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00190ea",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/red/Bat Room.json
+++ b/region/brinstar/red/Bat Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00190f6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019102",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001910e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001911a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0019126",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x00190de",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x00190a2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x00190ae",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -60,6 +62,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0019096",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -83,6 +86,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00190d2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -91,6 +95,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00190c6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -98,7 +103,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x00190ba"
+      "nodeAddress": "0x00190ba",
+      "doorOrientation": "up"
     }
   ],
   "obstacles": [

--- a/region/brinstar/red/Caterpillar Save Room.json
+++ b/region/brinstar/red/Caterpillar Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001926a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001907e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001908a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001905a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019066",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001902a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0019036",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001904e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -68,6 +71,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019042",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -76,6 +80,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001901e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/red/Sloaters Refill.json
+++ b/region/brinstar/red/Sloaters Refill.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00191fe",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/red/Spazer Room.json
+++ b/region/brinstar/red/Spazer Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019132",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019072",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "viewableNodes": [
         {

--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aba0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001abac",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/ceres/main/Ceres Elevator Room.json
+++ b/region/ceres/main/Ceres Elevator Room.json
@@ -37,6 +37,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab4c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/ceres/main/Ceres Elevator Room.json
+++ b/region/ceres/main/Ceres Elevator Room.json
@@ -13,6 +13,7 @@
       "name": "Elevator",
       "nodeType": "exit",
       "nodeSubType": "elevator",
+      "doorOrientation": "up",
       "locks": [
         {
           "name": "Ceres Elevator Lock",

--- a/region/ceres/main/Ceres Ridley's Room.json
+++ b/region/ceres/main/Ceres Ridley's Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001abb8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/ceres/main/Dead Scientist Room.json
+++ b/region/ceres/main/Dead Scientist Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab88",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab94",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/ceres/main/Falling Tile Room.json
+++ b/region/ceres/main/Falling Tile Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab58",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab64",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/ceres/main/Magnet Stairs Room.json
+++ b/region/ceres/main/Magnet Stairs Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab70",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab7c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/central/Blue Brinstar Elevator Room.json
+++ b/region/crateria/central/Blue Brinstar Elevator Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018b92",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -21,7 +22,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0018b9e"
+      "nodeAddress": "0x0018b9e",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [],

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018baa",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018b3e",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018b6e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018b4a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -68,6 +71,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0018b56",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -105,6 +109,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018b62",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/central/Crateria Map Room.json
+++ b/region/crateria/central/Crateria Map Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c2e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189b2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/central/Crateria Save Room.json
+++ b/region/crateria/central/Crateria Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189be",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c6a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c76",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x0018ac6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x0018ad2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c82",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c8e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bb6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018bc2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -131,7 +131,8 @@
         "powerbomb",
         "energy",
         "reserve"
-      ]
+      ],
+      "doorOrientation": "down"
     },
     {
       "id": 6,

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001892e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018916",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -46,6 +48,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x001893a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -83,6 +86,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0018922",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001895e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001899a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -62,6 +64,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189a6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -86,6 +89,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001896a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -94,6 +98,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018982",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -102,6 +107,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018976",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -139,6 +145,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001898e",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018b7a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +46,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018b86",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bce",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bda",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/central/The Final Missile.json
+++ b/region/crateria/central/The Final Missile.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c9a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a12",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a1e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a96",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018aae",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a2a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0018a36",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0018a42",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a66",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a72",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/east/Forgotten Highway Elbow.json
+++ b/region/crateria/east/Forgotten Highway Elbow.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018aa2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0018aba",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a4e",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -21,7 +22,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0018a5a"
+      "nodeAddress": "0x0018a5a",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [],

--- a/region/crateria/east/Forgotten Highway Kago Room.json
+++ b/region/crateria/east/Forgotten Highway Kago Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a7e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018a8a",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/east/Homing Geemer Room.json
+++ b/region/crateria/east/Homing Geemer Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018b26",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018b32",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0018af6",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -36,7 +37,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0018b02"
+      "nodeAddress": "0x0018b02",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [],

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018ade",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018aea",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189ca",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189ee",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189fa",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -39,6 +42,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0018a06",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -62,6 +66,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x00189d6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -85,6 +90,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189e2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -93,6 +99,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189ca",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "note": [
         "This door can only be accessed with the use of glitchy techniques.",
@@ -105,6 +112,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00189d6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "note": [
         "This door can only be accessed with the use of glitchy techniques.",

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018b1a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018b0e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018952",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018946",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/west/Green Brinstar Elevator Room.json
+++ b/region/crateria/west/Green Brinstar Elevator Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bfe",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -21,7 +22,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0018c0a"
+      "nodeAddress": "0x0018c0a",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [],

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c5e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c3a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c46",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -38,6 +41,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0018c52",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c22",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018c16",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00191e6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00191f2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0019216",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -34,7 +35,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x0019222"
+      "nodeAddress": "0x0019222",
+      "doorOrientation": "down"
     },
     {
       "id": 3,

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018be6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0018bf2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019996",
+      "doorOrientation": "left",
       "doorEnvironments": [
         {
           "physics": "air",
@@ -36,6 +37,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00199a2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00198e2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019906",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019912",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -39,6 +42,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00198ee",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
+++ b/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00199d2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00199de",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -40,6 +40,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00198d6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "eye",
       "nodeAddress": "0x00198ca",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a92",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019aaa",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a9e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00199ae",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00199c6",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00199ba",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019852",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001985e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -36,7 +38,8 @@
       "name": "Top of Elevator Ride",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x001986a"
+      "nodeAddress": "0x001986a",
+      "doorOrientation": "up"
     }
   ],
   "enemies": [

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0019a32",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -40,6 +41,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a3e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001992a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -58,6 +59,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019936",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019942",
+      "doorOrientation": "left",
       "doorEnvironments": [
         {
           "physics": "air",
@@ -29,6 +30,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001994e",
+      "doorOrientation": "right",
       "doorEnvironments": [
         {
           "physics": "air",

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001995a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "devNote": "FIXME can leave charged by charging in the acid"
     },
@@ -24,6 +25,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019966",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "devNote": "FIXME can leave charged by charging in the acid"
     },

--- a/region/lowernorfair/east/Red Kihunter Shaft Save Room.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019ab6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00199f6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x00199ea",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -46,6 +48,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a0e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -54,6 +57,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a02",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Ridley Tank Room.json
+++ b/region/lowernorfair/east/Ridley Tank Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a62",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x00198b2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x00198be",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019972",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001998a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001997e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a4a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a56",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -39,7 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a26",
-      "doorOrientation": "right",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0019a1a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a26",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019846",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001983a",
+      "doorOrientation": "right",
       "doorEnvironments": [
         {
           "physics": "air",

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001988e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001989a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/west/Golden Torizo Energy Recharge.json
+++ b/region/lowernorfair/west/Golden Torizo Energy Recharge.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00198a6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019876",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x0019882",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a86",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a7a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019a6e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a7b0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "note": "The center door that is accessible from the puyo side",
       "twinDoorAddresses": [
@@ -30,6 +31,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a7bc",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "twinDoorAddresses": [
         {

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a684",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a690",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -30,7 +32,8 @@
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a69c"
+      "nodeAddress": "0x001a69c",
+      "doorOrientation": "up"
     },
     {
       "id": 4,

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a660",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a66c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001a678",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "water"}],
       "spawnAt": 4,
       "locks": [

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a780",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a798",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "twinDoorAddresses": [
         {
@@ -37,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a78c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "note": "The center door that is accessible from the grapple block side"
     },

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a8c4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a8d0",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a7c8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a528",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a534",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     }
   ],

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a63c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a648",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -30,7 +32,8 @@
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a654"
+      "nodeAddress": "0x001a654",
+      "doorOrientation": "up"
     },
     {
       "id": 4,

--- a/region/maridia/inner-pink/Aqueduct Save Room.json
+++ b/region/maridia/inner-pink/Aqueduct Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a828",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a708",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a744",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -45,14 +47,16 @@
       "name": "Left Sand Pit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a714"
+      "nodeAddress": "0x001a714",
+      "doorOrientation": "down"
     },
     {
       "id": 4,
       "name": "Right Sand Pit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a720"
+      "nodeAddress": "0x001a720",
+      "doorOrientation": "down"
     },
     {
       "id": 5,
@@ -60,6 +64,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a738",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -68,6 +73,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a72c",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "water"}],
       "spawnAt": 9
     },

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -15,19 +15,22 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a7d4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
       "id": 2,
       "name": "Left Sand Entrance",
       "nodeType": "entrance",
-      "nodeSubType": "sandpit"
+      "nodeSubType": "sandpit",
+      "doorOrientation": "up"
     },
     {
       "id": 3,
       "name": "Right Sand Entrance",
       "nodeType": "entrance",
-      "nodeSubType": "sandpit"
+      "nodeSubType": "sandpit",
+      "doorOrientation": "up"
     }
   ],
   "enemies": [

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a84c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -22,14 +23,16 @@
       "name": "Left Sand Pit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a864"
+      "nodeAddress": "0x001a864",
+      "doorOrientation": "down"
     },
     {
       "id": 3,
       "name": "Right Sand Pit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a858"
+      "nodeAddress": "0x001a858",
+      "doorOrientation": "down"
     },
     {
       "id": 4,
@@ -37,6 +40,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a870",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a768",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a774",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     }
   ],

--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -13,27 +13,31 @@
       "id": 1,
       "name": "Top Left Sand Entrance",
       "nodeType": "entrance",
-      "nodeSubType": "sandpit"
+      "nodeSubType": "sandpit",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
       "name": "Bottom Left Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a8ac"
+      "nodeAddress": "0x001a8ac",
+      "doorOrientation": "down"
     },
     {
       "id": 3,
       "name": "Top Right Sand Entrance",
       "nodeType": "entrance",
-      "nodeSubType": "sandpit"
+      "nodeSubType": "sandpit",
+      "doorOrientation": "up"
     },
     {
       "id": 4,
       "name": "Bottom Right Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a8b8"
+      "nodeAddress": "0x001a8b8",
+      "doorOrientation": "down"
     },
     {
       "id": 5,

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a90c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeSubType": "blue",
       "nodeType": "door",
       "nodeAddress": "0x001a918",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a7e0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001a7f8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -46,6 +48,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a7ec",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a4b0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001a4c8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -48,6 +48,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a4bc",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "water"}],
       "devNote": "No spawnAt and no junction below, because the door can be entered with just a crouch jump"
     }

--- a/region/maridia/inner-pink/Draygon Save Room.json
+++ b/region/maridia/inner-pink/Draygon Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a888",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a87c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a978",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a96c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {

--- a/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
@@ -14,14 +14,16 @@
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6f0"
+      "nodeAddress": "0x001a6f0",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
       "name": "Bottom Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6fc"
+      "nodeAddress": "0x001a6fc",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a954",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a960",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -14,14 +14,16 @@
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6c0"
+      "nodeAddress": "0x001a6c0",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
       "name": "Bottom Right Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6cc"
+      "nodeAddress": "0x001a6cc",
+      "doorOrientation": "down"
     },
     {
       "id": 3,

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a900",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a8dc",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a8f4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -53,6 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a8e8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/maridia/inner-pink/Maridia Health Refill Room.json
+++ b/region/maridia/inner-pink/Maridia Health Refill Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a930",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/inner-pink/Maridia Missile Refill Room.json
+++ b/region/maridia/inner-pink/Maridia Missile Refill Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a894",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/inner-pink/Space Jump Room.json
+++ b/region/maridia/inner-pink/Space Jump Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a924",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -15,14 +15,16 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a834",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
       "id": 2,
-      "name": "Bottom Right Door",
+      "name": "Bottom Left Door",
       "nodeType": "door",
       "nodeSubType": "eye",
       "nodeAddress": "0x001a840",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {

--- a/region/maridia/inner-pink/Toilet Bowl.json
+++ b/region/maridia/inner-pink/Toilet Bowl.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "vertical",
       "nodeAddress": "0x001a60c",
+      "doorOrientation": "up",
       "spawnAt": 2
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "vertical",
       "nodeAddress": "0x001a600",
+      "doorOrientation": "down",
       "spawnAt": 1
     }
   ],

--- a/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
@@ -14,14 +14,16 @@
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6d8"
+      "nodeAddress": "0x001a6d8",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
       "name": "Bottom Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6e4"
+      "nodeAddress": "0x001a6e4",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a93c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a948",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -14,14 +14,16 @@
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6a8"
+      "nodeAddress": "0x001a6a8",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
       "name": "Bottom Left Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a6b4"
+      "nodeAddress": "0x001a6b4",
+      "doorOrientation": "down"
     },
     {
       "id": 3,

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a630",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "spawnAt": 4
     },
@@ -23,7 +24,8 @@
       "name": "Bottom Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a624"
+      "nodeAddress": "0x001a624",
+      "doorOrientation": "down"
     },
     {
       "id": 3,
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a618",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "spawnAt": 5
     },

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a750",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a75c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -44,7 +46,8 @@
       "id": 3,
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
-      "nodeSubType": "sandpit"
+      "nodeSubType": "sandpit",
+      "doorOrientation": "up"
     }
   ],
   "enemies": [

--- a/region/maridia/inner-yellow/Forgotten Highway Save Room.json
+++ b/region/maridia/inner-yellow/Forgotten Highway Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a5f4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a5d0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a5dc",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a57c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a588",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -45,7 +47,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x001a594"
+      "nodeAddress": "0x001a594",
+      "doorOrientation": "up"
     },
     {
       "id": 4,

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a498",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a4a4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/inner-yellow/Plasma Beach Quicksand Room.json
+++ b/region/maridia/inner-yellow/Plasma Beach Quicksand Room.json
@@ -13,14 +13,16 @@
       "id": 1,
       "name": "Top Sand Entrance",
       "nodeType": "entrance",
-      "nodeSubType": "sandpit"
+      "nodeSubType": "sandpit",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
       "name": "Bottom Sand Exit",
       "nodeType": "exit",
       "nodeSubType": "sandpit",
-      "nodeAddress": "0x001a8a0"
+      "nodeAddress": "0x001a8a0",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a558",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001a5ac",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -39,6 +40,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a5a0",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -47,6 +49,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a5c4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -55,6 +58,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a5b8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a540",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a54c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a4d4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a4e0",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a564",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a570",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a48c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a378",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a384",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a390",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x001a4f8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a510",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a51c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -53,6 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x001a504",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a414",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a420",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     }
   ],

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a3d8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a3e4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a3fc",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -53,6 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a3f0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "spawnAt": 8
     },

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -47,7 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a3fc",
-      "doorOrientation": "right",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -56,7 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a3f0",
-      "doorOrientation": "left",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "water"}],
       "spawnAt": 8
     },

--- a/region/maridia/outer/Glass Tunnel Save Room.json
+++ b/region/maridia/outer/Glass Tunnel Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a324",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x001a33c",
+      "doorOrientation": "left",
       "doorEnvironments": [
         {
           "physics": "water",
@@ -27,6 +28,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a354",
+      "doorOrientation": "right",
       "doorEnvironments": [
         {
           "physics": "water",
@@ -55,6 +57,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x001a348",
+      "doorOrientation": "right",
       "doorEnvironments": [
         {
           "physics": "water",
@@ -68,6 +71,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a330",
+      "doorOrientation": "up",
       "doorEnvironments": [
         {
           "physics": "water",

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a39c",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a3a8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "locks": [
         {
@@ -45,6 +47,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a3b4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -53,6 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a3c0",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -61,6 +65,7 @@
       "nodeType": "door",
       "nodeSubType": "passage",
       "nodeAddress": "0x001a3cc",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}],
       "note": "It's not quite a door, but it is a morph passage transition to another room"
     },

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a408",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/outer/Maridia Map Room.json
+++ b/region/maridia/outer/Maridia Map Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a5e8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -23,7 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a444",
-      "doorOrientation": "left",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -32,7 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a450",
-      "doorOrientation": "right",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "water"}]
     },
     {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a438",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a444",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a450",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -38,6 +41,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a468",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
@@ -46,6 +50,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a42c",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "water"}],
       "spawnAt": 9
     },
@@ -55,6 +60,7 @@
       "nodeType": "door",
       "nodeSubType": "passage",
       "nodeAddress": "0x001a45c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "water"}],
       "note": "It's not quite a door, but it is a morph passage transition to another room"
     },

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -30,8 +30,7 @@
       "id": 3,
       "name": "Bottom Right Ledge",
       "nodeType": "junction",
-      "nodeSubType": "junction",
-      "doorOrientation": "right"
+      "nodeSubType": "junction"
     }
   ],
   "enemies": [

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a480",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,13 +23,15 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a474",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "water"}]
     },
     {
       "id": 3,
       "name": "Bottom Right Ledge",
       "nodeType": "junction",
-      "nodeSubType": "junction"
+      "nodeSubType": "junction",
+      "doorOrientation": "right"
     }
   ],
   "enemies": [

--- a/region/maridia/outer/West Glass Tube Tunnel.json
+++ b/region/maridia/outer/West Glass Tube Tunnel.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a36c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a360",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00193de",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x00193ea",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}],
       "spawnAt": 5,
       "locks": [

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019522",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019516",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Grapple Tutorial Room 1.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 1.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194fe",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001950a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/crocomire/Grapple Tutorial Room 2.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 2.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194e6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194f2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194b6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194c2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -39,7 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001944a",
-      "doorOrientation": "left",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001943e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001944a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -46,6 +48,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019456",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -54,6 +57,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019432",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194da",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194ce",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Missile Room.json
+++ b/region/norfair/crocomire/Post Crocomire Missile Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00194aa",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
+++ b/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001946e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Save Room.json
+++ b/region/norfair/crocomire/Post Crocomire Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019462",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019486",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001949e",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x0019492",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -54,6 +57,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001947a",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001974a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019756",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019762",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197aa",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197b6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Bubble Mountain Save Room.json
+++ b/region/norfair/east/Bubble Mountain Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197ce",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x0019552",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001959a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -46,6 +48,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001955e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -54,6 +57,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001956a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -62,6 +66,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019576",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -70,6 +75,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019582",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -78,6 +84,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001958e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00192a6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x00192b2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001928e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001929a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019606",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019612",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001961e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/norfair/east/Frog Savestation.json
+++ b/region/norfair/east/Frog Savestation.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019816",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001980a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197da",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197e6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019546",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001953a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019666",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001968a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x001967e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -54,6 +57,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019672",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00196de",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00196d2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Lower Norfair Elevator Save Room.json
+++ b/region/norfair/east/Lower Norfair Elevator Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001982e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019702",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00196ea",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -36,7 +38,8 @@
       "name": "Bottom of Elevator Ride",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x00196f6"
+      "nodeAddress": "0x00196f6",
+      "doorOrientation": "down"
     }
   ],
   "enemies": [],

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019696",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00196a2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001952e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Nutella Refill.json
+++ b/region/norfair/east/Nutella Refill.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019786",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019792",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Purple Farming Room.json
+++ b/region/norfair/east/Purple Farming Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001979e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00196ae",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00196c6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00196ba",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197fe",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197f2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019732",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001973e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00195ca",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00195ee",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00195e2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -39,6 +42,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x00195d6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -62,6 +66,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00195fa",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00195a6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x00195b2",
+      "doorOrientation": "right",
       "doorEnvironments": [
         {
           "physics": "air",

--- a/region/norfair/east/Speed Booster Room.json
+++ b/region/norfair/east/Speed Booster Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00195be",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001976e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001977a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019636",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019642",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001970e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019726",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001971a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -26,6 +26,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001964e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -34,6 +35,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001965a",
+      "doorOrientation": "left",
       "doorEnvironments": [
         {
           "physics": "lava",

--- a/region/norfair/east/Wave Beam Room.json
+++ b/region/norfair/east/Wave Beam Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001962a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x00192be",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "yellow",
       "nodeAddress": "0x0019306",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -61,6 +63,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x00192d6",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -84,6 +87,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00192e2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -92,6 +96,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00192fa",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -100,6 +105,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00192ca",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -107,7 +113,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x00192ee"
+      "nodeAddress": "0x00192ee",
+      "doorOrientation": "up"
     },
     {
       "id": 8,

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019402",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001940e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Crocomire Save Room.json
+++ b/region/norfair/west/Crocomire Save Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019822",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00193ae",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00193a2",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x00193d2",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -54,6 +57,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00193c6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -62,6 +66,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00193ba",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001938a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019396",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Hi Jump Boots Room.json
+++ b/region/norfair/west/Hi Jump Boots Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00193f6",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019426",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001941a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019282",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019276",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019312",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "spawnAt": 6,
       "note": "Samus is considered to spawn at 6 because of the crumble blocks"
@@ -25,6 +26,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001931e",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -33,6 +35,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019336",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -41,6 +44,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001932a",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Ice Beam Room.json
+++ b/region/norfair/west/Ice Beam Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001935a",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019372",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001937e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -31,6 +33,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019366",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x0019342",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -23,6 +24,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001934e",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/norfair/west/Norfair Map Room.json
+++ b/region/norfair/west/Norfair Map Room.json
@@ -15,6 +15,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x00197c2",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x001aa44",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001aa38",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aa08",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aa14",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "useImplicitDoorUnlocks": false
     }

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001aa2c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001aa20",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Lower Tourian Save Room.json
+++ b/region/tourian/main/Lower Tourian Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aad4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a9b4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a9a8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a9c0",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a9cc",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a9d8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a9e4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a9f0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a9fc",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -18,6 +18,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x001aa8c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -41,6 +42,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aa80",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aab0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aabc",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001aac8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "doorway",
       "nodeAddress": "0x001aa50",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aa68",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001aa5c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "closedWall",
       "nodeAddress": "0x001aae0",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -38,6 +39,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aaec",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001aaf8",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab04",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001ab10",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab1c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001ab28",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -37,6 +38,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab34",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aa98",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "eye",
       "nodeAddress": "0x001aaa4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/tourian/main/Tourian First Room.json
+++ b/region/tourian/main/Tourian First Room.json
@@ -13,7 +13,8 @@
       "name": "Elevator",
       "nodeType": "door",
       "nodeSubType": "elevator",
-      "nodeAddress": "0x001a990"
+      "nodeAddress": "0x001a990",
+      "doorOrientation": "up"
     },
     {
       "id": 2,
@@ -21,6 +22,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a984",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -29,6 +31,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a99c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/tourian/main/Tourian Recharge Room.json
+++ b/region/tourian/main/Tourian Recharge Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001aa74",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/tourian/main/Upper Tourian Save Room.json
+++ b/region/tourian/main/Upper Tourian Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001ab40",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Assembly Line.json
+++ b/region/wreckedship/main/Assembly Line.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a1ec",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a1e0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -40,6 +41,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a1c8",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -65,6 +67,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a1d4",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a2a0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a294",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "eye",
       "nodeAddress": "0x001a2ac",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a18c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a198",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -46,6 +48,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a1a4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "red",
       "nodeAddress": "0x001a27c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -39,6 +40,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a264",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -47,6 +49,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a270",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a300",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a30c",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a2c4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a24c",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a258",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a2d0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a2dc",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a2f4",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a288",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Wrecked Ship Entrance.json
+++ b/region/wreckedship/main/Wrecked Ship Entrance.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a1b0",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a1bc",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     }
   ],

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a228",
+      "doorOrientation": "up",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -22,6 +23,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a1f8",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -30,6 +32,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a210",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -53,6 +56,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a240",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -61,6 +65,7 @@
       "nodeType": "door",
       "nodeSubType": "grey",
       "nodeAddress": "0x001a204",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {
@@ -84,6 +89,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a234",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {
@@ -92,6 +98,7 @@
       "nodeType": "door",
       "nodeSubType": "green",
       "nodeAddress": "0x001a21c",
+      "doorOrientation": "down",
       "doorEnvironments": [{"physics": "air"}],
       "locks": [
         {

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a2b8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a318",
+      "doorOrientation": "left",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/region/wreckedship/main/Wrecked Ship West Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship West Super Room.json
@@ -14,6 +14,7 @@
       "nodeType": "door",
       "nodeSubType": "blue",
       "nodeAddress": "0x001a2e8",
+      "doorOrientation": "right",
       "doorEnvironments": [{"physics": "air"}]
     },
     {

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1584,6 +1584,13 @@
             "description": "Memory address of this location",
             "examples": ["0x0019852", "0x001985e"]
           },
+          "doorOrientation": {
+            "$id": "#/properties/nodes/items/properties/doorOrientation",
+            "type": "string",
+            "title": "Door Orientation",
+            "description": "The direction that leaving the room through this door will take Samus: left, right, up, or down.",
+            "enum": ["left", "right", "up", "down"]
+          },
           "doorEnvironments": {
             "$id": "#/properties/nodes/items/properties/doorEnvironments",
             "type": "array",

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -87,6 +87,7 @@ def process_keyvalue(k, v, metadata):
         "direction",  # validated by schema
         "blue",  # validated by schema
         "movementType",  # validated by schema
+        "doorOrientation",  # validated by schema
         "types",  # validated by schema in 'unlocksDoors', manually in 'enemyDamage'
     ]
 


### PR DESCRIPTION
This adds a `doorOrientation` node property to indicate which direction a door leads. This information could already be inferred from the connection files but it was inconvenient to use that way. I included a test to check that the new data is consistent with the connection files.