### PR TITLE
Some clean-up in rooms with useImplicitDoorUnlocks false

### DIFF
--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -200,13 +200,20 @@
     {
       "link": [1, 1],
       "name": "Leave With Runway",
-      "requires": [],
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
       "exitCondition": {
         "leaveWithRunway": {
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": "FIXME: Add acid-filled version of the runway, and requirements to unlock the door with Missiles and Power Bombs."
     },
     {
       "link": [1, 1],
@@ -215,7 +222,11 @@
         {"obstaclesCleared": ["A"]},
         "h_canHeatedCrystalFlash"
       ],
-      "devNote": "FIXME: Add Crystal Flash strats in the acid too."
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": "FIXME: Add acid-filled version of the Crystal Flash, and requirements to unlock the door with Missiles and Power Bombs."
     },
     {
       "link": [1, 3],
@@ -227,7 +238,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCarefulJump",
         {"heatFrames": 300}
       ],
@@ -247,7 +257,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         "canCarefulJump",
         {"heatFrames": 240}
       ],
@@ -256,12 +265,6 @@
         "Entering with 3 tiles of run speed will let Samus pass under the ceiling and over the bottom center pirate.",
         "Pirates can be shot with any weapon to prevent them from firing."
       ]
-    },
-    {
-      "link": [1, 6],
-      "name": "Base",
-      "requires": [],
-      "clearsObstacles": ["A"]
     },
     {
       "link": [2, 1],
@@ -383,8 +386,9 @@
       "link": [2, 3],
       "name": "Reverse Amphitheatre, Vertical Dive",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         {"or": [
           "SpaceJump",
@@ -417,7 +421,6 @@
         {"heatFrames": 330},
         {"acidFrames": 330}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "note": [
         "Dive into the acid to the left of the first floating platform to quickly sink to the bottom of the room.",
         "It is possible to jump directly over the pirate at the bottom of the ramp directly to the gap between platforms.",
@@ -428,13 +431,13 @@
       "link": [2, 4],
       "name": "Reverse Amphitheatre Partial Dive",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         {"heatFrames": 180},
         {"acidFrames": 80}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "note": "Jump over the pirate and fall straight down to land on an upper-middle floating platform."
     },
     {
@@ -443,7 +446,7 @@
       "notable": true,
       "reusableRoomwideNotable": "Reverse Amphitheatre Thread the Needle",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "canInsaneJump",
         "canSuitlessLavaDive",
         "Charge",
@@ -476,7 +479,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "canInsaneJump",
         "canSuitlessLavaDive",
         "canSlowShortCharge",
@@ -494,8 +497,9 @@
       "link": [3, 1],
       "name": "Amphitheatre Space Jump Acid Climb",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         "Gravity",
         "SpaceJump",
@@ -511,14 +515,22 @@
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
-      "note": "SpaceJump diagonally towards the door through the acid."
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": "SpaceJump diagonally towards the door through the acid.",
+      "devNote": [
+        "FIXME: Add requirements to unlock the door with Missiles and Power Bombs."
+      ]
     },
     {
       "link": [3, 1],
       "name": "Amphitheatre Acid Stutter Shinespark",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "h_heatProof",
         "Gravity",
         "canSuitlessLavaDive",
@@ -529,7 +541,10 @@
         {"shinespark": {"frames": 55}},
         {"acidFrames": 600}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "There is just enough runway below the left door to build a shinespark.",
       "devNote": "This strat is only used to avoid walljumping."
     },
@@ -537,8 +552,9 @@
       "link": [3, 1],
       "name": "Amphitheatre Speedy Gravity Jump",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "HiJump",
         "canTrickyDashJump",
         "canGravityJump",
@@ -546,24 +562,28 @@
           "enemies": [["Yellow Space Pirate (standing)"]],
           "explicitWeapons": ["ScrewAttack", "Super", "Charge+Plasma"]
         }},
-        {"heatFrames": 390},
-        {"acidFrames": 390}
+        {"heatFrames": 240},
+        {"acidFrames": 240},
+        {"gravitylessHeatFrames": 150},
+        {"gravitylessAcidFrames": 150}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": [
         "Clear the runway by killing the pirate.",
         "Then Gravity jump after building as much run speed as possible."
       ],
       "devNote": [
-        "This strat is only used to avoid walljumping.",
-        "FIXME: Gravity heat reduction is disabled for part of this strat."
+        "This strat is only used to avoid walljumping."
       ]
     },
     {
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         {"or": [
           {"and": [
             "canWalljump",
@@ -589,7 +609,7 @@
       "link": [3, 4],
       "name": "Tricky Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "canTrickyJump",
         {"heatFrames": 480}
       ],
@@ -599,7 +619,7 @@
       "link": [3, 4],
       "name": "Frozen Pirate",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "Charge",
         "canUseFrozenEnemies",
         "Plasma",
@@ -611,8 +631,9 @@
       "link": [3, 5],
       "name": "Amphitheatre Acid Hop",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         {"or": [
           {"and": [
@@ -626,21 +647,24 @@
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "note": "Avoid the pirate while moving through the acid to get closer to the wall."
     },
     {
       "link": [4, 1],
       "name": "Reverse Amphitheatre SpaceJump",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "Gravity",
         "SpaceJump",
         {"heatFrames": 360},
         {"acidFrames": 360}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": [
         "Land on the fourth platform from the top and build some speed to spacejump across straight to the door.",
         "The optimal platform can be hit by simpily holding right when entering the acid."
@@ -651,7 +675,7 @@
       "link": [4, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         {"or": [
           "canCarefulJump",
           "canPreciseWalljump",
@@ -672,7 +696,7 @@
       "link": [4, 2],
       "name": "HiJump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         "HiJump",
         {"or": [
           "SpeedBooster",
@@ -711,7 +735,7 @@
       "link": [4, 2],
       "name": "Kill Pirates",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesCleared": ["A"]},
         {"or": [
           {"and": [
             {"enemyKill": {
@@ -746,8 +770,9 @@
       "link": [4, 3],
       "name": "Reverse Amphitheatre Continued Dive",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         {"or": [
           {"and": [
             "Gravity",
@@ -760,15 +785,15 @@
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "note": "Jump off the platform to the left with low horizontal speed and hold left to avoid landing on any pirates."
     },
     {
       "link": [5, 1],
       "name": "Amphitheatre Acid Wall Climb with Gravity",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "Gravity",
         {"or": [
           {"and": [
@@ -784,15 +809,19 @@
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "Climb to the top left door while in Acid."
     },
     {
       "link": [5, 1],
       "name": "Amphitheatre Acid Wall Climb without Gravity",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "canConsecutiveWalljump",
         {"or": [
           {"and": [
@@ -806,14 +835,16 @@
           ]}
         ]}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": "It is possible to walljump in acid without Gravity Suit."
     },
     {
       "link": [5, 1],
       "name": "Acidless",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"obstaclesCleared": ["A"]},
         {"or": [
           {"and": [
@@ -835,13 +866,19 @@
             {"heatFrames": 390}
           ]}
         ]}
+      ],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
     },
     {
       "link": [5, 1],
       "name": "Amphitheatre Triple SpringBall Jump",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "h_heatProof",
         "canSuitlessLavaDive",
         "canCrouchJump",
@@ -850,10 +887,13 @@
         {"acidFrames": 330},
         {"acidFrames": 1000}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "note": [
         "Acid allows for more time than water to perform Spring Ball jumps.",
         "This gives just barely enough time to fit in three spring ball jumps."
+      ],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "devNote": [
         "This strat is only used to avoid walljumping.",
@@ -864,8 +904,9 @@
       "link": [5, 1],
       "name": "Amphitheatre Gravity Jump SpringBall Jump",
       "notable": true,
+      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"obstaclesNotCleared": ["A"]},
         "HiJump",
         "canTrickyJump",
         "canGravityJump",
@@ -874,7 +915,10 @@
         {"heatFrames": 600},
         {"acidFrames": 600}
       ],
-      "reusableRoomwideNotable": "Amphitheatre Reverse Acid Dive",
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "note": [
         "Perform a gravity jump followed by a springball jump to reach the left side door.",
         "The gravity jump timing is very precise."
@@ -888,7 +932,6 @@
       "link": [6, 1],
       "name": "SpinJump Entry",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canPrepareForNextRoom",
         {"or": [
           "SpaceJump",
@@ -898,13 +941,16 @@
         ]},
         {"heatFrames": 80}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [6, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "ScrewAttack",
           {"heatFrames": 60}
@@ -921,7 +967,6 @@
       "link": [6, 4],
       "name": "SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canPrepareForNextRoom",
         "SpaceJump",
         {"heatFrames": 500}
@@ -932,7 +977,6 @@
       "link": [6, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 180}
       ],
       "clearsObstacles": ["A"]

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -583,8 +583,7 @@
         "After 6 hops, the bottom Hopper will do three big hops in a row.",
         "Roll under the Hopper while it does the third of those three big hops.",
         "Quickly unmorph and run to the right side of the room.",
-        "If successful, both Hoppers will remain off-camera, so you can safely Crystal Flash.",
-        "Reset the room through the top door before returning to the left."
+        "If successful, both Hoppers will remain off-camera, so you can safely Crystal Flash."
       ]
     },
     {

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -270,7 +270,7 @@
     },
     {
       "link": [1, 2],
-      "name": "Kill the enemies",
+      "name": "Kill the Enemies",
       "requires": [
         "canDodgeWhileShooting",
         "canTrickyJump",
@@ -284,6 +284,33 @@
         "Kill the top hopper quickly; the left hopper is more random.",
         "To be safe, plan to retreat right while attacking.",
         "It also helps to attempt to move the hopper off camera between attacks."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Kill the Enemies, Leave With Runway",
+      "requires": [
+        "canDodgeWhileShooting",
+        "canTrickyJump",
+        "canCameraManip",
+        {"enemyKill": {
+          "enemies": [["Blue Sidehopper", "Blue Sidehopper"]]
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 1,
+          "openEnd": 1
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Kill the top hopper quickly; the left hopper is more random.",
+        "To be safe, plan to retreat right while attacking.",
+        "It also helps to attempt to move the hopper off camera between attacks."
+      ],
+      "devNote": [
+        "FIXME: An alternative strat may be possible where the enemies are lured off-camera to the right instead of killed."
       ]
     },
     {
@@ -350,6 +377,10 @@
       "link": [1, 2],
       "name": "G-Mode Setup - Prepared Dodge",
       "notable": false,
+      "entranceCondition": {
+        "comeInNormally": {},
+        "comesThroughToilet": "no"
+      },
       "requires": [
         {"or": [
           "ScrewAttack",
@@ -375,7 +406,8 @@
             "hits": 1
           }}
         ]}
-      ]
+      ],
+      "devNote": "FIXME: add a Toilet entry version of this"
     },
     {
       "link": [1, 2],
@@ -539,32 +571,10 @@
       ]
     },
     {
-      "link": [2, 2],
-      "name": "Leave with Runway",
-      "requires": [
-        "never"
-      ],
-      "exitCondition": {
-        "leaveWithRunway": {
-          "length": 1,
-          "openEnd": 1
-        }
-      },
-      "devNote": "FIXME: Add requirements to be able to use this runway."
-    },
-    {
-      "link": [2, 2],
+      "link": [2, 1],
       "name": "Tourian Blue Hopper Crystal Flash",
       "notable": true,
       "requires": [
-        {"resetRoom": {
-          "nodes": [1],
-          "mustStayPut": false
-        }},
-        {"resetRoom": {
-          "nodes": [2],
-          "mustStayPut": false
-        }},
         "canTrickyJump",
         "h_canCrystalFlash"
       ],
@@ -590,7 +600,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 2],
@@ -616,7 +627,11 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "link": [2, 2],


### PR DESCRIPTION
- Add tests so we don't forget to add `unlocksDoors` on strats ending at door nodes with `"useImplicitDoorUnlocks": false`.
- Make these tests pass by adding at least rudimentary `unlocksDoors` in the places where it was missing.
- In Amphitheatre:
  - Remove obsolete "h_canNavigateHeatRooms"
  - Add `obstaclesCleared` or `obstaclesNotCleared` to more cleanly separate the acid vs. no-acid strats.
  - Split off `gravitylessHeatFrames`/`gravitylessAcidFrames` in the Gravity jump strat. The total frame count seemed loose (even with Screw Attack, the slowest method of killing the Pirate), but I didn't try to tighten it because I wasn't confident about the intended starting position of the strat.
  - Strats for unlocking the left door with Missiles or Power Bombs could be possible, but they are difficult to test without actually changing the door color; leaving those out for now.
- In Tourian Blue Hoppers:
  - Add a strat to use the left doorway runway by killing the enemies from right to left.
  - Simplify the "Tourian Blue Hopper Crystal Flash" strat to end at node 1 and remove the reset-room requirements. Previously we were concerned about this strat being able to be followed by a dodge strat without first resetting the room, but the dodge strats are now guarded by a `comeInNormally` entrance condition, so it should be fine.