### PR TITLE
Add canEnterGMode to Strats that don't Start at a Door

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -648,6 +648,7 @@
       "link": [4, 1],
       "name": "Artificial Morph Remotely Collect the Item",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ],
       "note": "After touching the item, roll back to the left before exiting G-Mode and remotely collect it.",
@@ -865,6 +866,7 @@
       "link": [5, 2],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ",
         {"or": [
           "canConsecutiveWalljump",
@@ -878,12 +880,15 @@
     {
       "link": [5, 4],
       "name": "G-Mode Morph",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     },
     {
       "link": [5, 4],
       "name": "G-Mode Morph with Power Bomb",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
@@ -893,6 +898,7 @@
       "link": [6, 2],
       "name": "G-Mode Morph Power Bomb the Item",
       "requires": [
+        "canEnterGMode",
         {"itemNotCollectedAtNode": 4},
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphPowerBomb",
@@ -911,6 +917,7 @@
       "link": [6, 4],
       "name": "G-Mode Morph Remotely Collect the Item",
       "requires": [
+        "canEnterGMode",
         {"itemNotCollectedAtNode": 4},
         "h_canArtificialMorphMovement"
       ],
@@ -927,7 +934,9 @@
     {
       "link": [6, 5],
       "name": "Base",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     }
   ]
 }

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -987,6 +987,7 @@
       "link": [4, 2],
       "name": "G-mode Morph Remote Acquire at the Top Right Door",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["A"]},
         {"or": [
           "h_canArtificialMorphIBJ",
@@ -1030,6 +1031,7 @@
       "link": [4, 5],
       "name": "G-mode Morph Remote Acquire",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["A"]}
       ],
       "note": "While in g-mode, touch the item, roll out of the pipe, then exit g-mode to obtain the item.",

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2121,6 +2121,7 @@
       "link": [15, 1],
       "name": "G-mode Morph",
       "requires": [
+        "canEnterGMode",
         {"or": [
           "Morph",
           {"and": [
@@ -2150,6 +2151,7 @@
       "link": [15, 1],
       "name": "G-mode Morph Overload PLMs with Power Bombs and Spring Ball",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphSpringBallBombJump",
         "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphPowerBomb",
@@ -2177,6 +2179,7 @@
       "link": [15, 4],
       "name": "G-mode Overload PLMs with Morph",
       "requires": [
+        "canEnterGMode",
         "canMidAirMorph"
       ],
       "clearsObstacles": ["C"],
@@ -2189,6 +2192,7 @@
       "link": [15, 4],
       "name": "G-mode Morph Overload PLMs with Bombs",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ],
       "clearsObstacles": ["C"],
@@ -2203,6 +2207,7 @@
       "link": [15, 4],
       "name": "G-mode Morph Overload PLMs with Bombs, Break Power Bomb Blocks",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphPowerBomb"
       ],
@@ -2219,6 +2224,7 @@
       "link": [15, 4],
       "name": "G-mode Morph Overload PLMs with Power Bombs and Spring Ball",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphSpringBall",
         "canCameraManip",
         "h_canArtificialMorphPowerBomb",
@@ -2241,6 +2247,7 @@
       "link": [15, 4],
       "name": "G-mode Morph Overload PLMs with Power Bombs and Spring Ball, Break Power Bomb Blocks",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphSpringBall",
         "canCameraManip",
         "h_canArtificialMorphPowerBomb",
@@ -2265,6 +2272,7 @@
       "link": [15, 8],
       "name": "G-mode Morph",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphMovement"
       ]
     },
@@ -2272,6 +2280,7 @@
       "link": [15, 10],
       "name": "G-mode Morph with Bombs",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ],
       "note": [
@@ -2285,6 +2294,7 @@
       "link": [15, 12],
       "name": "G-mode Morph Overload PLMs",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphMovement"
       ],
       "note": "Overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers."
@@ -2293,6 +2303,7 @@
       "link": [15, 13],
       "name": "G-mode Morph Power Bomb the Blocks",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphPowerBomb"
       ],

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -984,6 +984,7 @@
       "link": [3, 4],
       "name": "Remote Acquire Item",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["C"]}
       ]
     },
@@ -999,6 +1000,7 @@
       "link": [3, 5],
       "name": "Remote Acquire Item",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["C"]}
       ],
       "note": "Walk through the item or use Bombs to overload PLMs, fall through the speed blocks, then exit G-Mode to remote acquire the item."

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -1174,6 +1174,7 @@
       "link": [8, 1],
       "name": "G-Mode Morph Power Bomb",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphPowerBomb"
       ],
@@ -1186,6 +1187,7 @@
       "link": [8, 1],
       "name": "G-Mode Morph Screw Attack",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ",
         "ScrewAttack"
       ],
@@ -1195,6 +1197,7 @@
       "link": [8, 3],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ]
     },
@@ -1202,6 +1205,7 @@
       "link": [8, 4],
       "name": "G-Mode Morph Power Bomb",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B"],
@@ -1211,6 +1215,7 @@
       "link": [8, 4],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ],
       "devNote": "Over the wall."

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -2255,6 +2255,7 @@
       "link": [15, 16],
       "name": "G-mode Overload PLMs with Grapple",
       "requires": [
+        "canEnterGMode",
         "Grapple",
         "Morph"
       ]
@@ -2263,6 +2264,7 @@
       "link": [15, 16],
       "name": "G-mode Overload PLMs by Bombing Crumble Block with Space Jump",
       "requires": [
+        "canEnterGMode",
         "h_canUseMorphBombs",
         "SpaceJump",
         {"or": [
@@ -2276,6 +2278,7 @@
       "link": [15, 16],
       "name": "G-mode Overload PLMs by Bombing Crumble Block",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphCeilingBombJump"
       ],
@@ -2286,6 +2289,7 @@
       "link": [16, 14],
       "name": "Base",
       "requires": [
+        "canEnterGMode",
         {"or": [
           {"and": [
             "SpaceJump",
@@ -2305,6 +2309,7 @@
       "name": "West Ocean G-mode Overload PLMs by PBing Missile Item",
       "notable": true,
       "requires": [
+        "canEnterGMode",
         {"itemNotCollectedAtNode": 10},
         "h_canUsePowerBombs",
         {"or": [
@@ -2327,6 +2332,7 @@
       "link": [17, 16],
       "name": "West Ocean G-mode Overload PLMs by PBing Missile Item Softlock Risk",
       "requires": [
+        "canEnterGMode",
         {"itemNotCollectedAtNode": 10},
         "canRiskPermanentLossOfAccess",
         {"or": [

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -1479,12 +1479,15 @@
     {
       "link": [10, 2],
       "name": "Base",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     },
     {
       "link": [10, 4],
       "name": "G-Mode Morph Pirate Kill",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphBombThings",
         "h_additionalBomb"
       ]
@@ -1493,6 +1496,7 @@
       "link": [10, 9],
       "name": "G-Mode Morph - Power Bomb to the Beetoms",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
@@ -1502,6 +1506,7 @@
       "link": [10, 9],
       "name": "G-Mode Morph - Overload PLMs to the Beetoms",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphBombs",
         {"or": [
           {"and": [

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1965,6 +1965,7 @@
       "link": [10, 1],
       "name": "Overload PLMs - Bomb the Speed Blocks, To the Middle Left Door",
       "requires": [
+        "canEnterGMode",
         "Gravity",
         "h_canArtificialMorphIBJ"
       ]
@@ -1973,6 +1974,7 @@
       "link": [10, 2],
       "name": "Break the Power Bomb Blocks",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
@@ -1982,6 +1984,7 @@
       "link": [10, 7],
       "name": "Overload PLMs - Bomb the Speed Blocks, To the Top Right Items",
       "requires": [
+        "canEnterGMode",
         "Gravity",
         "h_canArtificialMorphIBJ"
       ]
@@ -1990,6 +1993,7 @@
       "link": [10, 11],
       "name": "Overload PLMs - Bomb the Speed Blocks",
       "requires": [
+        "canEnterGMode",
         "Gravity",
         "h_canArtificialMorphIBJ"
       ]
@@ -1998,6 +2002,7 @@
       "link": [10, 11],
       "name": "Overload PLMs - Bomb the Speed Blocks",
       "requires": [
+        "canEnterGMode",
         "h_canUseMorphBombs",
         {"or": [
           "canSnailClimb",
@@ -2011,6 +2016,7 @@
       "link": [10, 11],
       "name": "Overload PLMs - Morphed Suitless Snail Climb",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphBombs",
         "HiJump",
         "h_canArtificialMorphSpringBall",
@@ -2021,6 +2027,7 @@
       "link": [10, 11],
       "name": "Overload PLMs - Morphed Suitless Snail Climb, No Jump Assist",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphBombs",
         "h_canArtificialMorphSpringBall",
         "canSnailClimb",
@@ -2036,6 +2043,7 @@
       "link": [11, 1],
       "name": "G-Mode Overloaded PLMs Through the Bomb Blocks",
       "requires": [
+        "canEnterGMode",
         {"or": [
           "canSnailClimb",
           {"and": [
@@ -2053,6 +2061,7 @@
       "link": [11, 7],
       "name": "G-Mode Overloaded PLMs Through the Speed Blocks",
       "requires": [
+        "canEnterGMode",
         "canSnailClimb",
         {"or": [
           "Gravity",

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -636,13 +636,17 @@
     {
       "link": [4, 3],
       "name": "Base",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     },
     {
       "link": [4, 3],
       "name": "Carry G-Mode Up the Elevator",
       "notable": false,
-      "requires": [],
+      "requires": [
+        "canEnterGMode"
+      ],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": false

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -1405,12 +1405,16 @@
     {
       "link": [5, 1],
       "name": "Exit G-Mode",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     },
     {
       "link": [5, 1],
       "name": "Carry G-Mode Morph Left",
-      "requires": [],
+      "requires": [
+        "canEnterGMode"
+      ],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": true
@@ -1420,7 +1424,9 @@
     {
       "link": [5, 4],
       "name": "Carry G-Mode Morph Right",
-      "requires": [],
+      "requires": [
+        "canEnterGMode"
+      ],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": true

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -3459,13 +3459,17 @@
     {
       "link": [12, 6],
       "name": "Base",
-      "requires": [],
+      "requires": [
+        "canEnterGMode"
+      ],
       "devNote": "This technically requires h_EverestMorphTunnelExpanded or going through the transition while in G-Mode, but that shouldn't cause a problem."
     },
     {
       "link": [12, 6],
       "name": "Carry G-Mode Through the Tunnel",
-      "requires": [],
+      "requires": [
+        "canEnterGMode"
+      ],
       "exitCondition": {
         "leaveWithGMode": {
           "morphed": true

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -1334,6 +1334,7 @@
       "link": [6, 1],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ]
     },
@@ -1341,6 +1342,7 @@
       "link": [6, 4],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ]
     },
@@ -1348,6 +1350,7 @@
       "link": [6, 4],
       "name": "G-Mode Morph Spring Ball Bomb Jump",
       "requires": [
+        "canEnterGMode",
         "canTrickyJump",
         "h_canArtificialMorphSpringBallBombJump"
       ],

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -845,6 +845,7 @@
       "link": [3, 1],
       "name": "G-Mode Morph Remote Acquire - to Left Door (Using Previous Strat)",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["C", "D"]}
       ]
     },
@@ -852,6 +853,7 @@
       "link": [3, 2],
       "name": "G-Mode Morph Remote Acquire - to Right Door",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ]
     },
@@ -1179,18 +1181,22 @@
       "link": [6, 1],
       "name": "G-Mode Morph to Left Door (Using Previous Strat)",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["C"]}
       ]
     },
     {
       "link": [6, 2],
       "name": "G-Mode Morph",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     },
     {
       "link": [6, 2],
       "name": "G-Mode Morph Power Bomb the Blocks",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"]
@@ -1199,18 +1205,22 @@
       "link": [6, 3],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ]
     },
     {
       "link": [6, 5],
       "name": "Base",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     },
     {
       "link": [6, 6],
       "name": "G-Mode Morph Spring Ball IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphJumpIntoIBJ"
       ],
       "clearsObstacles": ["C"]
@@ -1219,6 +1229,7 @@
       "link": [6, 6],
       "name": "G-Mode Morph Diagonal Bomb Jump",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphDiagonalBombJump"
       ],
       "clearsObstacles": ["C"]
@@ -1227,6 +1238,7 @@
       "link": [6, 6],
       "name": "G-Mode Morph Acid Dive IBJ",
       "requires": [
+        "canEnterGMode",
         "Gravity",
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphBombHorizontally",

--- a/region/norfair/crocomire/Post Crocomire Missile Room.json
+++ b/region/norfair/crocomire/Post Crocomire Missile Room.json
@@ -179,6 +179,7 @@
       "link": [2, 1],
       "name": "G-mode Morph Remote Acquire",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["A"]}
       ]
     },

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -2694,6 +2694,7 @@
       "link": [10, 1],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ",
         {"or": [
           "h_canArtificialMorphPowerBomb",
@@ -2711,12 +2712,15 @@
     {
       "link": [10, 3],
       "name": "Base",
-      "requires": []
+      "requires": [
+        "canEnterGMode"
+      ]
     },
     {
       "link": [10, 3],
       "name": "G-Mode Morph Power Bomb the Blocks",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"]
@@ -2725,6 +2729,7 @@
       "link": [10, 7],
       "name": "G-Mode Morph IBJ",
       "requires": [
+        "canEnterGMode",
         "h_canArtificialMorphIBJ",
         {"or": [
           "h_canArtificialMorphPowerBomb",

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -594,6 +594,7 @@
       "link": [4, 1],
       "name": "Remote Acquire",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ]
     },
@@ -613,6 +614,7 @@
       "link": [4, 3],
       "name": "Remote Acquire",
       "requires": [
+        "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ],
       "note": "Overload PLMs by rolling through the item, then go through the bomb block and exit G-Mode to obtain the item.",


### PR DESCRIPTION
This is to make it so that G-Mode strats that don't have an entrance condition no longer show in `Basic` in Map Rando.