### PR TITLE
Add Items to Tech Pt.2 and Cleanup

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -734,11 +734,25 @@
           ]
         },
         {
-          "name": "h_canNonTrivialCeilingClip",
+          "name": "h_canXRayMorphIceClip",
+          "requires": [
+            "canXRayCeilingClip",
+            "canTrickyUseFrozenEnemies"
+          ]
+        },
+        {
+          "name": "h_canPreciseIceClip",
+          "requires": [
+            "canTrickyUseFrozenEnemies",
+            "canPreciseCeilingClip"
+          ]
+        },
+        {
+          "name": "h_canIceClip",
           "requires": [
             {"or":[
-              "canPreciseCeilingClip",
-              "canXRayCeilingClip"
+              "h_canXRayMorphIceClip",
+              "h_canPreciseIceClip"
             ]}
           ]
         },

--- a/helpers.json
+++ b/helpers.json
@@ -103,14 +103,16 @@
           "requires": [
             "h_MissileRefillStationAllAmmo",
             "h_can10PowerBombCrystalFlash",
-            {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
-          ]
+            {"refill": ["Missile", "Super", "PowerBomb"]}
+          ],
+          "devNote": "A partial refill of 1500 Energy is also included in h_can10PowerBombCrystalFlash."
         },
         {
           "name": "h_useEnergyRefillStation",
           "requires": [
             {"refill": ["RegularEnergy"]}
-          ]
+          ],
+          "devNote": "In Vanilla, Energy refill stations only refill regular energy. This can be changed if the stations refill Reserve energy as well."
         },
         {
           "name": "h_AccessTourianEscape1RightDoor",
@@ -698,15 +700,16 @@
           "name": "h_can10PowerBombCrystalFlash",
           "requires": [
             "can10PowerBombCrystalFlash",
-            {"refill": ["Energy"]}
+            {"partialRefill": {"type": "Energy", "limit": 1500}}
           ]
         },
         {
-          "name": "h_canXMode",
+          "name": "h_canHeated10PowerBombCrystalFlash",
           "requires": [
-            "canXMode",
-            "Morph"
-          ]
+            "can10PowerBombCrystalFlash",
+            "h_HeatedCrystalFlashRefill"
+          ],
+          "devNote": "All heat frames before and after the refill are added on the strats that use the helper."
         },
         {
           "name": "h_XModeSpikeHit",
@@ -731,19 +734,11 @@
           ]
         },
         {
-          "name": "h_canXRayCeilingClip",
-          "requires": [
-            "canXRayCeilingClip",
-            "Morph",
-            "canXRayStandUp"
-          ]
-        },
-        {
           "name": "h_canNonTrivialCeilingClip",
           "requires": [
             {"or":[
               "canPreciseCeilingClip",
-              "h_canXRayCeilingClip"
+              "canXRayCeilingClip"
             ]}
           ]
         },
@@ -983,10 +978,10 @@
             {"ammo": {"type": "Missile", "count": 10}},
             {"ammo": {"type": "Super", "count": 10}},
             {"ammo": {"type": "PowerBomb", "count": 10}},
-            {"refill": ["Energy"]},
+            {"partialRefill": {"type": "Energy", "limit": 1500}},
             {"noFlashSuit": {}}
           ],
-          "devNote": "FIXME: Samus may not get a full refill, depending on the tanks and environment."
+          "devNote": "FIXME: Samus may not get a full refill, depending on the number of tanks and environment."
         },
         {
           "name": "h_canArtificialMorphBombIntoCrystalFlashClip",

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -715,7 +715,7 @@
       "name": "Ice Clip",
       "requires": [
         {"obstaclesCleared": ["B"]},
-        "h_canXRayCeilingClip",
+        "canXRayCeilingClip",
         "canTrickyUseFrozenEnemies"
       ],
       "flashSuitChecked": true,

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -715,8 +715,7 @@
       "name": "Ice Clip",
       "requires": [
         {"obstaclesCleared": ["B"]},
-        "canXRayCeilingClip",
-        "canTrickyUseFrozenEnemies"
+        "h_canXRayMorphIceClip"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -653,8 +653,7 @@
       "name": "Etecoon E-Tank Beetom Clip",
       "notable": true,
       "requires": [
-        "h_canNonTrivialCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canIceClip",
         "Morph",
         {"enemyDamage": {
           "enemy": "Beetom",
@@ -662,7 +661,7 @@
           "hits": 2
         }},
         {"or": [
-          "canPreciseCeilingClip",
+          "h_canPreciseIceClip",
           "canWalljump",
           "HiJump",
           "SpaceJump",

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Leave Shinecharged (X-Mode)",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeThornHit",
         "h_XModeThornHit",
         "h_XModeThornHit",

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4049,8 +4049,7 @@
       "link": [13, 12],
       "name": "Green Brinstar Main Shaft Ice Clip",
       "requires": [
-        "h_canNonTrivialCeilingClip",
-        "canTrickyUseFrozenEnemies"
+        "h_canIceClip"
       ],
       "note": [
         "Freeze the wall crawler at a precise location in order to jump through the Power Bomb Blocks.",
@@ -4077,12 +4076,11 @@
           "type": "contact",
           "hits": 1
         }},
-        "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         {"or": [
-          "canXRayCeilingClip",
+          "h_canXRayMorphIceClip",
           {"and": [
-            "canPreciseCeilingClip",
+            "h_canPreciseIceClip",
             "canInsaneJump",
             "canBeVeryPatient"
           ]}

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4080,7 +4080,7 @@
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         {"or": [
-          "h_canXRayCeilingClip",
+          "canXRayCeilingClip",
           {"and": [
             "canPreciseCeilingClip",
             "canInsaneJump",

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -168,7 +168,7 @@
       "name": "Kihunter Ice Clip Door Lock Skip",
       "requires": [
         "canTrickyUseFrozenEnemies",
-        "h_canXRayCeilingClip"
+        "canXRayCeilingClip"
       ],
       "bypassesDoorShell": true,
       "note": [

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -167,8 +167,7 @@
       "link": [2, 2],
       "name": "Kihunter Ice Clip Door Lock Skip",
       "requires": [
-        "canTrickyUseFrozenEnemies",
-        "canXRayCeilingClip"
+        "h_canXRayMorphIceClip"
       ],
       "bypassesDoorShell": true,
       "note": [

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -536,8 +536,7 @@
       "link": [3, 3],
       "name": "Zeela Ice Clip Door Lock Skip",
       "requires": [
-        "canTrickyUseFrozenEnemies",
-        "h_canNonTrivialCeilingClip"
+        "h_canIceClip"
       ],
       "bypassesDoorShell": true,
       "note": [

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1860,9 +1860,8 @@
       "name": "Big Pink Reo Ice Clip With Morph and X-Ray",
       "notable": true,
       "requires": [
-        "canTrickyUseFrozenEnemies",
-        "canPreciseCeilingClip",
-        "canXRayCeilingClip"
+        "h_canPreciseIceClip",
+        "h_canXRayMorphIceClip"
       ],
       "note": [
         "Lure the Reo (Bee) to the left to use it as a platform for ice clipping up through the crumbles to the Power Bomb room exit door.",
@@ -1882,8 +1881,7 @@
       "name": "Big Pink Reo Ice Clip Without Morph and X-Ray",
       "notable": true,
       "requires": [
-        "canTrickyUseFrozenEnemies",
-        "canPreciseCeilingClip"
+        "h_canPreciseIceClip"
       ],
       "note": [
         "Lure the Reo (Bee) to the left to use it as a platform for ice clipping up through the crumbles to the Power Bomb room exit door.",
@@ -1902,14 +1900,13 @@
       "name": "Big Pink Zeb Ice Clip",
       "notable": true,
       "requires": [
-        "canTrickyUseFrozenEnemies",
         "canStaggeredWalljump",
         "canCameraManip",
         {"or": [
           "Wave",
           "Spazer"
         ]},
-        "canPreciseCeilingClip"
+        "h_canPreciseIceClip"
       ],
       "note": [
         "Raise a Zeb to be just below the crumble blocks and blindly freeze it to set up an ice clip to reach the Power Bomb room exit door.",

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1862,7 +1862,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies",
         "canPreciseCeilingClip",
-        "h_canXRayCeilingClip"
+        "canXRayCeilingClip"
       ],
       "note": [
         "Lure the Reo (Bee) to the left to use it as a platform for ice clipping up through the crumbles to the Power Bomb room exit door.",

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -176,7 +176,7 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "SpeedBooster",
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canShinechargeMovement"

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -401,11 +401,9 @@
         "canTrickyJump",
         {"or": [
           "canXRayCeilingClip",
-          {"and": [
-            "canTunnelCrawl",
-            "canPartialFloorClip"
-          ]}
+          "canTunnelCrawl"
         ]},
+        "canPartialFloorClip",
         "canCeilingClip"
       ],
       "note": [
@@ -413,8 +411,7 @@
         "The thorns do not cover the entire blocks above. Jump barely only onto the corner to avoid the damage.",
         "Carefully jump around the thorns, tunnel crawl slightly to avoid touching the thorns when partial floor clipping.",
         "Morph and x-ray can be used instead to setup the clip much easier."
-      ],
-      "devNote": "FIXME: Technically this canXRayCeilingClip does not require canUseEnemies."
+      ]
     },
     {
       "link": [3, 1],

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -400,7 +400,7 @@
       "requires": [
         "canTrickyJump",
         {"or": [
-          "h_canXRayCeilingClip",
+          "canXRayCeilingClip",
           {"and": [
             "canTunnelCrawl",
             "canPartialFloorClip"
@@ -413,7 +413,8 @@
         "The thorns do not cover the entire blocks above. Jump barely only onto the corner to avoid the damage.",
         "Carefully jump around the thorns, tunnel crawl slightly to avoid touching the thorns when partial floor clipping.",
         "Morph and x-ray can be used instead to setup the clip much easier."
-      ]
+      ],
+      "devNote": "FIXME: Technically this canXRayCeilingClip does not require canUseEnemies."
     },
     {
       "link": [3, 1],

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -137,7 +137,7 @@
       "link": [1, 1],
       "name": "Leave with Spark (X-Mode)",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canIframeSpikeJump",
@@ -418,7 +418,7 @@
       "name": "Shinespark (X-Mode)",
       "requires": [
         "canMidairShinespark",
-        "h_canXMode",
+        "canXMode",
         {"spikeHits": 2},
         {"canShineCharge": {
           "usedTiles": 33,
@@ -439,7 +439,7 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canMidairShinespark",
-        "h_canXMode",
+        "canXMode",
         {"spikeHits": 1},
         {"canShineCharge": {
           "usedTiles": 33,
@@ -639,7 +639,7 @@
       "link": [2, 2],
       "name": "Leave Shinecharged (X-Mode)",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         {"canShineCharge": {

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -177,7 +177,7 @@
       "link": [1, 1],
       "name": "X-Mode, Leave Shinecharged",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canShinechargeMovement",
@@ -498,7 +498,6 @@
       },
       "requires": [
         "canSuperJump",
-        "Morph",
         {"spikeHits": 3},
         {"or": [
           {"spikeHits": 3},
@@ -518,7 +517,6 @@
       "notable": true,
       "requires": [
         "canSuperJump",
-        "Morph",
         {"spikeHits": 3},
         {"canShineCharge": {
           "usedTiles": 33,

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1330,8 +1330,7 @@
           "canBeVeryPatient",
           {"ammo": {"type": "Super", "count": 1}}
         ]},
-        "canPreciseCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canPreciseIceClip",
         "canUseGrapple",
         "canXRayStandUp"
       ],
@@ -1357,8 +1356,7 @@
           "canBeVeryPatient",
           {"ammo": {"type": "Super", "count": 1}}
         ]},
-        "canPreciseCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canPreciseIceClip",
         {"enemyDamage": {
           "enemy": "Geemer (blue)",
           "type": "contact",

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -86,8 +86,7 @@
       "name": "Sciser Ice Clip Door Lock Skip",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
-        "canTrickyUseFrozenEnemies",
-        "h_canNonTrivialCeilingClip"
+        "h_canIceClip"
       ],
       "bypassesDoorShell": true,
       "note": [

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1597,8 +1597,7 @@
       "name": "West Ocean Bug Ice Clip",
       "notable": true,
       "requires": [
-        "h_canNonTrivialCeilingClip",
-        "canTrickyUseFrozenEnemies"
+        "h_canIceClip"
       ],
       "note": [
         "Freeze a bug three tiles to the right of the morph tunnel entrance, directly under the tile where ceiling is higher.",

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -1105,7 +1105,7 @@
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"heatFrames": 185},
-        "h_can10PowerBombCrystalFlash",
+        "h_canHeated10PowerBombCrystalFlash",
         {"heatFrames": 30}
       ],
       "note": [

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -367,7 +367,7 @@
       "name": "X-Mode",
       "requires": [
         "SpeedBooster",
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         {"or": [

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1541,8 +1541,7 @@
       "notable": true,
       "requires": [
         "h_heatProof",
-        "canPreciseCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canPreciseIceClip",
         "canPartialFloorClip",
         "canTrickyJump",
         "canCrumbleJump",
@@ -1573,8 +1572,7 @@
       "notable": true,
       "requires": [
         "h_heatProof",
-        "canXRayCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canXRayMorphIceClip",
         {"or": [
           "h_canCrouchJumpDownGrab",
           "canWalljump",
@@ -1596,8 +1594,7 @@
       "notable": true,
       "requires": [
         "h_heatProof",
-        "canPreciseCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canPreciseIceClip",
         {"enemyDamage": {
           "enemy": "Multiviola",
           "type": "contact",
@@ -1621,8 +1618,7 @@
       "name": "Mickey Mouse Viola Clip (XRay Standup and Morph)",
       "notable": true,
       "requires": [
-        "canXRayCeilingClip",
-        "canTrickyUseFrozenEnemies"
+        "h_canXRayMorphIceClip"
       ],
       "reusableRoomwideNotable": "Mickey Mouse Viola Ice Clip",
       "note": [
@@ -1636,8 +1632,7 @@
       "notable": true,
       "requires": [
         "h_heatProof",
-        "canPreciseCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canPreciseIceClip",
         {"enemyDamage": {
           "enemy": "Multiviola",
           "type": "contact",
@@ -1661,8 +1656,7 @@
       "notable": true,
       "requires": [
         "h_heatProof",
-        "canPreciseCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canPreciseIceClip",
         {"enemyDamage": {
           "enemy": "Multiviola",
           "type": "contact",

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1573,7 +1573,7 @@
       "notable": true,
       "requires": [
         "h_heatProof",
-        "h_canXRayCeilingClip",
+        "canXRayCeilingClip",
         "canTrickyUseFrozenEnemies",
         {"or": [
           "h_canCrouchJumpDownGrab",
@@ -1621,7 +1621,7 @@
       "name": "Mickey Mouse Viola Clip (XRay Standup and Morph)",
       "notable": true,
       "requires": [
-        "h_canXRayCeilingClip",
+        "canXRayCeilingClip",
         "canTrickyUseFrozenEnemies"
       ],
       "reusableRoomwideNotable": "Mickey Mouse Viola Ice Clip",

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -361,7 +361,7 @@
       "notable": true,
       "requires": [
         "Gravity",
-        "h_canXRayCeilingClip",
+        "canXRayCeilingClip",
         "canTrickyUseFrozenEnemies",
         {"or": [
           "canTrickyJump",

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -361,8 +361,7 @@
       "notable": true,
       "requires": [
         "Gravity",
-        "canXRayCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canXRayMorphIceClip",
         {"or": [
           "canTrickyJump",
           {"enemyDamage": {
@@ -384,8 +383,7 @@
       "notable": true,
       "requires": [
         "Gravity",
-        "canPreciseCeilingClip",
-        "canTrickyUseFrozenEnemies"
+        "h_canPreciseIceClip"
       ],
       "note": "Freeze the puyo at the start of its jump animation, on the right frame."
     },
@@ -395,8 +393,7 @@
       "notable": true,
       "requires": [
         "canSuitlessMaridia",
-        "h_canNonTrivialCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canIceClip",
         {"enemyDamage": {
           "enemy": "Puyo",
           "type": "contact",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -456,8 +456,12 @@
       "name": "Snail Clip to the Left Middle Door",
       "notable": true,
       "requires": [
-        "h_canNonTrivialCeilingClip",
-        "Gravity"
+        "Gravity",
+        "canUseEnemies",
+        {"or":[
+          "canPreciseCeilingClip",
+          "canXRayCeilingClip"
+        ]}
       ],
       "reusableRoomwideNotable": "Aqueduct Snail Clip",
       "note": [
@@ -1317,8 +1321,12 @@
       "name": "Snail Clip to the Items",
       "notable": true,
       "requires": [
-        "h_canNonTrivialCeilingClip",
-        "Gravity"
+        "Gravity",
+        "canUseEnemies",
+        {"or":[
+          "canPreciseCeilingClip",
+          "canXRayCeilingClip"
+        ]}
       ],
       "reusableRoomwideNotable": "Aqueduct Snail Clip",
       "note": [

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -642,12 +642,10 @@
           {"and": [
             "Gravity",
             "canUseFrozenEnemies",
+            "canCrouchJump",
             "canCeilingClip"
           ]},
-          {"and": [
-            "canTrickyUseFrozenEnemies",
-            "h_canNonTrivialCeilingClip"
-          ]}
+          "h_canIceClip"
         ]},
         "canGrappleClip"
       ],
@@ -658,7 +656,8 @@
         "Samus should be one tile below the grapple blocks and fully in the wall.",
         "Too short a tap and the next grapple will not work, too long and Samus will be stuck in the wall.",
         "Grapple diagonally again to be pushed into the transition."
-      ]
+      ],
+      "devNote": "FIXME: It doesnt seem like there is the normal 2-3 pixel window for this clip, but there is the high single pixel clip, which needs a separate tech."
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -529,12 +529,11 @@
       "notable": true,
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
-        "canTrickyUseFrozenEnemies",
         {"or": [
-          "canXRayCeilingClip",
+          "h_canXRayMorphIceClip",
           {"and": [
             "Gravity",
-            "canPreciseCeilingClip"
+            "h_canPreciseIceClip"
           ]}
         ]}
       ],

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -531,7 +531,7 @@
         {"ammo": {"type": "Super", "count": 1}},
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canXRayCeilingClip",
+          "canXRayCeilingClip",
           {"and": [
             "Gravity",
             "canPreciseCeilingClip"

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -176,7 +176,7 @@
       "link": [1, 1],
       "name": "X-Mode, Leave Shinecharged",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         {"or": [
@@ -405,7 +405,7 @@
       "link": [2, 2],
       "name": "X-Mode, Leave Shinecharged",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         {"or": [
@@ -538,7 +538,7 @@
       "name": "X-Mode Shinespark",
       "requires": [
         "Gravity",
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         {"or": [

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -734,8 +734,7 @@
       "name": "Suitless Double Spring Ball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "canDoubleSpringBallJumpMidAir",
-        "HiJump"
+        "h_canDoubleSpringBallJumpWithHiJump"
       ]
     },
     {

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -592,9 +592,8 @@
       "notable": true,
       "requires": [
         "h_canNavigateUnderwater",
-        "canTrickyUseFrozenEnemies",
         "canOffScreenMovement",
-        "canPreciseCeilingClip",
+        "h_canPreciseIceClip",
         {"or": [
           "Gravity",
           {"and": [

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -458,8 +458,7 @@
       "name": "Mella Ice Clip Door Lock Skip",
       "requires": [
         "canManipulateMellas",
-        "canTrickyUseFrozenEnemies",
-        "h_canNonTrivialCeilingClip"
+        "h_canIceClip"
       ],
       "bypassesDoorShell": true,
       "note": [
@@ -1140,8 +1139,7 @@
       "notable": true,
       "requires": [
         "Morph",
-        "h_canNonTrivialCeilingClip",
-        "canTrickyUseFrozenEnemies",
+        "h_canIceClip",
         {"or": [
           "canConsecutiveWalljump",
           {"and": [

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -439,7 +439,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies",
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canXRayCeilingClip",
+        "canXRayCeilingClip",
         {"or": [
           "canConsecutiveWalljump",
           "h_canFly",

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -437,9 +437,8 @@
       "link": [3, 4],
       "name": "Viola Ice Clip Door Lock Skip",
       "requires": [
-        "canTrickyUseFrozenEnemies",
         {"ammo": {"type": "Super", "count": 2}},
-        "canXRayCeilingClip",
+        "h_canXRayMorphIceClip",
         {"or": [
           "canConsecutiveWalljump",
           "h_canFly",

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -663,8 +663,7 @@
       "name": "Gamet Ice Clip Door Lock Skip",
       "requires": [
         {"heatFrames": 560},
-        "canTrickyUseFrozenEnemies",
-        "h_canNonTrivialCeilingClip"
+        "h_canIceClip"
       ],
       "bypassesDoorShell": true,
       "note": [

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1724,8 +1724,7 @@
       "link": [5, 9],
       "name": "Bubble Mountain Ice Clip",
       "requires": [
-        "h_canNonTrivialCeilingClip",
-        "canTrickyUseFrozenEnemies"
+        "h_canIceClip"
       ],
       "note": [
         "Freeze the wall crawler at a precise location in order to jump through the Power Bomb Blocks.",

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -187,7 +187,7 @@
       "requires": [
         "canPrepareForNextRoom",
         {"heatFrames": 570},
-        "h_can10PowerBombCrystalFlash"
+        "h_canHeated10PowerBombCrystalFlash"
       ],
       "note": [
         "Normalized movement through the room can be used to manipulate the Sm. Dessgeegas and do this strat reliably without heat protection.",
@@ -278,7 +278,7 @@
       "requires": [
         "canPrepareForNextRoom",
         {"heatFrames": 420},
-        "h_can10PowerBombCrystalFlash"
+        "h_canHeated10PowerBombCrystalFlash"
       ],
       "note": [
         "A normalized entrance to the room can be used to manipulate the Sm. Dessgeegas and do this strat reliably without heat protection.",

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -861,7 +861,7 @@
       "link": [3, 3],
       "name": "XMode with Walljump",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -880,7 +880,7 @@
       "link": [3, 3],
       "name": "XMode with HiJump",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -1021,7 +1021,7 @@
       "link": [3, 4],
       "name": "XMode Shinespark",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canTrickyJump",
@@ -1203,7 +1203,7 @@
       "link": [4, 3],
       "name": "XMode Shinespark",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canTrickyJump",

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -146,7 +146,7 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         {"heatFrames": 260},
-        "h_can10PowerBombCrystalFlash",
+        "h_canHeated10PowerBombCrystalFlash",
         {"heatFrames": 80}
       ],
       "note": [
@@ -381,7 +381,7 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         {"heatFrames": 240},
-        "h_can10PowerBombCrystalFlash",
+        "h_canHeated10PowerBombCrystalFlash",
         {"heatFrames": 70}
       ],
       "note": [
@@ -608,7 +608,7 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         {"heatFrames": 270},
-        "h_can10PowerBombCrystalFlash",
+        "h_canHeated10PowerBombCrystalFlash",
         {"heatFrames": 90}
       ],
       "note": [

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -240,8 +240,7 @@
       "name": "Atomic Ice Clip Door Lock Skip",
       "requires": [
         "f_DefeatedPhantoon",
-        "canTrickyUseFrozenEnemies",
-        "h_canNonTrivialCeilingClip"
+        "h_canIceClip"
       ],
       "bypassesDoorShell": true,
       "note": [

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -401,7 +401,7 @@
       "link": [2, 2],
       "name": "Leave Shinecharged (X-Mode or Phantoon Alive)",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -529,7 +529,7 @@
       "link": [2, 6],
       "name": "X-Mode",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit"
       ],
       "note": "Move in X-Mode until the Chozo Statue becomes visible and then jump before releasing XRay."

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -61,7 +61,7 @@
       "name": "Leave Shinecharged, X-Mode",
       "requires": [
         "f_DefeatedPhantoon",
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "Gravity",
@@ -423,7 +423,7 @@
       "name": "Leave Shinecharged, X-Mode",
       "requires": [
         "f_DefeatedPhantoon",
-        "h_canXMode",
+        "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "Gravity",

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -116,7 +116,7 @@
       "link": [1, 1],
       "name": "X-Mode and Space Jump, Leave with Shinespark",
       "requires": [
-        "h_canXMode",
+        "canXMode",
         "h_XModeThornHit",
         "h_XModeThornHit",
         "SpaceJump",

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -240,8 +240,7 @@
       "link": [1, 1],
       "name": "Covern or Atomic Ice Clip Door Lock Skip",
       "requires": [
-        "canTrickyUseFrozenEnemies",
-        "h_canNonTrivialCeilingClip"
+        "h_canIceClip"
       ],
       "bypassesDoorShell": true,
       "note": [

--- a/tech.json
+++ b/tech.json
@@ -1666,6 +1666,7 @@
           "techRequires": [],
           "otherRequires": [
             "XRayScope",
+            "Morph",
             {"noFlashSuit": {}}
           ],
           "note": [
@@ -1808,33 +1809,32 @@
               "name": "canXRayCeilingClip",
               "techRequires": [
                 "canCeilingClip",
-                "canUseEnemies"
+                "canUseEnemies",
+                "canXRayStandUp"
               ],
-              "otherRequires": [],
+              "otherRequires": ["Morph"],
               "note": [
                 "Setting up an enemy positioning to perform a ceiling clip. Jump and Morph onto the enemy, perform an X-Ray standup, and then jump through.",
                 "The enemy positioning will require approximately 1.5 to 2 tiles between the enemy and the ceiling. Just enough to unmorph while on top of it."
+              ]
+            },
+            {
+              "name": "canPreciseCeilingClip",
+              "techRequires": [
+                "canCeilingClip",
+                "canUseEnemies",
+                "canCrouchJump"
               ],
-              "devNote": "This tech cannot require Morph and canXRayStandUp, because it's extension removes those requirements.",
-              "extensionTechs": [
-                {
-                  "name": "canPreciseCeilingClip",
-                  "techRequires": [
-                    "canXRayCeilingClip",
-                    "canCrouchJump"
-                  ],
-                  "otherRequires": [],
-                  "note": [
-                    "Setting up an enemy positioning to perform a very precise ceiling clip.",
-                    "The enemy positioning will require a 2-3 pixel precision range, several pixels lower than what is possible with an X-Ray standup.",
-                    "A crouch jump is then required to clip through."
-                  ],
-                  "devNote": [
-                    "FIXME: There is a pixel perfect height in which you don't need a crouch jump, which could be used for preserving a flash suit.",
-                    "It is much higher - at the same height as the Botwoon Hallway Mochtroid Ice Clip.",
-                    "This will need to be a different tech with strats tested for it explicitly."
-                  ]
-                }
+              "otherRequires": [],
+              "note": [
+                "Setting up an enemy positioning to perform a very precise ceiling clip.",
+                "The enemy positioning will require a 2-3 pixel precision range, several pixels lower than what is possible with an X-Ray standup.",
+                "A crouch jump is then required to clip through."
+              ],
+              "devNote": [
+                "FIXME: There is a pixel perfect height in which you don't need a crouch jump, which could be used for preserving a flash suit.",
+                "It is much higher - at the same height as the Botwoon Hallway Mochtroid Ice Clip.",
+                "This will need to be a different tech with strats tested for it explicitly."
               ]
             }
           ]

--- a/tech.json
+++ b/tech.json
@@ -1809,7 +1809,6 @@
               "name": "canXRayCeilingClip",
               "techRequires": [
                 "canCeilingClip",
-                "canUseEnemies",
                 "canXRayStandUp"
               ],
               "otherRequires": ["Morph"],


### PR DESCRIPTION
This is very similar to previous PRs on the topic, but also with a bit of general helper cleanup.

Note that I removed the extension/requirement of `canXRayCeilingClip` in `canPreciseCeilingClip`. Although they are progressive in difficulty and accomplish the same thing, they didn't really feel like extensions to me. Let me know if you think it should be added back.