### PR TITLE
Ceres: Add G-Mode, PB Doors

### DIFF
--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -102,6 +102,9 @@
           "morphed": false
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -120,6 +123,9 @@
           "morphed": true
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -157,7 +163,10 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
     },
     {
       "link": [1, 2],
@@ -174,7 +183,10 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -196,7 +208,10 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 1],
@@ -213,7 +228,10 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -256,6 +274,9 @@
           "morphed": false
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -274,6 +295,9 @@
           "morphed": true
         }
       },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {

--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -27,6 +27,13 @@
       "doorEnvironments": [{"physics": "air"}]
     }
   ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Power Bombed the Doors",
+      "obstacleType": "inanimate"
+    }
+  ],
   "enemies": [],
   "links": [
     {
@@ -58,14 +65,155 @@
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Runway - Power Bombed the Doors",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 30,
+          "openEnd": 0
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Power Bomb the Doors",
+      "requires": [
+        "h_canUsePowerBombs"
+      ],
+      "clearsObstacles": ["A"],
+      "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["A"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []
     },
     {
+      "link": [1, 2],
+      "name": "Carry G-Mode Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry G-Mode Morph Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      }
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Morph Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      }
     },
     {
       "link": [2, 2],
@@ -78,6 +226,70 @@
         }
       },
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Runway - Power Bombed the Doors",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 30,
+          "openEnd": 0
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["A"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]
 }

--- a/region/ceres/main/Dead Scientist Room.json
+++ b/region/ceres/main/Dead Scientist Room.json
@@ -27,6 +27,13 @@
       "doorEnvironments": [{"physics": "air"}]
     }
   ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Power Bombed the Doors",
+      "obstacleType": "inanimate"
+    }
+  ],
   "enemies": [],
   "links": [
     {
@@ -59,14 +66,175 @@
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Runway - Power Bombed the Doors",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 30,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3,
+          "openEnd": 0
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Power Bomb the Doors",
+      "requires": [
+        "h_canUsePowerBombs"
+      ],
+      "clearsObstacles": ["A"],
+      "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["A"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []
     },
     {
+      "link": [1, 2],
+      "name": "Carry G-Mode Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry G-Mode Morph Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Morph Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -80,6 +248,78 @@
         }
       },
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Runway - Power Bombed the Doors",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 30,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3,
+          "openEnd": 0
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["A"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]
 }

--- a/region/ceres/main/Falling Tile Room.json
+++ b/region/ceres/main/Falling Tile Room.json
@@ -27,6 +27,18 @@
       "doorEnvironments": [{"physics": "air"}]
     }
   ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Power Bombed the Left Door",
+      "obstacleType": "inanimate"
+    },
+    {
+      "id": "B",
+      "name": "Power Bombed the Right Door",
+      "obstacleType": "inanimate"
+    }
+  ],
   "enemies": [],
   "links": [
     {
@@ -59,14 +71,203 @@
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Runway - Power Bombed the Door",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 10,
+          "steepUpTiles": 3,
+          "openEnd": 0
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Power Bomb the Doors",
+      "requires": [
+        "h_canUsePowerBombs"
+      ],
+      "clearsObstacles": ["A", "B"],
+      "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Morph - Power Bomb the Left Door",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["A"],
+      "note": "Destroy the left door with a Power Bomb."
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb",
+        {"or": [
+          "h_canArtificialMorphMovement",
+          "h_canArtificialMorphBombThings"
+        ]}
+      ],
+      "clearsObstacles": ["A", "B"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []
     },
     {
+      "link": [1, 2],
+      "name": "Carry G-Mode Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry G-Mode Morph Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"or": [
+          "h_canArtificialMorphMovement",
+          "h_canArtificialMorphBombThings"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Morph Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"or": [
+          "h_canArtificialMorphMovement",
+          "h_canArtificialMorphBombThings"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -80,6 +281,96 @@
         }
       },
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Runway - Power Bombed the Door",
+      "requires": [
+        {"obstaclesCleared": ["B"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 10,
+          "steepUpTiles": 3,
+          "openEnd": 0
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Morph - Power Bomb the Right Door",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["B"],
+      "note": "Destroy the right door with a Power Bomb."
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb",
+        {"or": [
+          "h_canArtificialMorphMovement",
+          "h_canArtificialMorphBombThings"
+        ]}
+      ],
+      "clearsObstacles": ["A", "B"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]
 }

--- a/region/ceres/main/Magnet Stairs Room.json
+++ b/region/ceres/main/Magnet Stairs Room.json
@@ -27,6 +27,18 @@
       "doorEnvironments": [{"physics": "air"}]
     }
   ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Power Bombed the Top Left Door",
+      "obstacleType": "inanimate"
+    },
+    {
+      "id": "B",
+      "name": "Power Bombed the Bottom Right Door",
+      "obstacleType": "inanimate"
+    }
+  ],
   "enemies": [],
   "links": [
     {
@@ -58,14 +70,175 @@
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Runway - Power Bombed the Door",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 11,
+          "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Power Bomb the Doors",
+      "requires": [
+        "h_canUsePowerBombs"
+      ],
+      "clearsObstacles": ["A", "B"],
+      "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["A", "B"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
+    },
+    {
       "link": [1, 2],
       "name": "Base",
       "requires": []
     },
     {
+      "link": [1, 2],
+      "name": "Carry G-Mode Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry G-Mode Morph Through Room (Left to Right)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry G-Mode Morph Through Room (Right to Left)",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphMovement"
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],
@@ -78,6 +251,93 @@
         }
       },
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Runway - Power Bombed the Door",
+      "requires": [
+        {"obstaclesCleared": ["B"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 13,
+          "steepDownTiles": 3,
+          "openEnd": 0
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "Carry G-Mode Morph Back Through Door",
+      "notable": false,
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["ammo"], "requires": ["never"]}
+      ],
+      "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Morph - Power Bomb the Right Door",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "clearsObstacles": ["B"],
+      "note": "Destroy the right door with a Power Bomb."
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Morph - Power Bomb the Doors",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphMovement"
+      ],
+      "clearsObstacles": ["A", "B"],
+      "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]
 }


### PR DESCRIPTION
I skipped the Ceres Ridley and Ceres Elevator rooms, as the practice hack wasn't working for them. These rooms are kind of cool and it would be fun to use them someday.