### PR TITLE
Remove Helpers after the Tech Migration

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -325,7 +325,7 @@
           "name": "h_IBJFromThorns",
           "requires": [
             "canIframeSpikeJump",
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             "canCarefulJump",
             {"thornHits": 1},
             {"or":[
@@ -338,7 +338,7 @@
           "name": "h_IBJFromSpikes",
           "requires": [
             "canIframeSpikeJump",
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             "canCarefulJump",
             {"spikeHits": 1},
             {"or":[
@@ -351,7 +351,7 @@
           "name": "h_HeatedIBJFromSpikes",
           "requires": [
             "canIframeSpikeJump",
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             "canCarefulJump",
             {"spikeHits": 1},
             {"heatFrames": 100},
@@ -434,14 +434,10 @@
           ]
         },
         {
-          "name": "h_canIBJ",
-          "requires": [ "canIBJ" ]
-        },
-        {
           "name": "h_canFly",
           "requires": [
             {"or": [
-              "h_canIBJ",
+              "canIBJ",
               "SpaceJump"
             ]}
           ]
@@ -592,50 +588,6 @@
             "h_canBreakOneDraygonTurret",
             "h_canBreakOneDraygonTurret"
           ]
-        },
-        {
-          "name": "h_canJumpIntoIBJ",
-          "requires": ["canJumpIntoIBJ"]
-        },
-        {
-          "name": "h_canBombAboveIBJ",
-          "requires": ["canBombAboveIBJ"]
-        },
-        {
-          "name": "h_canCeilingBombJump",
-          "requires": ["canCeilingBombJump"]
-        },
-        {
-          "name": "h_canDiagonalBombJump",
-          "requires": ["canDiagonalBombJump"]
-        },
-        {
-          "name": "h_canDoubleBombJump",
-          "requires": ["canDoubleBombJump"]
-        },
-        {
-          "name": "h_canStaggeredIBJ",
-          "requires": ["canStaggeredIBJ"]
-        },
-        {
-          "name": "h_canBombHorizontally",
-          "requires": ["canBombHorizontally"]
-        },
-        {
-          "name": "h_canHBJ",
-          "requires": ["canHBJ"]
-        },
-        {
-          "name": "h_canResetFallSpeed",
-          "requires": ["canResetFallSpeed"]
-        },
-        {
-          "name": "h_canSpringFling",
-          "requires": ["canSpringFling"]
-        },
-        {
-          "name": "h_canSpringBallBombJump",
-          "requires": ["canSpringBallBombJump"]
         },
         {
           "name": "h_canDoubleSpringBallJumpWithHiJump",
@@ -808,7 +760,7 @@
           "requires": [
             "canTrickySpringBallJump",
             "canSpringwall",
-            "h_canSpringFling",
+            "canSpringFling",
             "canTrickyJump"
           ]
         },

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -218,7 +218,7 @@
           "h_canCrouchJumpDownGrab",
           "canWalljump"
         ]},
-        "h_canSpringBallBombJump"
+        "canSpringBallBombJump"
       ],
       "unlocksDoors": [
         {"nodeId": 2, "types": ["ammo"], "requires": []}

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -310,7 +310,7 @@
       "link": [1, 3],
       "name": "IBJ",
       "requires": [
-        "h_canBombAboveIBJ"
+        "canBombAboveIBJ"
       ],
       "devNote": "Would've been notable due to breaking the shot block while maintaining ibj, but there's a tech for that."
     },
@@ -318,7 +318,7 @@
       "link": [1, 3],
       "name": "IBJ with Power Bomb",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         "h_canUsePowerBombs"
       ],
       "clearsObstacles": ["C"],
@@ -328,8 +328,8 @@
       "link": [1, 3],
       "name": "Ceiling E-Tank Jump Into IBJ",
       "requires": [
-        "h_canJumpIntoIBJ",
-        "h_canDoubleBombJump"
+        "canJumpIntoIBJ",
+        "canDoubleBombJump"
       ],
       "note": "An alternate strat to canBombAboveIBJ. Shoot the block, jump into an IBJ, then do a quick double bomb jump to make it in time."
     },

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -220,7 +220,7 @@
         "canTrickyJump",
         "canChainTemporaryBlue",
         "canSpringBallBounce",
-        "h_canSpringFling"
+        "canSpringFling"
       ],
       "note": [
         "Gain temporary blue at the end of the runway.",

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -3690,8 +3690,8 @@
           "canTrivialMidAirMorph",
           "h_canUseSpringBall",
           {"and": [
-            "h_canIBJ",
-            "h_canBombHorizontally"
+            "canIBJ",
+            "canBombHorizontally"
           ]}
         ]}
       ],
@@ -4130,7 +4130,7 @@
       "link": [14, 9],
       "name": "Full Etecoon IBJ",
       "requires": [
-        "h_canIBJ"
+        "canIBJ"
       ],
       "note": "This is the full climb, since you have to drop down to 10 and start there."
     },

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -513,7 +513,7 @@
       "name": "Spring Ball",
       "requires": [
         {"or": [
-          "h_canSpringBallBombJump",
+          "canSpringBallBombJump",
           "canSpringBallJumpMidAir",
           {"and": [
             "canMockball",

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -763,7 +763,7 @@
         {"or": [
           "canMidAirMorph",
           "h_canUseSpringBall",
-          "h_canIBJ"
+          "canIBJ"
         ]},
         {"obstaclesCleared": ["A"]}
       ]
@@ -776,7 +776,7 @@
         {"or": [
           "canMidAirMorph",
           "h_canUseSpringBall",
-          "h_canIBJ"
+          "canIBJ"
         ]}
       ],
       "clearsObstacles": ["A", "B", "C"]

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1933,7 +1933,7 @@
         {"or": [
           "Morph",
           "h_canUseSpringBall",
-          "h_canIBJ"
+          "canIBJ"
         ]},
         {"obstaclesCleared": ["F"]}
       ],

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -516,7 +516,7 @@
       "link": [1, 2],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"obstaclesCleared": ["A"]},
         {"or": [
           "Wave",
@@ -1137,7 +1137,7 @@
         "canTrickyJump",
         "canLateralMidAirMorph",
         "canTrickySpringBallJump",
-        "h_canSpringFling"
+        "canSpringFling"
       ],
       "note": [
         "X-Ray climb until Samus is a little over halfway off screen; the position is not precise.",

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -263,7 +263,7 @@
           "canBombJumpWaterEscape",
           {"and": [
             "h_canUseSpringBall",
-            "h_canJumpIntoIBJ"
+            "canJumpIntoIBJ"
           ]}
         ]}
       ]

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -340,7 +340,7 @@
           "canWalljump",
           "canSpringBallJumpMidAir",
           "h_canFly",
-          "h_canSpringBallBombJump"
+          "canSpringBallBombJump"
         ]}
       ]
     },

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -693,10 +693,10 @@
       "link": [2, 3],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"spikeHits": 1},
         {"or": [
-          "h_canBombHorizontally",
+          "canBombHorizontally",
           {"spikeHits": 1}
         ]}
       ]
@@ -833,7 +833,7 @@
       "notable": true,
       "requires": [
         "canTrickySpringBallJump",
-        "h_canSpringFling"
+        "canSpringFling"
       ],
       "note": [
         "Jump from the safe spot on the spikey stairs and use the momentum change from equipping SpringBall to move closer to the door's platform.",

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -2129,7 +2129,7 @@
           "HiJump",
           "canWalljump",
           "canSpringBallJumpMidAir",
-          "h_canIBJ"
+          "canIBJ"
         ]}
       ]
     },
@@ -2137,7 +2137,7 @@
       "link": [7, 6],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"and": [
             "canWalljump",
@@ -2165,8 +2165,8 @@
       "name": "Red Tower IBJ Between the Bottom Rippers",
       "notable": true,
       "requires": [
-        "h_canDoubleBombJump",
-        "h_canStaggeredIBJ"
+        "canDoubleBombJump",
+        "canStaggeredIBJ"
       ],
       "reusableRoomwideNotable": "Red Tower IBJ Between the Bottom Rippers",
       "note": "Requires switching between single and double IBJs. While Doubles are not techincally necessary, they make the strat more bearable."
@@ -2195,7 +2195,7 @@
       "notable": true,
       "requires": [
         "canWallJumpBombBoost",
-        "h_canHBJ"
+        "canHBJ"
       ],
       "note": [
         "Starting on the right ledge at the bottom of Red Tower, wall jump just below the middle plant, just above the top ripper.",
@@ -2208,7 +2208,7 @@
       "name": "Diagonal Bomb Jump",
       "requires": [
         "canWalljump",
-        "h_canDiagonalBombJump"
+        "canDiagonalBombJump"
       ]
     },
     {
@@ -2316,9 +2316,9 @@
       "link": [9, 5],
       "name": "Jump Into IBJ",
       "requires": [
-        "h_canJumpIntoIBJ",
+        "canJumpIntoIBJ",
         {"or": [
-          "h_canBombAboveIBJ",
+          "canBombAboveIBJ",
           {"ammo": {"type": "PowerBomb", "count": 1}}
         ]},
         {"obstaclesCleared": ["B"]}
@@ -2333,7 +2333,7 @@
       "name": "Long IBJ With Broken Ledges",
       "requires": [
         "canBeVeryPatient",
-        "h_canIBJ",
+        "canIBJ",
         {"ammo": {"type": "PowerBomb", "count": 1}},
         {"or": [
           {"obstaclesCleared": ["B"]},
@@ -2360,10 +2360,10 @@
             "canTrickyDashJump"
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"or": [
-              "h_canStaggeredIBJ",
-              "h_canDoubleBombJump"
+              "canStaggeredIBJ",
+              "canDoubleBombJump"
             ]}
           ]}
         ]}
@@ -2379,7 +2379,7 @@
         {"or": [
           "canWalljump",
           "SpaceJump",
-          "h_canJumpIntoIBJ",
+          "canJumpIntoIBJ",
           {"and": [
             "canSpringBallJumpMidAir",
             {"or": [

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -67,7 +67,7 @@
               "name": "IBJ",
               "notable": false,
               "requires": [
-                "h_canIBJ",
+                "canIBJ",
                 "canBePatient"
               ]
             }
@@ -1029,7 +1029,7 @@
         "canLongCeilingBombJump",
         "canPreciseWalljump",
         "canWallJumpInstantMorph",
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ]
     },
     {
@@ -1140,7 +1140,7 @@
           "canConsecutiveWalljump",
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "canUnmorphBombBoost"
           ]}
         ]},

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -366,7 +366,7 @@
               "HiJump",
               "canWalljump",
               "h_canCrouchJumpDownGrab",
-              "h_canIBJ",
+              "canIBJ",
               "canSpringBallJumpMidAir"
             ]}
           ]}

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -210,7 +210,7 @@
         "canTrickyJump",
         "canSpaceJumpWaterBounce",
         "canSpringBallBounce",
-        "h_canSpringFling",
+        "canSpringFling",
         "canMockball",
         {"or": [
           "canDownGrab",
@@ -741,7 +741,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canIBJ"
+          "canIBJ"
         ]}
       ]
     },
@@ -781,7 +781,7 @@
         "canSpringBallJumpMidAir",
         {"or": [
           "canTrickySpringBallJump",
-          "h_canResetFallSpeed",
+          "canResetFallSpeed",
           "canStationaryLateralMidAirMorph"
         ]},
         "canSpaceJumpWaterBounce",

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -781,7 +781,7 @@
       "name": "IBJ",
       "requires": [
         "Gravity",
-        "h_canIBJ",
+        "canIBJ",
         {"obstaclesNotCleared": ["A"]}
       ]
     },
@@ -798,7 +798,7 @@
       "link": [3, 2],
       "name": "Moat Horizontal Bomb Jump",
       "requires": [
-        "h_canHBJ",
+        "canHBJ",
         {"obstaclesNotCleared": ["A"]}
       ]
     },
@@ -815,7 +815,7 @@
       "link": [3, 2],
       "name": "Moat Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump",
+        "canCeilingBombJump",
         {"obstaclesNotCleared": ["A"]}
       ]
     }

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -850,11 +850,11 @@
           "canWalljump",
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"or": [
               "Gravity",
-              "h_canJumpIntoIBJ",
-              "h_canBombHorizontally"
+              "canJumpIntoIBJ",
+              "canBombHorizontally"
             ]}
           ]},
           {"and": [
@@ -902,11 +902,11 @@
           "canWalljump",
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"or": [
               "Gravity",
-              "h_canJumpIntoIBJ",
-              "h_canBombHorizontally"
+              "canJumpIntoIBJ",
+              "canBombHorizontally"
             ]}
           ]},
           {"and": [
@@ -939,11 +939,11 @@
           "canWalljump",
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"or": [
               "Gravity",
-              "h_canJumpIntoIBJ",
-              "h_canBombHorizontally"
+              "canJumpIntoIBJ",
+              "canBombHorizontally"
             ]}
           ]},
           {"and": [
@@ -1117,7 +1117,7 @@
       "name": "IBJ from the Water",
       "requires": [
         "Gravity",
-        "h_canIBJ"
+        "canIBJ"
       ]
     },
     {
@@ -1125,11 +1125,11 @@
       "name": "IBJ from the Platforms",
       "requires": [
         {"or": [
-          "h_canJumpIntoIBJ",
+          "canJumpIntoIBJ",
           {"and": [
-            "h_canIBJ",
-            "h_canBombHorizontally",
-            "h_canResetFallSpeed"
+            "canIBJ",
+            "canBombHorizontally",
+            "canResetFallSpeed"
           ]}
         ]}
       ],
@@ -1764,7 +1764,7 @@
         {"or": [
           "canTrivialMidAirMorph",
           "h_canUseSpringBall",
-          "h_canIBJ"
+          "canIBJ"
         ]},
         {"or": [
           {"obstaclesNotCleared": ["B"]},
@@ -2055,7 +2055,7 @@
         {"or": [
           "canWalljump",
           "HiJump",
-          "h_canIBJ"
+          "canIBJ"
         ]}
       ],
       "devNote": "A speedy jump would be obsoleted by another strat for being tricky."
@@ -2262,7 +2262,7 @@
         "h_canUseMorphBombs",
         "SpaceJump",
         {"or": [
-          "h_canCeilingBombJump",
+          "canCeilingBombJump",
           "canBeVeryPatient"
         ]}
       ],

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -860,7 +860,7 @@
           "canTrickyJump",
           {"and": [
             "canCarefulJump",
-            "h_canBombHorizontally",
+            "canBombHorizontally",
             {"acidFrames": 35}
           ]},
           {"acidFrames": 100}

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -412,7 +412,7 @@
         ]},
         {"heatFrames": 140},
         {"or": [
-          "h_canResetFallSpeed",
+          "canResetFallSpeed",
           "canPreciseWalljump",
           {"and": [
             {"heatFrames": 60},

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -322,11 +322,11 @@
             {"heatFrames": 180}
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 1320}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 540}
           ]}
         ]}
@@ -996,26 +996,26 @@
       "name": "IBJ",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"and": [
             {"or": [
-              "h_canBombAboveIBJ",
+              "canBombAboveIBJ",
               "h_canUsePowerBombs"
             ]},
             {"heatFrames": 1000}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 510}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 480}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
-            "h_canJumpIntoIBJ",
+            "canDoubleBombJump",
+            "canJumpIntoIBJ",
             {"heatFrames": 300}
           ]}
         ]},

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -443,7 +443,7 @@
         "h_canUseMorphBombs",
         {"or": [
           {"and": [
-            "h_canBombHorizontally",
+            "canBombHorizontally",
             {"or": [
               "Ice",
               "canCarefulJump"
@@ -951,7 +951,7 @@
       "link": [5, 7],
       "name": "Lower Norfair Fireflea IBJ",
       "requires": [
-        "h_canIBJ"
+        "canIBJ"
       ],
       "note": "IBJ on the right side of the platform."
     },
@@ -979,7 +979,7 @@
         "canCarefulJump",
         {"or": [
           "canTrickyJump",
-          "h_canResetFallSpeed"
+          "canResetFallSpeed"
         ]}
       ]
     },
@@ -1048,7 +1048,7 @@
       "link": [7, 6],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ"
+        "canIBJ"
       ]
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -952,7 +952,7 @@
       "name": "SpringBall Bomb Jump",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canSpringBallBombJump",
+        "canSpringBallBombJump",
         {"heatFrames": 240}
       ],
       "unlocksDoors": [
@@ -964,19 +964,19 @@
       "name": "Avoid Spawning Alcoon and IBJ",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"and": [
-            "h_canBombHorizontally",
+            "canBombHorizontally",
             {"heatFrames": 840}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
-            "h_canDoubleBombJump",
+            "canJumpIntoIBJ",
+            "canDoubleBombJump",
             {"heatFrames": 290}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 480}
           ]}
         ]}
@@ -990,7 +990,7 @@
       "name": "Kill Alcoon and IBJ",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"enemyKill": {
             "enemies": [["Alcoon"]],
@@ -1008,7 +1008,7 @@
         {"heatFrames": 50},
         {"or": [
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 500}
           ]},
           {"heatFrames": 860}
@@ -1138,7 +1138,7 @@
       "name": "SpringBall Bomb Jump",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canSpringBallBombJump",
+        "canSpringBallBombJump",
         {"heatFrames": 220}
       ]
     },
@@ -1147,19 +1147,19 @@
       "name": "Avoid Spawning Alcoon and IBJ",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"and": [
-            "h_canBombHorizontally",
+            "canBombHorizontally",
             {"heatFrames": 820}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
-            "h_canDoubleBombJump",
+            "canJumpIntoIBJ",
+            "canDoubleBombJump",
             {"heatFrames": 270}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 460}
           ]}
         ]}
@@ -1170,7 +1170,7 @@
       "name": "Kill Alcoon and IBJ",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"enemyKill": {
             "enemies": [["Alcoon"]],
@@ -1188,7 +1188,7 @@
         {"heatFrames": 50},
         {"or": [
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 480}
           ]},
           {"heatFrames": 840}

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -617,11 +617,11 @@
             {"heatFrames": 20}
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             {"heatFrames": 50}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 60}
           ]}
         ]}
@@ -668,7 +668,7 @@
         {"or": [
           {"and": [
             "can4HighMidAirMorph",
-            "h_canSpringFling"
+            "canSpringFling"
           ]},
           {"and": [
             "canLateralMidAirMorph",
@@ -711,8 +711,8 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canCrumbleJump",
-        "h_canJumpIntoIBJ",
-        "h_canDoubleBombJump",
+        "canJumpIntoIBJ",
+        "canDoubleBombJump",
         {"heatFrames": 360}
       ],
       "note": [
@@ -725,12 +725,12 @@
       "name": "Mickey Mouse Spring Ball IBJ",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canJumpIntoIBJ",
+        "canJumpIntoIBJ",
         "h_canUseSpringBall",
         {"or": [
           "canTrickyJump",
-          "h_canDoubleBombJump",
-          "h_canBombAboveIBJ",
+          "canDoubleBombJump",
+          "canBombAboveIBJ",
           {"ammo": {"type": "PowerBomb", "count": 1}}
         ]},
         {"heatFrames": 500}
@@ -1557,7 +1557,7 @@
           "canSpringBallJumpMidAir",
           "HiJump",
           "SpaceJump",
-          "h_canJumpIntoIBJ"
+          "canJumpIntoIBJ"
         ]}
       ],
       "reusableRoomwideNotable": "Mickey Mouse Viola Ice Clip",
@@ -1581,7 +1581,7 @@
           "canSpringBallJumpMidAir",
           "HiJump",
           "SpaceJump",
-          "h_canJumpIntoIBJ"
+          "canJumpIntoIBJ"
         ]}
       ],
       "reusableRoomwideNotable": "Mickey Mouse Viola Ice Clip",

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -231,7 +231,7 @@
         {"or": [
           {"and": [
             "canCarefulJump",
-            "h_canResetFallSpeed",
+            "canResetFallSpeed",
             {"heatFrames": 660}
           ]},
           {"and": [
@@ -358,7 +358,7 @@
         "h_canUseMorphBombs",
         "canWallJumpInstantMorph",
         "canInsaneJump",
-        "h_canResetFallSpeed",
+        "canResetFallSpeed",
         "canUnmorphBombBoost",
         "canSuitlessLavaDive",
         {"heatFrames": 1320},
@@ -390,8 +390,8 @@
       "requires": [
         "h_canUseMorphBombs",
         "Gravity",
-        "h_canResetFallSpeed",
-        "h_canJumpIntoIBJ",
+        "canResetFallSpeed",
+        "canJumpIntoIBJ",
         "canSuitlessLavaDive",
         {"enemyDamage": {
           "enemy": "Puromi",
@@ -685,9 +685,9 @@
       "requires": [
         "canWallJumpInstantMorph",
         "canInsaneJump",
-        "h_canResetFallSpeed",
+        "canResetFallSpeed",
         "canUnmorphBombBoost",
-        "h_canHBJ",
+        "canHBJ",
         "canSuitlessLavaDive",
         {"heatFrames": 1320},
         {"acidFrames": 128}
@@ -718,8 +718,8 @@
       "requires": [
         "h_canUseMorphBombs",
         "Gravity",
-        "h_canResetFallSpeed",
-        "h_canJumpIntoIBJ",
+        "canResetFallSpeed",
+        "canJumpIntoIBJ",
         "canSuitlessLavaDive",
         {"enemyDamage": {
           "enemy": "Puromi",

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -198,7 +198,7 @@
       "name": "IBJ",
       "requires": [
         "h_heatProof",
-        "h_canIBJ"
+        "canIBJ"
       ]
     },
     {

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -454,7 +454,7 @@
         "canTrickyUseFrozenEnemies",
         "Charge",
         "canPreciseWalljump",
-        "h_canResetFallSpeed",
+        "canResetFallSpeed",
         "canWalljumpWithCharge",
         "h_canUseMorphBombs",
         "canWallJumpInstantMorph",
@@ -489,7 +489,7 @@
         "h_canNavigateHeatRooms",
         "canFastWalljumpClimb",
         "canWallJumpBombBoost",
-        "h_canDiagonalBombJump",
+        "canDiagonalBombJump",
         "h_canUsePowerBombs",
         {"heatFrames": 930},
         {"or": [
@@ -671,7 +671,7 @@
           "canSpringBallJumpMidAir",
           "SpaceJump",
           "canWalljump",
-          "h_canIBJ",
+          "canIBJ",
           {"and": [
             "SpeedBooster",
             "HiJump"
@@ -1122,19 +1122,19 @@
       "name": "IBJ",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 1460}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 1000}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
-            "h_canDoubleBombJump",
+            "canJumpIntoIBJ",
+            "canDoubleBombJump",
             {"heatFrames": 800}
           ]},
           {"heatFrames": 2000}
@@ -1142,8 +1142,8 @@
         {"or": [
           "h_canUsePowerBombs",
           {"and": [
-            "h_canBombAboveIBJ",
-            "h_canStaggeredIBJ",
+            "canBombAboveIBJ",
+            "canStaggeredIBJ",
             {"heatFrames": 180}
           ]},
           {"and": [

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -442,11 +442,11 @@
           ]},
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 1820}
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb",
             {"heatFrames": 250}
@@ -524,7 +524,7 @@
             }}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 300}
           ]},
           "SpaceJump"
@@ -600,7 +600,7 @@
           ]},
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_heatProof",
             {"enemyDamage": {
               "enemy": "Kihunter (red)",
@@ -635,11 +635,11 @@
           ]},
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_heatProof"
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb",
             {"heatFrames": 250}
@@ -670,11 +670,11 @@
           ]},
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_heatProof"
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb",
             {"heatFrames": 250}
@@ -704,11 +704,11 @@
           ]},
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_heatProof"
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb",
             {"heatFrames": 250}
@@ -749,11 +749,11 @@
           ]},
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_heatProof"
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb",
             {"heatFrames": 250}
@@ -787,11 +787,11 @@
           ]},
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_heatProof"
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb",
             {"heatFrames": 250}
@@ -824,9 +824,9 @@
           "HiJump",
           "canSpringBallJumpMidAir",
           "SpaceJump",
-          "h_canIBJ",
+          "canIBJ",
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb"
           ]}

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -720,7 +720,7 @@
       "name": "Kzan Double Kago",
       "requires": [
         "canKago",
-        "h_canResetFallSpeed",
+        "canResetFallSpeed",
         {"enemyDamage": {
           "enemy": "Kzan",
           "type": "contact",

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -186,7 +186,7 @@
           "canWalljump",
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 780}
           ]}
         ]},
@@ -209,7 +209,7 @@
       "link": [1, 3],
       "name": "SpringFling over the acid",
       "requires": [
-        "h_canSpringFling",
+        "canSpringFling",
         "canDisableEquipment",
         "SpeedBooster",
         "canTrickyJump",
@@ -253,7 +253,7 @@
           "canSpringBallJumpMidAir",
           "canGravityJump",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"acidFrames": 1050},
             {"heatFrames": 1050}
           ]}
@@ -299,7 +299,7 @@
       "name": "Ceiling Bomb Jump",
       "requires": [
         "h_heatProof",
-        "h_canCeilingBombJump"
+        "canCeilingBombJump"
       ]
     },
     {
@@ -542,7 +542,7 @@
           "canWalljump",
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 780}
           ]}
         ]},
@@ -651,7 +651,7 @@
           "canWalljump",
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 1020}
           ]}
         ]},
@@ -670,7 +670,7 @@
           "canWalljump",
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 1020}
           ]}
         ]},

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -499,7 +499,7 @@
                   "HiJump",
                   "SpaceJump",
                   {"and": [
-                    "h_canIBJ",
+                    "canIBJ",
                     {"heatFrames": 300}
                   ]}
                 ]},
@@ -649,7 +649,7 @@
       "notable": true,
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canBombHorizontally",
+        "canBombHorizontally",
         {"heatFrames": 160}
       ],
       "reusableRoomwideNotable": "Golden Torizo Horizontal Bomb Jump",
@@ -885,7 +885,7 @@
       "notable": true,
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canBombHorizontally",
+        "canBombHorizontally",
         {"heatFrames": 190}
       ],
       "reusableRoomwideNotable": "Golden Torizo Horizontal Bomb Jump",
@@ -1068,7 +1068,7 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "f_DefeatedGoldenTorizo",
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 3000}
       ],
       "note": "Expects two IBJs; one to break a block, then another one to get back up.",

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -606,7 +606,7 @@
       "name": "Screw Attack Room IBJ to Break the Top Blocks",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 1200}
       ],
       "clearsObstacles": ["A"],
@@ -1029,7 +1029,7 @@
       "name": "Screw Attack Room IBJ",
       "requires": [
         "h_canNavigateHeatRooms",
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 1300}
       ],
       "devNote": [

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -994,7 +994,7 @@
         "HiJump",
         "canTrickySpringBallJump",
         "canStationaryLateralMidAirMorph",
-        "h_canSpringFling",
+        "canSpringFling",
         "canPlayInSand",
         {"or": [
           {"enemyDamage": {

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -1070,7 +1070,7 @@
           ]},
           {"and": [
             "Gravity",
-            "h_canIBJ"
+            "canIBJ"
           ]},
           {"and": [
             "h_canUseMorphBombs",

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -494,7 +494,7 @@
         "Gravity",
         "Grapple",
         "h_canUseSpringBall",
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ],
       "note": "Springball can keep Samus out of the sand.  Place the first bomb right after Samus begins falling back towards the sand."
     },
@@ -581,7 +581,7 @@
             ]}
           ]},
           "canWalljump",
-          "h_canResetFallSpeed"
+          "canResetFallSpeed"
         ]}
       ],
       "note": [
@@ -665,10 +665,10 @@
       "requires": [
         "HiJump",
         "h_canMaxHeightSpringBallJump",
-        "h_canSpringFling",
+        "canSpringFling",
         "canBombJumpWaterEscape",
-        "h_canJumpIntoIBJ",
-        "h_canDoubleBombJump"
+        "canJumpIntoIBJ",
+        "canDoubleBombJump"
       ],
       "note": [
         "Wait the water tide to reach its peak, then crouch jump into a spring ball jump into an IBJ.",

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -126,8 +126,8 @@
       "requires": [
         "Gravity",
         {"or": [
-          "h_canIBJ",
-          "h_canSpringBallBombJump",
+          "canIBJ",
+          "canSpringBallBombJump",
           "canSpringBallJumpMidAir",
           {"and": [
             "canMidAirMorph",

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -347,7 +347,7 @@
         "canPlayInSand",
         "canLateralMidAirMorph",
         "canTrickySpringBallJump",
-        "h_canSpringFling"
+        "canSpringFling"
       ],
       "note": [
         "Enter with at least 1 tile of run speed from an air room, with Speedbooster unequipped.",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1910,7 +1910,7 @@
         "canSuitlessMaridia",
         "canStationaryLateralMidAirMorph",
         "canTrickySpringBallJump",
-        "h_canResetFallSpeed"
+        "canResetFallSpeed"
       ]
     },
     {
@@ -1918,7 +1918,7 @@
       "name": "Spring Fling",
       "requires": [
         "canSuitlessMaridia",
-        "h_canSpringFling",
+        "canSpringFling",
         "canTrickySpringBallJump"
       ]
     },

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -543,8 +543,8 @@
           "canMidAirMorph",
           "h_canUseSpringBall",
           {"and": [
-            "h_canIBJ",
-            "h_canBombHorizontally"
+            "canIBJ",
+            "canBombHorizontally"
           ]}
         ]}
       ]

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -352,7 +352,7 @@
           "canSandIBJ",
           {"and": [
             "h_canUseSpringBall",
-            "h_canJumpIntoIBJ"
+            "canJumpIntoIBJ"
           ]}
         ]}
       ]
@@ -831,7 +831,7 @@
         }
       },
       "requires": [
-        "h_canJumpIntoIBJ",
+        "canJumpIntoIBJ",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround",
@@ -1047,11 +1047,11 @@
         ]},
         "h_canMaxHeightSpringBallJump",
         {"or": [
-          "h_canSpringFling",
+          "canSpringFling",
           "canInsaneJump"
         ]},
         "canBombJumpWaterEscape",
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ],
       "note": [
         "Stay out of the water, and by extension the sand, of Colosseum by using the spikes as platforms.",

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -443,10 +443,10 @@
           "canWalljump",
           "h_IBJFromSpikes",
           {"and": [
-            "h_canIBJ",
-            "h_canHBJ"
+            "canIBJ",
+            "canHBJ"
           ]},
-          "h_canDiagonalBombJump"
+          "canDiagonalBombJump"
         ]}
       ]
     },
@@ -460,7 +460,7 @@
           "HiJump",
           {"and": [
             "h_canMaxHeightSpringBallJump",
-            "h_canSpringFling"
+            "canSpringFling"
           ]}
         ]}
       ],
@@ -497,7 +497,7 @@
           "canStationaryLateralMidAirMorph",
           {"and": [
             {"tech": "canJumpIntoIBJ"},
-            "h_canBombHorizontally"
+            "canBombHorizontally"
           ]}
         ]}
       ],
@@ -583,9 +583,9 @@
         }
       },
       "requires": [
-        "h_canJumpIntoIBJ",
-        "h_canBombHorizontally",
-        "h_canResetFallSpeed",
+        "canJumpIntoIBJ",
+        "canBombHorizontally",
+        "canResetFallSpeed",
         "canCrossRoomJumpIntoWater",
         "canTrickyJump"
       ],
@@ -639,10 +639,10 @@
         "comeInWithBombBoost": {}
       },
       "requires": [
-        "h_canSpringBallBombJump",
+        "canSpringBallBombJump",
         "canCrossRoomJumpIntoWater",
         {"or": [
-          "h_canJumpIntoIBJ",
+          "canJumpIntoIBJ",
           "canUnmorphBombBoost"
         ]}
       ],
@@ -772,9 +772,9 @@
       "name": "IBJ",
       "requires": [
         "Gravity",
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
-          "h_canBombHorizontally",
+          "canBombHorizontally",
           "h_IBJFromSpikes"
         ]}
       ]
@@ -862,7 +862,7 @@
           "SpaceJump",
           "canWalljump",
           "canSpringBallJumpMidAir",
-          "h_canDiagonalBombJump",
+          "canDiagonalBombJump",
           "h_IBJFromSpikes"
         ]}
       ]
@@ -916,9 +916,9 @@
       "requires": [
         "HiJump",
         "h_canMaxHeightSpringBallJump",
-        "h_canSpringFling",
+        "canSpringFling",
         "canBombJumpWaterEscape",
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ],
       "note": [
         "Perform the spring ball jump near max height.",
@@ -934,8 +934,8 @@
         "Gravity",
         {"or": [
           "SpaceJump",
-          "h_canHBJ",
-          "h_canResetFallSpeed",
+          "canHBJ",
+          "canResetFallSpeed",
           {"enemyDamage": {
             "enemy": "Cacatac",
             "hits": 1,
@@ -946,9 +946,9 @@
           "SpaceJump",
           "canWalljump",
           "HiJump",
-          "h_canIBJ",
-          "h_canHBJ",
-          "h_canSpringBallBombJump",
+          "canIBJ",
+          "canHBJ",
+          "canSpringBallBombJump",
           {"spikeHits": 1}
         ]}
       ]
@@ -983,11 +983,11 @@
           "canSpaceJumpWaterEscape",
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             "h_canUseSpringBall"
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "canBombJumpWaterEscape"
           ]},
           {"spikeHits": 1}
@@ -1027,11 +1027,11 @@
             "canSpaceJumpWaterBounce"
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             "h_canUseSpringBall"
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "canBombJumpWaterEscape"
           ]},
           {"spikeHits": 1}
@@ -1067,7 +1067,7 @@
             ]}
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "canBombJumpWaterEscape"
           ]}
         ]},
@@ -1084,7 +1084,7 @@
         "Gravity",
         {"or": [
           "SpaceJump",
-          "h_canHBJ",
+          "canHBJ",
           {"spikeHits": 1}
         ]}
       ]

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -156,7 +156,7 @@
           {"and": [
             "h_canCrouchJumpDownGrab",
             "canBombJumpWaterEscape",
-            "h_canIBJ"
+            "canIBJ"
           ]}
         ]}
       ]
@@ -191,7 +191,7 @@
             {"or": [
               "canWalljump",
               "can4HighMidAirMorph",
-              "h_canJumpIntoIBJ"
+              "canJumpIntoIBJ"
             ]}
           ]}
         ]}
@@ -271,7 +271,7 @@
           ]},
           {"and": [
             "h_canUseSpringBall",
-            "h_canJumpIntoIBJ"
+            "canJumpIntoIBJ"
           ]},
           "canSandIBJ"
         ]}

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -622,11 +622,11 @@
         }
       },
       "requires": [
-        "h_canJumpIntoIBJ",
+        "canJumpIntoIBJ",
         {"or": [
           {"ammo": {"type": "PowerBomb", "count": 1}},
           {"and": [
-            "h_canCeilingBombJump",
+            "canCeilingBombJump",
             {"enemyDamage": {
               "enemy": "Mochtroid",
               "type": "contact",
@@ -634,7 +634,7 @@
             }}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"enemyDamage": {
               "enemy": "Mochtroid",
               "type": "contact",
@@ -1224,9 +1224,9 @@
       },
       "requires": [
         "canTrickySpringBallJump",
-        "h_canJumpIntoIBJ",
+        "canJumpIntoIBJ",
         {"or": [
-          "h_canDoubleBombJump",
+          "canDoubleBombJump",
           {"enemyDamage": {
             "enemy": "Mochtroid",
             "type": "contact",

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -122,7 +122,7 @@
           "HiJump",
           "canSpringBallJumpMidAir",
           "h_canFly",
-          "h_canSpringBallBombJump"
+          "canSpringBallBombJump"
         ]}
       ]
     },

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -179,7 +179,7 @@
           "SpaceJump",
           {"and": [
             "h_canUseSpringBall",
-            "h_canJumpIntoIBJ"
+            "canJumpIntoIBJ"
           ]}
         ]}
       ],
@@ -195,7 +195,7 @@
           "HiJump",
           "canSpringBallJumpMidAir",
           "canWalljump",
-          "h_canIBJ",
+          "canIBJ",
           "canGravityJump"
         ]}
       ],
@@ -306,7 +306,7 @@
         "canPlayInSand",
         "canShinechargeMovementTricky",
         {"or": [
-          "h_canResetFallSpeed",
+          "canResetFallSpeed",
           {"and": [
             "canPrepareForNextRoom",
             "h_canUsePowerBombs"
@@ -410,7 +410,7 @@
       "requires": [
         {"or": [
           "h_canUseSpringBall",
-          "h_canIBJ"
+          "canIBJ"
         ]}
       ]
     },
@@ -526,7 +526,7 @@
             {"tech": "canJumpIntoIBJ"},
             "h_canBombThings"
           ]},
-          "h_canSpringBallBombJump",
+          "canSpringBallBombJump",
           "HiJump"
         ]}
       ],
@@ -572,7 +572,7 @@
       "notable": true,
       "requires": [
         "canSuitlessMaridia",
-        "h_canJumpIntoIBJ",
+        "canJumpIntoIBJ",
         "canBombJumpWaterEscape",
         "canCrumbleJump"
       ],

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -282,15 +282,15 @@
             ]}
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"ammo": {"type": "Super", "count": 3}}
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_canUsePowerBombs",
             {"or": [
               "h_canUsePowerBombs",
-              "h_canStaggeredIBJ"
+              "canStaggeredIBJ"
             ]}
           ]}
         ]}
@@ -457,7 +457,7 @@
       "link": [2, 3],
       "name": "Kill Rippers Then IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"and": [
             {"enemyKill": {
@@ -575,15 +575,15 @@
             ]}
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"ammo": {"type": "Super", "count": 3}}
           ]},
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             "h_canUsePowerBombs",
             {"or": [
               "h_canUsePowerBombs",
-              "h_canStaggeredIBJ"
+              "canStaggeredIBJ"
             ]}
           ]}
         ]}

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -448,7 +448,7 @@
       "name": "Kill the Menus",
       "requires": [
         {"or": [
-          "h_canIBJ",
+          "canIBJ",
           "canWalljump",
           "canSpringBallJumpMidAir"
         ]},

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -201,7 +201,7 @@
       "link": [2, 1],
       "name": "Kill one then IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"or": [
           {"and": [
             "canShinechargeMovement",
@@ -243,7 +243,7 @@
       "link": [2, 1],
       "name": "Jump into IBJ",
       "requires": [
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ],
       "failures": [
         {

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -235,14 +235,14 @@
           "SpaceJump",
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"or": [
-              "h_canBombHorizontally",
+              "canBombHorizontally",
               "Gravity"
             ]}
           ]},
           {"and": [
-            "h_canSpringBallBombJump",
+            "canSpringBallBombJump",
             "h_additionalBomb",
             "h_additionalBomb"
           ]}
@@ -1002,8 +1002,8 @@
       "notable": true,
       "requires": [
         "canInsaneJump",
-        "h_canSpringFling",
-        "h_canResetFallSpeed",
+        "canSpringFling",
+        "canResetFallSpeed",
         "canDownBack"
       ],
       "note": [

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -376,7 +376,7 @@
       "requires": [
         "Gravity",
         {"or": [
-          "h_canIBJ",
+          "canIBJ",
           {"and": [
             "SpaceJump",
             "canMidAirMorph"

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -247,7 +247,7 @@
       "name": "IBJ",
       "requires": [
         "Gravity",
-        "h_canIBJ"
+        "canIBJ"
       ],
       "note": "Once high enough, it may be necessary to kill the fish and open the door."
     },
@@ -731,7 +731,7 @@
         "canTrickySpringBallJump",
         {"or": [
           "canStationaryLateralMidAirMorph",
-          "h_canSpringFling"
+          "canSpringFling"
         ]},
         {"or": [
           "canTrickyJump",
@@ -1077,7 +1077,7 @@
       },
       "requires": [
         "canSuitlessMaridia",
-        "h_canResetFallSpeed",
+        "canResetFallSpeed",
         "canPrepareForNextRoom"
       ],
       "note": [

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -752,8 +752,8 @@
           "canBeVeryPatient",
           {"and": [
             "Gravity",
-            "h_canCeilingBombJump",
-            "h_canIBJ"
+            "canCeilingBombJump",
+            "canIBJ"
           ]}
         ]}
       ],
@@ -1256,8 +1256,8 @@
           "canBeVeryPatient",
           {"and": [
             "Gravity",
-            "h_canCeilingBombJump",
-            "h_canIBJ"
+            "canCeilingBombJump",
+            "canIBJ"
           ]}
         ]}
       ],
@@ -1863,8 +1863,8 @@
           "canBeVeryPatient",
           {"and": [
             "Gravity",
-            "h_canCeilingBombJump",
-            "h_canIBJ"
+            "canCeilingBombJump",
+            "canIBJ"
           ]}
         ]}
       ],

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -661,7 +661,7 @@
       "link": [4, 2],
       "name": "Jump into IBJ",
       "requires": [
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ],
       "clearsObstacles": ["B"],
       "note": [
@@ -751,7 +751,7 @@
       "name": "Springwall",
       "requires": [
         "canSpringwall",
-        "h_canResetFallSpeed"
+        "canResetFallSpeed"
       ]
     },
     {
@@ -759,7 +759,7 @@
       "name": "Springwall onto Grapple Block",
       "requires": [
         "canSpringwall",
-        "h_canSpringFling"
+        "canSpringFling"
       ],
       "clearsObstacles": ["B"]
     },
@@ -768,7 +768,7 @@
       "name": "Walljumpless SpringFling",
       "requires": [
         "h_canMaxHeightSpringBallJump",
-        "h_canSpringFling"
+        "canSpringFling"
       ],
       "clearsObstacles": ["B"],
       "note": "Time a pause before jumping to give a significant momentum boost in order to reach the Grapple Block."

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -849,7 +849,7 @@
           "SpeedBooster",
           "h_canFly",
           "canSpringBallJumpMidAir",
-          "h_canSpringBallBombJump"
+          "canSpringBallBombJump"
         ]}
       ]
     },
@@ -2488,7 +2488,7 @@
             "canTrickySpringBallJump",
             {"or": [
               "canCrouchJump",
-              "h_canSpringFling",
+              "canSpringFling",
               "canStationaryLateralMidAirMorph"
             ]}
           ]}
@@ -2753,8 +2753,8 @@
           {"and": [
             "Gravity",
             {"or": [
-              "h_canIBJ",
-              "h_canBombHorizontally"
+              "canIBJ",
+              "canBombHorizontally"
             ]}
           ]},
           {"and": [

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -176,7 +176,7 @@
       "name": "Gravity IBJ",
       "requires": [
         "Gravity",
-        "h_canIBJ"
+        "canIBJ"
       ]
     },
     {
@@ -587,8 +587,8 @@
           "canWalljump",
           "SpaceJump",
           {"and": [
-            "h_canIBJ",
-            "h_canBombHorizontally"
+            "canIBJ",
+            "canBombHorizontally"
           ]},
           "canSpringBallJumpMidAir"
         ]},

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -418,7 +418,7 @@
           "canWalljump",
           "HiJump",
           "canSpringBallJumpMidAir",
-          "h_canIBJ",
+          "canIBJ",
           "canUseFrozenEnemies",
           "canGravityJump"
         ]}
@@ -671,7 +671,7 @@
         {"or": [
           "Grapple",
           "SpaceJump",
-          "h_canResetFallSpeed",
+          "canResetFallSpeed",
           {"and": [
             "canTrickyJump",
             "canLateralMidAirMorph"
@@ -744,7 +744,7 @@
         {"or": [
           "canWalljump",
           "canGravityJump",
-          "h_canIBJ",
+          "canIBJ",
           {"and": [
             "HiJump",
             "SpeedBooster"
@@ -794,7 +794,7 @@
       "requires": [
         "canCarefulJump",
         "canLateralMidAirMorph",
-        "h_canSpringFling",
+        "canSpringFling",
         "SpeedBooster"
       ]
     },

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -945,8 +945,8 @@
             "canPreciseGrapple"
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
-            "h_canDoubleBombJump"
+            "canJumpIntoIBJ",
+            "canDoubleBombJump"
           ]}
         ]}
       ],
@@ -1210,7 +1210,7 @@
       "link": [5, 4],
       "name": "Jump Into IBJ",
       "requires": [
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ],
       "note": [
         "Jump into an IBJ from the moving platform (Kamer).",

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -961,7 +961,7 @@
       "link": [5, 1],
       "name": "PCJR Door IBJ",
       "requires": [
-        "h_canJumpIntoIBJ"
+        "canJumpIntoIBJ"
       ]
     },
     {

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1716,7 +1716,7 @@
         {"or": [
           "canMidAirMorph",
           "h_canUseSpringBall",
-          "h_canIBJ"
+          "canIBJ"
         ]}
       ]
     },
@@ -2697,7 +2697,7 @@
             "canTrickyJump",
             {"or": [
               "canBePatient",
-              "h_canDoubleBombJump"
+              "canDoubleBombJump"
             ]}
           ]}
         ]}
@@ -2729,7 +2729,7 @@
             "canBePatient",
             {"or": [
               "canBeVeryPatient",
-              "h_canDoubleBombJump"
+              "canDoubleBombJump"
             ]}
           ]}
         ]}

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -775,11 +775,11 @@
       "requires": [
         {"or": [
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 1020}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 510}
           ]}
         ]}
@@ -791,11 +791,11 @@
       "requires": [
         {"or": [
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 450}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 300}
           ]}
         ]}

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -320,7 +320,7 @@
       "link": [2, 1],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 1450}
       ]
     },
@@ -940,7 +940,7 @@
         }
       },
       "requires": [
-        "h_canSpringFling",
+        "canSpringFling",
         "canLateralMidAirMorph",
         "canCarefulJump",
         {"heatFrames": 120}

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -635,10 +635,10 @@
           "h_lavaProof",
           "canSuitlessLavaDive"
         ]},
-        "h_canJumpIntoIBJ",
-        "h_canDoubleBombJump",
-        "h_canDiagonalBombJump",
-        "h_canStaggeredIBJ",
+        "canJumpIntoIBJ",
+        "canDoubleBombJump",
+        "canDiagonalBombJump",
+        "canStaggeredIBJ",
         "canInsaneJump",
         {"heatFrames": 1560},
         {"lavaFrames": 1520}
@@ -865,8 +865,8 @@
           "h_lavaProof",
           "canSuitlessLavaDive"
         ]},
-        "h_canJumpIntoIBJ",
-        "h_canDoubleBombJump",
+        "canJumpIntoIBJ",
+        "canDoubleBombJump",
         "Plasma",
         "Ice",
         "canCameraManip",

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -394,7 +394,7 @@
       "link": [2, 3],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 1200}
       ]
     },
@@ -656,7 +656,7 @@
       "link": [3, 4],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 1950}
       ],
       "note": "Jump the Alcoon and kill the Multiviola, then IBJ."
@@ -839,7 +839,7 @@
       "link": [4, 6],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 750}
       ],
       "note": "Kill the enemies, then IBJ."
@@ -982,7 +982,7 @@
       "link": [6, 1],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 1500}
       ],
       "note": "Kill the enemies, then IBJ."

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -312,7 +312,7 @@
       "name": "Spiky Acid Snakes Frozen Platforms (Left to Right)",
       "notable": true,
       "requires": [
-        "h_canResetFallSpeed",
+        "canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         {"or": [
@@ -561,7 +561,7 @@
       "name": "Spiky Acid Snakes Frozen Platforms (Right to Left)",
       "notable": true,
       "requires": [
-        "h_canResetFallSpeed",
+        "canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         {"or": [

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -748,7 +748,7 @@
       "link": [5, 4],
       "name": "IBJ",
       "requires": [
-        "h_canIBJ",
+        "canIBJ",
         {"heatFrames": 850}
       ],
       "note": "Kill a Gamet and don't pick up its drops, so that they won't spawn while performing the IBJ."

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -338,7 +338,7 @@
       "link": [2, 3],
       "name": "Croc Escape Jump IBJ",
       "requires": [
-        "h_canJumpIntoIBJ",
+        "canJumpIntoIBJ",
         {"heatFrames": 1650}
       ]
     },
@@ -348,7 +348,7 @@
       "requires": [
         "h_heatProof",
         "Gravity",
-        "h_canIBJ"
+        "canIBJ"
       ],
       "note": "Kill the Dragon with bombs, then start the IBJ in the lava. It's an option without canJumpIntoIBJ."
     },
@@ -410,7 +410,7 @@
         "canTrickyUseFrozenEnemies",
         "canCarefulJump",
         {"or": [
-          "h_canResetFallSpeed",
+          "canResetFallSpeed",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -265,8 +265,8 @@
       "link": [2, 1],
       "name": "Crumble Shaft IBJ (Right)",
       "requires": [
-        "h_canIBJ",
-        "h_canStaggeredIBJ",
+        "canIBJ",
+        "canStaggeredIBJ",
         {"heatFrames": 4000}
       ],
       "note": [
@@ -280,7 +280,7 @@
       "name": "Heatproof Crumble Shaft IBJ",
       "requires": [
         "h_heatProof",
-        "h_canIBJ"
+        "canIBJ"
       ],
       "note": [
         "Kill the Sova on the bottom-right platform, then IBJ right next to the left of the platform.",
@@ -468,8 +468,8 @@
       "link": [2, 3],
       "name": "Crumble Shaft IBJ (Left)",
       "requires": [
-        "h_canIBJ",
-        "h_canStaggeredIBJ",
+        "canIBJ",
+        "canStaggeredIBJ",
         {"heatFrames": 4000}
       ],
       "note": "IBJ against the left-most wall. Changing the IBJ speed may be necessary to get past the Sova."
@@ -479,7 +479,7 @@
       "name": "Heatproof Crumble Shaft IBJ",
       "requires": [
         "h_heatProof",
-        "h_canIBJ"
+        "canIBJ"
       ],
       "note": "IBJ against the left-most wall. Place bombs to kill the Sova. Drop to the bottom and restart if necessary."
     },

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -337,7 +337,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canIBJ",
+          "canIBJ",
           {"and": [
             "canMidAirMorph",
             {"or": [
@@ -570,7 +570,7 @@
         {"or": [
           "canMidAirMorph",
           "h_canUseSpringBall",
-          "h_canIBJ"
+          "canIBJ"
         ]}
       ],
       "clearsObstacles": ["C"]

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -458,16 +458,16 @@
           ]},
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 240}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
-            "h_canDoubleBombJump",
+            "canJumpIntoIBJ",
+            "canDoubleBombJump",
             {"heatFrames": 120}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 300}
           ]}
         ]},
@@ -503,20 +503,20 @@
           ]},
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canIBJ",
+            "canIBJ",
             {"heatFrames": 900}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
+            "canJumpIntoIBJ",
             {"heatFrames": 240}
           ]},
           {"and": [
-            "h_canJumpIntoIBJ",
-            "h_canDoubleBombJump",
+            "canJumpIntoIBJ",
+            "canDoubleBombJump",
             {"heatFrames": 120}
           ]},
           {"and": [
-            "h_canDoubleBombJump",
+            "canDoubleBombJump",
             {"heatFrames": 300}
           ]}
         ]},

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -943,14 +943,14 @@
         ]},
         {"or": [
           {"and": [
-            "h_canHBJ",
-            "h_canResetFallSpeed"
+            "canHBJ",
+            "canResetFallSpeed"
           ]},
           {"and": [
             {"obstaclesCleared": ["A"]},
-            "h_canDiagonalBombJump"
+            "canDiagonalBombJump"
           ]},
-          "h_canCeilingBombJump"
+          "canCeilingBombJump"
         ]}
       ],
       "note": "Bomb Jump between the two floating platforms."
@@ -1192,8 +1192,8 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"or": [
-          "h_canCeilingBombJump",
-          "h_canDiagonalBombJump"
+          "canCeilingBombJump",
+          "canDiagonalBombJump"
         ]}
       ],
       "note": "Bomb Jump between the two floating platforms."

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -142,7 +142,7 @@
           "HiJump",
           "SpaceJump",
           "canWalljump",
-          "h_canIBJ",
+          "canIBJ",
           "canSpringBallJumpMidAir"
         ]}
       ],
@@ -513,8 +513,8 @@
       "notable": true,
       "requires": [
         "canSuitlessLavaDive",
-        "h_canJumpIntoIBJ",
-        "h_canDoubleBombJump",
+        "canJumpIntoIBJ",
+        "canDoubleBombJump",
         {"or": [
           {"and": [
             "Gravity",
@@ -534,7 +534,7 @@
           "SpaceJump",
           "canWalljump",
           "h_canCrouchJumpDownGrab",
-          "h_canJumpIntoIBJ",
+          "canJumpIntoIBJ",
           "canSpringBallJumpMidAir"
         ]},
         {"or": [

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -469,7 +469,7 @@
       },
       "requires": [
         "canTrickyJump",
-        "h_canSpringFling",
+        "canSpringFling",
         "canLateralMidAirMorph",
         "canIframeSpikeJump",
         {"spikeHits": 1}

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -337,7 +337,7 @@
       "link": [1, 2],
       "name": "Ceiling Bomb Jump",
       "requires": [
-        "h_canCeilingBombJump"
+        "canCeilingBombJump"
       ],
       "devNote": "It is possible with a low vertical diagonal bomb jump, or a double HBJ, but those aren't tech yet."
     },

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -623,7 +623,7 @@
           "SpeedBooster",
           "h_canCrouchJumpDownGrab",
           "canSpringBallJumpMidAir",
-          "h_canSpringBallBombJump",
+          "canSpringBallBombJump",
           "canUseFrozenEnemies"
         ]}
       ]


### PR DESCRIPTION
This removes the now useless helpers. It was just from a find and replace, so it should be pretty simple.