### PR TITLE
Split tech requirements into two fields: tech and other

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -535,3 +535,14 @@ __Example:__
 ```json
 {"noFlashSuit": {}}
 ```
+
+### Other requirements
+
+#### tech object
+
+A `tech` object indicates the need to be able to perform a `tech`, but without its `otherRequires`. This can be used to override item, ammo, or other requirements that are normally associated with the tech. The removal of `otherRequires` requirements applies recursively to any tech in the `techRequires` of the referenced tech.
+
+__Example:__
+```json
+{"tech": "canIBJ"}
+```

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,9 @@ A file that contains techs and their [logical requirements](logicalRequirements.
 
 At the first level, the techs are grouped into broad tech categories. Each category contains an array of techs.
 
-Each individual tech can itself have an array of extension techs. Extension techs are more complex versions of their parent tech, and this structure is intended to help with organizing techs in a more presentable manner. Extension techs are expected to logically require their parent tech, but their logical requirements can still be understood without context and so this requirement is still stated explicitly in their requirements.
+Each tech can have logical dependencies, which are expressed in two properties `techRequires` and `otherRequires`. When a tech depends on another tech, this should be included in `techRequires`. Other requirements such as items and ammo should be included in `otherRequires`. These different types of requirements are separated because in certain situations item and ammo requirements of a tech may need to be overridden, whereas dependent tech are always included as requirements whenever using a tech. Each item in the `techRequires` should be either the name of a tech or a [`tech` logical requirement](logicalRequirements.md#tech-object), the latter being a way to express that a tech is a dependency but without inheriting its `otherRequires`. 
+
+Each individual tech can itself have an array of extension techs. Extension techs are more complex versions of their parent tech, and this structure is intended to help with organizing techs in a more presentable manner. Extension techs are expected to logically require their parent tech, but their logical requirements can be understood without the context of the extension hierarchy, so the requirement of the parent tech should be stated explicitly in the `techRequires`.
 
 ## Important concepts
 

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -728,6 +728,12 @@
             "description": "Fulfilled if Samus does not have a flash suit.",
             "additionalProperties": false,
             "properties": {}
+          },
+          "tech": {
+            "$id": "#/definitions/logicalRequirement/items/properties/tech",
+            "type": "string",
+            "title": "Tech Requirement",
+            "description": "A pure tech requirement, avoiding any other requirements normally associated with a tech."
           }
         }
       }

--- a/schema/m3-tech.schema.json
+++ b/schema/m3-tech.schema.json
@@ -47,7 +47,8 @@
               "description": "A tech that represents an in-game technique and the requirements for performing it",
               "required": [
                 "name",
-                "requires"
+                "techRequires",
+                "otherRequires"
               ],
               "additionalProperties": false,
               "properties": {
@@ -58,11 +59,17 @@
                   "description": "The name of this tech, to be referenced in logical requirements",
                   "pattern": "^(.*)$"
                 },
-                "requires": {
-                  "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
-                  "$id": "#/properties/techCategories/items/properties/techs/items/properties/requires",
+                "techRequires": {
+                  "$ref": "m3-requirements.schema.json#/definitions/logicalRequirements",
+                  "$id": "#/properties/techCategories/items/properties/techs/items/properties/techRequires",
                   "title": "Tech Requirements",
-                  "description": "Equipment, tech, and flag requirements to perform this tech"
+                  "description": "Dependent tech required for this tech."
+                },
+                "otherRequires": {
+                  "$ref": "m3-requirements.schema.json#/definitions/logicalRequirements",
+                  "$id": "#/properties/techCategories/items/properties/techs/items/properties/otherRequires",
+                  "title": "Other Requirements",
+                  "description": "Other requirements to perform this tech, such as items or ammo."
                 },
                 "extensionTechs": {
                   "$id": "#/properties/techCategories/items/properties/techs/items/properties/extensionTechs",

--- a/tech.json
+++ b/tech.json
@@ -7,17 +7,20 @@
       "techs": [
         {
           "name": "canBePatient",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Executing a strat that requires waiting or doing the same thing over and over again for a substantial amount of time, potentially more than 1.5 minutes, even with good execution.",
           "extensionTechs": [
             {
               "name": "canBeVeryPatient",
-              "requires": ["canBePatient"],
+              "techRequires": ["canBePatient"],
+              "otherRequires": [],
               "note": "Executing a strat that requires waiting or doing the same thing over and over again for a long time, potentially more than 3 minutes, even with good execution.",
               "extensionTechs": [
                 {
                   "name": "canBeExtremelyPatient",
-                  "requires": ["canBeVeryPatient"],
+                  "techRequires": ["canBeVeryPatient"],
+                  "otherRequires": [],
                   "note": "Executing a strat that requires waiting or doing the same thing over and over again for a very long time, potentially more than 6 minutes, even with good execution."
                 }
               ]
@@ -26,7 +29,8 @@
         },
         {
           "name": "canPrepareForNextRoom",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to know which room is coming next and use that information to enter the room in a specific way.",
             "This could be achieved from remembering which rooms Samus has been to, using the map to figure out which room is coming next, etc."
@@ -34,12 +38,14 @@
         },
         {
           "name": "canSuitlessLavaDive",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Navigating deep lava without lava immunity, or deep acid. This isn't required for entering shallow lava or acid in which Samus can easily jump out of."
         },
         {
           "name": "canHeatRun",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Navigating heated rooms without immunity to heat damage."
         },
         {
@@ -65,7 +71,8 @@
             },
             {
               "name": "canCrossRoomJumpIntoWater",
-              "techRequires": [ "canSuitlessMaridia" ],
+              "techRequires": ["canSuitlessMaridia"],
+              "otherRequires": [],
               "note": "Using the momentum from jumping through a doorway from normal to water physics."
             },
             {
@@ -83,6 +90,7 @@
                   "techRequires": [
                     "canSpaceJumpWaterBounce"
                   ],
+                  "otherRequires": [],
                   "note": "Using HiJump to escape the waterline during a Space Jump Water Bounce.",
                   "devNote": "Escaping tidal water without HiJump could be added as a more advanced tech."
                 }
@@ -92,7 +100,8 @@
         },
         {
           "name": "canDisableEquipment",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Collecting equipment can make movement more difficult in certain situations.",
             "Speedbooster will reduce Samus' jump height and turning Speedbooster off will return the jump height to normal.",
@@ -109,7 +118,8 @@
         },
         {
           "name": "canPlayInSand",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to control Samus while under the effects of sand physics.",
             "This includes the ability to perform a clean jump from the top of sand,",
@@ -121,11 +131,12 @@
           "extensionTechs": [
             {
               "name": "canEscapeSand",
-              "requires": [
+              "techRequires": [
                 "canPlayInSand",
                 "h_canCrouchJumpDownGrab",
                 "canSuitlessMaridia"
               ],
+              "otherRequires": [],
               "note": [
                 "The ability to escape from the bottom of a sand pit in water without Gravity Suit.",
                 "This means escaping 1-tile deep pits with a sandfall overtop without HiJump but with the help of the solid ledge or a frozen enemy.",
@@ -136,10 +147,11 @@
             },
             {
               "name": "canSandfallBounce",
-              "requires": [
+              "techRequires": [
                 "canPlayInSand",
                 "canSuitlessMaridia"
               ],
+              "otherRequires": [],
               "note": [
                 "Breaking the sand line while exiting a sandfall at the same time can be used as a way to gain an irregular amount of height."
               ],
@@ -147,9 +159,11 @@
             },
             {
               "name": "canSandBombBoost",
-              "requires": [
+              "techRequires": [
                 "canPlayInSand",
-                "canSuitlessMaridia",
+                "canSuitlessMaridia"
+              ],
+              "otherRequires": [
                 "h_canUseMorphBombs"
               ],
               "note": [
@@ -165,11 +179,12 @@
             },
             {
               "name": "canSandGrappleBoost",
-              "requires": [
+              "techRequires": [
                 "canPlayInSand",
                 "canSuitlessMaridia",
                 "canUseGrapple"
               ],
+              "otherRequires": [],
               "note": [
                 "Sink very slightly into a sand pit with an enemy nearby, close to the sand line.",
                 "Jump while firing grapple and aim down as soon as Grapple hits the enemy.",
@@ -181,7 +196,8 @@
         },
         {
           "name": "canManageReserves",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to manage reserve energy efficiently, including the following techniques:",
             "1) Avoiding wasted energy from reserves overfilling into regular energy, either manually or automatically,",
@@ -201,7 +217,8 @@
           "extensionTechs": [
             {
               "name": "canPauseAbuse",
-              "requires": [ "canManageReserves" ],
+              "techRequires": ["canManageReserves"],
+              "otherRequires": [],
               "note": [
                 "The ability to pause in order to avoid death while reaching 0 Energy.",
                 "Energy must be obtained before the unpause fade-in finishes, either by picking up an Energy drop or refilling with Reserve Energy."
@@ -223,17 +240,20 @@
       "techs": [
         {
           "name": "canDownGrab",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note":"The ability to aim down to reduce Samus' hitbox to reach higher ledges. Commonly paired with a Crouch Jump."
         },
         {
           "name": "canDownBack",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Holding the direction buttons down and then also backwards in order to move forwards, while in the correct falling state."
         },
         {
           "name": "canStopOnADime",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Holding the angle up or angle down buttons when no directional inputs are held will completely stop Samus in place.",
             "This is used to enter elevators instantly, but can also be used to avoid being carried into some rooms by momentum."
@@ -241,20 +261,23 @@
         },
         {
           "name": "canMoonwalk",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "This is an option that can be turned on in the special setting mode after selecting a save file. It is required for some tech.",
           "extensionTechs": [
             {
               "name": "canMoonfall",
-              "requires": [ "canMoonwalk" ],
+              "techRequires": ["canMoonwalk"],
+              "otherRequires": [],
               "note": "Jumping off a ledge while moonwalking to fall with an uncapped speed.",
               "extensionTechs": [
                 {
                   "name": "canMoondance",
-                  "requires": [
+                  "techRequires": [
                     "canMoonfall",
                     "canBePatient"
                   ],
+                  "otherRequires": [],
                   "note": [
                     "The ability to perform moonfalls a substantial number of times (176) in a row in order to sink through a solid floor.",
                     "Moondancing requires becoming partially trapped so that the moonfall ends in a crouch state where pressing forward returns Samus to a stand without losing the built up vertical speed.",
@@ -269,11 +292,11 @@
                   "extensionTechs": [
                     {
                       "name": "canExtendedMoondance",
-                      "requires": [
+                      "techRequires": [
                         "canMoondance",
-                        "Grapple",
                         "canBeVeryPatient"
                       ],
+                      "otherRequires": ["Grapple"],
                       "note": [
                         "Continue the moondance an additional 146 times to clip an additional tile into the floor when clipping.",
                         "Every moonfall will clip Samus 1 tile into the ground and Grapple must be used to return to a standing position.",
@@ -286,7 +309,8 @@
                 },
                 {
                   "name": "canEnemyStuckMoonfall",
-                  "requires": ["canMoonfall"],
+                  "techRequires": ["canMoonfall"],
+                  "otherRequires": [],
                   "note": [
                     "The ability to use two enemies spaced the appropriate vertical distance apart so that Samus can Moonfall and become 'trapped' between them.",
                     "The uncapped fall speed will continue increasing while 'trapped'.",
@@ -301,7 +325,8 @@
         },
         {
           "name": "canFreeFallClip",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to fall with enough speed to clip through solid tiles without a normalized setup.",
             "This can be initiated with either a Moonfall or a Grapple bounce."
@@ -309,13 +334,15 @@
         },
         {
           "name": "canResetFallSpeed",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Using unmorph as a way to reset fall speed.",
           "devNote": "Taking enemy damage can get the same effect but more situations where this is used would need to be found first."
         },
         {
           "name": "canMidAirMorph",
-          "requires": [ "Morph" ],
+          "techRequires": [],
+          "otherRequires": ["Morph"],
           "note": [
             "The ability to enter Morph Ball while in the air.",
             "There can be an expectation to Morph quickly as well, usually following a jump from the ground.",
@@ -325,10 +352,11 @@
           "extensionTechs": [
             {
               "name": "canWallJumpInstantMorph",
-              "requires": [
+              "techRequires": [
                 "canMidAirMorph",
                 "canWalljump"
               ],
+              "otherRequires": [],
               "note": [
                 "The ability to mid-air morph immediately out of a wall jump.",
                 "After the wall jump, continue holding jump in order to only need to press down a single time to morph.",
@@ -337,11 +365,12 @@
               "extensionTechs": [
                 {
                   "name": "can3HighWallMidAirMorph",
-                  "requires": [
+                  "techRequires": [
                     "canPreciseWalljump",
                     "canWallJumpInstantMorph",
                     "canDisableEquipment"
                   ],
+                  "otherRequires": [],
                   "note" : [
                     "Getting up into a morph passage from a 3-tile-high space by mid-air morphing off of a wall jump. This is easier from an opposite wall.",
                     "After the wall jump, continue holding jump in order to only need to press down a single time to morph."
@@ -351,10 +380,11 @@
             },
             {
               "name": "can4HighMidAirMorph",
-              "requires": [
+              "techRequires": [
                 "canMidAirMorph",
                 "canDisableEquipment"
               ],
+              "otherRequires": [],
               "note" : [
                 "A mid-air morph that has to be done in a 4-tile-high space.",
                 "It's a lot more precise than with more room. Turn off HiJump before attempting this."
@@ -362,10 +392,11 @@
             },
             {
               "name": "canRJump",
-              "requires": [
+              "techRequires": [
                 "canMidAirMorph",
                 "canDisableEquipment"
               ],
+              "otherRequires": [],
               "note": [
                 "A technique for mid-air morphing in a 3-tile-high space in air physics, or a 2-tile-high space in water physics.",
                 "The key point is that pausing can be used to morph much faster than double pressing down.",
@@ -378,20 +409,20 @@
             },
             {
               "name": "canLateralMidAirMorph",
-              "requires": [ "canMidAirMorph" ],
+              "techRequires": ["canMidAirMorph"],
+              "otherRequires": [],
               "note": "Performing the same input as a mockball, but in mid-air, in order to maintain forward momentum while morphing in mid-air.",
               "extensionTechs": [
                 {
                   "name": "canSpringBallBounce",
-                  "requires": [
-                    "canLateralMidAirMorph",
-                    "SpringBall"
-                  ],
+                  "techRequires": ["canLateralMidAirMorph"],
+                  "otherRequires": ["SpringBall"],
                   "note": "Using a lateral mid-air morph to bounce off a surface with Spring Ball while retaining previous momentum."
                 },
                 {
                   "name": "canStationaryLateralMidAirMorph",
-                  "requires": [ "canLateralMidAirMorph" ],
+                  "techRequires": ["canLateralMidAirMorph"],
+                  "otherRequires": [],
                   "note": [
                     "While performing a stationary vertical jump, it's possible to mid-air morph in a manner similar to a lateral mid-air morph.",
                     "Doing this immediately gives lateral momentum equivalent to maximum walk speed.",
@@ -404,7 +435,8 @@
         },
         {
           "name": "canMockball",
-          "requires": [ "Morph" ],
+          "techRequires": [],
+          "otherRequires": ["Morph"],
           "note": [
             "Maintaining running speed while morphed, by holding jump and down (to crouch) during a lateral jump, then morphing as Samus hits the ground while holding jump and transition from holding down to holding forward.",
             "Sometimes referred to as a Machball."
@@ -412,11 +444,11 @@
           "extensionTechs": [
             {
               "name": "canSpeedball",
-              "requires": [
+              "techRequires": [
                 "canMockball",
-                "SpeedBooster",
                 "canCarefulJump"
               ],
+              "otherRequires": ["SpeedBooster"],
               "note": [
                 "Maintain the SpeedBooster effect while rolling as a Morph Ball in order to destroy bomb blocks in Morph tunnels.",
                 "A Speedball involves performing a Mockball at faster speeds and additionally it will help to be able to perform short jumps to reduce the amount of space needed.",
@@ -427,12 +459,14 @@
         },
         {
           "name": "canBounceBall",
-          "requires": [ "Morph" ],
+          "techRequires": [],
+          "otherRequires": ["Morph"],
           "note": "Using Morph to retain momentum when transitioning to water physics."
         },
         {
           "name": "canTwoTileSqueeze",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Taking advantage of the smaller hitbox of spinjump and down-aim to squeeze through two-tile gaps.",
             "Aiming down while jumping into a two-tile gap will allow Samus to stand up."
@@ -440,12 +474,14 @@
           "extensionTechs": [
             {
               "name": "canCrouchGateClip",
-              "requires": [ "canTwoTileSqueeze" ],
+              "techRequires": ["canTwoTileSqueeze"],
+              "otherRequires": [],
               "note": "Using a spinjump and down-aim to clip into a closing gate, allowing Samus to walk through the gate."
             },
             {
               "name": "canTunnelCrawl",
-              "requires": [ "canTwoTileSqueeze" ],
+              "techRequires": ["canTwoTileSqueeze"],
+              "otherRequires": [],
               "note": [
                 "Moving along a 2-tile-high passage while standing up by repeatedly spin-jumping and then pressing down.",
                 "The tech comes with softlock risks without Morph Ball or a way to wiggle to the right with canTurnaroundAimCancel",
@@ -456,12 +492,14 @@
         },
         {
           "name": "canQuickCrumbleEscape",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note":"The combination of a crumble quick drop, and landing on a lower surface and jumping back over the crumble block before it re-forms."
         },
         {
           "name": "canMidairWiggle",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Turning around quickly so as to manipulate game physics.",
             "For using Screw Attack to break blocks and to shrink Samus' hitbox following a wall jump,",
@@ -470,7 +508,8 @@
         },
         {
           "name": "canOffScreenMovement",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to perform non-trivial movement while Samus is off-camera.",
             "This does not include movement where visual feedback is unimportant, such as simply falling down or holding a single direction."
@@ -478,7 +517,8 @@
         },
         {
           "name": "canUseGrapple",
-          "requires": [ "Grapple" ],
+          "techRequires": [],
+          "otherRequires": ["Grapple"],
           "note": [
             "The ability to fling Samus moderate distances by grappling onto attach points to build up momentum.",
             "Knowing how to use Grapple also means knowing that the Grapple Beam can be used as a weapon to instantly kill certain enemies."
@@ -486,14 +526,17 @@
           "extensionTechs": [
             {
               "name": "canPreciseGrapple",
-              "requires": [ "canUseGrapple" ],
+              "techRequires": ["canUseGrapple"],
+              "otherRequires": [],
               "note": "The ability to precisely aim at grapple points while moving quickly, and precise control of Samus' speed and trajectory when releasing from a grapplable object."
             },
             {
               "name": "canGrappleJump",
-              "requires": [
+              "techRequires": [
                 "canUseGrapple",
-                "canMidAirMorph",
+                "canMidAirMorph"
+              ],
+              "otherRequires": [
                 {"or": [
                   "HiJump",
                   "can4HighMidAirMorph"
@@ -506,9 +549,8 @@
               "extensionTechs": [
                 {
                   "name": "canTrickyGrappleJump",
-                  "requires": [
-                    "canGrappleJump"
-                  ],
+                  "techRequires": ["canGrappleJump"],
+                  "otherRequires": [],
                   "note": [
                     "The ability to Grapple Jump while also performing difficult movements.",
                     "1) Aiming a Grapple Fling with a precise angle.",
@@ -522,13 +564,13 @@
             },
             {
               "name": "canBombGrappleJump",
-              "requires": [
+              "techRequires": [
                 "canUseGrapple",
                 "canMidAirMorph",
-                "Bombs",
                 "canUseEnemies",
                 "canTrickyJump"
               ],
+              "otherRequires": ["Bombs"],
               "note": [
                 "Simultaneously use Grapple Beam to kill an enemy and detonate a bomb on Samus to gain the ability to jump for one frame.",
                 "By jumping first and performing this trick in the air, Samus gets a second jump.",
@@ -539,9 +581,8 @@
             },
             {
               "name": "canGrappleTeleport",
-              "requires": [
-                "canUseGrapple"
-              ],
+              "techRequires": ["canUseGrapple"],
+              "otherRequires": [],
               "note": [
                 "Exiting a door transition while grappled, in order to initiate a teleport in the next room.",
                 "The position to which Samus teleports corresponds to the position of the grapple block in the first room.",
@@ -551,9 +592,8 @@
             },
             {
               "name": "canGrappleBombHang",
-              "requires": [
-                "canUseGrapple"
-              ],
+              "techRequires": ["canUseGrapple"],
+              "otherRequires": [],
               "note": [
                 "Receiving a boost from a Bomb or Power Bomb while grappled, to enter a 'glitched grapple hanging' state.",
                 "Among other things, this state gives a way to trigger a door transition while still grappled.",
@@ -562,10 +602,8 @@
             },
             {
               "name": "canUnmorphGrappleHang",
-              "requires": [
-                "canUseGrapple",
-                "Morph"
-              ],
+              "techRequires": ["canUseGrapple"],
+              "otherRequires": ["Morph"],
               "note": [
                 "Entering a 'glitched grapple hanging' using a precisely timed unmorph, without the use of Bombs or Power Bombs.",
                 "The positioning required to make this work is very specific; normalized setups are described in individual strats.",
@@ -585,12 +623,14 @@
       "techs": [
         {
           "name": "canCrouchJump",
-          "requires": [{"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [{"noFlashSuit": {}}],
           "note":"The ability to crouch before jumping to reach higher ledges. Commonly paired with a down-grab or a mid-air Spring Ball jump."
         },
         {
           "name": "canTurnaroundSpinJump",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to buffer a jump by using the turnaround animation frames.",
             "This allows for an easier Spin Jump timing and works as a way jump far underwater without building up run speed."
@@ -598,10 +638,11 @@
           "extensionTechs": [
             {
               "name": "canFlatleyJump",
-              "requires": [ 
+              "techRequires": [
                 "canTurnaroundSpinJump",
                 "canTrickyJump"
               ],
+              "otherRequires": [],
               "note": [
                 "Positioning Samus at the very edge of a platform, facing away, then turning around and jumping to initiate the jump from a position that is off the platform (and slightly below it).",
                 "Sometimes referred to as a corner jump."
@@ -611,10 +652,8 @@
         },
         {
           "name": "canGravityJump",
-          "requires": [ 
-            "canDisableEquipment",
-            "Gravity"
-          ],
+          "techRequires": ["canDisableEquipment"],
+          "otherRequires": ["Gravity"],
           "note": [
             "Turning off Gravity Suit right after the start of an underwater jump to achieve a much higher jump.",
             "Can be performed in water, lava, or acid."
@@ -622,12 +661,14 @@
         },
         {
           "name": "canIframeSpikeJump",
-          "requires": [ "canCarefulJump" ],
+          "techRequires": ["canCarefulJump"],
+          "otherRequires": [],
           "note": "Take damage to gain invincibility frames so that Samus can run and jump on spike floors or setup a wall jump from a spike wall.  Enemies provide more i-frames than spikes."
         },
         {
           "name": "canStationarySpinJump",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Spin jumping with no horizontal movement by quickly pressing and releasing forward and then immediately pressing jump (after stopping).",
             "Doing this while holding run produces a spin jump with very low horizontal speed."
@@ -635,11 +676,11 @@
         },
         {
           "name": "canSpringBallJumpMidAir",
-          "requires": [
+          "techRequires": [
             "canDisableEquipment",
-            "canMidAirMorph",
-            "SpringBall"
+            "canMidAirMorph"
           ],
+          "otherRequires": ["SpringBall"],
           "note": [
             "It is possible to use Spring Ball while mid-air, if Samus is still climbing upwards. This gives an additional jump, allowing her to go higher.",
             "This can be done by morphing in mid-air, then quickly turning on Spring Ball while still climbing upwards, and then jumping again.",
@@ -649,7 +690,8 @@
           "extensionTechs": [
             {
               "name": "canTrickySpringBallJump",
-              "requires": [ "canSpringBallJumpMidAir" ],
+              "techRequires": ["canSpringBallJumpMidAir"],
+              "otherRequires": [],
               "note": [
                 "A precise, mid-air spring ball jump. This includes those with a relatively tight pause, jump, and morph, in order to spring ball jump just above shallow water.",
                 "And those which require the jump input to be pressed near the peak of the jump, which cannot be done by buffering the jump out of the pause menu.",
@@ -661,7 +703,8 @@
               "extensionTechs": [
                 {
                   "name": "canDoubleSpringBallJumpMidAir",
-                  "requires": [ "canTrickySpringBallJump" ],
+                  "techRequires": ["canTrickySpringBallJump"],
+                  "otherRequires": [],
                   "note": [
                     "Using a mid-air Spring Ball jump twice during a single jump to gain even more height.",
                     "This consists of a tight variant of mid-air Spring Ball jump, then turning off Spring Ball, then a second mid-air Spring Ball jump all while still climbing upwards.",
@@ -670,10 +713,11 @@
                 },
                 {
                   "name": "canUnderwaterBombIntoSpringBallJump",
-                  "requires": [ 
+                  "techRequires": [
                     "canTrickySpringBallJump",
-                    "h_canJumpIntoIBJ"
+                    "canJumpIntoIBJ"
                   ],
+                  "otherRequires": ["h_canJumpIntoIBJ"],
                   "note": [
                     "Use the tiny amount of height gain from an underwater Bomb explosion to re-equip Springball and perform a Springball jump.",
                     "This is most often used to get a second SpringBall jump when underwater without HiJump.",
@@ -685,10 +729,11 @@
             },
             {
               "name": "canSpringwall",
-              "requires": [
+              "techRequires": [
                 "canSpringBallJumpMidAir",
                 "canWallJumpInstantMorph"
               ],
+              "otherRequires": [],
               "note": [
                 "A mid-air Spring Ball jump that starts with a wall jump to gain more height.",
                 "It often benefits from the momentum change when equipping Spring Ball while morphed and moving horizontally after a WallJump."
@@ -696,10 +741,8 @@
             },
           {
             "name": "canSpringFling",
-            "requires": [
-              "canDisableEquipment",
-              "SpringBall"
-            ],
+            "techRequires": ["canDisableEquipment"],
+            "otherRequires": ["SpringBall"],
             "note": [
               "The ability to gain extra distance meerly by turning Springball on or off.",
               "When equipping or unequipping Springball while Morphed, Samus' speed is reset.",
@@ -711,7 +754,8 @@
         },
         {
           "name": "canCrumbleJump",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to jump off of a crumble block while it crumbles.",
             "A straight jump may employ the small amount of jump buffering the game offers, but a spinjump can only use the time before the crumble block breaks."
@@ -719,20 +763,20 @@
         },
         {
           "name": "canCarefulJump",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Executing a jump that requires somewhat precise or unintuitive movement.",
           "extensionTechs": [
             {
               "name": "canTrickyJump",
-              "requires": [ "canCarefulJump" ],
+              "techRequires": ["canCarefulJump"],
+              "otherRequires": [],
               "note": "Executing a jump that requires very precise timing.",
               "extensionTechs": [
                 {
                   "name": "canTrickyDashJump",
-                  "requires": [
-                    "canTrickyJump",
-                    "SpeedBooster"
-                  ],
+                  "techRequires": ["canTrickyJump"],
+                  "otherRequires": ["SpeedBooster"],
                   "note": [
                     "Using Speed Booster and jumping with a precise runway length in order to jump higher than with a slightly shorter or longer run.",
                     "This works because of the extreme non-linearity of the speed to jump height ratio, when Speed Booster is active."
@@ -740,17 +784,19 @@
                 },
                 {
                   "name": "canInsaneJump",
-                  "requires": ["canTrickyJump"],
+                  "techRequires": ["canTrickyJump"],
+                  "otherRequires": [],
                   "note": [
                     "Executing a jump that requires extremely precise timing, in the vicinity of frame-perfect precision."
                   ]
                 },
                 {
                   "name": "canCWJ",
-                  "requires": [
+                  "techRequires": [
                     "canTrickyJump",
                     "canWalljump"
                   ],
+                  "otherRequires": [],
                   "note": [
                     "A continuous wall jump (CWJ) consists of a wall jump without turning around.",
                     "It can be done by spinjumping forward and then wall jump off a solid object to retain all forward momentum.",
@@ -764,22 +810,26 @@
         },
         {
           "name": "canWalljump",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Jump off walls, as taught by the Etecoons.",
           "extensionTechs": [
             {
               "name": "canPreciseWalljump",
-              "requires": [ "canWalljump" ],
+              "techRequires": ["canWalljump"],
+              "otherRequires": [],
               "note": "A wall jump that needs to be performed at a fairly precise spot in order to yield the desired result.",
               "extensionTechs": [
                 {
                   "name": "canDelayedWalljump",
-                  "requires": [ "canPreciseWalljump" ],
+                  "techRequires": ["canPreciseWalljump"],
+                  "otherRequires": [],
                   "note": "A precise wall jump that needs to done as late as possible by moving away from the wall in order for Samus to start the jump as far from the wall as possible.",
                   "extensionTechs": [
                     {
                       "name": "canInsaneWalljump",
-                      "requires": [ "canDelayedWalljump" ],
+                      "techRequires": ["canDelayedWalljump"],
+                      "otherRequires": [],
                       "note": "A wall jump with extreme precision, in the vicinity of pixel and frame perfect precision. These jumps are typically delayed wall jumps."
                     }
                   ]
@@ -788,28 +838,31 @@
             },
             {
               "name": "canConsecutiveWalljump",
-              "requires": [ "canWalljump" ],
+              "techRequires": ["canWalljump"],
+              "otherRequires": [],
               "note" : "Climbing a wall with three or more consecutive wall jumps without a mistake.",
               "extensionTechs": [
                 {
                   "name": "canFastWalljumpClimb",
-                  "requires": [ "canConsecutiveWalljump" ],
+                  "techRequires": ["canConsecutiveWalljump"],
+                  "otherRequires": [],
                   "note": "Climbing a wall with consecutive wall jumps very quickly, e.g. for setting up a full halfie."
                 },
                 {
                   "name": "canStaggeredWalljump",
-                  "requires": [ "canConsecutiveWalljump" ],
+                  "techRequires": ["canConsecutiveWalljump"],
+                  "otherRequires": [],
                   "note" : "Controlling wall jump height and positioning to dodge enemies or to wait for something.",
                   "devNote": "FIXME This could be used to also set up a wall jump that needs a precise starting location."
                 },
                 {
                   "name": "canUnderwaterWalljump",
-                  "requires": [ 
+                  "techRequires": [
                     "canConsecutiveWalljump",
                     "canSuitlessMaridia",
-                    "canMidairWiggle",
-                    "HiJump"
+                    "canMidairWiggle"
                   ],
+                  "otherRequires": ["HiJump"],
                   "note": [
                     "The ability to gain height by walljumping underwater against a single wall.",
                     "The movement requires using the unintuitive behaviour of turning around in water in order to return Samus to a walljump position.",
@@ -823,7 +876,8 @@
         },
         {
           "name": "canJumpIntoRespawningBlock",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to time a jump up into a respawning block so that Samus gets stuck in it and can jump up again.",
             "The bottom of Samus' hitbox must be completely in the respawning block or she will fall out.",
@@ -838,15 +892,14 @@
       "techs": [
         {
           "name": "canUnmorphBombBoost",
-          "requires": [ "h_canBombThings" ],
+          "techRequires": [],
+          "otherRequires": ["h_canBombThings"],
           "note": "A tech that involves mid-air morphing to place a bomb or Power Bomb, then mid-air unmorphing to briefly hover above the bomb, in order to use the bomb blast to go just a bit higher than max jump height."
         },
         {
           "name": "canWallJumpBombBoost",
-          "requires": [
-            "h_canBombThings",
-            "canWallJumpInstantMorph"
-          ],
+          "techRequires": ["canWallJumpInstantMorph"],
+          "otherRequires": ["h_canBombThings"],
           "note": [
             "The ability to accurately place a bomb or Power Bomb in mid-air following a wall jump, then using that bomb explosion to propel Samus forward.",
             "There is a timing component where the bomb is placed while rising then hit while falling, and a momentum component for maximizing horizontal distance."
@@ -854,7 +907,8 @@
         },
         {
           "name": "canBombHorizontally",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Place a single bomb then move Samus to the side to be boosted horizontally from the explosion.",
             "This is typically used as a way to cross gaps or to reposition at the end of an IBJ.",
@@ -865,7 +919,8 @@
           "extensionTechs": [
             {
               "name": "canHBJ",
-              "requires": [ "canBombHorizontally" ],
+              "techRequires": ["canBombHorizontally"],
+              "otherRequires": [],
               "note": [
                 "A Horizontal Bomb Jump (HBJ) uses three bombs to execute. Place a bomb to get boosted horizontally; place a second bomb immediately as Samus is propelled.",
                 "Place a third bomb, mid-air, as far horizontally as possible while still being able to return and get propelled by the second and then third bombs."
@@ -876,7 +931,8 @@
         },
         {
           "name": "canIBJ",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Infinite Bomb Jump (IBJ) uses consecutive bomb jumps to gain height indefinitely. To start and continue an IBJ, place a bomb as the previous one is exploding.",
             "The vertical speed with which Samus moves is controlled by how high or how low each bomb is placed relative to the previous one.",
@@ -886,39 +942,43 @@
           "extensionTechs": [
             {
               "name": "canJumpIntoIBJ",
-              "requires": [ 
-                "canIBJ" 
-              ],
+              "techRequires": ["canIBJ"],
+              "otherRequires": [],
               "note": "The ability to start an IBJ from a jump or a spring ball jump. It is most often used in strats that need Samus to IBJ up faster or to avoid something near the ground."
             },
             {
               "name": "canBombAboveIBJ",
-              "requires": [ "canIBJ" ],
+              "techRequires": ["canIBJ"],
+              "otherRequires": [],
               "note": "The ability to break blocks above Samus while maintaining an ongoing IBJ without falling."
             },
             {
               "name": "canCeilingBombJump",
-              "requires": [ "canBombAboveIBJ" ],
+              "techRequires": ["canBombAboveIBJ"],
+              "otherRequires": [],
               "note": "The ability to IBJ at the ceiling and place bombs at a steady rhythm while slowly moving horizontally.",
               "extensionTechs": [
                 {
                   "name": "canLongCeilingBombJump",
-                  "requires": [ "canCeilingBombJump" ],
+                  "techRequires": ["canCeilingBombJump"],
+                  "otherRequires": [],
                   "note": "The ability to ceiling bomb jump over a distance of two screens or more."
                 }
               ]
             },
             {
               "name": "canDiagonalBombJump",
-              "requires": [ "canIBJ" ],
+              "techRequires": ["canIBJ"],
+              "otherRequires": [],
               "note": "The ability to IBJ with backspin which results in an IBJ with diagonal movement."
             },
             {
               "name": "canSandIBJ",
-              "requires": [ 
-                "h_canJumpIntoIBJ",
+              "techRequires": [
+                "canJumpIntoIBJ",
                 "canPlayInSand"
               ],
+              "otherRequires": ["h_canJumpIntoIBJ"],
               "note": [
                 "The ability to start an IBJ from sand.",
                 "Jumping from the top of sand into an IBJ takes more precision than a standard jump into IBJ.",
@@ -931,19 +991,22 @@
             },
             {
               "name": "canDoubleBombJump",
-              "requires": [ "canIBJ" ],
+              "techRequires": ["canIBJ"],
+              "otherRequires": [],
               "note": "The ability to place a second bomb near the top of a bomb boost during an IBJ in order to ascend much faster."
             },
             {
               "name": "canStaggeredIBJ",
-              "requires": [ "canIBJ" ],
+              "techRequires": ["canIBJ"],
+              "otherRequires": [],
               "note": "The ability to change the bomb placement timing in order control the speed with which you gain height. This is typically used to avoid an enemy moving in Samus' path above."
             }
           ]
         },
         {
           "name": "canSpringBallBombJump",
-          "requires": [ "SpringBall" ],
+          "techRequires": [],
+          "otherRequires": ["SpringBall"],
           "note": [
             "After gaining some height with a single bomb explosion from the ground, use Spring Ball to jump higher.",
             "Usable only when Samus' vertical speed is 0 (at the max height gained by the bomb)."
@@ -951,10 +1014,8 @@
         },
         {
           "name": "canBombJumpWaterEscape",
-          "requires": [ 
-            "canMidAirMorph",
-            "h_canBombThings" 
-          ],
+          "techRequires": ["canMidAirMorph"],
+          "otherRequires": ["h_canBombThings"],
           "note": "From a submerged platform, setting up a single bomb jump above the water line to propel Samus up and out of the water.",
           "devNote": "It's recommended to apply a number of tries as leniency here for the PBs version."
         }
@@ -966,13 +1027,15 @@
       "techs": [
         {
           "name": "canUseEnemies",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Using an enemy in a room to accomplish something that couldn't be done if it weren't there, e.g. when standing on or grappling from an enemy.",
           "devNote": "Turning this off should greatly improve the logic for enemizer contexts.",
           "extensionTechs": [
             {
               "name": "canSnailClimb",
-              "requires": [ "canUseEnemies" ],
+              "techRequires": ["canUseEnemies"],
+              "otherRequires": [],
               "note": [
                 "The ability to repeatedly manipulate Yards (snails) and use them as platforms.",
                 "The snail is damaging when out of its shell so Samus must face the center of the snail to cause it to hide.",
@@ -988,12 +1051,14 @@
             },
             {
               "name": "canNeutralDamageBoost",
-              "requires": [ "canUseEnemies" ],
+              "techRequires": ["canUseEnemies"],
+              "otherRequires": [],
               "note": "Using the small vertical knockback from taking enemy damage, while not holding any directional inputs, to assist Samus in her movement.",
               "extensionTechs": [
                 {
                   "name": "canHorizontalDamageBoost",
-                  "requires": [ "canNeutralDamageBoost" ],
+                  "techRequires": ["canNeutralDamageBoost"],
+                  "otherRequires": [],
                   "note": [
                     "Using the knockback from taking enemy damage to give Samus a large movement boost by holding the jump and backwards buttons.",
                     "By changing the timing of the directional input, the way that Samus is knocked back can be changed and has situational uses.",
@@ -1006,7 +1071,8 @@
             },
             {
               "name": "canManipulateMellas",
-              "requires": [ "canUseEnemies" ],
+              "techRequires": ["canUseEnemies"],
+              "otherRequires": [],
               "note": [
                 "The ability to manipulate bug enemies that moves in a diving pattern (Mella, Mellow, or Menu).",
                 "These enemies inch upwards or downwards with each dive, so making it dive repeatedly until it is at the proper height to execute a strat."
@@ -1014,7 +1080,8 @@
             },
             {
               "name": "canSamusEaterStandUp",
-              "requires": [ "canUseEnemies" ],
+              "techRequires": ["canUseEnemies"],
+              "otherRequires": [],
               "note": [
                 "The ability to gain a shinecharge in place while captured by a Samus Eater.",
                 "Note that Samus maintains control of most of her abilities while captured by a Samus Eater."
@@ -1022,7 +1089,8 @@
             },
             {
               "name": "canKago",
-              "requires": [ "canUseEnemies" ],
+              "techRequires": ["canUseEnemies"],
+              "otherRequires": [],
               "note": [
                 "Clipping through an enemy by performing an uninterruptible animation while coming into contact with them.",
                 "These animations include morphing, unmorphing, or performing a turnaround."
@@ -1030,20 +1098,20 @@
             },
             {
               "name": "canUseFrozenEnemies",
-              "requires": [
-                "Ice",
-                "canUseEnemies"
-              ],
+              "techRequires": ["canUseEnemies"],
+              "otherRequires": ["Ice"],
               "note": "Can use Ice Beam to freeze enemies to use as platforms or as wall jump supports, to reach higher areas",
               "extensionTechs": [
                 {
                   "name": "canMochtroidIceClimb",
-                  "requires": [ "canUseFrozenEnemies" ],
+                  "techRequires": ["canUseFrozenEnemies"],
+                  "otherRequires": [],
                   "note": "Using a frozen Mochtroid to climb upwards, by continually jumping as it thaws and refreezing it higher."
                 },
                 {
                   "name": "canTrickyUseFrozenEnemies",
-                  "requires": [ "canUseFrozenEnemies" ],
+                  "techRequires": ["canUseFrozenEnemies"],
+                  "otherRequires": [],
                   "note": [
                     "The ability to use Ice Beam to freeze enemies in especially precise positionings.",
                     "If supers are available, they can be used to knock wall crawlers off walls and freeze them mid air."
@@ -1051,7 +1119,8 @@
                   "extensionTechs": [
                     {
                       "name": "canWallIceClip",
-                      "requires": [ "canTrickyUseFrozenEnemies" ],
+                      "techRequires": ["canTrickyUseFrozenEnemies"],
+                      "otherRequires": [],
                       "note": [
                         "Collision will prioritize frozen enemies before walls which allows Samus to clip 1 pixel into a wall if an enemy is there.",
                         "This can be used to get Samus into position to X-Ray Climb.",
@@ -1060,7 +1129,8 @@
                     },
                     {
                       "name": "canCrazyCrabClimb",
-                      "requires": [ "canTrickyUseFrozenEnemies" ],
+                      "techRequires": ["canTrickyUseFrozenEnemies"],
+                      "otherRequires": [],
                       "note": [
                         "Repeatedly freezing a crab to climb up an uneven wall, using no other support.",
                         "These climbs often require high precision when jumping around ledges: too many pixels in any direction and Samus may fall off or clip through the crab.",
@@ -1073,7 +1143,8 @@
             },
             {
               "name": "canMetroidAvoid",
-              "requires": [],
+              "techRequires": [],
+              "otherRequires": [],
               "note": [
                 "Being proficient at avoiding metroids, and knowing where they are in the room.",
                 "Metroids will charge towards Samus but keep their momentum if they miss.",
@@ -1083,10 +1154,11 @@
             },
             {
               "name": "canBabyMetroidAvoid",
-              "requires": [
+              "techRequires": [
                 "canTrickyJump",
                 "canDodgeWhileShooting"
               ],
+              "otherRequires": [],
               "note": [
                 "The ability to skip the Baby Metroid health drain.",
                 "The Baby Metroid skip has three parts: The first jump, repeated jumps over the baby while clearing the vines, and the final jump into the transition.",
@@ -1095,17 +1167,20 @@
             },
             {
               "name": "canDodgeWhileShooting",
-              "requires": [],
+              "techRequires": [],
+              "otherRequires": [],
               "note": "The ability to run from, jump over, or duck under attacks that do not require precise avoidance movements while shooting the enemy."
             },
             {
               "name": "canEscapeEnemyGrab",
-              "requires": [],
+              "techRequires": [],
+              "otherRequires": [],
               "note": "The ability to become grabbed by Draygon or a Beetom and then escape by pressing 60+ inputs."
             },
             {
               "name": "canEnemyExtendRunway",
-              "requires": ["canUseEnemies"],
+              "techRequires": ["canUseEnemies"],
+              "otherRequires": [],
               "note": [
                 "The ability to use an enemy to extend the length of a runway.",
                 "This is typically set up with a frozen wall-crawler, but can include other frozen enemies or Snails, Trippers, etc.",
@@ -1119,7 +1194,8 @@
               "extensionTechs": [
                 {
                   "name": "canTrickyEnemyExtendRunway",
-                  "requires": [ "canEnemyExtendRunway" ],
+                  "techRequires": ["canEnemyExtendRunway"],
+                  "otherRequires": [],
                   "note": [
                     "The ability to use tricky enemy setups to extend the length of a runway.",
                     "This includes the use of unintuitive or particularly precise setups or the use of multiple enemies with non-trivial setups."
@@ -1137,7 +1213,8 @@
       "techs": [
         {
           "name": "canHitbox",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to pass through some enemies undamaged by shooting.",
             "May involve running through the enemy after making its hitbox inactive (e.g. Metal Pirates) or while the enemy has iframes (e.g. using Plasma)."
@@ -1145,7 +1222,8 @@
         },
         {
           "name": "canPseudoScrew",
-          "requires": ["Charge"],
+          "techRequires": [],
+          "otherRequires": ["Charge"],
           "note": [
             "The ability to spinjump with Charge beam stored.",
             "Pseudo screw gives Samus some protection from projecitles and enemies.",
@@ -1154,10 +1232,11 @@
           "extensionTechs": [
             {
               "name": "canWalljumpWithCharge",
-              "requires": [
+              "techRequires": [
                 "canPseudoScrew",
                 "canWalljump"
               ],
+              "otherRequires": [],
               "note": [
                 "The ability to store charge beam and continue wall jumping.",
                 "This is done by releasing the shoot button when trying to walljump, otherwise Samus will stop spinning.",
@@ -1168,7 +1247,8 @@
         },
         {
           "name": "canSpecialBeamAttack",
-          "requires": [
+          "techRequires": [],
+          "otherRequires": [
             "Charge",
             "PowerBomb",
             {"or": [
@@ -1185,7 +1265,8 @@
         },
         {
           "name": "canOffScreenSuperShot",
-          "requires": [ {"ammo": { "type": "Super", "count": 1 }} ],
+          "techRequires": [],
+          "otherRequires": [{"ammo": { "type": "Super", "count": 1 }}],
           "note": "The ability to shoot a Super at a precise location to hit an offscreen inanimate target, e.g. a Super block.",
           "devNote": [
             "It's recommended to apply a number of tries as leniency here.",
@@ -1194,7 +1275,8 @@
         },
         {
           "name": "canGateGlitch",
-          "requires": [{"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [{"noFlashSuit": {}}],
           "note": "The ability to open a left-facing blue or green gate from the right, using Missiles or Supers.",
           "devNote": [
             "A number of tries can't be applied as leniency on this tech, because the resource cost is not included in the tech (it varies with circumstances).",
@@ -1203,7 +1285,8 @@
         },
         {
           "name": "canWrapAroundShot",
-          "requires": [
+          "techRequires": [],
+          "otherRequires": [
             "Wave",
             "Charge"
           ],
@@ -1211,13 +1294,15 @@
         },
         {
           "name": "canGrappleClip",
-          "requires": [ "Grapple" ],
+          "techRequires": [],
+          "otherRequires": ["Grapple"],
           "note": "Using Grapple on an enemy or grapple block to clip into walls and other surfaces.",
           "devNote": "FIXME This could use a better description."
         },
         {
           "name": "canHeroShot",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to follow a shot to prevent it from despawning before hitting its target.",
             "This may include aiming between enemies or waiting for the shot to travel some distance before following it."
@@ -1225,7 +1310,8 @@
         },
         {
           "name": "canAutoCancelWeapon",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to set a HUD equipment item (Missile, Super, Power Bomb, Grapple, XRay Scope) to be single use.",
             "Doing this allows for a fast beam shot following the item use, or can reduce button input complexity.",
@@ -1240,7 +1326,8 @@
       "techs": [
         {
           "name": "canShinespark",
-          "requires": [ "SpeedBooster" ],
+          "techRequires": [],
+          "otherRequires": ["SpeedBooster"],
           "note": [
             "The ability to use the Speed Booster to store a shinecharge, then fly in a direction until an obstacle is hit or Samus gets down to 29 energy.",
             "Assumes Samus can shinespark vertically or diagonally from the ground."
@@ -1248,7 +1335,8 @@
           "extensionTechs": [
             {
               "name": "canHorizontalShinespark",
-              "requires": [ "canShinespark" ],
+              "techRequires": ["canShinespark"],
+              "otherRequires": [],
               "note": [
                 "The ability to shinespark horizontally from the ground.",
                 "This can be achieved by starting without horizontal momentum and pressing jump and then forward while still holding jump (or repressing jump).",
@@ -1258,7 +1346,8 @@
               "extensionTechs": [
                 {
                   "name": "canMidairShinespark",
-                  "requires": [ "canHorizontalShinespark" ],
+                  "techRequires": ["canHorizontalShinespark"],
+                  "otherRequires": [],
                   "note": [
                     "The ability to jump and shinespark mid-air: vertically, horizontally, or diagonally.",
                     "Mid-air horizontal sparks are the most tricky.",
@@ -1270,7 +1359,8 @@
                   "extensionTechs": [
                     {
                       "name": "canShinesparkDeepStuck",
-                      "requires": [ "canMidairShinespark" ],
+                      "techRequires": ["canMidairShinespark"],
+                      "otherRequires": [],
                       "note": [
                         "Activating a shinespark to get deep stuck in a door.",
                         "This is done by shooting open the door and spin-jumping towards it with a shine charge, then pressing angle up to activate a shinespark on the same frame as getting a wall jump check by moving away from the transition tiles.",
@@ -1283,7 +1373,8 @@
             },
             {
               "name": "canShinechargeMovement",
-              "requires": [ "canShinespark" ],
+              "techRequires": ["canShinespark"],
+              "otherRequires": [],
               "note": [
                 "The ability to perform simple jumps with a shinespark charge timer running to get into position to shinespark.",
                 "This reposition may be necessary to avoid obstacles, conserve energy, etc."
@@ -1291,7 +1382,8 @@
               "extensionTechs": [
                 {
                   "name": "canShinechargeMovementComplex",
-                  "requires": [ "canShinechargeMovement" ],
+                  "techRequires": ["canShinechargeMovement"],
+                  "otherRequires": [],
                   "note": [
                     "The ability to make multiple movement actions with a shinespark charge timer running to get into position to shinespark.",
                     "This reposition may be necessary to avoid obstacles, conserve energy, etc."
@@ -1299,7 +1391,8 @@
                   "extensionTechs": [
                     {
                       "name": "canShinechargeMovementTricky",
-                      "requires": [ "canShinechargeMovementComplex" ],
+                      "techRequires": ["canShinechargeMovementComplex"],
+                      "otherRequires": [],
                       "note": [
                         "The ability to make precise and potentially unintuitive movement actions with a shinespark charge timer running to get into position to shinespark.",
                         "A common example is using the Shinespark Wind-Up animation to wait for a hero shot to open an off-camera door."
@@ -1311,14 +1404,16 @@
             },
             {
               "name": "canUseSpeedEchoes",
-              "requires": [ "canShinespark" ],
+              "techRequires": ["canShinespark"],
+              "otherRequires": [],
               "note": "Using the Samus echoes that are emitted after a shinespark bonk as a weapon to kill enemies."
             }
           ]
         },
         {
           "name": "canSlowShortCharge",
-          "requires": ["SpeedBooster"],
+          "techRequires": [],
+          "otherRequires": ["SpeedBooster"],
           "note": [
             "The ability to control Samus' run speed while shortcharging by releasing run after achieving blue.",
             "Being able to 4 tap is expected as that brings out the most value from this tech."
@@ -1326,7 +1421,8 @@
         },
         {
           "name": "canSpikeSuit",
-          "requires": [{"gainFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [{"gainFlashSuit": {}}],
           "note": [
             "The ability to gain a flash suit using spikes or similar damage source.",
             "Gain a shinecharge, take a spike hit while morphed, unmorphing either 1 or 2 frames after taking damage.",
@@ -1335,11 +1431,11 @@
         },
         {
           "name": "canSpeedKeep",
-          "requires": [
-            "SpeedBooster",
+          "techRequires": [
             "canBounceBall",
             "canIframeSpikeJump"
           ],
+          "otherRequires": ["SpeedBooster"],
           "note": [
             "The ability to retain the Dash counter and momentum by frame perfectly unmorphing before taking damage from spikes.",
             "It is necessary to bounce while in Morph Ball, either by falling or by taking damage, to set the correct fall state for a SpeedKeep.",
@@ -1349,14 +1445,14 @@
         },
         {
           "name": "canPreciseSpaceJump",
-          "requires": [
-            "SpaceJump"
-          ],
+          "techRequires": [],
+          "otherRequires": ["SpaceJump"],
           "note": "Carefully controlling the height and timing of Space Jump in order to carry momentum, and possibly blue speed, across substantial distances to specific locations."
         },
         {
           "name": "canBlueSpaceJump",
-          "requires": [
+          "techRequires": [],
+          "otherRequires": [
             "SpeedBooster",
             "SpaceJump"
           ],
@@ -1364,7 +1460,11 @@
         },
         {
           "name": "canTemporaryBlue",
-          "requires": ["SpeedBooster", {"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [
+            "SpeedBooster",
+            {"noFlashSuit": {}}
+          ],
           "note": [
             "Maintaining the desctructive capabilities of speedbooster after running has stopped.",
             "Used to fall on top of breakable bomb blocks or enemies.",
@@ -1374,10 +1474,11 @@
           "extensionTechs": [
             {
               "name": "canChainTemporaryBlue",
-              "requires": [
+              "techRequires": [
                 "canTemporaryBlue",
                 "canLateralMidAirMorph"
               ],
+              "otherRequires": [],
               "note": [
                 "The ability to move while maintaining Temporary Blue. This can be done by jumping, releasing angle, then doing a mid-air morph on the descent, using mockball inputs.",
                 "Afterwards, hold angle again while soft unmorphing and continue to hold angle after landing.",
@@ -1387,9 +1488,8 @@
               "extensionTechs": [
                 {
                   "name": "canLongChainTemporaryBlue",
-                  "requires": [
-                    "canChainTemporaryBlue"
-                  ],
+                  "techRequires": ["canChainTemporaryBlue"],
+                  "otherRequires": [],
                   "note": [
                     "The ability to move across large distances while maintaining Temporary Blue."
                   ]
@@ -1400,10 +1500,8 @@
         },
         {
           "name": "canWaterShineCharge",
-          "requires": [
-            "canSuitlessMaridia",
-            "SpeedBooster"
-          ],
+          "techRequires": ["canSuitlessMaridia"],
+          "otherRequires": ["SpeedBooster"],
           "note": [
             "Starting from an air environment, run into water and charge a spark in the water. This is typically done while crossing a door transition from a room with air physics to a room with water.",
             "This is easy to do; the tech just represents knowledge that it is possible."
@@ -1411,7 +1509,8 @@
           "extensionTechs": [
             {
               "name": "canStutterWaterShineCharge",
-              "requires": [ "canWaterShineCharge" ],
+              "techRequires": ["canWaterShineCharge"],
+              "otherRequires": [],
               "note": [
                 "Performing a canWaterShineCharge in a shorter runway by using a stutter that is greatly extended by the water slowdown.",
                 "Perform a stutter shortly before entering water, typically through a door transition, by briefly releasing and then repressing forward before, but as close to, the transition as possible while continuing the dash.",
@@ -1430,7 +1529,11 @@
       "techs": [
         {
           "name": "canXRayWaitForIFrames",
-          "requires": ["XRayScope", {"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [
+            "XRayScope",
+            {"noFlashSuit": {}}
+          ],
           "note": [
             "Use X-Ray to pause time until invulnerability frames are finished.",
             "Combine with Plasma Beam to repeatedly damage enemies with one fired shot, called Microwave.",
@@ -1439,7 +1542,11 @@
         },
         {
           "name": "canXRayTurnaround",
-          "requires": ["XRayScope", {"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [
+            "XRayScope",
+            {"noFlashSuit": {}}
+          ],
           "note": [
             "Using X-Ray to turn around in place without changing pixel position.",
             "Alternating X-Ray turnarounds with regular turnarounds enables movement in either direction even while crouched.",
@@ -1448,12 +1555,17 @@
         },
         {
           "name": "canXRayStandUp",
-          "requires": ["XRayScope", {"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [
+            "XRayScope",
+            {"noFlashSuit": {}}
+          ],
           "note": "Force Samus to stand up from a crouching position by canceling the use of the X-Ray Scope while turning around.",
           "extensionTechs": [
             {
               "name": "canXRayClimb",
-              "requires": [ "canXRayStandUp" ],
+              "techRequires": ["canXRayStandUp"],
+              "otherRequires": [],
               "note": [
                 "Repeatedly using X-Ray's forced standup trick to climb up through in-bound walls.",
                 "This requires Samus to be partially clipped into the wall to begin climbing, which is often set up by getting stuck in a closing door.",
@@ -1464,7 +1576,8 @@
               "extensionTechs": [
                 {
                   "name": "canRightSideDoorStuck",
-                  "requires": [ "canStationarySpinJump" ],
+                  "techRequires": ["canStationarySpinJump"],
+                  "otherRequires": [],
                   "note": [
                     "Getting stuck in a right side (left facing) door.",
                     "Starting from the room to the right, perform a dashing stationary spinjump into a doorcheck.",
@@ -1474,10 +1587,11 @@
                   "extensionTechs": [
                     {
                       "name": "canRightSideDoorStuckFromWater",
-                      "requires": [
+                      "techRequires": [
                         "canRightSideDoorStuck",
                         "canTrickyJump"
                       ],
+                      "otherRequires": [],
                       "note": [
                         "When the adjacent room is underwater it is not possible to gain dash state for the stationary spinjump.",
                         "Instead, an extremely precise jump is required followed by aiming down to shrink Samus' hitbox.",
@@ -1494,7 +1608,11 @@
         },
         {
           "name": "canXMode",
-          "requires": ["XRayScope", {"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [
+            "XRayScope",
+            {"noFlashSuit": {}}
+          ],
           "note": [
             "Ability to enter X-Mode using spikes by unmorphing frame perfectly before knockback ends with X-Ray ready to activate.",
             "This can be used to charge a shinespark or to slowly move forward by armpumping.",
@@ -1507,7 +1625,8 @@
           "extensionTechs": [
             {
               "name": "canSuperJump",
-              "requires": ["canXMode"],
+              "techRequires": ["canXMode"],
+              "otherRequires": [],
               "note": [
                 "Ability to Shinespark while in XMode in a controlled way.",
                 "A side effect of Super Jumping is that Samus gains a Blue Suit."
@@ -1517,7 +1636,12 @@
         },
         {
           "name": "canEnterRMode",
-          "requires": ["XRayScope", "ReserveTank", "canUseEnemies", {"noFlashSuit": {}}],
+          "techRequires": ["canUseEnemies"],
+          "otherRequires": [
+            "XRayScope",
+            "ReserveTank",
+            {"noFlashSuit": {}}
+          ],
           "note": [
             "Ability to enter R-mode.",
             "Have some energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray after reserves have finished filling."
@@ -1525,7 +1649,8 @@
           "extensionTechs": [
             {
               "name": "canEnterGMode",
-              "requires": [ "canEnterRMode" ],
+              "techRequires": ["canEnterRMode"],
+              "otherRequires": [],
               "note": [
                 "Ability to enter G-mode starting with low reserve energy.",
                 "Have 4 or fewer energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray before reserves have finished filling (a 4-frame window when starting with 4 reserve energy).",
@@ -1534,7 +1659,8 @@
               "extensionTechs": [
                 {
                   "name": "canEnterGModeImmobile",
-                  "requires": [ "canEnterGMode" ],
+                  "techRequires": ["canEnterGMode"],
+                  "otherRequires": [],
                   "note": [
                     "Ability to enter G-mode starting with high reserve energy, resulting in Samus being immobilized.",
                     "Have 5 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window when starting with 12 or more reserve energy, a much larger frame window if you have between 5 and 11).",
@@ -1543,7 +1669,8 @@
                 },
                 {
                   "name": "canArtificialMorph",
-                  "requires": [ "canEnterGMode" ],
+                  "techRequires": ["canEnterGMode"],
+                  "otherRequires": [],
                   "note": [
                     "Ability to obtain artificial morph with G-mode.",
                     "For low-energy G-mode setups, turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
@@ -1555,7 +1682,8 @@
             },
             {
               "name": "canDownwardGModeSetup",
-              "requires": [ "canEnterRMode" ],
+              "techRequires": ["canEnterRMode"],
+              "otherRequires": [],
               "note": [
                 "Ability to setup an R-mode or G-mode through a downward door.",
                 "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
@@ -1564,7 +1692,8 @@
             },
             {
               "name": "canUpwardGModeSetup",
-              "requires": [ "canEnterRMode" ],
+              "techRequires": ["canEnterRMode"],
+              "otherRequires": [],
               "note": [
                 "Ability to setup an R-mode or G-mode through an upward door.",
                 "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
@@ -1583,7 +1712,8 @@
       "techs": [
         {
           "name": "canAwakenZebes",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Understanding game behavior related to how the planet is awakened.",
             "The planet is awakened by unlocking any gray door locked by killing enemies in the room (not including bosses or minibosses).",
@@ -1599,7 +1729,8 @@
         },
         {
           "name": "canRiskPermanentLossOfAccess",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The acceptance that changes to game state can result in a strat becoming impossible.",
             "If that strat needed to be executed before the game state change, the game becomes incompletable.",
@@ -1614,15 +1745,17 @@
       "techs": [
         {
           "name": "canCeilingClip",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Basic variant of jumping into a two block high space and performing the actions needed to clip up through a one-tile-thick ceiling.",
           "extensionTechs": [
             {
               "name": "canXRayCeilingClip",
-              "requires": [
+              "techRequires": [
                 "canCeilingClip",
                 "canUseEnemies"
               ],
+              "otherRequires": [],
               "note": [
                 "Setting up an enemy positioning to perform a ceiling clip. Jump and Morph onto the enemy, perform an X-Ray standup, and then jump through.",
                 "The enemy positioning will require approximately 1.5 to 2 tiles between the enemy and the ceiling. Just enough to unmorph while on top of it."
@@ -1631,7 +1764,8 @@
               "extensionTechs": [
                 {
                   "name": "canPreciseCeilingClip",
-                  "requires": [ "canXRayCeilingClip" ],
+                  "techRequires": ["canXRayCeilingClip"],
+                  "otherRequires": [],
                   "note": "Setting up an enemy positioning to perform a very precise ceiling clip. The enemy positioning will require a 2-3 pixel precision range, several pixels lower than what is possible with an X-Ray standup."
                 }
               ]
@@ -1640,7 +1774,8 @@
         },
         {
           "name": "canPartialFloorClip",
-          "requires": [{"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [{"noFlashSuit": {}}],
           "note": [
             "While standing upright in a two-tile gap between solid tiles, jump in such a way as to clip a pixel into the below floor as a setup to another tech.",
             "This is done by, in quick succession: jumping, aiming down, and then pressing forward."
@@ -1649,7 +1784,8 @@
         },
         {
           "name": "canCrystalFlash",
-          "requires": [{"noFlashSuit": {}}],
+          "techRequires": [],
+          "otherRequires": [{"noFlashSuit": {}}],
           "note": [
             "Performing a Crystal Flash (CF).",
             "Initiating the Crystal Flash requires energy at 50 or lower, empty Reserve energy, 1 Power Bomb to initiate, and holding L+R+Shoot+Down with no other inputs.",
@@ -1659,11 +1795,11 @@
           "extensionTechs": [
             {
               "name": "canBombIntoCrystalFlashClip",
-              "requires": [ 
+              "techRequires": [
                 "canCrystalFlash",
-                "canCeilingClip",
-                "Bombs"
+                "canCeilingClip"
               ],
+              "otherRequires": ["Bombs"],
               "note": [
                 "Setting up a Crystal Flash in a 3 tile high space with bombs to clip into the above tile.",
                 "This requires bombing once to place the power bomb against the ceiling, then bombing again to position Samus for the Crystal Flash.",
@@ -1674,10 +1810,11 @@
             },
             {
               "name": "canJumpIntoCrystalFlashClip",
-              "requires": [
+              "techRequires": [
                 "canCrystalFlash",
                 "canCeilingClip"
               ],
+              "otherRequires": [],
               "note": [
                 "Setting up a Crystal Flash by jumping and morphing. Once to place the Power Bomb, then again to activate the Crystal Flash.",
                 "This trick has a 1 frame window.",
@@ -1688,21 +1825,24 @@
             },
             {
               "name": "can10PowerBombCrystalFlash",
-              "requires": [ 
+              "techRequires": [
                 "canCrystalFlash"
               ],
+              "otherRequires": [],
               "note": "Setting up a Crystal Flash with only a 10 Power Bomb capacity, by picking up a Power Bomb in between placing the first Power Bomb and activating the Crystal Flash."
             }
           ]
         },
         {
           "name": "canTurnaroundAimCancel",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": "Canceling an aim angle while crouching and turning around, to wiggle to the right."
         },
         {
           "name": "canMomentumConservingTurnaround",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Uses the uninteruptable frames of turning around in order to continue moving after hitting a solid object.",
             "Can be used to make it through an opening door, or barely just past a ledge.",
@@ -1711,7 +1851,8 @@
         },
         {
           "name": "canMomentumConservingMorph",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Uses the uninteruptable frames of morphing or unmorphing in order to continue moving up after hitting a solid object above.",
             "Can be used to make it barely just past a ledge."
@@ -1719,7 +1860,8 @@
         },
         {
           "name": "canCameraManip",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to scroll the camera to bring enemies or projectiles on or off camera.",
             "Most enemes become inactive while off camera, and most projectiles cease to exist.",
@@ -1729,7 +1871,8 @@
         },
         {
           "name": "canDeepTransition",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to trigger a door transition deeper than normal, resulting in a more distant spawn position in the next room.",
             "There are many possible ways that this could be achieved; this tech includes two methods:",
@@ -1743,7 +1886,8 @@
         },
         {
           "name": "canSkipDoorLock",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "The ability to trigger a door transition without opening a door lock in front of it.",
             "Specific techniques for achieving this are covered in other tech."

--- a/tech.json
+++ b/tech.json
@@ -44,7 +44,8 @@
         },
         {
           "name": "canSuitlessMaridia",
-          "requires": [],
+          "techRequires": [],
+          "otherRequires": [],
           "note": [
             "Navigating underwater without Gravity.",
             "This is not required for falling down a submerged room or for simple underwater platforming, such as where missing a jump does not leave Samus stuck somewhere."
@@ -52,10 +53,11 @@
           "extensionTechs": [
             {
               "name": "canSunkenTileWideWallClimb",
-              "requires": [
+              "techRequires": [
                 "canSuitlessMaridia",
                 "canConsecutiveWalljump"
               ],
+              "otherRequires": [],
               "note": [
                 "Using two walls spaced 1 tile apart to climb upward underwater.",
                 "Samus will not be able to move away from the wall while wall jumping and so will be able to continuously gain height with fast jump presses."
@@ -63,20 +65,24 @@
             },
             {
               "name": "canCrossRoomJumpIntoWater",
-              "requires": [ "canSuitlessMaridia" ],
+              "techRequires": [ "canSuitlessMaridia" ],
               "note": "Using the momentum from jumping through a doorway from normal to water physics."
             },
             {
               "name": "canSpaceJumpWaterBounce",
-              "requires": [
-                "canSuitlessMaridia",
+              "techRequires": [
+                "canSuitlessMaridia"
+              ],
+              "otherRequires": [
                 "SpaceJump"
               ],
               "note": "Using Space Jump to bounce along the water line. It can be used to escape the water with a wall jump, or to get onto low platforms just above the water level.",
               "extensionTechs": [
                 {
                   "name": "canSpaceJumpWaterEscape",
-                  "requires": [ "canSpaceJumpWaterBounce" ],
+                  "techRequires": [
+                    "canSpaceJumpWaterBounce"
+                  ],
                   "note": "Using HiJump to escape the waterline during a Space Jump Water Bounce.",
                   "devNote": "Escaping tidal water without HiJump could be added as a more advanced tech."
                 }


### PR DESCRIPTION
This is the first step towards adding items back to tech (i.e. morph to canIBJ); then `h_canArtificialMorphIBJ` can be defined as `{"tech": "canIBJ"}`.