### PR TITLE
Crateria remote runway strats

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -418,6 +418,25 @@ __Example:__
 }},
 ```
 
+
+#### speedBall object
+
+A `speedBall` object represents the need for Samus to be able to gain blue speed and jump into a speedball using a specified runway. It includes a `canSpeedball` tech requirement. Whether a speedball can performed within a given runway length depends on the player's ability to shortcharge as well as to perform a short-hop mockball. The [blue run speed table](strats.md#blue-run-speed-table) describes several tiers of shortcharging skill, their associated runway lengths over which blue speed can be attained, and the resulting run speed. For determining whether a speedball is logically possible, the lowest run speed should be used within the range of what is possible for that skill level; this corresponds to using the "Ideal speed" from the table. The total runway length required can then be computed as follows:
+
+$$\text{minimum speedball runway} = \text{minimal blue speed runway} + \text{short-hop mockball frames} * \text{mid-air speed}$$
+
+Here the "mid-air speed" is obtained by adding the extra run speed (from the "Ideal speed" at the end of getting blue speed) to a base speed of $1.5, which is the average of the spin-jump base speed of $1.6 and the aim-down base speed of $1.4, assuming that roughly half of the jump will be spent in each of those two states. The "short-hop mockball frames" is the amount of frames between the start of the jump and when the morph-sized hitbox is achieved; it is a parameter that can be varied based on assumed player skill: a value of 6 is at or near TAS-level, while 40 would be a lenient value where Samus can jump several tiles into the air.
+
+__Example:__
+```json
+{"speedBall": {
+  "length": 25,
+  "steepUpTiles": 3,
+  "steepDownTiles": 3,
+  "openEnd": 1
+}},
+```
+
 #### itemNotCollectedAtNode object
 An `itemNotCollectedAtNode` object represents the need to have not yet collected the item at a given node in the same room. For example, such
 an item could be used to overload PLMs in G-mode assuming the item has spawned. Note that any conditions for the item to spawn (e.g. for

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -250,7 +250,7 @@
       "link": [1, 5],
       "name": "Room Entry Speedball",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 2,
           "openEnd": 0
         }
@@ -716,7 +716,7 @@
       "name": "Morph Ball Room Speedball (Right to Left)",
       "requires": [
         {"obstaclesCleared": ["B"]},
-        {"canShineCharge": {
+        {"getBlueSpeed": {
           "usedTiles": 21,
           "openEnd": 1
         }},
@@ -786,10 +786,9 @@
       "link": [6, 5],
       "name": "Morph Ball Room Speedball (Left to Right)",
       "requires": [
-        "canSpeedball",
         {"obstaclesCleared": ["C"]},
-        {"canShineCharge": {
-          "usedTiles": 18,
+        {"speedBall": {
+          "length": 25,
           "openEnd": 0
         }}
       ],

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -187,6 +187,136 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning (Bomb Torizo Intact)",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball (Bomb Torizo Intact)",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 6,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Bomb Torizo Intact)",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping (Bomb Torizo Intact)",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning (Bomb Torizo Dead)",
+      "requires": [
+        "f_DefeatedBombTorizo"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 10,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball (Bomb Torizo Dead)",
+      "requires": [
+        "f_DefeatedBombTorizo"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Bomb Torizo Dead)",
+      "requires": [
+        "f_DefeatedBombTorizo"        
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping (Bomb Torizo Dead)",
+      "requires": [
+        "f_DefeatedBombTorizo"        
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -315,6 +315,38 @@
       ]
     },
     {
+      "link": [1, 4],
+      "name": "Speedy Jump Spring Fling",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 28,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canLateralMidAirMorph",
+        "canSpringFling"
+      ],
+      "note": "Run and jump into an airball, pressing pause just as Samus hits the ceiling, in order to unequip Spring Ball to reset fall speed.",
+      "devNote": "This can be done with 26 tiles of other-room runway, but it would probably require a higher movement tech."
+    },
+    {
+      "link": [1, 4],
+      "name": "Spring Ball Bounce Spring Fling",
+      "entranceCondition": {
+        "comeInWithSpringBallBounce": {
+          "remoteAndLandingMinTiles": [[30, 1]],
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canLateralMidAirMorph",
+        "canSpringFling"
+      ]
+    },
+    {
       "link": [1, 5],
       "name": "G-Mode Morph and Bombs to Overload Speed Blocks",
       "entranceCondition": {
@@ -478,6 +510,40 @@
         "Unmorphing before the Morph tunnel to better control the bounce can help."
       ],
       "devNote": "There are 2 unusable tiles in this runway."
+    },
+    {
+      "link": [1, 6],
+      "name": "Speedy Jump Spring Fling Temporary Blue",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 28,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canLateralMidAirMorph",
+        "canSpringFling",
+        "canTemporaryBlue"
+      ],
+      "note": "Run and jump into an airball, pressing pause just as Samus hits the ceiling, in order to unequip Spring Ball to reset fall speed.",
+      "devNote": "This can be done with 26 tiles of other-room runway, but it would probably require a higher movement tech."
+    },
+    {
+      "link": [1, 6],
+      "name": "Spring Ball Bounce Spring Fling Temporary Blue",
+      "entranceCondition": {
+        "comeInWithSpringBallBounce": {
+          "remoteAndLandingMinTiles": [[30, 1]],
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canLateralMidAirMorph",
+        "canSpringFling",
+        "canTemporaryBlue"
+      ]
     },
     {
       "link": [1, 6],

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -467,7 +467,6 @@
       "requires": [
         {"or": [
           "canBlueSpaceJump",
-          "canSpringBallBounce",
           {"and": [
             "canSpringBallBounce",
             "canTrickyJump"

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -315,14 +315,14 @@
       "exitCondition": {
         "leaveSpinning": {
           "remoteRunway": {
-            "length": 28,
+            "length": 31,
             "openEnd": 1,
-            "steepUpTiles": 8
-          }
+            "steepUpTiles": 9
+          },
+          "maxExtraRunSpeed": "$5.A"
         }
       },
-      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it into the next room.",
-      "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
+      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it into the next room."
     },
     {
       "link": [1, 1],
@@ -334,18 +334,18 @@
       "exitCondition": {
         "leaveWithMockball": {
           "remoteRunway": {
-            "length": 28,
+            "length": 31,
             "openEnd": 1,
-            "steepUpTiles": 8
+            "steepUpTiles": 9
           },
           "landingRunway": {
             "length": 3,
             "openEnd": 1
-          }
+          },
+          "maxExtraRunSpeed": "$5.A"
         }
       },
-      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a mockball (or speedball) at the doorway.",
-      "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
+      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a mockball (or speedball) at the doorway."
     },
     {
       "link": [1, 1],
@@ -357,22 +357,19 @@
       "exitCondition": {
         "leaveWithSpringBallBounce": {
           "remoteRunway": {
-            "length": 28,
+            "length": 31,
             "openEnd": 1,
-            "steepUpTiles": 8
+            "steepUpTiles": 9
           },
           "landingRunway": {
             "length": 3,
             "openEnd": 1
           },
-          "movementType": "uncontrolled"
+          "movementType": "uncontrolled",
+          "maxExtraRunSpeed": "$5.A"
         }
       },
-      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a spring ball bounce into the other room.",
-      "devNote": [
-        "This runway has some unusable tiles because the Space Jump descent will not work with too high speed.",
-        "FIXME: This could be done without Space Jump, but it needs some way to encode a minimum speed that we will have to exit with. "
-      ]
+      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a spring ball bounce into the other room."
     },
     {
       "link": [1, 1],
@@ -384,10 +381,11 @@
       "exitCondition": {
         "leaveSpaceJumping": {
           "remoteRunway": {
-            "length": 28,
+            "length": 31,
             "openEnd": 1,
-            "steepUpTiles": 8
-          }
+            "steepUpTiles": 9
+          },
+          "maxExtraRunSpeed": "$5.A"
         }
       },
       "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry into the other room.",
@@ -741,6 +739,34 @@
         "The jump can be set up by using the full runway with a one-tap shortcharge, with the tap being at the top of the lowest slope."
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [3, 1],
+      "name": "Leave With Controlled Spring Ball Bounce (Long Runway)",
+      "requires": [
+        {"obstaclesCleared": ["A", "C"]},
+        "SpeedBooster"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 31,
+            "openEnd": 1,
+            "steepUpTiles": 9
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "controlled",
+          "minExtraRunSpeed": "$4.9"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Gain speed using the long runway at the top-right of room, do a big jump across the room into a speedball, then use controlled bounces to make it through the top-left door."
+      ],
+      "devNote": "Unlocking doors would be done ahead-of-time when the door is opened, i.e. when obstacle 'C' is set."
     },
     {
       "link": [3, 1],

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -748,7 +748,8 @@
       "name": "Leave With Controlled Spring Ball Bounce (Long Runway)",
       "requires": [
         {"obstaclesCleared": ["A", "C"]},
-        "SpeedBooster"
+        "SpeedBooster",
+        "canInsaneJump"
       ],
       "exitCondition": {
         "leaveWithSpringBallBounce": {

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -259,6 +259,139 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Mockball (Short Runway)",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Short Runway)",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping (Short Runway)",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning (Long Runway)",
+      "requires": [
+        "canPreciseSpaceJump",
+        {"obstaclesCleared": ["A", "C"]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 28,
+            "openEnd": 1,
+            "steepUpTiles": 8
+          }
+        }
+      },
+      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it into the next room.",
+      "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball (Long Runway)",
+      "requires": [
+        "canPreciseSpaceJump",
+        {"obstaclesCleared": ["A", "C"]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 28,
+            "openEnd": 1,
+            "steepUpTiles": 8
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a mockball (or speedball) at the doorway.",
+      "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Long Runway)",
+      "requires": [
+        "canPreciseSpaceJump",
+        {"obstaclesCleared": ["A", "C"]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 28,
+            "openEnd": 1,
+            "steepUpTiles": 8
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a spring ball bounce into the other room.",
+      "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping (Long Runway)",
+      "requires": [
+        "canPreciseSpaceJump",
+        {"obstaclesCleared": ["A", "C"]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 28,
+            "openEnd": 1,
+            "steepUpTiles": 8
+          }
+        }
+      },
+      "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry into the other room.",
+      "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
+    },
+    {
+      "link": [1, 1],
       "name": "Open Door",
       "requires": [
         {"doorUnlockedAtNode": 1}
@@ -320,6 +453,58 @@
         ]}
       ],
       "clearsObstacles": ["A"]
+    },
+    {
+      "link": [1, 7],
+      "name": "Come in Getting Blue Speed, Break Bomb Blocks",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"or": [
+          "canBlueSpaceJump",
+          "canSpringBallBounce",
+          "canLongChainTemporaryBlue"
+        ]}
+      ]
+    },
+    {
+      "link": [1, 7],
+      "name": "Come in With Blue Spring Ball Bounce, Break Bomb Blocks",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canTrickyJump"
+      ]
+    },
+    {
+      "link": [1, 7],
+      "name": "Come In Blue Spinning, Space Jump Break Bomb Blocks",
+      "entranceCondition": {
+        "comeInBlueSpinning": {
+          "unusableTiles": 0
+        }
+      },
+      "requires": [
+        "canBlueSpaceJump"
+      ]
+    },
+    {
+      "link": [1, 7],
+      "name": "Come In With Temporary Blue, Break Bomb Blocks",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "can4HighMidAirMorph"
+      ]
     },
     {
       "link": [1, 8],

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -369,7 +369,10 @@
         }
       },
       "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a spring ball bounce into the other room.",
-      "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
+      "devNote": [
+        "This runway has some unusable tiles because the Space Jump descent will not work with too high speed.",
+        "FIXME: This could be done without Space Jump, but it needs some way to encode a minimum speed that we will have to exit with. "
+      ]
     },
     {
       "link": [1, 1],

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -468,6 +468,10 @@
         {"or": [
           "canBlueSpaceJump",
           "canSpringBallBounce",
+          {"and": [
+            "canSpringBallBounce",
+            "canTrickyJump"
+          ]},
           "canLongChainTemporaryBlue"
         ]}
       ]

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -473,7 +473,8 @@
           ]},
           "canLongChainTemporaryBlue"
         ]}
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 7],
@@ -485,7 +486,8 @@
       },
       "requires": [
         "canTrickyJump"
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 7],
@@ -497,7 +499,8 @@
       },
       "requires": [
         "canBlueSpaceJump"
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 7],
@@ -508,7 +511,8 @@
       "requires": [
         "canLongChainTemporaryBlue",
         "can4HighMidAirMorph"
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [1, 8],

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -768,7 +768,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
-        "Gain speed using the long runway at the top-right of room, do a big jump across the room into a speedball, then use controlled bounces to make it through the top-left door."
+        "Gain speed using the long runway at the top-right of room, do a big jump across the room into a mockball or speedball, then use controlled bounces to make it through the top-left door."
       ],
       "devNote": "Unlocking doors would be done ahead-of-time when the door is opened, i.e. when obstacle 'C' is set."
     },

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -73,6 +73,21 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "minExtraRunSpeed": "$1.5"
+        }
+      },
+      "devNote": "Leaving with lower speed (e.g. $1.2) is possible with SpeedBooster equipped; not sure if this matters for anything though."
+    },
+    {
+      "link": [1, 1],
       "name": "Leave With Mockball",
       "requires": [],
       "exitCondition": {
@@ -243,6 +258,20 @@
         "leaveWithRunway": {
           "length": 3,
           "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "minExtraRunSpeed": "$1.5"
         }
       }
     },

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -73,6 +73,56 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 2,
+            "openEnd": 1
+          }
+        }
+      },
+      "devNote": [
+        "One tile of landing runway is unusable; it could be used with a shorter remoteRunway, but there's no application yet."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Mellow and Reo Farm",
       "requires": [
         {"resetRoom": {
@@ -193,6 +243,54 @@
         "leaveWithRunway": {
           "length": 3,
           "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
         }
       }
     },

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -213,6 +213,83 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 32,
+            "openEnd": 1,
+            "gentleUpTiles": 2,
+            "steepDownTiles": 4
+          }
+        }
+      },
+      "devNote": [
+        "FIXME: If low speed is needed in the next room, it could be a problem; refine this later as needed.",
+        "It might be better to define the position of the jump point(s), like a horizontal version of leaveWithPlatformBelow.",
+        "One more tile could be added to the runway if the door at node 1 is unlocked."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 32,
+            "openEnd": 1,
+            "gentleUpTiles": 2,
+            "steepDownTiles": 4
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 30,
+            "openEnd": 1,
+            "gentleUpTiles": 2,
+            "steepDownTiles": 4
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 25,
+            "openEnd": 1,
+            "gentleUpTiles": 2,
+            "steepDownTiles": 2
+          }
+        }
+      },
+      "devNote": [
+        "FIXME: A longer runway could be used if getting blue speed."
+      ]
+    },
+    {
+      "link": [2, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
         {"canShineCharge": {

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -222,14 +222,10 @@
             "openEnd": 1,
             "gentleUpTiles": 2,
             "steepDownTiles": 4
-          }
+          },
+          "minExtraRunSpeed": "$3.E"
         }
-      },
-      "devNote": [
-        "FIXME: If low speed is needed in the next room, it could be a problem; refine this later as needed.",
-        "It might be better to define the position of the jump point(s), like a horizontal version of leaveWithPlatformBelow.",
-        "One more tile could be added to the runway if the door at node 1 is unlocked."
-      ]
+      }
     },
     {
       "link": [2, 2],
@@ -246,7 +242,8 @@
           "landingRunway": {
             "length": 4,
             "openEnd": 1
-          }
+          },
+          "minExtraRunSpeed": "$0.8"
         }
       }
     },
@@ -266,6 +263,7 @@
             "length": 1,
             "openEnd": 1
           },
+          "minExtraRunSpeed": "$1.9",
           "movementType": "uncontrolled"
         }
       }

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -189,39 +189,26 @@
         "Gravity",
         "canLongChainTemporaryBlue",
         "can4HighMidAirMorph",
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 0,
+          "steepUpTiles": 4,
+          "steepDownTiles": 2,
+          "startingDownTiles": 1
+        }},
         {"or": [
-          {"and": [
-            {"canShineCharge": {
-              "usedTiles": 20,
-              "openEnd": 0,
-              "steepUpTiles": 4,
-              "steepDownTiles": 2,
-              "startingDownTiles": 1
-            }},
-            "canXRayTurnaround"  
-          ]},
-          {"and": [
-            {"canShineCharge": {
-              "usedTiles": 22,
-              "openEnd": 0,
-              "steepUpTiles": 3,
-              "steepDownTiles": 3
-            }},
-            {"or": [
-              "HiJump",
-              "canGravityJump"
-            ]}
-          ]}
+          "HiJump",
+          "canGravityJump"
         ]}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
       "note": [
-        "Gain temporary blue, either with the runway on the left side of the room using X-Ray turnarounds, or with the runway on the right side using HiJump or a Gravity jump to get onto the first ocean platform."
+        "Gain temporary blue using the runway on the left side of the room, using HiJump or a Gravity jump where needed to get onto the ocean platforms."
       ],
       "devNote": [
-        "With very precise mid-air morphs/unmorphs, it is possible to get onto the first or second ocean platform directly without HiJump or canGravityJump."
+        "With very precise mid-air morphs/unmorphs, it is possible to get onto the first or second ocean platform directly without HiJump or canGravityJump, by using the runway on the right side of the room."
       ]
     },
     {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -161,6 +161,30 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        "Gravity",
+        "canBlueSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 18,
+            "openEnd": 1,
+            "steepUpTiles": 1,
+            "steepDownTiles": 2
+          },
+          "landingRunway": {
+            "length": 8,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          },
+          "movementType": "controlled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Leave With Mockball (Space Jump)",
       "requires": [
         "Gravity",
@@ -178,6 +202,25 @@
             "length": 8,
             "openEnd": 1,
             "steepUpTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 18,
+            "openEnd": 1,
+            "steepUpTiles": 1,
+            "steepDownTiles": 2
           }
         }
       }

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -202,9 +202,11 @@
             "length": 8,
             "openEnd": 1,
             "steepUpTiles": 1
-          }
+          },
+          "maxExtraRunSpeed": "$2.F"
         }
-      }
+      },
+      "devNote": "A bit higher speed can also work but would be more difficult"
     },
     {
       "link": [1, 1],
@@ -221,7 +223,9 @@
             "openEnd": 1,
             "steepUpTiles": 1,
             "steepDownTiles": 2
-          }
+          },
+          "minExtraRunSpeed": "$1.3",
+          "maxExtraRunSpeed": "$2.A"
         }
       }
     },

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -161,23 +161,61 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Mockball (Space Jump)",
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 18,
+            "openEnd": 1,
+            "steepUpTiles": 1,
+            "steepDownTiles": 2
+          },
+          "landingRunway": {
+            "length": 8,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        {"canShineCharge": {
-          "usedTiles": 20,
-          "openEnd": 0,
-          "steepUpTiles": 4,
-          "steepDownTiles": 2,
-          "startingDownTiles": 1
-        }},
         "canLongChainTemporaryBlue",
-        "canXRayTurnaround",
-        "can4HighMidAirMorph"
+        "can4HighMidAirMorph",
+        {"or": [
+          {"and": [
+            {"canShineCharge": {
+              "usedTiles": 20,
+              "openEnd": 0,
+              "steepUpTiles": 4,
+              "steepDownTiles": 2,
+              "startingDownTiles": 1
+            }},
+            "canXRayTurnaround"  
+          ]},
+          {"and": [
+            {"canShineCharge": {
+              "usedTiles": 22,
+              "openEnd": 0,
+              "steepUpTiles": 3,
+              "steepDownTiles": 3
+            }},
+            "HiJump"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "note": [
+        "Gain temporary blue, either using the runway on the left side of the room with X-Ray turnarounds, or using the runway on the right side with HiJump."
+      ]
     },
     {
       "link": [1, 1],
@@ -446,6 +484,74 @@
           "length": 5,
           "openEnd": 1,
           "steepUpTiles": 1
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "Gravity",
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 17,
+            "openEnd": 1,
+            "steepUpTiles": 3,
+            "steepDownTiles": 2,
+            "startingDownTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball (Space Jump)",
+      "requires": [
+        "Gravity",
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 17,
+            "openEnd": 1,
+            "steepUpTiles": 3,
+            "steepDownTiles": 2,
+            "startingDownTiles": 1
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        "Gravity",
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 17,
+            "openEnd": 1,
+            "steepUpTiles": 3,
+            "steepDownTiles": 2,
+            "startingDownTiles": 1
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          },
+          "movementType": "uncontrolled"
         }
       }
     },

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -163,6 +163,7 @@
       "link": [1, 1],
       "name": "Leave With Mockball (Space Jump)",
       "requires": [
+        "Gravity",
         "canPreciseSpaceJump"
       ],
       "exitCondition": {
@@ -206,7 +207,10 @@
               "steepUpTiles": 3,
               "steepDownTiles": 3
             }},
-            "HiJump"
+            {"or": [
+              "HiJump",
+              "canGravityJump"
+            ]}
           ]}
         ]}
       ],
@@ -214,7 +218,10 @@
         "leaveWithTemporaryBlue": {}
       },
       "note": [
-        "Gain temporary blue, either using the runway on the left side of the room with X-Ray turnarounds, or using the runway on the right side with HiJump."
+        "Gain temporary blue, either with the runway on the left side of the room using X-Ray turnarounds, or with the runway on the right side using HiJump or a Gravity jump to get onto the first ocean platform."
+      ],
+      "devNote": [
+        "With very precise mid-air morphs/unmorphs, it is possible to get onto the first or second ocean platform directly without HiJump or canGravityJump."
       ]
     },
     {

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -166,13 +166,14 @@
       "name": "Insane Speedy Airball",
       "entranceCondition": {
         "comeInRunning": {
-          "minTiles": 10,
+          "minTiles": 11,
           "speedBooster": true
         }
       },
       "requires": [
         "canInsaneJump",
-        "canLateralMidAirMorph"
+        "canLateralMidAirMorph",
+        "canMomentumConservingMorph"
       ]
     },
     {
@@ -385,11 +386,11 @@
       "link": [1, 2],
       "name": "Come in Shinecharging, Leave With Temporary Blue (Speedy Jump)",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 2,
           "steepDownTiles": 1,
           "openEnd": 0,
-          "minTiles": 21
+          "minExtraRunSpeed": "$4.0"
         }
       },
       "requires": [
@@ -409,16 +410,16 @@
       "link": [1, 2],
       "name": "Come in Shinecharging, Leave With Temporary Blue (Insane Speedy Jump)",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 2,
           "steepDownTiles": 1,
           "openEnd": 0,
-          "minTiles": 16
+          "minExtraRunSpeed": "$3.2"
         }
       },
       "requires": [
         "canInsaneJump",
-        "canLateralMidAirMorph",
+        "canMomentumConservingMorph",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -426,7 +427,8 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
-        "Enter with enough speed to jump over all the water, morphing mid-air and then unmorphing into temporary blue."
+        "Enter with enough speed to jump over all the water, morphing mid-air and then unmorphing into temporary blue.",
+        "Morph just before hitting the ceiling, in order to extend the jump horizontally."
       ]
     },
     {
@@ -546,10 +548,10 @@
       "link": [2, 1],
       "name": "Come in Shinecharging, Leave With Temporary Blue (Speedy Jump)",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 4,
           "openEnd": 0,
-          "minTiles": 9
+          "minExtraRunSpeed": "$1.2"
         }
       },
       "requires": [
@@ -560,7 +562,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
-        "Enter with enough speed to jump over all the water, morphing mid-air and then unmorphing into temporary blue."
+        "Enter with enough speed to jump onto or over the item pedestal, morphing mid-air and then unmorphing into temporary blue."
       ]
     },
     {

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -698,12 +698,9 @@
     },
     {
       "link": [3, 3],
-      "name": "Leave With Spring Ball Bounce",
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
       "requires": [
-        {"or": [
-          "SpaceJump",
-          "canInsaneJump"
-        ]}
+        "SpaceJump"
       ],
       "exitCondition": {
         "leaveWithSpringBallBounce": {
@@ -718,10 +715,31 @@
           },
           "movementType": "uncontrolled"
         }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Spring Ball Bounce (Neutral Bounce)",
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 7,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          },
+          "movementType": "uncontrolled",
+          "minExtraRunSpeed": "$5.2"
+        }
       },
       "note": [
-        "Use Space Jump to position the bounce.",
-        "Alternatively, use a neutral bounce (lateral mid-air morph into not holding jump while landing) into an uncontrolled bounce."
+        "Do a neutral bounce (lateral mid-air morph into not holding jump while landing) into an uncontrolled bounce."
       ]
     },
     {

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -689,7 +689,7 @@
             "openEnd": 1
           },
           "landingRunway": {
-            "length": 7,
+            "length": 11,
             "openEnd": 1,
             "steepUpTiles": 1
           }
@@ -698,9 +698,12 @@
     },
     {
       "link": [3, 3],
-      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "name": "Leave With Spring Ball Bounce",
       "requires": [
-        "SpaceJump"
+        {"or": [
+          "SpaceJump",
+          "canInsaneJump"
+        ]}
       ],
       "exitCondition": {
         "leaveWithSpringBallBounce": {
@@ -715,7 +718,11 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "note": [
+        "Use Space Jump to position the bounce.",
+        "Alternatively, use a neutral bounce (lateral mid-air morph into not holding jump while landing) into an uncontrolled bounce."
+      ]
     },
     {
       "link": [3, 3],

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -545,6 +545,77 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 7,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 7,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
         {"canShineCharge": {
@@ -589,6 +660,75 @@
           "length": 33,
           "openEnd": 1,
           "steepUpTiles": 4
+        }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 7,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 7,
+            "openEnd": 1,
+            "steepUpTiles": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
         }
       }
     },

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -403,7 +403,8 @@
         }
       },
       "requires": [
-        "canSlowShortCharge"
+        "canSlowShortCharge",
+        "canTrickyJump"
       ],
       "clearsObstacles": ["A"]
     },
@@ -593,7 +594,8 @@
         }
       },
       "requires": [
-        "canSlowShortCharge"
+        "canSlowShortCharge",
+        "canTrickyJump"```
       ],
       "clearsObstacles": ["A"]
     },

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -419,7 +419,10 @@
         }
       },
       "requires": [
-        "canSlowShortCharge"
+        "canSlowShortCharge",
+        "canSpeedball",
+        "canSpringBallBounce",
+        "canTrickyJump"
       ],
       "clearsObstacles": ["A"]
     },
@@ -606,7 +609,10 @@
         }
       },
       "requires": [
-        "canSlowShortCharge"
+        "canSlowShortCharge",
+        "canSpeedball",
+        "canSpringBallBounce",
+        "canTrickyJump"
       ],
       "clearsObstacles": ["A"]
     },

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -396,6 +396,35 @@
     },
     {
       "link": [1, 2],
+      "name": "Come In With Blue Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canSlowShortCharge"
+      ],
+      "clearsObstacles": ["A"]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come In Getting Blue Speed, Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 6,
+          "openEnd": 1,
+          "steepUpTiles": 1,
+          "steepDownTiles": 1
+        }
+      },
+      "requires": [
+        "canSlowShortCharge"
+      ],
+      "clearsObstacles": ["A"]
+    },
+    {
+      "link": [1, 2],
       "name": "G-Mode Setup - Get hit by Waver, Using Power Bombs",
       "notable": false,
       "requires": [
@@ -551,6 +580,35 @@
         "This is a series of precise jumps to fit between the solid walls while clearing a path through the room.",
         "Breaking the center blocks opens up a runway that can be used to charge a new spark in room."
       ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come In With Blue Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canSlowShortCharge"
+      ],
+      "clearsObstacles": ["A"]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come In Getting Blue Speed, Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 6,
+          "openEnd": 1,
+          "steepUpTiles": 1,
+          "steepDownTiles": 1
+        }
+      },
+      "requires": [
+        "canSlowShortCharge"
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "link": [2, 1],

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -371,8 +371,7 @@
       "note": [
         "This is a series of precise jumps to fit between the solid walls while clearing a path through the room.",
         "Breaking the center blocks opens up a runway that can be used to charge a new spark in room."
-      ],
-      "devNote": "TODO: There is a blue SpringBall strat to investigate."
+      ]
     },
     {
       "link": [1, 2],
@@ -399,14 +398,19 @@
       "name": "Come In With Blue Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
-          "movementType": "controlled"
+          "movementType": "controlled",
+          "minExtraRunSpeed": "$1.2",
+          "maxExtraRunSpeed": "$2.8"
         }
       },
       "requires": [
-        "canSlowShortCharge",
         "canTrickyJump"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "devNote": [
+        "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
+        "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
+      ]
     },
     {
       "link": [1, 2],
@@ -416,7 +420,9 @@
           "length": 6,
           "openEnd": 1,
           "steepUpTiles": 1,
-          "steepDownTiles": 1
+          "steepDownTiles": 1,
+          "minExtraRunSpeed": "$1.2",
+          "maxExtraRunSpeed": "$2.8"
         }
       },
       "requires": [
@@ -425,7 +431,11 @@
         "canSpringBallBounce",
         "canTrickyJump"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "devNote": [
+        "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
+        "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
+      ]
     },
     {
       "link": [1, 2],
@@ -590,14 +600,19 @@
       "name": "Come In With Blue Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
-          "movementType": "controlled"
+          "movementType": "controlled",
+          "minExtraRunSpeed": "$2.2",
+          "maxExtraRunSpeed": "$2.8"
         }
       },
       "requires": [
-        "canSlowShortCharge",
-        "canTrickyJump"```
+        "canTrickyJump"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "devNote": [
+        "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
+        "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
+      ]
     },
     {
       "link": [2, 1],
@@ -607,16 +622,21 @@
           "length": 6,
           "openEnd": 1,
           "steepUpTiles": 1,
-          "steepDownTiles": 1
+          "steepDownTiles": 1,
+          "minExtraRunSpeed": "$2.2",
+          "maxExtraRunSpeed": "$2.8"
         }
       },
       "requires": [
-        "canSlowShortCharge",
         "canSpeedball",
         "canSpringBallBounce",
         "canTrickyJump"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "devNote": [
+        "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
+        "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
+      ]
     },
     {
       "link": [2, 1],

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -189,6 +189,38 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 2,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Create a runway by destroying all but the bottom row of shot blocks."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Create a runway by destroying all but the bottom row of shot blocks."
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -74,6 +74,67 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
         {"canShineCharge": {
@@ -170,6 +231,67 @@
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": 140
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
         }
       }
     },

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -81,7 +81,8 @@
           "remoteRunway": {
             "length": 45,
             "openEnd": 1
-          }
+          },
+          "minExtraRunSpeed": "$1.3"
         }
       }
     },
@@ -243,7 +244,8 @@
           "remoteRunway": {
             "length": 45,
             "openEnd": 1
-          }
+          },
+          "minExtraRunSpeed": "$1.3"
         }
       }
     },

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -517,7 +517,12 @@
           "movementType": "controlled"
         }
       },
-      "requires": [],
+      "requires": [
+        {"or": [
+          "canTrickyJump",
+          "canSlowShortCharge"
+        ]}
+      ],
       "note": [
         "Gain a speedball in the other room, and either roll in or do a controlled bounce to enter while descending close to the ground.",
         "Bounce anywhere on the platform in front of the door, clearing the whole room at once.",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -509,6 +509,30 @@
     },
     {
       "link": [2, 1],
+      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
+      "notable": true,
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "adjacentMinTiles": 18,
+          "adjacentBlueSpeedTiles": 15,
+          "remoteAndLandingMinTiles": [[15, 1]],
+          "movementType": "controlled"
+        }
+      },
+      "requires": [],
+      "note": [
+        "Gain a speedball in the other room, and either roll in or do a controlled bounce to enter while descending.",
+        "Bounce anywhere on the platform in front of the door, clearing the whole room at once.",
+        "If needed, blue speed will destroy any Evirs along the way and allow bouncing on the sand at the end to make it onto the ledge."
+      ],
+      "devNote": [
+        "FIXME: This can work with a bit shorter runway, but it probably requires bouncing on the pillars.",
+        "FIXME: This can also work without blue speed; it is probably harder as it requires momentum in a more specific range.",
+        "FIXME: Add left-to-right version"
+      ]
+    },
+    {
+      "link": [2, 1],
       "name": "East Sand Hall Cross-Room SpringBall Jump (Right to Left)",
       "notable": true,
       "entranceCondition": {

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -513,20 +513,18 @@
       "notable": true,
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
-          "adjacentMinTiles": 18,
-          "adjacentBlueSpeedTiles": 15,
-          "remoteAndLandingMinTiles": [[15, 1]],
+          "minExtraRunSpeed": "$2.0",
           "movementType": "controlled"
         }
       },
       "requires": [],
       "note": [
-        "Gain a speedball in the other room, and either roll in or do a controlled bounce to enter while descending.",
+        "Gain a speedball in the other room, and either roll in or do a controlled bounce to enter while descending close to the ground.",
         "Bounce anywhere on the platform in front of the door, clearing the whole room at once.",
         "If needed, blue speed will destroy any Evirs along the way and allow bouncing on the sand at the end to make it onto the ledge."
       ],
       "devNote": [
-        "FIXME: This can work with a bit shorter runway, but it probably requires bouncing on the pillars.",
+        "FIXME: This can work with less speed, but it probably requires HiJump and/or bouncing on the pillars.",
         "FIXME: This can also work without blue speed; it is probably harder as it requires momentum in a more specific range.",
         "FIXME: Add left-to-right version"
       ]

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -631,6 +631,70 @@
               }
             }
           },
+          "speedBall": {
+            "$id": "#/definitions/logicalRequirement/items/properties/speedBall",
+            "type": "object",
+            "title": "Speed Ball",
+            "description": "Fulfilled by being able to gain a speedball with a specified amount of runway.",
+            "required": [
+              "length",
+              "openEnd"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "length": {
+                "$id": "#/definitions/logicalRequirement/items/properties/speedBall/properties/length",
+                "type": "number",
+                "minimum": 1,
+                "maximum": 45,
+                "title": "Runway length",
+                "description": "The number of contiguous tiles that are available to gain blue speed and jump into a speedball."
+              },
+              "gentleUpTiles": {
+                "$id": "#/definitions/logicalRequirement/items/properties/speedBall/properties/gentleUpTiles",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Gentle Up Tiles",
+                "description": "The number of tiles that slope gently upward (going up by half a tile)."
+              },
+              "gentleDownTiles": {
+                "$id": "#/definitions/logicalRequirement/items/properties/speedBall/properties/gentleDownTiles",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Gentle Down Tiles",
+                "description": "The number of tiles that slope gently downward (going down by half a tile)."
+              },
+              "steepUpTiles": {
+                "$id": "#/definitions/logicalRequirement/items/properties/speedBall/properties/steepUpTiles",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Steep Up Tiles",
+                "description": "The number of tiles that slope steeply upward (going up by a tile)."
+              },
+              "steepDownTiles": {
+                "$id": "#/definitions/logicalRequirement/items/properties/speedBall/properties/steepDownTiles",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Steep Down Tiles",
+                "description": "The number of tiles that slope steeply downward (going down by a tile)."
+              },
+              "startingDownTiles": {
+                "$id": "#/definitions/logicalRequirement/items/properties/speedBall/properties/startingDownTiles",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Starting Down Tiles",
+                "description": "The number of tiles that slope downwards at the start of a run, preventing the execution of a stutter."
+              },
+              "openEnd": {
+                "$id": "#/definitions/logicalRequirement/items/properties/speedBall/properties/openEnd",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 2,
+                "title": "Number of Open Ends",
+                "description": "The number of open ends in the runway. An open end is a runway edge that ends in a dropoff rather than a wall. Each open end adds a bit of extra room."
+              }
+            }
+          },
           "shinespark": {
             "$id": "#/definitions/logicalRequirement/items/properties/shinespark",
             "type": "object",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -48,6 +48,12 @@
           "type": "integer",
           "title": "Steep Down Tiles",
           "description": "Number of tiles in the runway that steeply slope (one vertical tile) downwards"
+        },
+        "startingDownTiles": {
+          "$id": "#/definitions/runway/properties/startingDownTiles",
+          "type": "integer",
+          "title": "Steep Down Tiles",
+          "description": "Number of tiles at the start of the runway that steeply slope downwards, preventing a stutter."
         }
       }
     },
@@ -572,6 +578,51 @@
                 {"required": ["remoteAndLandingMinTiles"]}
               ]
             },
+            "comeInWithBlueSpringBallBounce": {
+              "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce",
+              "type": "object",
+              "title": "Come In With Blue Spring Ball Bounce",
+              "description": "Represents that Samus must jump into the room with a blue spring ball bounce in the doorway of the previous room.",
+              "required": ["movementType"],
+              "additionalProperties": false,
+              "properties": {
+                "movementType": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/movementType",
+                  "type": "string",
+                  "title": "Movement Type",
+                  "enum": ["controlled", "uncontrolled", "any"],
+                  "description": "The type of bounce to enter with."
+                },
+                "adjacentMinTiles": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/adjacentMinTiles",
+                  "type": "number",
+                  "title": "Minimum Tiles for Adjacent Runway",
+                  "description": "The minimum effective runway tiles available in front of the door for gaining speed and jumping into a bounce."
+                },
+                "adjacentBlueSpeedTiles": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/adjacentBlueSpeedTiles",
+                  "type": "number",
+                  "title": "Minimum Blue Speed Tiles for Adjacent Runway",
+                  "description": "The minimum effective runway length that needs to be used for gaining blue speed before jumping."
+                },
+                "remoteAndLandingMinTiles": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/remoteAndLandingMinTiles",
+                  "type": "array",
+                  "title": "Minimum Tiles for Remote and Landing Runways",
+                  "description": "Possible minimum values for combinations of remote runway length and landing length.",
+                  "items": {
+                    "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/remoteAndLandingMinTiles/items",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/remoteAndLandingMinTiles/items/items",
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            },
             "comeInWithStoredFallSpeed": {
               "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithStoredFallSpeed",
               "type": "object",
@@ -750,6 +801,7 @@
             {"required": ["comeInWithTemporaryBlue"]},
             {"required": ["comeInWithMockball"]},
             {"required": ["comeInWithSpringBallBounce"]},
+            {"required": ["comeInWithBlueSpringBallBounce"]},
             {"required": ["comeInBlueSpinning"]},
             {"required": ["comeInWithStoredFallSpeed"]},
             {"required": ["comeInWithRMode"]},

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -288,12 +288,6 @@
                   "type": "integer",
                   "title": "Steep Down Tiles",
                   "description": "Number of tiles in the runway that steeply slope (one vertical tile) downwards (when running away from the door)"
-                },
-                "minTiles": {
-                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInShinecharging/properties/minTiles",
-                  "type": "integer",
-                  "title": "Minimum Tiles",
-                  "description": "Minimum number of tiles of runway in the other room required to be used (in order to gain enough momentum)."
                 }
               }
             },
@@ -349,11 +343,17 @@
                   "title": "Steep Down Tiles",
                   "description": "Number of tiles in the runway that steeply slope (one vertical tile) downwards (when running away from the door)"
                 },
-                "minTiles": {
-                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInGettingBlueSpeed/properties/minTiles",
-                  "type": "integer",
-                  "title": "Minimum Tiles",
-                  "description": "Minimum number of tiles of runway in the other room required to be used (in order to gain enough momentum)."
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInGettingBlueSpeed/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) which will satisfy this condition."
+                },
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInGettingBlueSpeed/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) which will satisfy this condition."
                 }
               }
             },
@@ -486,11 +486,17 @@
               "required": ["unusableTiles"],
               "additionalProperties": false,
               "properties": {
-                "minTiles": {
-                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInBlueSpinning/properties/minTiles",
-                  "type": "number",
-                  "title": "Minimum Runway Tiles",
-                  "description": "The minimum effective runway tiles needed before jumping, in order to gain sufficient momentum."
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInBlueSpinning/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) which will satisfy this condition."
+                },
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInBlueSpinning/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) which will satisfy this condition."
                 },
                 "unusableTiles": {
                   "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInBlueSpinning/properties/unusableTiles",
@@ -593,33 +599,22 @@
                   "enum": ["controlled", "uncontrolled", "any"],
                   "description": "The type of bounce to enter with."
                 },
-                "adjacentMinTiles": {
-                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/adjacentMinTiles",
-                  "type": "number",
-                  "title": "Minimum Tiles for Adjacent Runway",
-                  "description": "The minimum effective runway tiles available in front of the door for gaining speed and jumping into a bounce."
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) which will satisfy this condition."
                 },
-                "adjacentBlueSpeedTiles": {
-                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/adjacentBlueSpeedTiles",
-                  "type": "number",
-                  "title": "Minimum Blue Speed Tiles for Adjacent Runway",
-                  "description": "The minimum effective runway length that needs to be used for gaining blue speed before jumping."
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) which will satisfy this condition."
                 },
-                "remoteAndLandingMinTiles": {
-                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/remoteAndLandingMinTiles",
-                  "type": "array",
-                  "title": "Minimum Tiles for Remote and Landing Runways",
-                  "description": "Possible minimum values for combinations of remote runway length and landing length.",
-                  "items": {
-                    "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/remoteAndLandingMinTiles/items",
-                    "type": "array",
-                    "minItems": 2,
-                    "maxItems": 2,
-                    "items": {
-                      "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/remoteAndLandingMinTiles/items/items",
-                      "type": "number"
-                    }
-                  }
+                "minLandingTiles": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithBlueSpringBallBounce/properties/minLandingTiles",
+                  "type": "number",
+                  "description": "Minimum length of landing runway which will satisfy this condition."
                 }
               }
             },
@@ -966,6 +961,18 @@
                   "$ref": "#/definitions/runway",
                   "description": "Runway that is available to gain momentum for the spin jump."
                 },
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveSpinning/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
+                },
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveSpinning/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
+                },
                 "blue": {
                   "$id": "#/definitions/strat/properties/exitCondition/properties/leaveSpinning/properties/blue",
                   "type": "string",
@@ -993,6 +1000,18 @@
                   "$ref": "#/definitions/runway",
                   "description": "Runway that is available to land while entering mockball and gain speed before the transition."
                 },
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithMockball/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
+                },
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithMockball/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
+                },
                 "blue": {
                   "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithMockball/properties/blue",
                   "type": "string",
@@ -1019,6 +1038,18 @@
                   "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithSpringBallBounce/properties/landingRunway",
                   "$ref": "#/definitions/runway",
                   "description": "Runway that is available for landing, either for entering a mockball, or for bouncing after an airball."
+                },
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithSpringBallBounce/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
+                },
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithSpringBallBounce/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
                 },
                 "blue": {
                   "$id": "#/definitions/strat/properties/exitCondition/properties/leaveWithSpringBallBounce/properties/blue",
@@ -1048,6 +1079,18 @@
                   "$id": "#/definitions/strat/properties/exitCondition/properties/leaveSpaceJumping/properties/remoteRunway",
                   "$ref": "#/definitions/runway",
                   "description": "Runway that is available to gain momentum for the Space Jump."
+                },
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveSpaceJumping/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
+                },
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/exitCondition/properties/leaveSpaceJumping/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
                 },
                 "blue": {
                   "$id": "#/definitions/strat/properties/exitCondition/properties/leaveSpaceJumping/properties/blue",

--- a/strats.md
+++ b/strats.md
@@ -1518,126 +1518,126 @@ There are many kinds of cross-room strats that require Samus to enter the room w
 - Extra run speed: This increases by $0.1 for each frame that dash is held while running. With Speed Booster it reaches a maximum value of $7.0, while without Speed Booster it reaches a maximum value of $2.0. When stopping holding forward while walking/running, the extra run speed is immediately converted into base speed, i.e., base speed is increased by the value of the extra run speed, while the extra run speed immediately becomes zero. Other actions will either leave the extra run speed unchanged (e.g., jumping, breaking spin with jump held, or performing an airball or mockball) or immediately set it to zero (e.g., turning around, or breaking spin without jump held).
 - Combined run speed: This is the total of base speed and extra run speed, and represents the actual amount that Samus will move horizontally.
 
-All these speed values are measured in pixels (and subpixels) per frame. Since extra run speed remains stable through various movement actions, it is generally the more useful quantity to reference in cross-room strats. The following table shows how Samus' relative position and horizontal speeds change while running, starting from a stand, with dash held the entire time, with Speedbooster equipped. 
+All these speed values are measured in pixels (and subpixels) per frame. Since extra run speed remains stable through various movement actions, it is generally the more useful quantity to reference in cross-room strats. The following table shows how Samus' relative position and horizontal speeds change while running, starting from a stand, with dash held the entire time, with Speedbooster equipped. The initial vertical speed when jumping is also shown (both without and with HiJump).
 
-| Frame | Position | Base Speed | Extra Run Speed |
-| ----- | -------- | ---------- | --------------- |
-| 0     |  $0.0    |    $0.0     |      $0.0       |
-| 1     |  $1.0    |    $0.0     |      $0.0       |
-| 2     |  $1.4    |    $0.3     |      $0.1       |
-| 3     |  $1.C    |    $0.6     |      $0.2       |
-| 4     |  $2.8    |    $0.9     |      $0.3       |
-| 5     |  $3.8    |    $0.C     |      $0.4       |
-| 6     |  $4.C    |    $0.F     |      $0.5       |
-| 7     |  $6.4    |    $1.2     |      $0.6       |
-| 8     |  $8.0    |    $1.5     |      $0.7       |
-| 9     |  $A.0    |    $1.8     |      $0.8       |
-| 10    |  $C.4    |    $1.B     |      $0.9       |
-| 11    |  $E.C    |    $1.E     |      $0.A       |
-| 12    |  $12.3   |    $2.C     |      $0.B       |
-| 13    |  $15.B   |    $2.C     |      $0.C       |
-| 14    |  $19.4   |    $2.C     |      $0.D       |
-| 15    |  $1C.E   |    $2.C     |      $0.E       |
-| 16    |  $20.9   |    $2.C     |      $0.F       |
-| 17    |  $24.5   |    $2.C     |      $1.0       |
-| 18    |  $28.2   |    $2.C     |      $1.1       |
-| 19    |  $2C.0   |    $2.C     |      $1.2       |
-| 20    |  $2F.F   |    $2.C     |      $1.3       |
-| 21    |  $33.F   |    $2.C     |      $1.4       |
-| 22    |  $38.0   |    $2.C     |      $1.5       |
-| 23    |  $3C.2   |    $2.C     |      $1.6       |
-| 24    |  $40.5   |    $2.C     |      $1.7       |
-| 25    |  $44.9   |    $2.C     |      $1.8       |
-| 26    |  $48.E   |    $2.C     |      $1.9       |
-| 27    |  $4D.4   |    $2.C     |      $1.A       |
-| 28    |  $51.B   |    $2.C     |      $1.B       |
-| 29    |  $56.3   |    $2.C     |      $1.C       |
-| 30    |  $5A.C   |    $2.C     |      $1.D       |
-| 31    |  $5F.6   |    $2.C     |      $1.E       |
-| 32    |  $64.1   |    $2.C     |      $1.F       |
-| 33    |  $68.D   |    $2.C     |      $2.0       |
-| 34    |  $6D.A   |    $2.C     |      $2.1       |
-| 35    |  $72.8   |    $2.C     |      $2.2       |
-| 36    |  $77.7   |    $2.C     |      $2.3       |
-| 37    |  $7C.7   |    $2.C     |      $2.4       |
-| 38    |  $81.8   |    $2.C     |      $2.5       |
-| 39    |  $86.A   |    $2.C     |      $2.6       |
-| 40    |  $8B.D   |    $2.C     |      $2.7       |
-| 41    |  $91.1   |    $2.C     |      $2.8       |
-| 42    |  $96.6   |    $2.C     |      $2.9       |
-| 43    |  $9B.C   |    $2.C     |      $2.A       |
-| 44    |  $A1.3   |    $2.C     |      $2.B       |
-| 45    |  $A6.B   |    $2.C     |      $2.C       |
-| 46    |  $AC.4   |    $2.C     |      $2.D       |
-| 47    |  $B1.E   |    $2.C     |      $2.E       |
-| 48    |  $B7.9   |    $2.C     |      $2.F       |
-| 49    |  $BD.5   |    $2.C     |      $3.0       |
-| 50    |  $C3.2   |    $2.C     |      $3.1       |
-| 51    |  $C9.0   |    $2.C     |      $3.2       |
-| 52    |  $CE.F   |    $2.C     |      $3.3       |
-| 53    |  $D4.F   |    $2.C     |      $3.4       |
-| 54    |  $DB.0   |    $2.C     |      $3.5       |
-| 55    |  $E1.2   |    $2.C     |      $3.6       |
-| 56    |  $E7.5   |    $2.C     |      $3.7       |
-| 57    |  $ED.9   |    $2.C     |      $3.8       |
-| 58    |  $F3.E   |    $2.C     |      $3.9       |
-| 59    |  $FA.4   |    $2.C     |      $3.A       |
-| 60    |  $100.B  |    $2.C     |      $3.B       |
-| 61    |  $107.3  |    $2.C     |      $3.C       |
-| 62    |  $10D.C  |    $2.C     |      $3.D       |
-| 63    |  $114.6  |    $2.C     |      $3.E       |
-| 64    |  $11B.1  |    $2.C     |      $3.F       |
-| 65    |  $121.D  |    $2.C     |      $4.0       |
-| 66    |  $128.A  |    $2.C     |      $4.1       |
-| 67    |  $12F.8  |    $2.C     |      $4.2       |
-| 68    |  $136.7  |    $2.C     |      $4.3       |
-| 69    |  $13D.7  |    $2.C     |      $4.4       |
-| 70    |  $144.8  |    $2.C     |      $4.5       |
-| 71    |  $14B.A  |    $2.C     |      $4.6       |
-| 72    |  $152.D  |    $2.C     |      $4.7       |
-| 73    |  $15A.1  |    $2.C     |      $4.8       |
-| 74    |  $161.6  |    $2.C     |      $4.9       |
-| 75    |  $168.C  |    $2.C     |      $4.A       |
-| 76    |  $170.3  |    $2.C     |      $4.B       |
-| 77    |  $177.B  |    $2.C     |      $4.C       |
-| 78    |  $17F.4  |    $2.C     |      $4.D       |
-| 79    |  $186.E  |    $2.C     |      $4.E       |
-| 80    |  $18E.9  |    $2.C     |      $4.F       |
-| 81    |  $196.5  |    $2.C     |      $5.0       |
-| 82    |  $19E.2  |    $2.C     |      $5.1       |
-| 83    |  $1A6.0  |    $2.C     |      $5.2       |
-| 84    |  $1AD.F  |    $2.C     |      $5.3       |
-| 85    |  $1B5.F  |    $2.C     |      $5.4       |
-| 86    |  $1BE.0  |    $2.C     |      $5.5       |
-| 87    |  $1C6.2  |    $2.C     |      $5.6       |
-| 88    |  $1CE.5  |    $2.C     |      $5.7       |
-| 89    |  $1D6.9  |    $2.C     |      $5.8       |
-| 90    |  $1DE.E  |    $2.C     |      $5.9       |
-| 91    |  $1E7.4  |    $2.C     |      $5.A       |
-| 92    |  $1EF.B  |    $2.C     |      $5.B       |
-| 93    |  $1F8.3  |    $2.C     |      $5.C       |
-| 94    |  $200.C  |    $2.C     |      $5.D       |
-| 95    |  $209.6  |    $2.C     |      $5.E       |
-| 96    |  $212.1  |    $2.C     |      $5.F       |
-| 97    |  $21A.D  |    $2.C     |      $6.0       |
-| 98    |  $223.A  |    $2.C     |      $6.1       |
-| 99    |  $22C.8  |    $2.C     |      $6.2       |
-| 100   |  $235.7  |    $2.C     |      $6.3       |
-| 101   |  $23E.7  |    $2.C     |      $6.4       |
-| 102   |  $247.8  |    $2.C     |      $6.5       |
-| 103   |  $250.A  |    $2.C     |      $6.6       |
-| 104   |  $259.D  |    $2.C     |      $6.7       |
-| 105   |  $263.1  |    $2.C     |      $6.8       |
-| 106   |  $26C.6  |    $2.C     |      $6.9       |
-| 107   |  $275.C  |    $2.C     |      $6.A       |
-| 108   |  $27F.3  |    $2.C     |      $6.B       |
-| 109   |  $288.B  |    $2.C     |      $6.C       |
-| 110   |  $292.4  |    $2.C     |      $6.D       |
-| 111   |  $29B.E  |    $2.C     |      $6.E       |
-| 112   |  $2A5.9  |    $2.C     |      $6.F       |
-| 113   |  $2AF.5  |    $2.C     |      $7.0       |
+| Frame | Position | Base Speed | Extra Run Speed | Jump Speed | HiJump Speed
+| ----- | -------- | ---------- | --------------- | ---------- | ------------
+| 0     |  $0.0    |    $0.0    |      $0.0       |    $4.E    |     $6.0
+| 1     |  $1.0    |    $0.0    |      $0.0       |    $4.E    |     $6.0
+| 2     |  $1.4    |    $0.3    |      $0.1       |    $4.F    |     $6.1
+| 3     |  $1.C    |    $0.6    |      $0.2       |    $4.0    |     $6.2
+| 4     |  $2.8    |    $0.9    |      $0.3       |    $4.1    |     $6.3
+| 5     |  $3.8    |    $0.C    |      $0.4       |    $4.2    |     $6.4
+| 6     |  $4.C    |    $0.F    |      $0.5       |    $4.3    |     $6.5
+| 7     |  $6.4    |    $1.2    |      $0.6       |    $4.4    |     $6.6
+| 8     |  $8.0    |    $1.5    |      $0.7       |    $4.5    |     $6.7
+| 9     |  $A.0    |    $1.8    |      $0.8       |    $4.6    |     $6.8
+| 10    |  $C.4    |    $1.B    |      $0.9       |    $4.7    |     $6.9
+| 11    |  $E.C    |    $1.E    |      $0.A       |    $4.8    |     $6.A
+| 12    |  $12.3   |    $2.C    |      $0.B       |    $4.9    |     $6.B
+| 13    |  $15.B   |    $2.C    |      $0.C       |    $4.A    |     $6.C
+| 14    |  $19.4   |    $2.C    |      $0.D       |    $4.B    |     $6.D
+| 15    |  $1C.E   |    $2.C    |      $0.E       |    $4.C    |     $6.E
+| 16    |  $20.9   |    $2.C    |      $0.F       |    $4.D    |     $6.F
+| 17    |  $24.5   |    $2.C    |      $1.0       |    $4.E    |     $6.0
+| 18    |  $28.2   |    $2.C    |      $1.1       |    $4.F    |     $6.1
+| 19    |  $2C.0   |    $2.C    |      $1.2       |    $4.0    |     $6.2
+| 20    |  $2F.F   |    $2.C    |      $1.3       |    $4.1    |     $6.3
+| 21    |  $33.F   |    $2.C    |      $1.4       |    $4.2    |     $6.4
+| 22    |  $38.0   |    $2.C    |      $1.5       |    $4.3    |     $6.5
+| 23    |  $3C.2   |    $2.C    |      $1.6       |    $4.4    |     $6.6
+| 24    |  $40.5   |    $2.C    |      $1.7       |    $4.5    |     $6.7
+| 25    |  $44.9   |    $2.C    |      $1.8       |    $4.6    |     $6.8
+| 26    |  $48.E   |    $2.C    |      $1.9       |    $4.7    |     $6.9
+| 27    |  $4D.4   |    $2.C    |      $1.A       |    $4.8    |     $6.A
+| 28    |  $51.B   |    $2.C    |      $1.B       |    $4.9    |     $6.B
+| 29    |  $56.3   |    $2.C    |      $1.C       |    $4.A    |     $6.C
+| 30    |  $5A.C   |    $2.C    |      $1.D       |    $4.B    |     $6.D
+| 31    |  $5F.6   |    $2.C    |      $1.E       |    $4.C    |     $6.E
+| 32    |  $64.1   |    $2.C    |      $1.F       |    $4.D    |     $6.F
+| 33    |  $68.D   |    $2.C    |      $2.0       |    $5.E    |     $7.0
+| 34    |  $6D.A   |    $2.C    |      $2.1       |    $5.F    |     $7.1
+| 35    |  $72.8   |    $2.C    |      $2.2       |    $5.0    |     $7.2
+| 36    |  $77.7   |    $2.C    |      $2.3       |    $5.1    |     $7.3
+| 37    |  $7C.7   |    $2.C    |      $2.4       |    $5.2    |     $7.4
+| 38    |  $81.8   |    $2.C    |      $2.5       |    $5.3    |     $7.5
+| 39    |  $86.A   |    $2.C    |      $2.6       |    $5.4    |     $7.6
+| 40    |  $8B.D   |    $2.C    |      $2.7       |    $5.5    |     $7.7
+| 41    |  $91.1   |    $2.C    |      $2.8       |    $5.6    |     $7.8
+| 42    |  $96.6   |    $2.C    |      $2.9       |    $5.7    |     $7.9
+| 43    |  $9B.C   |    $2.C    |      $2.A       |    $5.8    |     $7.A
+| 44    |  $A1.3   |    $2.C    |      $2.B       |    $5.9    |     $7.B
+| 45    |  $A6.B   |    $2.C    |      $2.C       |    $5.A    |     $7.C
+| 46    |  $AC.4   |    $2.C    |      $2.D       |    $5.B    |     $7.D
+| 47    |  $B1.E   |    $2.C    |      $2.E       |    $5.C    |     $7.E
+| 48    |  $B7.9   |    $2.C    |      $2.F       |    $5.D    |     $7.F
+| 49    |  $BD.5   |    $2.C    |      $3.0       |    $5.E    |     $7.0
+| 50    |  $C3.2   |    $2.C    |      $3.1       |    $5.F    |     $7.1
+| 51    |  $C9.0   |    $2.C    |      $3.2       |    $5.0    |     $7.2
+| 52    |  $CE.F   |    $2.C    |      $3.3       |    $5.1    |     $7.3
+| 53    |  $D4.F   |    $2.C    |      $3.4       |    $5.2    |     $7.4
+| 54    |  $DB.0   |    $2.C    |      $3.5       |    $5.3    |     $7.5
+| 55    |  $E1.2   |    $2.C    |      $3.6       |    $5.4    |     $7.6
+| 56    |  $E7.5   |    $2.C    |      $3.7       |    $5.5    |     $7.7
+| 57    |  $ED.9   |    $2.C    |      $3.8       |    $5.6    |     $7.8
+| 58    |  $F3.E   |    $2.C    |      $3.9       |    $5.7    |     $7.9
+| 59    |  $FA.4   |    $2.C    |      $3.A       |    $5.8    |     $7.A
+| 60    |  $100.B  |    $2.C    |      $3.B       |    $5.9    |     $7.B
+| 61    |  $107.3  |    $2.C    |      $3.C       |    $5.A    |     $7.C
+| 62    |  $10D.C  |    $2.C    |      $3.D       |    $5.B    |     $7.D
+| 63    |  $114.6  |    $2.C    |      $3.E       |    $5.C    |     $7.E
+| 64    |  $11B.1  |    $2.C    |      $3.F       |    $5.D    |     $7.F
+| 65    |  $121.D  |    $2.C    |      $4.0       |    $6.E    |     $8.0
+| 66    |  $128.A  |    $2.C    |      $4.1       |    $6.F    |     $8.1
+| 67    |  $12F.8  |    $2.C    |      $4.2       |    $6.0    |     $8.2
+| 68    |  $136.7  |    $2.C    |      $4.3       |    $6.1    |     $8.3
+| 69    |  $13D.7  |    $2.C    |      $4.4       |    $6.2    |     $8.4
+| 70    |  $144.8  |    $2.C    |      $4.5       |    $6.3    |     $8.5
+| 71    |  $14B.A  |    $2.C    |      $4.6       |    $6.4    |     $8.6
+| 72    |  $152.D  |    $2.C    |      $4.7       |    $6.5    |     $8.7
+| 73    |  $15A.1  |    $2.C    |      $4.8       |    $6.6    |     $8.8
+| 74    |  $161.6  |    $2.C    |      $4.9       |    $6.7    |     $8.9
+| 75    |  $168.C  |    $2.C    |      $4.A       |    $6.8    |     $8.A
+| 76    |  $170.3  |    $2.C    |      $4.B       |    $6.9    |     $8.B
+| 77    |  $177.B  |    $2.C    |      $4.C       |    $6.A    |     $8.C
+| 78    |  $17F.4  |    $2.C    |      $4.D       |    $6.B    |     $8.D
+| 79    |  $186.E  |    $2.C    |      $4.E       |    $6.C    |     $8.E
+| 80    |  $18E.9  |    $2.C    |      $4.F       |    $6.D    |     $8.F
+| 81    |  $196.5  |    $2.C    |      $5.0       |    $6.E    |     $8.0
+| 82    |  $19E.2  |    $2.C    |      $5.1       |    $6.F    |     $8.1
+| 83    |  $1A6.0  |    $2.C    |      $5.2       |    $6.0    |     $8.2
+| 84    |  $1AD.F  |    $2.C    |      $5.3       |    $6.1    |     $8.3
+| 85    |  $1B5.F  |    $2.C    |      $5.4       |    $6.2    |     $8.4
+| 86    |  $1BE.0  |    $2.C    |      $5.5       |    $6.3    |     $8.5
+| 87    |  $1C6.2  |    $2.C    |      $5.6       |    $6.4    |     $8.6
+| 88    |  $1CE.5  |    $2.C    |      $5.7       |    $6.5    |     $8.7
+| 89    |  $1D6.9  |    $2.C    |      $5.8       |    $6.6    |     $8.8
+| 90    |  $1DE.E  |    $2.C    |      $5.9       |    $6.7    |     $8.9
+| 91    |  $1E7.4  |    $2.C    |      $5.A       |    $6.8    |     $8.A
+| 92    |  $1EF.B  |    $2.C    |      $5.B       |    $6.9    |     $8.B
+| 93    |  $1F8.3  |    $2.C    |      $5.C       |    $6.A    |     $8.C
+| 94    |  $200.C  |    $2.C    |      $5.D       |    $6.B    |     $8.D
+| 95    |  $209.6  |    $2.C    |      $5.E       |    $6.C    |     $8.E
+| 96    |  $212.1  |    $2.C    |      $5.F       |    $6.D    |     $8.F
+| 97    |  $21A.D  |    $2.C    |      $6.0       |    $7.E    |     $9.0
+| 98    |  $223.A  |    $2.C    |      $6.1       |    $7.F    |     $9.1
+| 99    |  $22C.8  |    $2.C    |      $6.2       |    $7.0    |     $9.2
+| 100   |  $235.7  |    $2.C    |      $6.3       |    $7.1    |     $9.3
+| 101   |  $23E.7  |    $2.C    |      $6.4       |    $7.2    |     $9.4
+| 102   |  $247.8  |    $2.C    |      $6.5       |    $7.3    |     $9.5
+| 103   |  $250.A  |    $2.C    |      $6.6       |    $7.4    |     $9.6
+| 104   |  $259.D  |    $2.C    |      $6.7       |    $7.5    |     $9.7
+| 105   |  $263.1  |    $2.C    |      $6.8       |    $7.6    |     $9.8
+| 106   |  $26C.6  |    $2.C    |      $6.9       |    $7.7    |     $9.9
+| 107   |  $275.C  |    $2.C    |      $6.A       |    $7.8    |     $9.A
+| 108   |  $27F.3  |    $2.C    |      $6.B       |    $7.9    |     $9.B
+| 109   |  $288.B  |    $2.C    |      $6.C       |    $7.A    |     $9.C
+| 110   |  $292.4  |    $2.C    |      $6.D       |    $7.B    |     $9.D
+| 111   |  $29B.E  |    $2.C    |      $6.E       |    $7.C    |     $9.E
+| 112   |  $2A5.9  |    $2.C    |      $6.F       |    $7.D    |     $9.F
+| 113   |  $2AF.5  |    $2.C    |      $7.0       |    $7.E    |     $9.0
 
-Without Speedbooster, the same table is also valid up through row 33 (when extra run speed reaches $2.0).
+Without Speedbooster, the same table is also valid up through row 33 (when extra run speed reaches $2.0), except that in that case the Jump Speed and HiJump Speeds are just constants ($4.E and $6.0) independent of run speed.
 
 # Full run speed table
 

--- a/strats.md
+++ b/strats.md
@@ -1124,7 +1124,7 @@ There are additional requirements depending on the exit condition:
   "name": "Come In With Blue Spring Ball Bounce",
   "notable": false,
   "entranceCondition": {
-    "comeInWithSpringBallBounce": {
+    "comeInWithBlueSpringBallBounce": {
       "remoteAndLandingMinTiles": [[15, 1]],
       "movementType": "controlled"
     }

--- a/strats.md
+++ b/strats.md
@@ -548,6 +548,7 @@ In all strats with an `entranceCondition`, the `from` node of the strat must be 
 - _comeInWithTemporaryBlue_: This indicates that Samus must come in by jumping through this door with temporary blue.
 - _comeInWithMockball_: This indicates that Samus must roll into the room with a mockball with a certain amount of momentum.
 - _comeInWithSpringBallBounce_: This indicates that Samus get a spring ball bounce in the doorway of the previous room.
+- _comeInWithBlueSpringBallBounce_: This indicates that Samus get a spring ball bounce in the doorway of the previous room while having blue speed.
 - _comeInBlueSpinning_: This indicates that Samus come in with a spin jump through the doorway while having blue speed.
 - _comeInWithStoredFallSpeed_: This indicates that Samus must enter the room with fall speed stored, and is able to clip through a floor with a Moonfall.
 - _comeInWithRMode_: This indicates that Samus must have or obtain R-mode while coming through this door.
@@ -1037,7 +1038,7 @@ A `comeInWithMockball` entrance condition must match with one of the following c
 
 ### Come In With Spring Ball Bounce
 
-A `comeInWithSpringBallBounce` entrance condition indicates that Samus must enter the room by spring ball bouncing in the doorway of the previous room, applicable to horizontal transitions. It has the following properties:
+A `comeInWithSpringBallBounce` entrance condition indicates that Samus must enter the room by spring ball bouncing in from the previous room, applicable to horizontal transitions. It has the following properties:
 
 - _adjacentMinTiles_: This is the minimum effective runway length in case an adjacent runway (connected to the door) is used to gain speed, jump, and bounce.
 - _remoteAndLandingMinTiles_: A list of pairs, where in each pair the first value gives a minimal remote runway used to gain speed, and the second value gives the corresponding minimal amount of landing tiles in front of the door usable for the bounce.
@@ -1045,19 +1046,27 @@ A `comeInWithSpringBallBounce` entrance condition indicates that Samus must ente
   - "controlled" refers to movement type $12, which occurs when jumping using Spring Ball while rolling on the ground (e.g. from a mockball). In this state it is possible to control the height of each bounce by releasing jump.
   - "uncontrolled" refers to movement type $13, which occurs when performing a lateral mid-air morph high enough that the morph animation completes before landing and bouncing. This state also occurs when rolling off of a ledge (e.g. after a mockball). In this state, Samus' horizontal speed will reach a slightly higher value, and without the need for a longer landing platform to accelerate on. However, it will not be possible to control the height of the bounce.
 
-A `comeInWithSpringBallBounce` entrance condition must match with a `leaveWithSpringBallBounce` or `leaveWithMockball` on the other side of the door. The following requirements apply in both cases:
+A `comeInWithSpringBallBounce` entrance condition must match with a `leaveWithSpringBallBounce`, `leaveWithMockball`, or `leaveWithRunway` on the other side of the door. The following requirement applies in every case:
 - The `canSpringBallBounce` tech (including `Morph` and `SpringBall` items) is implicitly required.
-- The `blue` property of the exit condition must be "no" or "any". 
-- `remoteAndLandingMinTiles` must contain at least one pair `(minRemoteLength, minLandingLength)` such that the effective length of the `remoteRunway` is at least `minRemoteLength` and the effective length of the `landingRunway` is at least `minLandingLength`.
 
 There are additional requirements depending on the exit condition:
 
 - A match with `leaveWithSpringBallBounce` has the following additional requirements:
   - The `movementType` of the exit condition must equal that of the entrance condition, or one of them must be "any".
   - If the `movementType` of either the exit condition or entrance condition is "controlled", then `canMockball` is required.
+  - `remoteAndLandingMinTiles` must contain at least one pair `(minRemoteLength, minLandingLength)` such that the effective length of the `remoteRunway` is at least `minRemoteLength` and the effective length of the `landingRunway` is at least `minLandingLength`.
+  - The `blue` property of the exit condition must be "no" or "any". 
 - A match with `leaveWithMockball` has the following requirements:
   - The `movementType` of the entrance condition must be "controlled" or "any".
   - The `canMockball` tech is required.
+  - `remoteAndLandingMinTiles` must contain at least one pair `(minRemoteLength, minLandingLength)` such that the effective length of the `remoteRunway` is at least `minRemoteLength` and the effective length of the `landingRunway` is at least `minLandingLength`.
+  - The `blue` property of the exit condition must be "no" or "any".
+- A match with `leaveWithRunway` has the following requirements:
+  - The effective runway length must be at least `adjacentMinTiles`.
+  - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as for `comeInRunning` (and `comeInJumping`).
+  - If the previous door environment is water, then `Gravity` is required.
+  - The `canMockball` tech (including `Morph` item) is required.
+
 
 ```json
 {
@@ -1072,6 +1081,55 @@ There are additional requirements depending on the exit condition:
   "requires": [
     "canCrossRoomJumpIntoWater"
   ]
+}
+```
+
+### Come In With Blue Spring Ball Bounce
+
+A `comeInWithBlueSpringBallBounce` entrance condition indicates that Samus must enter the room by spring ball bouncing in from the previous room, while having blue speed. This is applicable to horizontal transitions. It has the following properties:
+
+- _adjacentMinTiles_: This is the minimum effective runway length in case an adjacent runway (connected to the door) is used to gain speed, jump, and bounce. This includes the entire length of runway from where the run begins, up to the door transition.
+- _adjacentBlueSpeedTiles_: This is the minimum length of the part of the runway used to gain blue speed (before jumping), in case an adjacent runway (connected to the door) is used.
+- _remoteAndLandingMinTiles_: A list of pairs, where in each pair the first value gives a minimal remote runway used to gain speed, and the second value gives the corresponding minimal amount of landing tiles in front of the door usable for the bounce.
+- _movementType_: This takes one of three possible values, "controlled", "uncontrolled", and "any", indicating the type of bounce that is required.
+  - "controlled" refers to movement type $12, which occurs when jumping using Spring Ball while rolling on the ground (e.g. from a mockball). In this state it is possible to control the height of each bounce by releasing jump.
+  - "uncontrolled" refers to movement type $13, which occurs when performing a lateral mid-air morph high enough that the morph animation completes before landing and bouncing. This state also occurs when rolling off of a ledge (e.g. after a mockball). In this state, Samus' horizontal speed will reach a slightly higher value, and without the need for a longer landing platform to accelerate on. However, it will not be possible to control the height of the bounce.
+
+A `comeInWithBlueSpringBallBounce` entrance condition must match with a `leaveWithSpringBallBounce`, `leaveWithMockball`, or `leaveWithRunway` on the other side of the door. The following requirement applies in every case:
+- The `canSpringBallBounce` tech (including `Morph` and `SpringBall` items) is implicitly required.
+
+There are additional requirements depending on the exit condition:
+
+- A match with `leaveWithBlueSpringBallBounce` has the following additional requirements:
+  - The `movementType` of the exit condition must equal that of the entrance condition, or one of them must be "any".
+  - If the `movementType` of either the exit condition or entrance condition is "controlled", then `canSpeedball` is required.
+  - `remoteAndLandingMinTiles` must contain at least one pair `(minRemoteLength, minLandingLength)` such that the effective length of the `remoteRunway` is at least `minRemoteLength` and the effective length of the `landingRunway` is at least `minLandingLength`.
+  - The `blue` property of the exit condition must be "yes" or "any". 
+  - A `getBlueSpeed` requirement based on remote runway length.
+- A match with `leaveWithMockball` has the following requirements:
+  - The `movementType` of the entrance condition must be "controlled" or "any".
+  - The `canMockball` tech is required.
+  - `remoteAndLandingMinTiles` must contain at least one pair `(minRemoteLength, minLandingLength)` such that the effective length of the `remoteRunway` is at least `minRemoteLength` and the effective length of the `landingRunway` is at least `minLandingLength`.
+  - The `blue` property of the exit condition must be "yes" or "any".
+  - A `getBlueSpeed` requirement based on remote runway length.
+- A match with `leaveWithRunway` has the following requirements:
+  - The effective runway length must be at least `adjacentMinTiles`.
+  - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as for `comeInRunning` (and `comeInJumping`).
+  - If the previous door environment is water, then `Gravity` is required.
+  - The `canSpeedball` tech (including `Morph` item) is required.
+  - A `getBlueSpeed` requirement based on length `adjacentBlueSpeedTiles`.
+
+```json
+{
+  "name": "Come In With Blue Spring Ball Bounce",
+  "notable": false,
+  "entranceCondition": {
+    "comeInWithSpringBallBounce": {
+      "remoteAndLandingMinTiles": [[15, 1]],
+      "movementType": "controlled"
+    }
+  },
+  "requires": []
 }
 ```
 

--- a/strats.md
+++ b/strats.md
@@ -248,11 +248,13 @@ The direction of the spark is assumed to be horizontal when sparking through hor
 
 ### Leave Spinning
 
-A `leaveSpinning` exit condition represents that Samus can spin jump through a horizontal transition with a certain amount of momentum, and possibly with blue speed, depending on the length of available runway and short-charging skill assumption. This exit condition applies to jumps from a runway disconnected from the door (e.g. below a ledge in front of the door). It should only be applied in cases where there is flexibility to exit at a wide range of positions between the top and bottom of the doorway. It should also only be applied where there is air physics at the door.
+A `leaveSpinning` exit condition represents that Samus can spin jump through a horizontal transition with a certain amount of momentum, and possibly with blue speed, depending on the length of available runway and short-charging skill assumption. This exit condition applies to jumps from a runway disconnected from the door (e.g. below a ledge in front of the door). It should only be applied where there is air physics at the door. It should also only be applied in cases where there is flexibility to exit at a wide range of positions between the top and bottom of the doorway. Specifically, for every vertical position at least 8 pixels below the top of the doorway, it should be possible to control the jump to leave at that position. This means being able to leave at screen positions in the range between 116 ($74) and 148 ($94); the highest of these positions corresponds to Samus' hitbox just barely fitting in the top half of the doorway.
 
 The `leaveSpinning` object has the following properties:
 
 - _remoteRunway_: A [runway geometry](#runway-geometry) object describing the tiles available to gain speed for the jump.
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. For leaving with blue speed, there is already an implicit minimum speed based on shortcharging skill, so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at low speeds.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. There is already an implicit speed limit based on the length of the remote runway (see the [full run speed table](#full-run-speed-table)), and for leaving with blue speed there is a different implicit limit based on a combination of runway length and shortcharging skill (see the [blue run speed table](#blue-run-speed-table)); so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at high speeds.
 - _blue_: This takes one of three possible values, "yes", "no", or "any", indicating whether this strat can be used for leaving with blue speed, without blue speed, or either. This could be used, for example, in case of a difference in usable runway length if shortcharging is being performed, or a difference in heat damage taken. The default is "any".
 
 If a `leaveSpinning` condition is used for blue speed in the next room, then it implicitly includes a `canShinecharge` requirement (including the `SpeedBooster` item). Heat frames are not included and would have to described explicitly in the strat "requires".
@@ -282,6 +284,8 @@ The `leaveWithMockball` object has the following properties:
 
 - _remoteRunway_: A [runway geometry](#runway-geometry) object describing the tiles available to gain speed for the jump before the mockball.
 - _landingRunway_: A [runway geometry](#runway-geometry) object describing the tiles available to land and gain speed in a mockball before hitting the transition.
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. For leaving with blue speed, there is already an implicit minimum speed based on shortcharging skill, so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at low speeds.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. There is already an implicit speed limit based on the length of the remote runway (see the [full run speed table](#full-run-speed-table)), and for leaving with blue speed there is a different implicit limit based on a combination of runway length and shortcharging skill (see the [blue run speed table](#blue-run-speed-table)); so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at high speeds.
 - _blue_: This takes one of three possible values, "yes", "no", or "any", indicating whether this strat can be used for leaving with blue speed, without blue speed, or either. The default is "any".
 
 A `leaveWithMockball` condition implicitly includes the `canMockball` tech requirement (including the `Morph` item requirement). If it is used for blue speed in the next room, then it also implicitly includes a `canShinecharge` requirement (including the `SpeedBooster` item) and the `canSpeedball` tech requirement. Heat frames are not included and would have to described explicitly in the strat "requires".
@@ -315,6 +319,8 @@ The `leaveWithSpringBallBounce` object has the following properties:
 
 - _remoteRunway_: A [runway geometry](#runway-geometry) object describing the tiles available to gain speed for the jump before the mockball.
 - _landingRunway_: A [runway geometry](#runway-geometry) object describing the tiles available to land and gain speed in a mockball before hitting the transition.
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. For leaving with blue speed, there is already an implicit minimum speed based on shortcharging skill, so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at low speeds.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. There is already an implicit speed limit based on the length of the remote runway (see the [full run speed table](#full-run-speed-table)), and for leaving with blue speed there is a different implicit limit based on a combination of runway length and shortcharging skill (see the [blue run speed table](#blue-run-speed-table)); so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at high speeds.
 - _blue_: This takes one of three possible values, "yes", "no", or "any", indicating whether this strat can be used for leaving with blue speed, without blue speed, or either. The default is "any".
 - _movementType_: This takes one of three possible values, "controlled", "uncontrolled", or "any", indicating the type of bounce that can be used. 
   - "controlled" refers to movement type $12, which occurs when jumping using Spring Ball while rolling on the ground (e.g. from a mockball). In this state it is possible to control the height of each bounce by releasing jump.
@@ -353,6 +359,8 @@ A `leaveSpaceJumping` exit condition represents that Samus can Space Jump throug
 The `leaveSpaceJumping` object has the following properties:
 
 - _remoteRunway_: A [runway geometry](#runway-geometry) object describing the tiles available to gain speed for the Space Jump.
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. For leaving with blue speed, there is already an implicit minimum speed based on shortcharging skill, so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at low speeds.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. There is already an implicit speed limit based on the length of the remote runway (see the [full run speed table](#full-run-speed-table)), and for leaving with blue speed there is a different implicit limit based on a combination of runway length and shortcharging skill (see the [blue run speed table](#blue-run-speed-table)); so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at high speeds.
 - _blue_: This takes one of three possible values, "yes", "no", or "any", indicating whether this strat can be used for leaving with blue speed, without blue speed, or either. The default is "any".
 
 A `leaveSpaceJumping` condition implicitly includes the `SpaceJump` item requirement. If it is used for blue speed in the next room, then it also implicitly includes a `canShinecharge` requirement (including the `SpeedBooster` item) and the `canBlueSpaceJump` tech requirement. Heat frames are not included and would have to described explicitly in the strat "requires".
@@ -691,9 +699,7 @@ A `comeInShinecharging` entrance condition represents the need for Samus to run 
 
 * _length_, _openEnd_, _gentleUpTiles_, _gentleDownTiles_, _steepUpTiles_, _steepDownTiles_
 
-The length should not include any tiles that Samus skips over through the transition (e.g. door transition tiles and door shell tiles). It also has the following property:
-
-* _minTiles_: If specified, this is the minimum number of tiles of runway in the other room required to be used, in order to gain enough momentum.
+The length should not include any tiles that Samus skips over through the transition (e.g. door transition tiles and door shell tiles). 
 
 A `comeInShinecharging` must match with a corresponding `leaveWithRunway` condition on the other side of the door. 
 
@@ -752,7 +758,10 @@ The way to calculate minimally required heat frames depends on the type of `leav
 
 ### Come In Getting Blue Speed
 
-A `comeInGettingBlueSpeed` entrance condition represents the need for Samus to run into the room with enough space to gain blue speed. It is similar to `comeInShinecharging` and has the same set of properties. 
+A `comeInGettingBlueSpeed` entrance condition represents the need for Samus to run into the room with enough space to gain blue speed. It is similar to `comeInShinecharging` and includes the same set of properties, with the following additional properties:
+
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) needed at the end of the combined runway. This can be specified if something would prevent the strat from working at too low of a speed.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) needed at the end of the combined runway.  This can be specified if something would prevent the strat from working at too high of a speed.
 
 A `comeInGettingBlueSpeed` must match with a corresponding `leaveWithRunway` condition on the other side of the door, and it includes the same requirements as a `comeInShinecharging` except with a `getBlueSpeed` requirement in place of a `canShinecharge`.
 
@@ -944,18 +953,16 @@ A `comeInSpeedballing` entrance condition indicates that Samus must enter the ro
 
 It is assumed that the runway in the current room is level or sloping up; adjustments would be needed to handle a case where it sloped down.
 
-Note that a `comeInSpeedballing` entrance condition can always be satisfied by coming into the room while already in a speedball. Therefore, a different entrance condition must be used if the strat specifically requires obtaining the speedball after entering the room (either by jumping through the transition, or by running through the transition and jumping afterward).
+Note that a `comeInSpeedballing` entrance condition can always be satisfied by coming into the room while already in a speedball. Therefore, a different entrance condition (e.g. `comeInGettingBlueSpeed` or `comeInBlueSpinning`) must be used if the strat specifically requires obtaining the speedball after entering the room (either by jumping through the transition, or by running through the transition and jumping afterward).
 
 A `comeInSpeedballing` entrance condition must match with one of the following conditions on the other side of the door: `leaveWithRunway`, `leaveSpinning`, `leaveWithMockball`. 
 
 In every case, there is an implicit tech requirement of `canSpeedball`. A match with a `leaveWithRunway` comes with the following implicit requirements:
-  - A `canShineCharge` based on the combined runway length, minus the amount of tiles needed to perform the jump into the speedball. The amount of tiles needed for the jump depends on the player's shortcharge ability (as well as ability to short-hop mockball): obtaining blue speed with lower run speed means less space needed to perform the jump. This can be approximated in a simple way with the following assumptions:
-    - If the tech `canSlowShortCharge` is enabled, then 5 tiles are needed for the jump into the speedball.
-    - Otherwise 14 tiles are needed.
+  - A `speedBall` requirement based on the combined runway length.
   - If the previous door environment is water, then `Gravity` is required.
   - If the previous room is heated, then `heatFrames` are required based on the time needed. This can be calculated in the same way as for `comeInShinecharging`.
 
-For `leaveSpinning` and `leaveWithMockball`, their `blue` property must be either "yes" or "any", and there is an implicit `canShineCharge` requirement based on the runway length in the exit condition.
+For `leaveSpinning` and `leaveWithMockball`, their `blue` property must be either "yes" or "any", and there is an implicit `getBlueSpeed` requirement based on the runway length in the exit condition.
 
 ### Come In With Temporary Blue
 
@@ -975,18 +982,18 @@ A `comeInWithTemporaryBlue` entrance condition must match with one of the follow
 
 A `comeInBlueSpinning` entrance condition indicates that Samus must come in with a spin jump through the doorway, possibly while having blue speed, applicable to horizontal transitions. It has the following properties:
 
-  - _minTiles_: The minimum effective runway length required to obtain sufficient speed before the jump. This can be omitted if the strat does not require coming in with any particular amount of momentum.
-  - _unusableTiles_: For a runway connected to the door, the number of tiles before the door that are unusable for gaining speed, because of needing to jump.
+- _unusableTiles_: For a runway connected to the door, the number of tiles before the door that are unusable for gaining speed, because of needing to jump.
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) needed. This only needs to be specified if something would prevent the strat from working at too low of a speed.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) needed. This only needs to be specified if something would prevent the strat from working at too high of a speed.
 
 A `comeInBlueSpinning` entrance condition must match with a `leaveSpinning` or `leaveWithRunway` exit condition on the other side of the door.
 
 - A match with `leaveSpinning` has the following requirements:
   - The `blue` property must be "yes" or "any".
-  - If `minTiles` is specified, the effective runway length of the `remoteRunway` in the `leaveSpinning` must be at least `minTiles`.
-  - A `canShinecharge` requirement is included based on the runway length. This includes a `SpeedBooster` item requirement as well as a check that the effective runway length is enough that gaining a shinecharge is possible. Note that in these cases the `unusableTiles` property is ignored (i.e., not subtracted).
+  - A `SpeedBooster` requirement.
+  - There must exist a possible value of extra run speed satisfying any applicable constraints, including any `minExtraRunSpeed` or `maxExtraRunSpeed` properties in the entrance condition and/or exit condition, along with implicit constraints based on shortcharge skill and the effective runway length of the `remoteRunway` in the exit condition (see the [blue run speed table](#blue-run-speed-table)). Note that `unusableTiles` is ignored in this case.
 - A match with `leaveWithRunway` has the following requirements:
-  - If `blue` is "yes", a `canShinecharge` requirement (including `SpeedBooster` item) is required. Here `unusableTiles` are subtracted from the available runway length.
-  - If `minTiles` is specified, the effective runway length must be at least `minTiles + unusableTiles`.
+  - There must exist a possible value of extra run speed satisfying any applicable constraints: `minExtraRunSpeed` or `maxExtraRunSpeed` in the entrance condition, along with implicit constraints based on shortcharge skill and the effective runway length (with `unusableTiles` subtracted) in the exit condition (see the [blue run speed table](#blue-run-speed-table)).
   - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as in `comeInShinecharging`, except here there is no second runway to combine with. The `unusableTiles` are ignored (i.e. not subtracted) for the purposes of determining heat frames, since heat damage is still taken during the jump.
   - If the previous door environment is water, then `Gravity` is required.
 
@@ -1088,36 +1095,36 @@ There are additional requirements depending on the exit condition:
 
 A `comeInWithBlueSpringBallBounce` entrance condition indicates that Samus must enter the room by spring ball bouncing in from the previous room, while having blue speed. This is applicable to horizontal transitions. It has the following properties:
 
-- _adjacentMinTiles_: This is the minimum effective runway length in case an adjacent runway (connected to the door) is used to gain speed, jump, and bounce. This includes the entire length of runway from where the run begins, up to the door transition.
-- _adjacentBlueSpeedTiles_: This is the minimum length of the part of the runway used to gain blue speed (before jumping), in case an adjacent runway (connected to the door) is used.
-- _remoteAndLandingMinTiles_: A list of pairs, where in each pair the first value gives a minimal remote runway used to gain speed, and the second value gives the corresponding minimal amount of landing tiles in front of the door usable for the bounce.
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) needed. This only needs to be specified if something would prevent the strat from working at too low of a speed.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) needed.  This only needs to be specified if something would prevent the strat from working at too high of a speed.
+- _minLandingTiles_: The minimum effective length of landing runway in the other room which is needed to ensure the strat can work.
 - _movementType_: This takes one of three possible values, "controlled", "uncontrolled", and "any", indicating the type of bounce that is required.
   - "controlled" refers to movement type $12, which occurs when jumping using Spring Ball while rolling on the ground (e.g. from a mockball). In this state it is possible to control the height of each bounce by releasing jump.
   - "uncontrolled" refers to movement type $13, which occurs when performing a lateral mid-air morph high enough that the morph animation completes before landing and bouncing. This state also occurs when rolling off of a ledge (e.g. after a mockball). In this state, Samus' horizontal speed will reach a slightly higher value, and without the need for a longer landing platform to accelerate on. However, it will not be possible to control the height of the bounce.
 
 A `comeInWithBlueSpringBallBounce` entrance condition must match with a `leaveWithSpringBallBounce`, `leaveWithMockball`, or `leaveWithRunway` on the other side of the door. The following requirement applies in every case:
-- The `canSpringBallBounce` tech (including `Morph` and `SpringBall` items) is implicitly required.
+- The `canSpringBallBounce` tech (including `Morph` and `SpringBall` items).
+- The `Speedbooster` item.
+- There must exist a possible value of extra run speed satisfying any applicable constraints, including any `minExtraRunSpeed` or `maxExtraRunSpeed` properties in the entrance condition and/or exit condition, along with implicit constraints based on shortcharge skill and the effective runway length of the runway in the exit condition (see the [blue run speed table](#blue-run-speed-table)).
 
 There are additional requirements depending on the exit condition:
 
 - A match with `leaveWithBlueSpringBallBounce` has the following additional requirements:
   - The `movementType` of the exit condition must equal that of the entrance condition, or one of them must be "any".
   - If the `movementType` of either the exit condition or entrance condition is "controlled", then `canSpeedball` is required.
-  - `remoteAndLandingMinTiles` must contain at least one pair `(minRemoteLength, minLandingLength)` such that the effective length of the `remoteRunway` is at least `minRemoteLength` and the effective length of the `landingRunway` is at least `minLandingLength`.
+  - The effective length of the `landingRunway` is at least `minLandingLength` (if specified).
   - The `blue` property of the exit condition must be "yes" or "any". 
-  - A `getBlueSpeed` requirement based on remote runway length.
+  - A `getBlueSpeed` requirement is included based on the remote runway length.
 - A match with `leaveWithMockball` has the following requirements:
   - The `movementType` of the entrance condition must be "controlled" or "any".
-  - The `canMockball` tech is required.
-  - `remoteAndLandingMinTiles` must contain at least one pair `(minRemoteLength, minLandingLength)` such that the effective length of the `remoteRunway` is at least `minRemoteLength` and the effective length of the `landingRunway` is at least `minLandingLength`.
+  - The `canSpeedball` tech is required.
+  - The effective length of the `landingRunway` is at least `minLandingLength` (if specified).
   - The `blue` property of the exit condition must be "yes" or "any".
-  - A `getBlueSpeed` requirement based on remote runway length.
+  - A `getBlueSpeed` requirement is included based on the remote runway length.
 - A match with `leaveWithRunway` has the following requirements:
-  - The effective runway length must be at least `adjacentMinTiles`.
-  - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as for `comeInRunning` (and `comeInJumping`).
+  - A `speedBall` requirement is included based on the runway length minus `minLandingLength`, except that the `canSpeedball` tech requirement is only included if the `movementType` of the entrance condition is "controlled".
+  - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames can be approximately calculated in the same way as for `comeInGettingBlueSpeed`.
   - If the previous door environment is water, then `Gravity` is required.
-  - The `canSpeedball` tech (including `Morph` item) is required.
-  - A `getBlueSpeed` requirement based on length `adjacentBlueSpeedTiles`.
 
 ```json
 {
@@ -1502,3 +1509,213 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
   "setsFlags": ["f_MaridiaTubeBroken"]
 }
 ```
+
+## Run Speed
+
+There are many kinds of cross-room strats that require Samus to enter the room with a certain amount of speed. For easier interpretation, these requirements are usually specified in terms of runway tiles required. In certain situations, however, it is necessary to directly reference speed values. There are several types of Samus horizontal speed:
+
+- Base speed: This gradually increases from to $0.0 to $2.C over the first 11 frames of Samus beginning walking or running. It gradually decreases to $0.0 when stopping holding forward while walking/running. Base speed will change in certain ways when Samus jumps, breaks spin, morphs, or performs other actions.
+- Extra run speed: This increases by $0.1 for each frame that dash is held while running. With Speed Booster it reaches a maximum value of $7.0, while without Speed Booster it reaches a maximum value of $2.0. When stopping holding forward while walking/running, the extra run speed is immediately converted into base speed, i.e., base speed is increased by the value of the extra run speed, while the extra run speed immediately becomes zero. Other actions will either leave the extra run speed unchanged (e.g., jumping, breaking spin with jump held, or performing an airball or mockball) or immediately set it to zero (e.g., turning around, or breaking spin without jump held).
+- Combined run speed: This is the total of base speed and extra run speed, and represents the actual amount that Samus will move horizontally.
+
+All these speed values are measured in pixels (and subpixels) per frame. Since extra run speed remains stable through various movement actions, it is generally the more useful quantity to reference in cross-room strats. The following table shows how Samus' relative position and horizontal speeds change while running, starting from a stand, with dash held the entire time, with Speedbooster equipped. 
+
+| Frame | Position | Base Speed | Extra Run Speed |
+| ----- | -------- | ---------- | --------------- |
+| 0     |  $0.0    |    $0.0     |      $0.0       |
+| 1     |  $1.0    |    $0.0     |      $0.0       |
+| 2     |  $1.4    |    $0.3     |      $0.1       |
+| 3     |  $1.C    |    $0.6     |      $0.2       |
+| 4     |  $2.8    |    $0.9     |      $0.3       |
+| 5     |  $3.8    |    $0.C     |      $0.4       |
+| 6     |  $4.C    |    $0.F     |      $0.5       |
+| 7     |  $6.4    |    $1.2     |      $0.6       |
+| 8     |  $8.0    |    $1.5     |      $0.7       |
+| 9     |  $A.0    |    $1.8     |      $0.8       |
+| 10    |  $C.4    |    $1.B     |      $0.9       |
+| 11    |  $E.C    |    $1.E     |      $0.A       |
+| 12    |  $12.3   |    $2.C     |      $0.B       |
+| 13    |  $15.B   |    $2.C     |      $0.C       |
+| 14    |  $19.4   |    $2.C     |      $0.D       |
+| 15    |  $1C.E   |    $2.C     |      $0.E       |
+| 16    |  $20.9   |    $2.C     |      $0.F       |
+| 17    |  $24.5   |    $2.C     |      $1.0       |
+| 18    |  $28.2   |    $2.C     |      $1.1       |
+| 19    |  $2C.0   |    $2.C     |      $1.2       |
+| 20    |  $2F.F   |    $2.C     |      $1.3       |
+| 21    |  $33.F   |    $2.C     |      $1.4       |
+| 22    |  $38.0   |    $2.C     |      $1.5       |
+| 23    |  $3C.2   |    $2.C     |      $1.6       |
+| 24    |  $40.5   |    $2.C     |      $1.7       |
+| 25    |  $44.9   |    $2.C     |      $1.8       |
+| 26    |  $48.E   |    $2.C     |      $1.9       |
+| 27    |  $4D.4   |    $2.C     |      $1.A       |
+| 28    |  $51.B   |    $2.C     |      $1.B       |
+| 29    |  $56.3   |    $2.C     |      $1.C       |
+| 30    |  $5A.C   |    $2.C     |      $1.D       |
+| 31    |  $5F.6   |    $2.C     |      $1.E       |
+| 32    |  $64.1   |    $2.C     |      $1.F       |
+| 33    |  $68.D   |    $2.C     |      $2.0       |
+| 34    |  $6D.A   |    $2.C     |      $2.1       |
+| 35    |  $72.8   |    $2.C     |      $2.2       |
+| 36    |  $77.7   |    $2.C     |      $2.3       |
+| 37    |  $7C.7   |    $2.C     |      $2.4       |
+| 38    |  $81.8   |    $2.C     |      $2.5       |
+| 39    |  $86.A   |    $2.C     |      $2.6       |
+| 40    |  $8B.D   |    $2.C     |      $2.7       |
+| 41    |  $91.1   |    $2.C     |      $2.8       |
+| 42    |  $96.6   |    $2.C     |      $2.9       |
+| 43    |  $9B.C   |    $2.C     |      $2.A       |
+| 44    |  $A1.3   |    $2.C     |      $2.B       |
+| 45    |  $A6.B   |    $2.C     |      $2.C       |
+| 46    |  $AC.4   |    $2.C     |      $2.D       |
+| 47    |  $B1.E   |    $2.C     |      $2.E       |
+| 48    |  $B7.9   |    $2.C     |      $2.F       |
+| 49    |  $BD.5   |    $2.C     |      $3.0       |
+| 50    |  $C3.2   |    $2.C     |      $3.1       |
+| 51    |  $C9.0   |    $2.C     |      $3.2       |
+| 52    |  $CE.F   |    $2.C     |      $3.3       |
+| 53    |  $D4.F   |    $2.C     |      $3.4       |
+| 54    |  $DB.0   |    $2.C     |      $3.5       |
+| 55    |  $E1.2   |    $2.C     |      $3.6       |
+| 56    |  $E7.5   |    $2.C     |      $3.7       |
+| 57    |  $ED.9   |    $2.C     |      $3.8       |
+| 58    |  $F3.E   |    $2.C     |      $3.9       |
+| 59    |  $FA.4   |    $2.C     |      $3.A       |
+| 60    |  $100.B  |    $2.C     |      $3.B       |
+| 61    |  $107.3  |    $2.C     |      $3.C       |
+| 62    |  $10D.C  |    $2.C     |      $3.D       |
+| 63    |  $114.6  |    $2.C     |      $3.E       |
+| 64    |  $11B.1  |    $2.C     |      $3.F       |
+| 65    |  $121.D  |    $2.C     |      $4.0       |
+| 66    |  $128.A  |    $2.C     |      $4.1       |
+| 67    |  $12F.8  |    $2.C     |      $4.2       |
+| 68    |  $136.7  |    $2.C     |      $4.3       |
+| 69    |  $13D.7  |    $2.C     |      $4.4       |
+| 70    |  $144.8  |    $2.C     |      $4.5       |
+| 71    |  $14B.A  |    $2.C     |      $4.6       |
+| 72    |  $152.D  |    $2.C     |      $4.7       |
+| 73    |  $15A.1  |    $2.C     |      $4.8       |
+| 74    |  $161.6  |    $2.C     |      $4.9       |
+| 75    |  $168.C  |    $2.C     |      $4.A       |
+| 76    |  $170.3  |    $2.C     |      $4.B       |
+| 77    |  $177.B  |    $2.C     |      $4.C       |
+| 78    |  $17F.4  |    $2.C     |      $4.D       |
+| 79    |  $186.E  |    $2.C     |      $4.E       |
+| 80    |  $18E.9  |    $2.C     |      $4.F       |
+| 81    |  $196.5  |    $2.C     |      $5.0       |
+| 82    |  $19E.2  |    $2.C     |      $5.1       |
+| 83    |  $1A6.0  |    $2.C     |      $5.2       |
+| 84    |  $1AD.F  |    $2.C     |      $5.3       |
+| 85    |  $1B5.F  |    $2.C     |      $5.4       |
+| 86    |  $1BE.0  |    $2.C     |      $5.5       |
+| 87    |  $1C6.2  |    $2.C     |      $5.6       |
+| 88    |  $1CE.5  |    $2.C     |      $5.7       |
+| 89    |  $1D6.9  |    $2.C     |      $5.8       |
+| 90    |  $1DE.E  |    $2.C     |      $5.9       |
+| 91    |  $1E7.4  |    $2.C     |      $5.A       |
+| 92    |  $1EF.B  |    $2.C     |      $5.B       |
+| 93    |  $1F8.3  |    $2.C     |      $5.C       |
+| 94    |  $200.C  |    $2.C     |      $5.D       |
+| 95    |  $209.6  |    $2.C     |      $5.E       |
+| 96    |  $212.1  |    $2.C     |      $5.F       |
+| 97    |  $21A.D  |    $2.C     |      $6.0       |
+| 98    |  $223.A  |    $2.C     |      $6.1       |
+| 99    |  $22C.8  |    $2.C     |      $6.2       |
+| 100   |  $235.7  |    $2.C     |      $6.3       |
+| 101   |  $23E.7  |    $2.C     |      $6.4       |
+| 102   |  $247.8  |    $2.C     |      $6.5       |
+| 103   |  $250.A  |    $2.C     |      $6.6       |
+| 104   |  $259.D  |    $2.C     |      $6.7       |
+| 105   |  $263.1  |    $2.C     |      $6.8       |
+| 106   |  $26C.6  |    $2.C     |      $6.9       |
+| 107   |  $275.C  |    $2.C     |      $6.A       |
+| 108   |  $27F.3  |    $2.C     |      $6.B       |
+| 109   |  $288.B  |    $2.C     |      $6.C       |
+| 110   |  $292.4  |    $2.C     |      $6.D       |
+| 111   |  $29B.E  |    $2.C     |      $6.E       |
+| 112   |  $2A5.9  |    $2.C     |      $6.F       |
+| 113   |  $2AF.5  |    $2.C     |      $7.0       |
+
+Without Speedbooster, the same table is also valid up through row 33 (when extra run speed reaches $2.0).
+
+# Full run speed table
+
+The following table shows the maximum extra run speed attainable with a last-frame jump from a given runway length, with a closed end at the start and an open end before the jump, with Speedbooster equipped and holding dash the entire time:
+
+| Runway length | Extra run speed |
+| ------------- | --------------- |
+| 1             |      $0.A       |
+| 2             |      $0.E       |
+| 3             |      $1.2       |
+| 4             |      $1.6       |
+| 5             |      $1.A       |
+| 6             |      $1.E       |
+| 7             |      $2.1       |
+| 8             |      $2.4       |
+| 9             |      $2.7       |
+| 10            |      $2.A       |
+| 11            |      $2.D       |
+| 12            |      $3.0       |
+| 13            |      $3.3       |
+| 14            |      $3.5       |
+| 15            |      $3.8       |
+| 16            |      $3.A       |
+| 17            |      $3.D       |
+| 18            |      $3.F       |
+| 19            |      $4.2       |
+| 20            |      $4.4       |
+| 21            |      $4.6       |
+| 22            |      $4.8       |
+| 23            |      $4.A       |
+| 24            |      $4.D       |
+| 25            |      $4.F       |
+| 26            |      $5.1       |
+| 27            |      $5.3       |
+| 28            |      $5.5       |
+| 29            |      $5.7       |
+| 30            |      $5.9       |
+| 31            |      $5.B       |
+| 32            |      $5.C       |
+| 33            |      $5.E       |
+| 34            |      $6.0       |
+| 35            |      $6.2       |
+| 36            |      $6.4       |
+| 37            |      $6.5       |
+| 38            |      $6.7       |
+| 39            |      $6.9       |
+| 40            |      $6.B       |
+| 41            |      $6.C       |
+| 42            |      $6.E       |
+| 43+           |      $7.0       |
+
+Without Speed Booster, the same table is valid except that extra run speed is capped at $2.0.
+
+### Blue run speed table
+
+Calculating attainable run speed becomes more complex when using a runway to gain blue speed state before jumping, e.g. to be able to destroy bomb blocks and enemies on contact. The amount of speed obtained can depend on how the shortcharge is executed as well as the length of runway used. Lowest speed can be achieved by pressing dash only with crisp taps on the 4 magic frames, in order to minimize the time that dash is held; given a limited length of runway, stutters also help to reset Samus' base speed at the start of the run. High speed can be achieved by again using stutters and crisp taps, but with as few taps as necessary, holding dash continuously at the end of the run, starting as soon as possible while still getting blue before the end of the runway. We define several levels of shortcharging skill:
+
+| Difficulty level | Minimal shortcharge length | Description                                                        |
+| ---------------- | -------------------------- | ------------------------------------------------------------------ |
+|        A         |             25             | No stutter, 1-tap held at least 15 frames before first magic frame |
+|        B         |             20             | Single stutter, up to 2-tap, taps at least 11 frames each          |
+|        C         |             16             | Single stutter, up to 3-tap, taps at least 7 frames each           |
+|        D         |             15             | Single stutter, up to 4-tap, taps at least 5 frames each           |
+|        E         |             14             | Double stutter, up to 4-tap, taps at least 4 frames each           |
+|        F         |             13             | Triple stutter, up to 4-tap, taps at least 3 frames each           |
+|        G         |             11             | Near-perfect stutters and taps                                     |
+
+Based on these definitions and some testing, we can determine a range of attainable run speed for each combination of runway length and skill level. For each runway length, we define an "ideal speed" to be the extra run speed that would result by performing the shortcharge in the easiest possible way for that length of runway, i.e. using the techniques in the lowest possible difficulty level. For each difficulty level at or above that level, we then measure a maximum speed reasonably attainable using those techniques. The following table shows possible values for representative runway lengths; values for other runway lengths can be obtained by linearly interpolating the values in this table. All speed values refer to extra run speed:
+
+| Runway length | Ideal speed  |  A   |  B   |  C   |  D   |  E   |  F   |  G   |
+| ------------- | ------------ | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
+|      30       |     $5.9     | $5.9 | $5.9 | $5.9 | $5.9 | $5.9 | $5.9 | $5.9 |
+|      25       |     $4.8     | $4.9 | $4.B | $4.C | $4.D | $4.E | $4.E | $4.E |
+|      20       |     $3.7     |  -   | $3.A | $3.C | $3.E | $4.0 | $4.1 | $4.2 |
+|      17       |     $1.E     |  -   |  -   | $2.9 | $2.D | $3.3 | $3.8 | $3.A |
+|      16       |     $1.B     |  -   |  -   | $2.3 | $2.B | $3.1 | $3.3 | $3.5 |
+|      15       |     $1.6     |  -   |  -   |  -   | $1.B | $2.9 | $2.B | $2.F |
+|      14       |     $1.2     |  -   |  -   |  -   |  -   | $1.A | $2.4 | $2.A |
+|      13       |     $1.0     |  -   |  -   |  -   |  -   |  -   | $1.2 | $1.E |
+|      12       |     $0.B     |  -   |  -   |  -   |  -   |  -   |   -  | $0.B |
+|      11       |     $0.7     |  -   |  -   |  -   |  -   |  -   |  -   | $0.7 |

--- a/tech.json
+++ b/tech.json
@@ -1708,7 +1708,8 @@
           "requires": [],
           "note": [
             "Uses the uninteruptable frames of morphing or unmorphing in order to continue moving up after hitting a solid object above.",
-            "Can be used to make it barely just past a ledge."
+            "This can be used to make it barely just past a ledge.",
+            "The same technique can also be used to temporarily glide along a ceiling to extend a jump horizontally."
           ]
         },
         {

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -88,6 +88,8 @@ def process_keyvalue(k, v, metadata):
         "blue",  # validated by schema
         "movementType",  # validated by schema
         "doorOrientation",  # validated by schema
+        "minExtraRunSpeed", # validated by schema
+        "maxExtraRunSpeed", # validated by schema
         "types",  # validated by schema in 'unlocksDoors', manually in 'enemyDamage'
     ]
 


### PR DESCRIPTION
- Setups and applications of remote runways in Crateria
- One application in East Sand Hall
- Update `comeInWithSpringBallBounce` docs to clarify it can also match with `leaveWithRunway`
- New entrance condition `comeInWithBlueSpringBallBounce` (like `comeInWithSpringBallJump` but with blue speed).
- Add `startingDownTiles` in (remote) runway schema.