### PR TITLE
Fix X-Ray version of bottom Green Brin Main Shaft ice clip

### DIFF
--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4137,7 +4137,7 @@
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         {"or": [
-          "canXRayCeilingClip",
+          "h_canXRayCeilingClip",
           {"and": [
             "canPreciseCeilingClip",
             "canInsaneJump",


### PR DESCRIPTION
Looks like this was the only strat using the tech "canXRayCeilingClip" instead of the helper "h_canXRayCeilingClip".