### PR TITLE
Tightened Volcano Room Heat Frames

### DIFF
--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -164,9 +164,9 @@
         "Morph",
         {"or": [
           "canMockball",
-          {"heatFrames": 25}
+          {"heatFrames": 35}
         ]},
-        {"heatFrames": 480}
+        {"heatFrames": 420}
       ],
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 20}]},
@@ -180,9 +180,9 @@
         "Morph",
         {"or": [
           "canMockball",
-          {"heatFrames": 25}
+          {"heatFrames": 35}
         ]},
-        {"heatFrames": 440}
+        {"heatFrames": 380}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -204,9 +204,9 @@
         "SpaceJump",
         {"or": [
           "canMockball",
-          {"heatFrames": 25}
+          {"heatFrames": 35}
         ]},
-        {"heatFrames": 440}
+        {"heatFrames": 405}
       ]
     },
     {


### PR DESCRIPTION
Took a full second off Base (best time is exactly 7 seconds), and nearly a second off space jump (best time 6seconds 42 frames) However I could not get the additional time for not mockballing below 34 frames. Taking 40 frames for the runway was accurate.