### PR TITLE
Metal Pirate Low Resource Strats

### DIFF
--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -129,7 +129,6 @@
       "link": [1, 2],
       "name": "Dead Pirates",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 200},
         {"obstaclesCleared": ["A"]}
       ]
@@ -138,7 +137,6 @@
       "link": [1, 2],
       "name": "Hitbox Through Pirates",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canHitbox",
         {"heatFrames": 200}
       ]
@@ -177,9 +175,18 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 125}
       ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Pirate Attack Animation Cancel",
+      "requires": [
+        "canHitbox",
+        "canInsaneJump",
+        {"heatFrames": 100}
+      ],
+      "note": "Shoot the Pirate twice to force it to block instead of kicking or shooting towards the door."
     },
     {
       "link": [2, 1],
@@ -294,31 +301,47 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 125}
       ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Pirate Attack Animation Cancel",
+      "requires": [
+        "canHitbox",
+        "canInsaneJump",
+        {"heatFrames": 100}
+      ],
+      "note": "Shoot the Pirate twice to force it to block instead of kicking or shooting towards the door."
     },
     {
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 125}
+      ],
+      "devNote": [
+        "Timed from drop collection.",
+        "FIXME: Samus will be closer to one door than the other.",
+        "Drops will also spawn closer to a door which may or may not be the desired one."
       ]
     },
     {
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 125}
+      ],
+      "devNote": [
+        "Timed from drop collection.",
+        "FIXME: Samus will be closer to one door than the other.",
+        "Drops will also spawn closer to a door which may or may not be the desired one."
       ]
     },
     {
       "link": [3, 3],
       "name": "Charge Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Charge",
         "Plasma",
         {"or": [
@@ -365,15 +388,92 @@
             "canXRayWaitForIFrames",
             {"heatFrames": 250}
           ]}
+        ]},
+        {"or": [
+          {"and": [
+            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
+            {"partialRefill": {"type": "Energy", "limit": 40}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 120}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 120}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"partialRefill": {"type": "Energy", "limit": 120}}
         ]}
       ],
       "clearsObstacles": ["A"]
     },
     {
       "link": [3, 3],
+      "name": "Charge Plasma Double Hit Kill",
+      "requires": [
+        "Charge",
+        "Plasma",
+        "canTrickyJump",
+        {"or": [
+          {"and": [
+            "Wave",
+            "Ice",
+            {"or": [
+              "h_heatProof",
+              {"resourceAvailable": [{"type": "Energy", "count": 50}]}
+            ]},
+            {"heatFrames": 15}
+          ]},
+          {"and": [
+            {"or": [
+              "Ice",
+              "Wave"
+            ]},
+            "canInsaneJump",
+            {"or": [
+              "h_heatProof",
+              {"resourceAvailable": [{"type": "Energy", "count": 65}]}
+            ]},
+            {"heatFrames": 195}
+          ]},
+          {"and": [
+            "canInsaneJump",
+            {"heatFrames": 350}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
+            {"partialRefill": {"type": "Energy", "limit": 40}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 120}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 120}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"partialRefill": {"type": "Energy", "limit": 120}}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "Stand under the Metal Pirate as it does a dive kick and fire the plasma shot so that it stays with the Pirate longer, hitting twice.",
+        "Uncharged shots can finish off a Pirate if Ice or Wave is also equipped."
+      ],
+      "devNote": [
+        "Treats 400 heat frames worth of damage as being healed by drops."
+      ]
+    },
+    {
+      "link": [3, 3],
       "name": "Charge Spazer Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canDodgeWhileShooting",
         "Charge",
         "Spazer",
@@ -392,6 +492,23 @@
             "Wave",
             {"heatFrames": 1750}
           ]}
+        ]},
+        {"or": [
+          {"and": [
+            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
+            {"partialRefill": {"type": "Energy", "limit": 40}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 120}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 120}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"partialRefill": {"type": "Energy", "limit": 120}}
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -400,7 +517,6 @@
       "link": [3, 3],
       "name": "Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canDodgeWhileShooting",
           {"enemyDamage": {
@@ -410,7 +526,24 @@
           }}
         ]},
         "Plasma",
-        {"heatFrames": 2000}
+        {"heatFrames": 2000},
+        {"or": [
+          {"and": [
+            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
+            {"partialRefill": {"type": "Energy", "limit": 40}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 120}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 120}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"partialRefill": {"type": "Energy", "limit": 120}}
+        ]}
       ],
       "clearsObstacles": ["A"]
     },
@@ -421,7 +554,22 @@
         "h_heatProof",
         "canDodgeWhileShooting",
         "Charge",
-        "Wave"
+        "Wave",
+        {"or": [
+          {"and": [
+            {"partialRefill": {"type": "Energy", "limit": 140}},
+            {"partialRefill": {"type": "Super", "limit": 2}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 200}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 200}},
+            {"partialRefill": {"type": "Super", "limit": 2}}
+          ]}
+        ]}
       ],
       "clearsObstacles": ["A"]
     },
@@ -445,6 +593,21 @@
             "Ice",
             "canBePatient"
           ]}
+        ]},
+        {"or": [
+          {"and": [
+            {"partialRefill": {"type": "Energy", "limit": 140}},
+            {"partialRefill": {"type": "Super", "limit": 2}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 200}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 200}},
+            {"partialRefill": {"type": "Super", "limit": 2}}
+          ]}
         ]}
       ],
       "clearsObstacles": ["A"],
@@ -455,7 +618,6 @@
       "link": [3, 3],
       "name": "Super Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canDodgeWhileShooting",
           {"enemyDamage": {
@@ -473,15 +635,29 @@
           ],
           "explicitWeapons": ["Super"]
         }},
-        {"heatFrames": 450}
+        {"heatFrames": 450},
+        {"partialRefill": {"type": "Energy", "limit": 80}}
       ],
       "clearsObstacles": ["A"]
     },
     {
       "link": [3, 3],
+      "name": "Super Kill and Farm",
+      "requires": [
+        "canFarmWhileShooting",
+        {"ammo": {"type": "Super", "count": 5}},
+        {"heatFrames": 250},
+        {"partialRefill": {"type": "Energy", "limit": 119}}
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "If energy would fall into Health Bomb range, immediately collect some health drops so that the second wave of drops (from a single pirate) will be able to spawn Supers."
+      ]
+    },
+    {
+      "link": [3, 3],
       "name": "Missile Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canDodgeWhileShooting",
           {"enemyDamage": {
@@ -499,7 +675,24 @@
           ],
           "explicitWeapons": ["Missile"]
         }},
-        {"heatFrames": 2700}
+        {"heatFrames": 2700},
+        {"or": [
+          {"and": [
+            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
+            {"partialRefill": {"type": "Energy", "limit": 40}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 120}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 120}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"partialRefill": {"type": "Energy", "limit": 120}}
+        ]}
       ],
       "clearsObstacles": ["A"]
     },
@@ -508,15 +701,51 @@
       "name": "Metal Pirates Speed Echoes Kill",
       "notable": true,
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseSpeedEchoes",
         "canHitbox",
-        {"heatFrames": 450},
         {"canShineCharge": {
           "usedTiles": 33,
           "openEnd": 2
         }},
-        {"shinespark": {"frames": 18}}
+        {"or": [
+          {"heatFrames": 350},
+          {"and": [
+            {"heatFrames": 90},
+            "canFarmWhileShooting"
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 1}}
+          ]},
+          {"and": [
+            "canTrickyJump",
+            {"shinespark": {"frames": 18}}
+          ]},
+          {"and": [
+            "canInsaneJump",
+            {"shinespark": {"frames": 18, "excessFrames": 18}}
+          ]}
+        ]},
+        {"heatFrames": 100},
+        {"or": [
+          {"and": [
+            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
+            {"partialRefill": {"type": "Energy", "limit": 40}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"and": [
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "Energy", "limit": 120}}
+          ]},
+          {"and": [
+            "canFarmWhileShooting",
+            {"partialRefill": {"type": "Energy", "limit": 120}},
+            {"partialRefill": {"type": "Super", "limit": 1}}
+          ]},
+          {"partialRefill": {"type": "Energy", "limit": 120}}
+        ]}
       ],
       "clearsObstacles": ["A"],
       "reusableRoomwideNotable": "Metal Pirates Speed Echoes Kill",

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -358,7 +358,12 @@
               "Ice",
               "Wave"
             ]},
-            {"heatFrames": 700}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 700,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 12}
+              ]
+            }}
           ]},
           {"and": [
             {"or": [
@@ -371,7 +376,12 @@
             ]},
             "Ice",
             "Wave",
-            {"heatFrames": 450}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 450,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 12}
+              ]
+            }}
           ]},
           {"and": [
             {"or": [
@@ -382,30 +392,31 @@
                 "hits": 2
               }}
             ]},
-            {"heatFrames": 950}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 950,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 12}
+              ]
+            }}
           ]},
           {"and": [
             "canXRayWaitForIFrames",
-            {"heatFrames": 250}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 210,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 210,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }}
           ]}
         ]},
-        {"or": [
-          {"and": [
-            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
-            {"partialRefill": {"type": "Energy", "limit": 40}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 120}}
-          ]},
-          {"and": [
-            "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 120}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"partialRefill": {"type": "Energy", "limit": 120}}
-        ]}
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"]
     },
@@ -420,11 +431,18 @@
           {"and": [
             "Wave",
             "Ice",
-            {"or": [
-              "h_heatProof",
-              {"resourceAvailable": [{"type": "Energy", "count": 50}]}
-            ]},
-            {"heatFrames": 15}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 200,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 200,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }}
           ]},
           {"and": [
             {"or": [
@@ -432,42 +450,42 @@
               "Wave"
             ]},
             "canInsaneJump",
-            {"or": [
-              "h_heatProof",
-              {"resourceAvailable": [{"type": "Energy", "count": 65}]}
-            ]},
-            {"heatFrames": 195}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 260,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 260,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }}
           ]},
           {"and": [
             "canInsaneJump",
-            {"heatFrames": 350}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 350,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 350,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }}
           ]}
         ]},
-        {"or": [
-          {"and": [
-            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
-            {"partialRefill": {"type": "Energy", "limit": 40}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 120}}
-          ]},
-          {"and": [
-            "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 120}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"partialRefill": {"type": "Energy", "limit": 120}}
-        ]}
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"],
       "note": [
         "Stand under the Metal Pirate as it does a dive kick and fire the plasma shot so that it stays with the Pirate longer, hitting twice.",
         "Uncharged shots can finish off a Pirate if Ice or Wave is also equipped."
-      ],
-      "devNote": [
-        "Treats 400 heat frames worth of damage as being healed by drops."
       ]
     },
     {
@@ -478,38 +496,43 @@
         "Charge",
         "Spazer",
         {"or": [
-          {"heatFrames": 4400},
+          {"heatFramesWithEnergyDrops": {
+            "frames": 4400,
+            "drops": [
+              {"enemy": "Space Pirate (fighting)", "count": 12}
+            ]
+          }},
           {"and": [
             "Ice",
-            {"heatFrames": 3000}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 3000,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 12}
+              ]
+            }}
           ]},
           {"and": [
             "Wave",
-            {"heatFrames": 2650}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 2650,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 12}
+              ]
+            }}
           ]},
           {"and": [
             "Ice",
             "Wave",
-            {"heatFrames": 1750}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 1750,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 12}
+              ]
+            }}
           ]}
         ]},
-        {"or": [
-          {"and": [
-            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
-            {"partialRefill": {"type": "Energy", "limit": 40}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 120}}
-          ]},
-          {"and": [
-            "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 120}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"partialRefill": {"type": "Energy", "limit": 120}}
-        ]}
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"]
     },
@@ -526,24 +549,14 @@
           }}
         ]},
         "Plasma",
-        {"heatFrames": 2000},
-        {"or": [
-          {"and": [
-            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
-            {"partialRefill": {"type": "Energy", "limit": 40}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 120}}
-          ]},
-          {"and": [
-            "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 120}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"partialRefill": {"type": "Energy", "limit": 120}}
-        ]}
+        {"heatFramesWithEnergyDrops": {
+          "frames": 2000,
+          "drops": [
+            {"enemy": "Space Pirate (fighting)", "count": 12}
+          ]
+        }},
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"]
     },
@@ -555,21 +568,8 @@
         "canDodgeWhileShooting",
         "Charge",
         "Wave",
-        {"or": [
-          {"and": [
-            {"partialRefill": {"type": "Energy", "limit": 140}},
-            {"partialRefill": {"type": "Super", "limit": 2}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 200}}
-          ]},
-          {"and": [
-            "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 200}},
-            {"partialRefill": {"type": "Super", "limit": 2}}
-          ]}
-        ]}
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"]
     },
@@ -594,21 +594,8 @@
             "canBePatient"
           ]}
         ]},
-        {"or": [
-          {"and": [
-            {"partialRefill": {"type": "Energy", "limit": 140}},
-            {"partialRefill": {"type": "Super", "limit": 2}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 200}}
-          ]},
-          {"and": [
-            "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 200}},
-            {"partialRefill": {"type": "Super", "limit": 2}}
-          ]}
-        ]}
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"],
       "note": "Uncharged Spazer does half damage.",
@@ -635,8 +622,14 @@
           ],
           "explicitWeapons": ["Super"]
         }},
-        {"heatFrames": 450},
-        {"partialRefill": {"type": "Energy", "limit": 80}}
+        {"heatFramesWithEnergyDrops": {
+          "frames": 450,
+          "drops": [
+            {"enemy": "Space Pirate (fighting)", "count": 12}
+          ]
+        }},
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"]
     },
@@ -645,13 +638,33 @@
       "name": "Super Kill and Farm",
       "requires": [
         "canFarmWhileShooting",
-        {"ammo": {"type": "Super", "count": 5}},
-        {"heatFrames": 250},
+        {"or": [
+          {"and": [
+            {"resourceAvailable": [{"type":"Energy", "count": 73}]},
+            {"ammo": {"type": "Super", "count": 4}}
+          ]},
+          {"ammo": {"type": "Super", "count": 5}}
+        ]},
+        {"heatFramesWithEnergyDrops": {
+          "frames": 225,
+          "drops": [
+            {"enemy": "Space Pirate (fighting)", "count": 6}
+          ]
+        }},
+        {"heatFramesWithEnergyDrops": {
+          "frames": 225,
+          "drops": [
+            {"enemy": "Space Pirate (fighting)", "count": 6}
+          ]
+        }},
         {"partialRefill": {"type": "Energy", "limit": 119}}
       ],
       "clearsObstacles": ["A"],
       "note": [
         "If energy would fall into Health Bomb range, immediately collect some health drops so that the second wave of drops (from a single pirate) will be able to spawn Supers."
+      ],
+      "devNote": [
+        "Collecting Super drops is shown by spending fewer to kill the pirates."
       ]
     },
     {
@@ -675,24 +688,14 @@
           ],
           "explicitWeapons": ["Missile"]
         }},
-        {"heatFrames": 2700},
-        {"or": [
-          {"and": [
-            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
-            {"partialRefill": {"type": "Energy", "limit": 40}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 120}}
-          ]},
-          {"and": [
-            "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 120}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"partialRefill": {"type": "Energy", "limit": 120}}
-        ]}
+        {"heatFramesWithEnergyDrops": {
+          "frames": 2700,
+          "drops": [
+            {"enemy": "Space Pirate (fighting)", "count": 12}
+          ]
+        }},
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"]
     },
@@ -708,13 +711,6 @@
           "openEnd": 2
         }},
         {"or": [
-          {"heatFrames": 350},
-          {"and": [
-            {"heatFrames": 90},
-            "canFarmWhileShooting"
-          ]}
-        ]},
-        {"or": [
           {"and": [
             "HiJump",
             {"shinespark": {"frames": 1}}
@@ -722,36 +718,43 @@
           {"and": [
             "canTrickyJump",
             {"shinespark": {"frames": 18}}
-          ]},
-          {"and": [
-            "canInsaneJump",
-            {"shinespark": {"frames": 18, "excessFrames": 18}}
           ]}
         ]},
-        {"heatFrames": 100},
         {"or": [
-          {"and": [
-            {"resourceAvailable": [{"type": "Energy", "count": 50}]},
-            {"partialRefill": {"type": "Energy", "limit": 40}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"and": [
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "Energy", "limit": 120}}
-          ]},
+          {"heatFramesWithEnergyDrops": {
+            "frames": 450,
+            "drops": [
+              {"enemy": "Space Pirate (fighting)", "count": 12}
+            ]
+          }},
           {"and": [
             "canFarmWhileShooting",
-            {"partialRefill": {"type": "Energy", "limit": 120}},
-            {"partialRefill": {"type": "Super", "limit": 1}}
-          ]},
-          {"partialRefill": {"type": "Energy", "limit": 120}}
-        ]}
+            {"heatFramesWithEnergyDrops": {
+              "frames": 225,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 225,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }}
+          ]}
+        ]},
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"],
       "reusableRoomwideNotable": "Metal Pirates Speed Echoes Kill",
       "note": [
         "Use the Echoes created by shinesparking to defeat the Metal Pirates.",
         "This involves Shineparking into a precise point while also turning the Pirates vulnerable as the echoes reach them."
+      ],
+      "devNote": [
+        "FIXME: It's possible to activate a spark on the ground at 27 energy and collect drops in time.",
+        "The canFarmWhileShooting presumes spawning the drops on the ground where they can be collected while charging the next shinespark."
       ]
     },
     {

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -189,6 +189,74 @@
       "note": "Shoot the Pirate twice to force it to block instead of kicking or shooting towards the door."
     },
     {
+      "link": [1, 3],
+      "name": "Metal Pirates Speed Echoes Kill (Left to Right)",
+      "notable": true,
+      "requires": [
+        {"obstaclesNotCleared": ["A"]},
+        "canUseSpeedEchoes",
+        "canHitbox",
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        {"or": [
+          {"canShineCharge": {
+            "usedTiles": 23,
+            "openEnd": 2
+          }},
+          {"heatFrames": 60}
+        ]},
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 1}},
+            {"shinespark": {"frames": 1}}
+          ]},
+          {"and": [
+            "canTrickyJump",
+            {"shinespark": {"frames": 9}},
+            {"shinespark": {"frames": 9}}
+          ]}
+        ]},
+        {"or": [
+          {"heatFramesWithEnergyDrops": {
+            "frames": 630,
+            "drops": [
+              {"enemy": "Space Pirate (fighting)", "count": 12}
+            ]
+          }},
+          {"and": [
+            "canFarmWhileShooting",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 360,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 270,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }}
+          ]}
+        ]},
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
+      ],
+      "clearsObstacles": ["A"],
+      "reusableRoomwideNotable": "Metal Pirates Speed Echoes Kill",
+      "note": [
+        "Use the Echoes created by shinesparking to defeat the Metal Pirates.",
+        "This involves Shineparking into a precise point while also turning the Pirates vulnerable as the echoes reach them."
+      ],
+      "devNote": [
+        "FIXME: It's possible to activate a spark on the ground at 27 energy and collect drops in time.",
+        "The canFarmWhileShooting presumes spawning the drops on the ground where they can be collected while charging the next shinespark."
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Dead Pirates",
       "requires": [
@@ -313,6 +381,74 @@
         {"heatFrames": 100}
       ],
       "note": "Shoot the Pirate twice to force it to block instead of kicking or shooting towards the door."
+    },
+    {
+      "link": [2, 3],
+      "name": "Metal Pirates Speed Echoes Kill (Right to Left)",
+      "notable": true,
+      "requires": [
+        {"obstaclesNotCleared": ["A"]},
+        "canUseSpeedEchoes",
+        "canHitbox",
+        {"canShineCharge": {
+          "usedTiles": 33,
+          "openEnd": 2
+        }},
+        {"or": [
+          {"canShineCharge": {
+            "usedTiles": 23,
+            "openEnd": 2
+          }},
+          {"heatFrames": 60}
+        ]},
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 1}},
+            {"shinespark": {"frames": 1}}
+          ]},
+          {"and": [
+            "canTrickyJump",
+            {"shinespark": {"frames": 9}},
+            {"shinespark": {"frames": 9}}
+          ]}
+        ]},
+        {"or": [
+          {"heatFramesWithEnergyDrops": {
+            "frames": 630,
+            "drops": [
+              {"enemy": "Space Pirate (fighting)", "count": 12}
+            ]
+          }},
+          {"and": [
+            "canFarmWhileShooting",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 360,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 270,
+              "drops": [
+                {"enemy": "Space Pirate (fighting)", "count": 6}
+              ]
+            }}
+          ]}
+        ]},
+        {"partialRefill": {"type": "Energy", "limit": 99}},
+        {"partialRefill": {"type": "Super", "limit": 1}}
+      ],
+      "clearsObstacles": ["A"],
+      "reusableRoomwideNotable": "Metal Pirates Speed Echoes Kill",
+      "note": [
+        "Use the Echoes created by shinesparking to defeat the Metal Pirates.",
+        "This involves Shineparking into a precise point while also turning the Pirates vulnerable as the echoes reach them."
+      ],
+      "devNote": [
+        "FIXME: It's possible to activate a spark on the ground at 27 energy and collect drops in time.",
+        "The canFarmWhileShooting presumes spawning the drops on the ground where they can be collected while charging the next shinespark."
+      ]
     },
     {
       "link": [3, 1],
@@ -698,64 +834,6 @@
         {"partialRefill": {"type": "Super", "limit": 1}}
       ],
       "clearsObstacles": ["A"]
-    },
-    {
-      "link": [3, 3],
-      "name": "Metal Pirates Speed Echoes Kill",
-      "notable": true,
-      "requires": [
-        "canUseSpeedEchoes",
-        "canHitbox",
-        {"canShineCharge": {
-          "usedTiles": 33,
-          "openEnd": 2
-        }},
-        {"or": [
-          {"and": [
-            "HiJump",
-            {"shinespark": {"frames": 1}}
-          ]},
-          {"and": [
-            "canTrickyJump",
-            {"shinespark": {"frames": 18}}
-          ]}
-        ]},
-        {"or": [
-          {"heatFramesWithEnergyDrops": {
-            "frames": 450,
-            "drops": [
-              {"enemy": "Space Pirate (fighting)", "count": 12}
-            ]
-          }},
-          {"and": [
-            "canFarmWhileShooting",
-            {"heatFramesWithEnergyDrops": {
-              "frames": 225,
-              "drops": [
-                {"enemy": "Space Pirate (fighting)", "count": 6}
-              ]
-            }},
-            {"heatFramesWithEnergyDrops": {
-              "frames": 225,
-              "drops": [
-                {"enemy": "Space Pirate (fighting)", "count": 6}
-              ]
-            }}
-          ]}
-        ]},
-        {"partialRefill": {"type": "Energy", "limit": 99}},
-        {"partialRefill": {"type": "Super", "limit": 1}}
-      ],
-      "clearsObstacles": ["A"],
-      "reusableRoomwideNotable": "Metal Pirates Speed Echoes Kill",
-      "note": [
-        "Use the Echoes created by shinesparking to defeat the Metal Pirates.",
-        "This involves Shineparking into a precise point while also turning the Pirates vulnerable as the echoes reach them."
-      ],
-      "devNote": [
-        "FIXME: It's possible to activate a spark on the ground at 27 energy and collect drops in time.",
-        "The canFarmWhileShooting presumes spawning the drops on the ground where they can be collected while charging the next shinespark."
-      ]
     },
     {
       "link": [3, 3],

--- a/tech.json
+++ b/tech.json
@@ -1188,7 +1188,8 @@
                   "otherRequires": [],
                   "note": [
                     "The ability to actively kill enemies to spawn drops and collect them while racing a timer.",
-                    "There is a low chance that the required drop(s) will not spawn."
+                    "There is a low chance that the required drop(s) will not spawn.",
+                    "This does not apply to easy farm bugs, like Gamets."
                   ]
                 }
               ]

--- a/tech.json
+++ b/tech.json
@@ -1180,7 +1180,18 @@
               "name": "canDodgeWhileShooting",
               "techRequires": [],
               "otherRequires": [],
-              "note": "The ability to run from, jump over, or duck under attacks that do not require precise avoidance movements while shooting the enemy."
+              "note": "The ability to run from, jump over, or duck under attacks that do not require precise avoidance movements while shooting the enemy.",
+              "extensionTechs": [
+                {
+                  "name": "canFarmWhileShooting",
+                  "techRequires": ["canDodgeWhileShooting"],
+                  "otherRequires": [],
+                  "note": [
+                    "The ability to actively kill enemies to spawn drops and collect them while racing a timer.",
+                    "There is a low chance that the required drop(s) will not spawn."
+                  ]
+                }
+              ]
             },
             {
               "name": "canEscapeEnemyGrab",

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -71,6 +71,7 @@ def process_keyvalue(k, v, metadata):
         "physics",          # validated by schema
         "utility",          # validated by schema
         "resourceCapacity", # validated by schema
+        "resourceAvailable",# validated by schema
         "refill",           # validated by schema
         "partialRefill",    # validated by schema
         "comeInWithSpark",  # validated by schema


### PR DESCRIPTION
`canFarmWhileShooting` was intended more for other rooms where you shoot things that aren't on screen yet.  

The instances where you can heal all of the heat damage taken was split in two to allow for lower available energy.