### PR TITLE
Add Items to Tech Pt.1 - Artificial Morph

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -435,10 +435,7 @@
         },
         {
           "name": "h_canIBJ",
-          "requires": [
-            "canIBJ",
-            "h_canUseMorphBombs"
-          ]
+          "requires": [ "canIBJ" ]
         },
         {
           "name": "h_canFly",
@@ -598,63 +595,35 @@
         },
         {
           "name": "h_canJumpIntoIBJ",
-          "requires": [
-            "canJumpIntoIBJ",
-            {"or": [
-              "SpringBall",
-              "canMidAirMorph"
-            ]},
-            "h_canUseMorphBombs"
-          ]
+          "requires": ["canJumpIntoIBJ"]
         },
         {
           "name": "h_canBombAboveIBJ",
-          "requires": [
-            "canBombAboveIBJ",
-            "h_canUseMorphBombs"
-          ]
+          "requires": ["canBombAboveIBJ"]
         },
         {
           "name": "h_canCeilingBombJump",
-          "requires": [
-            "canCeilingBombJump",
-            "h_canUseMorphBombs"
-          ]
+          "requires": ["canCeilingBombJump"]
         },
         {
           "name": "h_canDiagonalBombJump",
-          "requires": [
-            "canDiagonalBombJump",
-            "h_canUseMorphBombs"
-          ]
+          "requires": ["canDiagonalBombJump"]
         },
         {
           "name": "h_canDoubleBombJump",
-          "requires": [
-            "canDoubleBombJump",
-            "h_canUseMorphBombs"
-          ]
+          "requires": ["canDoubleBombJump"]
         },
         {
           "name": "h_canStaggeredIBJ",
-          "requires": [
-            "canStaggeredIBJ",
-            "h_canUseMorphBombs"
-          ]
+          "requires": ["canStaggeredIBJ"]
         },
         {
           "name": "h_canBombHorizontally",
-          "requires": [
-            "canBombHorizontally",
-            "h_canBombThings"
-          ]
+          "requires": ["canBombHorizontally"]
         },
         {
           "name": "h_canHBJ",
-          "requires": [
-            "canHBJ",
-            "h_canUseMorphBombs"
-          ]
+          "requires": ["canHBJ"]
         },
         {
           "name": "h_canResetFallSpeed",
@@ -665,17 +634,11 @@
         },
         {
           "name": "h_canSpringFling",
-          "requires": [
-            "canSpringFling",
-            "Morph"
-          ]
+          "requires": ["canSpringFling"]
         },
         {
           "name": "h_canSpringBallBombJump",
-          "requires": [
-            "h_canBombThings",
-            "canSpringBallBombJump"
-          ]
+          "requires": ["canSpringBallBombJump"]
         },
         {
           "name": "h_canDoubleSpringBallJumpWithHiJump",
@@ -685,20 +648,9 @@
           ]
         },
         {
-          "name": "h_CrystalFlashRequirements",
-          "requires": [
-            "canCrystalFlash",
-            "Morph",
-            {"ammo": {"type": "PowerBomb", "count": 1}},
-            {"ammo": {"type": "Missile", "count": 10}},
-            {"ammo": {"type": "Super", "count": 10}},
-            {"ammo": {"type": "PowerBomb", "count": 10}}
-          ]
-        },
-        {
           "name": "h_canCrystalFlash",
           "requires": [
-            "h_CrystalFlashRequirements",
+            "canCrystalFlash",
             {"partialRefill": {"type": "Energy", "limit": 1500}}
           ]
         },
@@ -706,7 +658,7 @@
           "name": "h_canAcidCrystalFlash",
           "requires": [
             {"acidFrames": 185},
-            "h_CrystalFlashRequirements",
+            "canCrystalFlash",
             "h_AcidCrystalFlashRefill",
             {"acidFrames": 20},
             {"or": [
@@ -722,7 +674,7 @@
           "name": "h_canHeatedCrystalFlash",
           "requires": [
             {"heatFrames": 185},
-            "h_CrystalFlashRequirements",
+            "canCrystalFlash",
             "h_HeatedCrystalFlashRefill",
             {"heatFrames": 20}
           ],
@@ -735,7 +687,7 @@
           "requires": [
             {"heatFrames": 185},
             {"lavaFrames": 185},
-            "h_CrystalFlashRequirements",
+            "canCrystalFlash",
             "h_HeatedLavaCrystalFlashRefill",
             {"heatFrames": 20},
             {"lavaFrames": 20},
@@ -756,7 +708,7 @@
           "requires": [
             {"heatFrames": 185},
             {"acidFrames": 185},
-            "h_CrystalFlashRequirements",
+            "canCrystalFlash",
             "h_HeatedAcidCrystalFlashRefill",
             {"heatFrames": 20},
             {"acidFrames": 20},
@@ -775,7 +727,8 @@
         {
           "name": "h_canBombIntoCrystalFlashClip",
           "requires": [
-            "canBombIntoCrystalFlashClip",
+            {"tech": "canBombIntoCrystalFlashClip"},
+            "Bombs",
             "h_canCrystalFlash",
             "h_BombIntoCrystalFlashClipLeniency"
           ]
@@ -783,7 +736,7 @@
         {
           "name": "h_canJumpIntoCrystalFlashClip",
           "requires": [
-            "canJumpIntoCrystalFlashClip",
+            {"tech": "canJumpIntoCrystalFlashClip"},
             {"or": [
               "SpringBall",
               "canMidAirMorph"
@@ -796,10 +749,6 @@
           "name": "h_can10PowerBombCrystalFlash",
           "requires": [
             "can10PowerBombCrystalFlash",
-            "Morph",
-            {"ammo": {"type": "Missile", "count": 10}},
-            {"ammo": {"type": "Super", "count": 10}},
-            {"ammo": {"type": "PowerBomb", "count": 10}},
             {"refill": ["Energy"]}
           ]
         },
@@ -862,7 +811,7 @@
           "requires": [
             "canTrickySpringBallJump",
             "canSpringwall",
-            "canSpringFling",
+            "h_canSpringFling",
             "canTrickyJump"
           ]
         },
@@ -1014,6 +963,13 @@
           ]
         },
         {
+          "name": "h_canArtificialMorphLongCeilingBombJump",
+          "requires": [
+            {"tech": "canLongCeilingBombJump"},
+            "Bombs"
+          ]
+        },
+        {
           "name": "h_canArtificialMorphDiagonalBombJump",
           "requires": [
             {"tech": "canDiagonalBombJump"},
@@ -1063,6 +1019,7 @@
           "name": "h_canArtificialMorphSpringBallBombJump",
           "requires": [
             {"tech": "canSpringBallBombJump"},
+            "SpringBall",
             {"or": [
               "Bombs",
               {"ammo": {"type": "PowerBomb", "count": 1}}
@@ -1077,13 +1034,16 @@
             {"ammo": {"type": "Missile", "count": 10}},
             {"ammo": {"type": "Super", "count": 10}},
             {"ammo": {"type": "PowerBomb", "count": 10}},
-            {"refill": ["Energy"]}
-          ]
+            {"refill": ["Energy"]},
+            {"noFlashSuit": {}}
+          ],
+          "devNote": "FIXME: Samus may not get a full refill, depending on the tanks and environment."
         },
         {
           "name": "h_canArtificialMorphBombIntoCrystalFlashClip",
           "requires": [
             {"tech": "canBombIntoCrystalFlashClip"},
+            "Bombs",
             "h_canArtificialMorphCrystalFlash",
             "h_BombIntoCrystalFlashClipLeniency"
           ]

--- a/helpers.json
+++ b/helpers.json
@@ -1009,11 +1009,11 @@
         },
         {
           "name": "h_canArtificialMorphResetFallSpeed",
-          "requires": [ {"tech": "canResetFallSpeed"} ]
+          "requires": [{"tech": "canResetFallSpeed"}]
         },
         {
           "name": "h_canArtificialMorphSpringFling",
-          "requires": [ {"tech": "canSpringFling"} ]
+          "requires": [{"tech": "canSpringFling"}]
         },
         {
           "name": "h_canArtificialMorphSpringBallBombJump",

--- a/helpers.json
+++ b/helpers.json
@@ -627,10 +627,7 @@
         },
         {
           "name": "h_canResetFallSpeed",
-          "requires": [
-            "canResetFallSpeed",
-            "Morph"
-          ]
+          "requires": ["canResetFallSpeed"]
         },
         {
           "name": "h_canSpringFling",

--- a/helpers.json
+++ b/helpers.json
@@ -987,14 +987,14 @@
         {
           "name": "h_canArtificialMorphIBJ",
           "requires": [
-            "canIBJ",
+            {"tech": "canIBJ"},
             "Bombs"
           ]
         },
         {
           "name": "h_canArtificialMorphJumpIntoIBJ",
           "requires": [
-            "canJumpIntoIBJ",
+            {"tech": "canJumpIntoIBJ"},
             "Bombs",
             "SpringBall"
           ]
@@ -1002,42 +1002,42 @@
         {
           "name": "h_canArtificialMorphBombAboveIBJ",
           "requires": [
-            "canBombAboveIBJ",
+            {"tech": "canBombAboveIBJ"},
             "Bombs"
           ]
         },
         {
           "name": "h_canArtificialMorphCeilingBombJump",
           "requires": [
-            "canCeilingBombJump",
+            {"tech": "canCeilingBombJump"},
             "Bombs"
           ]
         },
         {
           "name": "h_canArtificialMorphDiagonalBombJump",
           "requires": [
-            "canDiagonalBombJump",
+            {"tech": "canDiagonalBombJump"},
             "Bombs"
           ]
         },
         {
           "name": "h_canArtificialMorphDoubleBombJump",
           "requires": [
-            "canDoubleBombJump",
+            {"tech": "canDoubleBombJump"},
             "Bombs"
           ]
         },
         {
           "name": "h_canArtificialMorphStaggeredIBJ",
           "requires": [
-            "canStaggeredIBJ",
+            {"tech": "canStaggeredIBJ"},
             "Bombs"
           ]
         },
         {
           "name": "h_canArtificialMorphBombHorizontally",
           "requires": [
-            "canBombHorizontally",
+            {"tech": "canBombHorizontally"},
             {"or": [
               "Bombs",
               {"ammo": {"type": "PowerBomb", "count": 1}}
@@ -1047,22 +1047,22 @@
         {
           "name": "h_canArtificialMorphHBJ",
           "requires": [
-            "canHBJ",
+            {"tech": "canHBJ"},
             "Bombs"
           ]
         },
         {
           "name": "h_canArtificialMorphResetFallSpeed",
-          "requires": [ "canResetFallSpeed" ]
+          "requires": [ {"tech": "canResetFallSpeed"} ]
         },
         {
           "name": "h_canArtificialMorphSpringFling",
-          "requires": [ "canSpringFling" ]
+          "requires": [ {"tech": "canSpringFling"} ]
         },
         {
           "name": "h_canArtificialMorphSpringBallBombJump",
           "requires": [
-            "canSpringBallBombJump",
+            {"tech": "canSpringBallBombJump"},
             {"or": [
               "Bombs",
               {"ammo": {"type": "PowerBomb", "count": 1}}
@@ -1072,7 +1072,7 @@
         {
           "name": "h_canArtificialMorphCrystalFlash",
           "requires": [
-            "canCrystalFlash",
+            {"tech": "canCrystalFlash"},
             {"ammo": {"type": "PowerBomb", "count": 1}},
             {"ammo": {"type": "Missile", "count": 10}},
             {"ammo": {"type": "Super", "count": 10}},
@@ -1083,7 +1083,7 @@
         {
           "name": "h_canArtificialMorphBombIntoCrystalFlashClip",
           "requires": [
-            "canBombIntoCrystalFlashClip",
+            {"tech": "canBombIntoCrystalFlashClip"},
             "h_canArtificialMorphCrystalFlash",
             "h_BombIntoCrystalFlashClipLeniency"
           ]

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -218,8 +218,7 @@
           "h_canCrouchJumpDownGrab",
           "canWalljump"
         ]},
-        "canSpringBallBombJump",
-        "h_canBombThings"
+        "h_canSpringBallBombJump"
       ],
       "unlocksDoors": [
         {"nodeId": 2, "types": ["ammo"], "requires": []}

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -369,7 +369,7 @@
       "requires": [
         "canCrouchJump",
         "canMidAirMorph",
-        "canJumpIntoIBJ",
+        {"tech": "canJumpIntoIBJ"},
         "canUnmorphBombBoost"
       ],
       "note": [

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -220,7 +220,7 @@
         "canTrickyJump",
         "canChainTemporaryBlue",
         "canSpringBallBounce",
-        "canSpringFling"
+        "h_canSpringFling"
       ],
       "note": [
         "Gain temporary blue at the end of the runway.",

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -3485,7 +3485,7 @@
           ]},
           {"and": [
             "h_canArtificialMorphSpringBall",
-            "canSpringBallBombJump",
+            {"tech": "canSpringBallBombJump"},
             {"ammo": {"type": "PowerBomb", "count": 6}}
           ]}
         ]}

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -1137,7 +1137,7 @@
         "canTrickyJump",
         "canLateralMidAirMorph",
         "canTrickySpringBallJump",
-        "canSpringFling"
+        "h_canSpringFling"
       ],
       "note": [
         "X-Ray climb until Samus is a little over halfway off screen; the position is not precise.",

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -340,7 +340,7 @@
           "canWalljump",
           "canSpringBallJumpMidAir",
           "h_canFly",
-          "canSpringBallBombJump"
+          "h_canSpringBallBombJump"
         ]}
       ]
     },

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -837,7 +837,7 @@
       "notable": true,
       "requires": [
         "canTrickySpringBallJump",
-        "canSpringFling"
+        "h_canSpringFling"
       ],
       "note": [
         "Jump from the safe spot on the spikey stairs and use the momentum change from equipping SpringBall to move closer to the door's platform.",

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -700,7 +700,7 @@
         "h_canIBJ",
         {"spikeHits": 1},
         {"or": [
-          "canBombHorizontally",
+          "h_canBombHorizontally",
           {"spikeHits": 1}
         ]}
       ]

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -312,7 +312,6 @@
       "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
       "notable": true,
       "requires": [
-        "h_canCeilingBombJump",
         "canLongCeilingBombJump",
         "canBeVeryPatient"
       ],
@@ -333,8 +332,7 @@
         }
       },
       "requires": [
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "canBeVeryPatient",
         "canInsaneJump"
       ],
@@ -567,7 +565,6 @@
       "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
       "notable": true,
       "requires": [
-        "h_canCeilingBombJump",
         "canLongCeilingBombJump",
         "canBeVeryPatient"
       ],
@@ -587,8 +584,7 @@
       "requires": [
         "h_canArtificialMorphBombHorizontally",
         "h_canArtificialMorphIBJ",
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "canBeVeryPatient",
         "canInsaneJump"
       ],

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -2318,7 +2318,7 @@
       "requires": [
         "h_canJumpIntoIBJ",
         {"or": [
-          "canBombAboveIBJ",
+          "h_canBombAboveIBJ",
           {"ammo": {"type": "PowerBomb", "count": 1}}
         ]},
         {"obstaclesCleared": ["B"]}
@@ -2362,8 +2362,8 @@
           {"and": [
             "h_canJumpIntoIBJ",
             {"or": [
-              "canStaggeredIBJ",
-              "canDoubleBombJump"
+              "h_canStaggeredIBJ",
+              "h_canDoubleBombJump"
             ]}
           ]}
         ]}

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -211,8 +211,7 @@
         }
       },
       "requires": [
-        "canLongCeilingBombJump",
-        "h_canArtificialMorphCeilingBombJump"
+        "h_canArtificialMorphLongCeilingBombJump"
       ],
       "clearsObstacles": ["C"]
     },
@@ -227,10 +226,7 @@
       },
       "requires": [
         {"or": [
-          {"and": [
-            "canLongCeilingBombJump",
-            "h_canArtificialMorphCeilingBombJump"
-          ]},
+          "h_canArtificialMorphLongCeilingBombJump",
           {"and": [
             "h_canArtificialMorphSpringBall",
             {"spikeHits": 3},
@@ -310,8 +306,7 @@
       "link": [1, 4],
       "name": "Ceiling Bomb Jump Over Spikes",
       "requires": [
-        "canLongCeilingBombJump",
-        "h_canCeilingBombJump"
+        "canLongCeilingBombJump"
       ]
     },
     {
@@ -355,10 +350,7 @@
               {"spikeHits": 2}
             ]}
           ]},
-          {"and": [
-            "canLongCeilingBombJump",
-            "h_canArtificialMorphCeilingBombJump"
-          ]}
+          "h_canArtificialMorphLongCeilingBombJump"
         ]}
       ],
       "devNote": "The IBJ from spikes has 2 extra spike hits added as a leniency."
@@ -1035,7 +1027,6 @@
       "name": "Jump into Ceiling Bomb Jump Over Spikes",
       "requires": [
         "canLongCeilingBombJump",
-        "h_canCeilingBombJump",
         "canPreciseWalljump",
         "canWallJumpInstantMorph",
         "h_canJumpIntoIBJ"

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -1038,7 +1038,7 @@
         "h_canCeilingBombJump",
         "canPreciseWalljump",
         "canWallJumpInstantMorph",
-        "canJumpIntoIBJ"
+        "h_canJumpIntoIBJ"
       ]
     },
     {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -210,7 +210,7 @@
         "canTrickyJump",
         "canSpaceJumpWaterBounce",
         "canSpringBallBounce",
-        "canSpringFling",
+        "h_canSpringFling",
         "canMockball",
         {"or": [
           "canDownGrab",
@@ -781,7 +781,7 @@
         "canSpringBallJumpMidAir",
         {"or": [
           "canTrickySpringBallJump",
-          "canResetFallSpeed",
+          "h_canResetFallSpeed",
           "canStationaryLateralMidAirMorph"
         ]},
         "canSpaceJumpWaterBounce",

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1128,7 +1128,7 @@
           "h_canJumpIntoIBJ",
           {"and": [
             "h_canIBJ",
-            "canBombHorizontally",
+            "h_canBombHorizontally",
             "canResetFallSpeed"
           ]}
         ]}

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1129,7 +1129,7 @@
           {"and": [
             "h_canIBJ",
             "h_canBombHorizontally",
-            "canResetFallSpeed"
+            "h_canResetFallSpeed"
           ]}
         ]}
       ],

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -659,7 +659,7 @@
             {"or": [
               "HiJump",
               "h_canArtificialMorphSpringBallBombJump",
-              "canJumpIntoIBJ"
+              {"tech": "canJumpIntoIBJ"}
             ]}
           ]}
         ]}
@@ -981,7 +981,7 @@
             {"or": [
               "HiJump",
               "h_canArtificialMorphSpringBallBombJump",
-              "canJumpIntoIBJ"
+              {"tech": "canJumpIntoIBJ"}
             ]}
           ]}
         ]}

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -412,7 +412,7 @@
         ]},
         {"heatFrames": 140},
         {"or": [
-          "canResetFallSpeed",
+          "h_canResetFallSpeed",
           "canPreciseWalljump",
           {"and": [
             {"heatFrames": 60},

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -443,7 +443,7 @@
         "h_canUseMorphBombs",
         {"or": [
           {"and": [
-            "canBombHorizontally",
+            "h_canBombHorizontally",
             {"or": [
               "Ice",
               "canCarefulJump"

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -979,7 +979,7 @@
         "canCarefulJump",
         {"or": [
           "canTrickyJump",
-          "canResetFallSpeed"
+          "h_canResetFallSpeed"
         ]}
       ]
     },

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -967,12 +967,12 @@
         "h_canIBJ",
         {"or": [
           {"and": [
-            "canBombHorizontally",
+            "h_canBombHorizontally",
             {"heatFrames": 840}
           ]},
           {"and": [
             "h_canJumpIntoIBJ",
-            "canDoubleBombJump",
+            "h_canDoubleBombJump",
             {"heatFrames": 290}
           ]},
           {"and": [
@@ -1008,7 +1008,7 @@
         {"heatFrames": 50},
         {"or": [
           {"and": [
-            "canDoubleBombJump",
+            "h_canDoubleBombJump",
             {"heatFrames": 500}
           ]},
           {"heatFrames": 860}
@@ -1150,12 +1150,12 @@
         "h_canIBJ",
         {"or": [
           {"and": [
-            "canBombHorizontally",
+            "h_canBombHorizontally",
             {"heatFrames": 820}
           ]},
           {"and": [
             "h_canJumpIntoIBJ",
-            "canDoubleBombJump",
+            "h_canDoubleBombJump",
             {"heatFrames": 270}
           ]},
           {"and": [
@@ -1188,7 +1188,7 @@
         {"heatFrames": 50},
         {"or": [
           {"and": [
-            "canDoubleBombJump",
+            "h_canDoubleBombJump",
             {"heatFrames": 480}
           ]},
           {"heatFrames": 840}

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -712,7 +712,7 @@
         {"obstaclesCleared": ["A"]},
         "canCrumbleJump",
         "h_canJumpIntoIBJ",
-        "canDoubleBombJump",
+        "h_canDoubleBombJump",
         {"heatFrames": 360}
       ],
       "note": [
@@ -729,8 +729,8 @@
         "h_canUseSpringBall",
         {"or": [
           "canTrickyJump",
-          "canDoubleBombJump",
-          "canBombAboveIBJ",
+          "h_canDoubleBombJump",
+          "h_canBombAboveIBJ",
           {"ammo": {"type": "PowerBomb", "count": 1}}
         ]},
         {"heatFrames": 500}

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -668,7 +668,7 @@
         {"or": [
           {"and": [
             "can4HighMidAirMorph",
-            "canSpringFling"
+            "h_canSpringFling"
           ]},
           {"and": [
             "canLateralMidAirMorph",

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -231,7 +231,7 @@
         {"or": [
           {"and": [
             "canCarefulJump",
-            "canResetFallSpeed",
+            "h_canResetFallSpeed",
             {"heatFrames": 660}
           ]},
           {"and": [
@@ -358,7 +358,7 @@
         "h_canUseMorphBombs",
         "canWallJumpInstantMorph",
         "canInsaneJump",
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "canUnmorphBombBoost",
         "canSuitlessLavaDive",
         {"heatFrames": 1320},
@@ -390,7 +390,7 @@
       "requires": [
         "h_canUseMorphBombs",
         "Gravity",
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "h_canJumpIntoIBJ",
         "canSuitlessLavaDive",
         {"enemyDamage": {
@@ -685,7 +685,7 @@
       "requires": [
         "canWallJumpInstantMorph",
         "canInsaneJump",
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "canUnmorphBombBoost",
         "h_canHBJ",
         "canSuitlessLavaDive",
@@ -718,7 +718,7 @@
       "requires": [
         "h_canUseMorphBombs",
         "Gravity",
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "h_canJumpIntoIBJ",
         "canSuitlessLavaDive",
         {"enemyDamage": {

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -391,7 +391,7 @@
         "h_canUseMorphBombs",
         "Gravity",
         "canResetFallSpeed",
-        "canJumpIntoIBJ",
+        "h_canJumpIntoIBJ",
         "canSuitlessLavaDive",
         {"enemyDamage": {
           "enemy": "Puromi",
@@ -683,12 +683,11 @@
         }
       },
       "requires": [
-        "h_canUseMorphBombs",
         "canWallJumpInstantMorph",
         "canInsaneJump",
         "canResetFallSpeed",
         "canUnmorphBombBoost",
-        "canHBJ",
+        "h_canHBJ",
         "canSuitlessLavaDive",
         {"heatFrames": 1320},
         {"acidFrames": 128}
@@ -720,7 +719,7 @@
         "h_canUseMorphBombs",
         "Gravity",
         "canResetFallSpeed",
-        "canJumpIntoIBJ",
+        "h_canJumpIntoIBJ",
         "canSuitlessLavaDive",
         {"enemyDamage": {
           "enemy": "Puromi",

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -454,7 +454,7 @@
         "canTrickyUseFrozenEnemies",
         "Charge",
         "canPreciseWalljump",
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "canWalljumpWithCharge",
         "h_canUseMorphBombs",
         "canWallJumpInstantMorph",

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -1125,16 +1125,16 @@
         "h_canIBJ",
         {"or": [
           {"and": [
-            "canJumpIntoIBJ",
+            "h_canJumpIntoIBJ",
             {"heatFrames": 1460}
           ]},
           {"and": [
-            "canDoubleBombJump",
+            "h_canDoubleBombJump",
             {"heatFrames": 1000}
           ]},
           {"and": [
-            "canJumpIntoIBJ",
-            "canDoubleBombJump",
+            "h_canJumpIntoIBJ",
+            "h_canDoubleBombJump",
             {"heatFrames": 800}
           ]},
           {"heatFrames": 2000}
@@ -1143,7 +1143,7 @@
           "h_canUsePowerBombs",
           {"and": [
             "h_canBombAboveIBJ",
-            "canStaggeredIBJ",
+            "h_canStaggeredIBJ",
             {"heatFrames": 180}
           ]},
           {"and": [

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -720,8 +720,7 @@
       "name": "Kzan Double Kago",
       "requires": [
         "canKago",
-        "Morph",
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         {"enemyDamage": {
           "enemy": "Kzan",
           "type": "contact",

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -209,7 +209,7 @@
       "link": [1, 3],
       "name": "SpringFling over the acid",
       "requires": [
-        "canSpringFling",
+        "h_canSpringFling",
         "canDisableEquipment",
         "SpeedBooster",
         "canTrickyJump",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -994,7 +994,7 @@
         "HiJump",
         "canTrickySpringBallJump",
         "canStationaryLateralMidAirMorph",
-        "canSpringFling",
+        "h_canSpringFling",
         "canPlayInSand",
         {"or": [
           {"enemyDamage": {

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -665,7 +665,7 @@
       "requires": [
         "HiJump",
         "h_canMaxHeightSpringBallJump",
-        "canSpringFling",
+        "h_canSpringFling",
         "canBombJumpWaterEscape",
         "h_canJumpIntoIBJ",
         "h_canDoubleBombJump"

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -667,8 +667,8 @@
         "h_canMaxHeightSpringBallJump",
         "canSpringFling",
         "canBombJumpWaterEscape",
-        "canDoubleBombJump",
-        "h_canJumpIntoIBJ"
+        "h_canJumpIntoIBJ",
+        "h_canDoubleBombJump"
       ],
       "note": [
         "Wait the water tide to reach its peak, then crouch jump into a spring ball jump into an IBJ.",

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -347,7 +347,7 @@
         "canPlayInSand",
         "canLateralMidAirMorph",
         "canTrickySpringBallJump",
-        "canSpringFling"
+        "h_canSpringFling"
       ],
       "note": [
         "Enter with at least 1 tile of run speed from an air room, with Speedbooster unequipped.",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1910,7 +1910,7 @@
         "canSuitlessMaridia",
         "canStationaryLateralMidAirMorph",
         "canTrickySpringBallJump",
-        "canResetFallSpeed"
+        "h_canResetFallSpeed"
       ]
     },
     {

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1047,7 +1047,7 @@
         ]},
         "h_canMaxHeightSpringBallJump",
         {"or": [
-          "canSpringFling",
+          "h_canSpringFling",
           "canInsaneJump"
         ]},
         "canBombJumpWaterEscape",

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -460,7 +460,7 @@
           "HiJump",
           {"and": [
             "h_canMaxHeightSpringBallJump",
-            "canSpringFling"
+            "h_canSpringFling"
           ]}
         ]}
       ],
@@ -916,7 +916,7 @@
       "requires": [
         "HiJump",
         "h_canMaxHeightSpringBallJump",
-        "canSpringFling",
+        "h_canSpringFling",
         "canBombJumpWaterEscape",
         "h_canJumpIntoIBJ"
       ],

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -496,7 +496,7 @@
         {"or": [
           "canStationaryLateralMidAirMorph",
           {"and": [
-            "canJumpIntoIBJ",
+            {"tech": "canJumpIntoIBJ"},
             "h_canBombHorizontally"
           ]}
         ]}

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -306,7 +306,7 @@
         "canPlayInSand",
         "canShinechargeMovementTricky",
         {"or": [
-          "canResetFallSpeed",
+          "h_canResetFallSpeed",
           {"and": [
             "canPrepareForNextRoom",
             "h_canUsePowerBombs"

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -523,13 +523,10 @@
         "h_canUseSpringBall",
         {"or": [
           {"and": [
-            "canJumpIntoIBJ",
+            {"tech": "canJumpIntoIBJ"},
             "h_canBombThings"
           ]},
-          {"and": [
-            "canSpringBallBombJump",
-            "h_canBombThings"
-          ]},
+          "h_canSpringBallBombJump",
           "HiJump"
         ]}
       ],

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -290,7 +290,7 @@
             "h_canUsePowerBombs",
             {"or": [
               "h_canUsePowerBombs",
-              "canStaggeredIBJ"
+              "h_canStaggeredIBJ"
             ]}
           ]}
         ]}
@@ -583,7 +583,7 @@
             "h_canUsePowerBombs",
             {"or": [
               "h_canUsePowerBombs",
-              "canStaggeredIBJ"
+              "h_canStaggeredIBJ"
             ]}
           ]}
         ]}

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -1003,7 +1003,7 @@
       "requires": [
         "canInsaneJump",
         "h_canSpringFling",
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "canDownBack"
       ],
       "note": [

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -237,7 +237,7 @@
           {"and": [
             "h_canIBJ",
             {"or": [
-              "canBombHorizontally",
+              "h_canBombHorizontally",
               "Gravity"
             ]}
           ]},

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -731,7 +731,7 @@
         "canTrickySpringBallJump",
         {"or": [
           "canStationaryLateralMidAirMorph",
-          "canSpringFling"
+          "h_canSpringFling"
         ]},
         {"or": [
           "canTrickyJump",

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -707,8 +707,8 @@
             "h_canArtificialMorphSpringBall",
             "canGravityJump"
           ]},
-          "canDoubleBombJump",
-          "canStaggeredIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
           "canBeVeryPatient",
           "h_canArtificialMorphPowerBomb"
         ]},
@@ -781,8 +781,8 @@
         "Wave",
         {"or": [
           "h_canArtificialMorphJumpIntoIBJ",
-          "canDoubleBombJump",
-          "canStaggeredIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
           "canBeVeryPatient",
           "h_canArtificialMorphPowerBomb"
         ]},
@@ -974,7 +974,7 @@
         "comeInWithBombBoost": {}
       },
       "requires": [
-        "canSpringBallBombJump",
+        {"tech": "canSpringBallBombJump"},
         "canCrossRoomJumpIntoWater",
         {"or": [
           "Gravity",
@@ -1212,8 +1212,8 @@
             "h_canArtificialMorphSpringBall",
             "canGravityJump"
           ]},
-          "canDoubleBombJump",
-          "canStaggeredIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
           "canBeVeryPatient",
           "h_canArtificialMorphPowerBomb"
         ]},

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -751,7 +751,7 @@
       "name": "Springwall",
       "requires": [
         "canSpringwall",
-        "canResetFallSpeed"
+        "h_canResetFallSpeed"
       ]
     },
     {
@@ -759,7 +759,7 @@
       "name": "Springwall onto Grapple Block",
       "requires": [
         "canSpringwall",
-        "canSpringFling"
+        "h_canSpringFling"
       ],
       "clearsObstacles": ["B"]
     },
@@ -768,7 +768,7 @@
       "name": "Walljumpless SpringFling",
       "requires": [
         "h_canMaxHeightSpringBallJump",
-        "canSpringFling"
+        "h_canSpringFling"
       ],
       "clearsObstacles": ["B"],
       "note": "Time a pause before jumping to give a significant momentum boost in order to reach the Grapple Block."

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -2488,7 +2488,7 @@
             "canTrickySpringBallJump",
             {"or": [
               "canCrouchJump",
-              "canSpringFling",
+              "h_canSpringFling",
               "canStationaryLateralMidAirMorph"
             ]}
           ]}

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -297,8 +297,7 @@
         }
       },
       "requires": [
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "f_DefeatedCrocomire",
         "canBePatient"
       ],
@@ -410,8 +409,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "f_DefeatedCrocomire",
         "canBePatient"
       ],
@@ -471,7 +469,6 @@
       "link": [3, 6],
       "name": "Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump",
         "canLongCeilingBombJump",
         "canBePatient"
       ]
@@ -480,8 +477,7 @@
       "link": [3, 6],
       "name": "G-mode Morph Ceiling Bomb Jump",
       "requires": [
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "canBeVeryPatient",
         {"obstaclesCleared": ["A"]}
       ],
@@ -754,7 +750,6 @@
       "link": [6, 3],
       "name": "Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump",
         "canLongCeilingBombJump",
         "canBePatient"
       ]

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -217,7 +217,7 @@
           "HiJump",
           {"and": [
             "canInsaneJump",
-            "canResetFallSpeed",
+            "h_canArtificialMorphResetFallSpeed",
             {"ammo": {"type": "PowerBomb", "count": 3}}
           ]}
         ]}

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -794,7 +794,7 @@
       "requires": [
         "canCarefulJump",
         "canLateralMidAirMorph",
-        "canSpringFling",
+        "h_canSpringFling",
         "SpeedBooster"
       ]
     },

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -671,7 +671,7 @@
         {"or": [
           "Grapple",
           "SpaceJump",
-          "canResetFallSpeed",
+          "h_canResetFallSpeed",
           {"and": [
             "canTrickyJump",
             "canLateralMidAirMorph"

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -777,7 +777,7 @@
         {"or": [
           "h_canArtificialMorphSpringBall",
           {"and": [
-            "canBombHorizontally",
+            {"tech": "canBombHorizontally"},
             "h_canArtificialMorphPowerBomb"
           ]},
           {"and": [
@@ -813,7 +813,7 @@
         {"or": [
           "h_canArtificialMorphSpringBall",
           {"and": [
-            "canBombHorizontally",
+            {"tech": "canBombHorizontally"},
             "h_canArtificialMorphPowerBomb"
           ]},
           {"and": [

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -2482,7 +2482,7 @@
         }
       },
       "requires": [
-        "canBombHorizontally",
+        {"tech": "canBombHorizontally"},
         "h_canArtificialMorphPowerBomb",
         "h_additionalBomb"
       ],

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -940,7 +940,7 @@
         }
       },
       "requires": [
-        "canSpringFling",
+        "h_canSpringFling",
         "canLateralMidAirMorph",
         "canCarefulJump",
         {"heatFrames": 120}

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -312,7 +312,7 @@
       "name": "Spiky Acid Snakes Frozen Platforms (Left to Right)",
       "notable": true,
       "requires": [
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         {"or": [
@@ -561,7 +561,7 @@
       "name": "Spiky Acid Snakes Frozen Platforms (Right to Left)",
       "notable": true,
       "requires": [
-        "canResetFallSpeed",
+        "h_canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         {"or": [

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -410,7 +410,7 @@
         "canTrickyUseFrozenEnemies",
         "canCarefulJump",
         {"or": [
-          "canResetFallSpeed",
+          "h_canResetFallSpeed",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -393,8 +393,7 @@
       },
       "requires": [
         "f_KilledMetroidRoom1",
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "canBePatient"
       ]
     },

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -945,7 +945,7 @@
         {"or": [
           {"and": [
             "h_canHBJ",
-            "canResetFallSpeed"
+            "h_canResetFallSpeed"
           ]},
           {"and": [
             {"obstaclesCleared": ["A"]},

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -514,7 +514,7 @@
       "requires": [
         "canSuitlessLavaDive",
         "h_canJumpIntoIBJ",
-        "canDoubleBombJump",
+        "h_canDoubleBombJump",
         {"or": [
           {"and": [
             "Gravity",

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -469,7 +469,7 @@
       },
       "requires": [
         "canTrickyJump",
-        "canSpringFling",
+        "h_canSpringFling",
         "canLateralMidAirMorph",
         "canIframeSpikeJump",
         {"spikeHits": 1}

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -539,7 +539,6 @@
       "name": "Bowling Alley Ceiling Bomb Jump",
       "notable": true,
       "requires": [
-        "h_canCeilingBombJump",
         "canLongCeilingBombJump",
         "canBeVeryPatient"
       ],

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -295,7 +295,6 @@
       "link": [1, 2],
       "name": "Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump",
         "canLongCeilingBombJump",
         "canBePatient"
       ]
@@ -371,8 +370,7 @@
         }
       },
       "requires": [
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "canBePatient"
       ],
       "clearsObstacles": ["A"]
@@ -459,7 +457,6 @@
       "link": [2, 1],
       "name": "Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump",
         "canLongCeilingBombJump",
         "canBePatient"
       ]
@@ -468,8 +465,7 @@
       "link": [2, 1],
       "name": "G-mode Morph Ceiling Bomb Jump",
       "requires": [
-        "h_canArtificialMorphCeilingBombJump",
-        "canLongCeilingBombJump",
+        "h_canArtificialMorphLongCeilingBombJump",
         "canBeVeryPatient",
         {"obstaclesCleared": ["A"]}
       ],

--- a/tech.json
+++ b/tech.json
@@ -728,7 +728,7 @@
                     "canTrickySpringBallJump",
                     "canJumpIntoIBJ"
                   ],
-                  "otherRequires": ["h_canJumpIntoIBJ"],
+                  "otherRequires": [],
                   "note": [
                     "Use the tiny amount of height gain from an underwater Bomb explosion to re-equip Springball and perform a Springball jump.",
                     "This is most often used to get a second SpringBall jump when underwater without HiJump.",
@@ -753,7 +753,10 @@
           {
             "name": "canSpringFling",
             "techRequires": ["canDisableEquipment"],
-            "otherRequires": ["SpringBall"],
+            "otherRequires": [
+              "Morph",
+              "SpringBall"
+            ],
             "note": [
               "The ability to gain extra distance meerly by turning Springball on or off.",
               "When equipping or unequipping Springball while Morphed, Samus' speed is reset.",
@@ -919,7 +922,13 @@
         {
           "name": "canBombHorizontally",
           "techRequires": [],
-          "otherRequires": [],
+          "otherRequires": [
+            "Morph",
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ],
           "note": [
             "Place a single bomb then move Samus to the side to be boosted horizontally from the explosion.",
             "This is typically used as a way to cross gaps or to reposition at the end of an IBJ.",
@@ -931,7 +940,7 @@
             {
               "name": "canHBJ",
               "techRequires": ["canBombHorizontally"],
-              "otherRequires": [],
+              "otherRequires": ["Bombs"],
               "note": [
                 "A Horizontal Bomb Jump (HBJ) uses three bombs to execute. Place a bomb to get boosted horizontally; place a second bomb immediately as Samus is propelled.",
                 "Place a third bomb, mid-air, as far horizontally as possible while still being able to return and get propelled by the second and then third bombs."
@@ -943,7 +952,10 @@
         {
           "name": "canIBJ",
           "techRequires": [],
-          "otherRequires": [],
+          "otherRequires": [
+            "Morph",
+            "Bombs"
+          ],
           "note": [
             "Infinite Bomb Jump (IBJ) uses consecutive bomb jumps to gain height indefinitely. To start and continue an IBJ, place a bomb as the previous one is exploding.",
             "The vertical speed with which Samus moves is controlled by how high or how low each bomb is placed relative to the previous one.",
@@ -954,7 +966,12 @@
             {
               "name": "canJumpIntoIBJ",
               "techRequires": ["canIBJ"],
-              "otherRequires": [],
+              "otherRequires": [
+                {"or": [
+                  "SpringBall",
+                  "canMidAirMorph"
+                ]}
+              ],
               "note": "The ability to start an IBJ from a jump or a spring ball jump. It is most often used in strats that need Samus to IBJ up faster or to avoid something near the ground."
             },
             {
@@ -989,7 +1006,7 @@
                 "canJumpIntoIBJ",
                 "canPlayInSand"
               ],
-              "otherRequires": ["h_canJumpIntoIBJ"],
+              "otherRequires": [],
               "note": [
                 "The ability to start an IBJ from sand.",
                 "Jumping from the top of sand into an IBJ takes more precision than a standard jump into IBJ.",
@@ -1017,7 +1034,14 @@
         {
           "name": "canSpringBallBombJump",
           "techRequires": [],
-          "otherRequires": ["SpringBall"],
+          "otherRequires": [
+            "Morph",
+            "SpringBall",
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ],
           "note": [
             "After gaining some height with a single bomb explosion from the ground, use Spring Ball to jump higher.",
             "Usable only when Samus' vertical speed is 0 (at the max height gained by the bomb)."
@@ -1808,13 +1832,21 @@
         {
           "name": "canCrystalFlash",
           "techRequires": [],
-          "otherRequires": [{"noFlashSuit": {}}],
+          "otherRequires": [
+            "Morph",
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"ammo": {"type": "Missile", "count": 10}},
+            {"ammo": {"type": "Super", "count": 10}},
+            {"ammo": {"type": "PowerBomb", "count": 10}},
+            {"noFlashSuit": {}}
+          ],
           "note": [
             "Performing a Crystal Flash (CF).",
             "Initiating the Crystal Flash requires energy at 50 or lower, empty Reserve energy, 1 Power Bomb to initiate, and holding L+R+Shoot+Down with no other inputs.",
             "A Crystal Flash will refill 1500 energy at the cost of 10 Missiles, 10 Supers, and 10 Power Bombs.",
             "The Crystal Flash will also put Samus in a standing position even if she is in a Morph tunnel."
           ],
+          "devNote": "Note that this does not include the refill, as the amount is dependent on if Samus' environment.",
           "extensionTechs": [
             {
               "name": "canBombIntoCrystalFlashClip",
@@ -1837,7 +1869,12 @@
                 "canCrystalFlash",
                 "canCeilingClip"
               ],
-              "otherRequires": [],
+              "otherRequires": [
+                {"or": [
+                  "SpringBall",
+                  "canMidAirMorph"
+                ]}
+              ],
               "note": [
                 "Setting up a Crystal Flash by jumping and morphing. Once to place the Power Bomb, then again to activate the Crystal Flash.",
                 "This trick has a 1 frame window.",
@@ -1849,10 +1886,17 @@
             {
               "name": "can10PowerBombCrystalFlash",
               "techRequires": [
-                "canCrystalFlash"
+                {"tech": "canCrystalFlash"}
               ],
-              "otherRequires": [],
-              "note": "Setting up a Crystal Flash with only a 10 Power Bomb capacity, by picking up a Power Bomb in between placing the first Power Bomb and activating the Crystal Flash."
+              "otherRequires": [
+                "Morph",
+                {"ammo": {"type": "Missile", "count": 10}},
+                {"ammo": {"type": "Super", "count": 10}},
+                {"ammo": {"type": "PowerBomb", "count": 10}},
+                {"noFlashSuit": {}}
+              ],
+              "note": "Setting up a Crystal Flash with only a 10 Power Bomb capacity, by picking up a Power Bomb in between placing the first Power Bomb and activating the Crystal Flash.",
+              "devNote": "Note that this does not include the refill, as the amount is dependent on Samus' environment."
             }
           ]
         },

--- a/tech.json
+++ b/tech.json
@@ -1866,7 +1866,7 @@
             "A Crystal Flash will refill 1500 energy at the cost of 10 Missiles, 10 Supers, and 10 Power Bombs.",
             "The Crystal Flash will also put Samus in a standing position even if she is in a Morph tunnel."
           ],
-          "devNote": "Note that this does not include the refill, as the amount is dependent on if Samus' environment.",
+          "devNote": "Note that this does not include the refill, as the amount is dependent on Samus' environment.",
           "extensionTechs": [
             {
               "name": "canBombIntoCrystalFlashClip",

--- a/tech.json
+++ b/tech.json
@@ -337,7 +337,7 @@
         {
           "name": "canResetFallSpeed",
           "techRequires": [],
-          "otherRequires": [],
+          "otherRequires": ["Morph"],
           "note": "Using unmorph as a way to reset fall speed.",
           "devNote": "Taking enemy damage can get the same effect but more situations where this is used would need to be found first."
         },

--- a/tech.json
+++ b/tech.json
@@ -133,7 +133,8 @@
               "name": "canEscapeSand",
               "techRequires": [
                 "canPlayInSand",
-                "h_canCrouchJumpDownGrab",
+                "canCrouchJump",
+                "canDownGrab",
                 "canSuitlessMaridia"
               ],
               "otherRequires": [],
@@ -164,7 +165,8 @@
                 "canSuitlessMaridia"
               ],
               "otherRequires": [
-                "h_canUseMorphBombs"
+                "Morph",
+                "Bombs"
               ],
               "note": [
                 "Sit on the very edge of a sand pit that is flush with the ground and place a bomb.",
@@ -907,13 +909,25 @@
         {
           "name": "canUnmorphBombBoost",
           "techRequires": [],
-          "otherRequires": ["h_canBombThings"],
+          "otherRequires": [
+            "Morph",
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ],
           "note": "A tech that involves mid-air morphing to place a bomb or Power Bomb, then mid-air unmorphing to briefly hover above the bomb, in order to use the bomb blast to go just a bit higher than max jump height."
         },
         {
           "name": "canWallJumpBombBoost",
           "techRequires": ["canWallJumpInstantMorph"],
-          "otherRequires": ["h_canBombThings"],
+          "otherRequires": [
+            "Morph",
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ],
           "note": [
             "The ability to accurately place a bomb or Power Bomb in mid-air following a wall jump, then using that bomb explosion to propel Samus forward.",
             "There is a timing component where the bomb is placed while rising then hit while falling, and a momentum component for maximizing horizontal distance."
@@ -1050,7 +1064,13 @@
         {
           "name": "canBombJumpWaterEscape",
           "techRequires": ["canMidAirMorph"],
-          "otherRequires": ["h_canBombThings"],
+          "otherRequires": [
+            "Morph",
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ],
           "note": "From a submerged platform, setting up a single bomb jump above the water line to propel Samus up and out of the water.",
           "devNote": "It's recommended to apply a number of tries as leniency here for the PBs version."
         }


### PR DESCRIPTION
Added item requirements to tech that had artificial morph variants. This should improve clarity and reduce the likelihood of future errors, and became possible after #1507.
- Converted all remaining instances of `canIBJ`, `canJumpIntoIBJ`, etc. to `h_canIBJ` or `{"tech": "canIBJ"}`, etc.
- Added items, such as `Morph` to tech and used `{"tech": "canIBJ"}`, etc. in the artificial morph helpers, and simplified the regular helpers.
- Removed all helpers from the tech file.

This is only part of adding all items to their tech, but this is likely the majority of it. In a future PR, all helpers, such as `h_canIBJ` can be removed and `canIBJ` used instead.

The only error found was escaping Beta PBs with a springball bomb jump which didn't include a bomb, as well as 7 instances of `canResetFallSpeed` that didn't require `Morph`. These 7 still need to be verified and are all included in the final commit `Add morph to canResetFallSpeed`.