### PR TITLE
Add flashSuitChecked to all G-Mode Strats

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -298,6 +298,7 @@
           "Morph"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "In direct g-mode, the door will not close, and the in-room doorsill gives enough running room to make it up to the invisible ledge."
     },
     {
@@ -313,6 +314,7 @@
         "h_canArtificialMorphJumpIntoIBJ",
         "h_canArtificialMorphBombHorizontally"
       ],
+      "flashSuitChecked": true,
       "note": "Starting an IBJ from spring ball with no other items is not very precise, it just takes a bit of an odd timing."
     },
     {

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -264,7 +264,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -554,6 +555,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Falling down the shaft and breaking the crumble block does not require Morph."
     },
     {
@@ -575,6 +577,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Falling down the shaft and breaking the crumble block does not require Morph."
     },
     {
@@ -587,6 +590,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Falling down the shaft and breaking the crumble block does not require Morph."
     },
     {

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -278,7 +278,8 @@
         }},
         "h_ZebesIsAwake"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -660,6 +661,7 @@
         "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ],
+      "flashSuitChecked": true,
       "note": "After touching the item, roll back to the left before exiting G-Mode and remotely collect it.",
       "devNote": "This does not include canRiskPermanentLossOfAccess, because the only reason to do this strat is if the item is there."
     },
@@ -883,6 +885,7 @@
           "canOffScreenMovement"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs by repeatidly bombing the Power Bomb blocks or the side of the crumble block, then enter through the crumble block.",
       "devNote": "The off screen movement is just during an IBJ, and only if wall jumps are disabled. But the IBJ is long and Samus is covered for most of it."
     },
@@ -891,7 +894,8 @@
       "name": "G-Mode Morph",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 4],
@@ -901,6 +905,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true,
       "note": "The blocks will not break if PLMs are already overloaded. Exiting G-Mode before the Power Bomb explodes will ensure they break."
     },
     {
@@ -917,6 +922,7 @@
           "SpaceJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs with a single Power Bomb by hitting the item at the right end of the room.",
         "This can be done with a single precisely placed Power Bomb. There should be 4 empty tiles between Samus and the left of the blocks when the bomb is placed."
@@ -931,6 +937,7 @@
         "h_canArtificialMorphMovement"
       ],
       "clearsObstacles": ["D"],
+      "flashSuitChecked": true,
       "note": [
         "Touch the item to either roll back to the left before exiting G-Mode and remotely collect it,",
         "or to overload PLMs and go up through the crumble block and bomb block."
@@ -945,7 +952,8 @@
       "name": "Base",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -419,6 +419,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "It is possible to roll off of the ledge and avoid the Geemers, but it is somewhat tight and the timing is likely earlier than expected.",
       "devNote": "An immobile strat only takes one hit on entry, skipping the Geemer hit, which is modeled by going 1->6->5."
     },
@@ -446,6 +447,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Blue Brinstar Energy Tank G-Mode Flashing Lights",
+      "flashSuitChecked": true,
       "note": [
         "The eye scanners are particularly annoying while in g-mode. They scan Samus with bright flashing lights which remain for a further distance.",
         "This is notable so a player can disable having to enter these flashing lights. If disabled, Samus will only require being in g-mode in this room if Zebes is awake."
@@ -474,6 +476,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "It is possible to roll off of the ledge and avoid the Geemers, but it is somewhat tight and the timing is likely earlier than expected."
     },
     {
@@ -489,6 +492,7 @@
       "requires": [
         "h_ZebesIsAwake"
       ],
+      "flashSuitChecked": true,
       "devNote": "The immobile case is included as a separate strat, since the Geemer hit to restore mobility provides i-frames eliminating a need to account for a subsequent Geemer hit (or a way to evade it)."
     },
     {
@@ -515,6 +519,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Blue Brinstar Energy Tank G-Mode Flashing Lights",
+      "flashSuitChecked": true,
       "note": [
         "The eye scanners are particularly annoying while in G-mode. They scan Samus with bright flashing lights which remain for a further distance.",
         "This is notable so a player can disable having to enter these flashing lights. If disabled, Samus will only require being in g-mode in this room if Zebes is awake."

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -454,6 +454,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -552,7 +553,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -127,6 +127,7 @@
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Shoot a Super at the wall, while the Geemer is moving vertically. If it is on the bottom of the shot blocks, it will not fall."
     },
     {
@@ -339,6 +340,7 @@
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Shoot a Super at the wall, while the Geemer is moving vertically. If it is on the bottom of the shot blocks, it will not fall."
     },
     {

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -111,6 +111,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Carefully shoot the shoot blocks at the right time to knock off a Geemer without killing it."
     },
     {
@@ -322,6 +323,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Carefully shoot the shoot blocks at the right time to knock off a Geemer without killing it."
     },
     {
@@ -524,6 +526,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Carefully shoot the shoot blocks at the right time to knock off a Geemer without killing it."
     },
     {

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -237,7 +237,8 @@
         }},
         "h_ZebesIsAwake"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -279,6 +279,7 @@
         "h_ZebesNotAwake"
       ],
       "clearsObstacles": ["D"],
+      "flashSuitChecked": true,
       "note": "Overload the PLMs by rolling through the camera scroll blocks which are 4 tiles to the right of the stair by the door."
     },
     {
@@ -311,6 +312,7 @@
         ]}
       ],
       "clearsObstacles": ["D"],
+      "flashSuitChecked": true,
       "note": [
         "Either kill the Sidehoppers immediately on entry by placing a Power Bomb while rolling off the stair or tank their hits.",
         "If Samus has Morph Ball, it is also possible to kill the Sidehoppers upon room entry with Screw Attack or a powerful beam.",
@@ -350,6 +352,7 @@
         ]}
       ],
       "clearsObstacles": ["D"],
+      "flashSuitChecked": true,
       "note": [
         "Tank the Sidehopper hits or kill them after a single hit by quickly placing a Power Bomb.",
         "It is also possible to kill the Sidehoppers with a very fast Screw Attack, if Samus has Morph Ball.",
@@ -580,7 +583,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -623,6 +627,7 @@
         "h_canArtificialMorphMovement"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Place the Power Bomb, then exit g-mode before the bomb goes off."
     },
     {

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -223,7 +223,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -274,7 +274,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -906,7 +907,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -376,6 +376,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
     },
     {
@@ -744,6 +745,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
     },
     {
@@ -1131,6 +1133,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
     },
     {
@@ -1157,6 +1160,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -2004,6 +2008,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
     },
     {
@@ -2048,6 +2053,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -2095,6 +2101,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -2575,6 +2582,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
     },
     {
@@ -2640,6 +2648,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -3093,6 +3102,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb, then exit g-mode in order to break the Power Bomb blocks."
     },
     {
@@ -3129,6 +3139,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 3 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -3147,6 +3158,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -3245,6 +3257,7 @@
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks in front of the bomb block, then go through the morph tunnel and IBJ to the top."
     },
     {
@@ -3259,6 +3272,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks in front of the bomb block, then go through the morph tunnel and exit g-mode."
     },
     {
@@ -3274,6 +3288,7 @@
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks in front of the bomb block, then go through the morph tunnel and IBJ to the top.",
       "devNote": "This is only useful if the item is Morph"
     },
@@ -3302,6 +3317,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb while on the top single tile platform, then exit g-mode before the Power Bomb explodes in order to break the blocks above."
     },
     {
@@ -3323,6 +3339,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 6 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -3342,6 +3359,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 5 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -3361,6 +3379,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 4 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -3422,6 +3441,7 @@
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks in front of the bomb block, then go through the morph tunnel and IBJ to the top."
     },
     {
@@ -3436,6 +3456,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks in front of the bomb block, then go through the morph tunnel and exit g-mode."
     },
     {
@@ -3451,6 +3472,7 @@
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks in front of the bomb block, then go through the morph tunnel and IBJ to the top.",
       "devNote": "This is only useful if the item is Morph"
     },
@@ -3491,6 +3513,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb while on the top single tile platform, then exit g-mode before the Power Bomb explodes in order to break the blocks above."
     },
     {
@@ -3568,7 +3591,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [9, 9],
@@ -3588,7 +3612,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [9, 10],
@@ -3638,6 +3663,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "This is only useful if the item is Morph."
     },
     {
@@ -3657,6 +3683,7 @@
         "canBePatient",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Place bombs against the item Chozo ball to overload PLMs. Then go through the bomb blocks and tunnel.",
         "IBJ up the left side, blind, until getting on the top small platform. Place a Power Bomb and exit g-mode before the bomb goes off to break the blocks."
@@ -3676,6 +3703,7 @@
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "Place bombs against the item Chozo ball to overload PLMs. Then go through the bomb blocks and tunnel, then exit g-mode."
     },
     {
@@ -3721,7 +3749,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 10],
@@ -3754,6 +3783,7 @@
       "requires": [
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "This is only useful if the item is Morph."
     },
     {
@@ -3773,6 +3803,7 @@
         "canBePatient",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "IBJ up and place bombs against the item Chozo ball to overload PLMs. Then go through the bomb blocks and tunnel.",
         "IBJ up again, blind, until getting on the top small platform. Place a Power Bomb and exit g-mode before the bomb goes off to break the blocks."
@@ -3809,6 +3840,7 @@
         "h_canArtificialMorphIBJ",
         "canBePatient"
       ],
+      "flashSuitChecked": true,
       "note": "IBJ up and place bombs against the item Chozo ball to overload PLMs. Then go through the bomb blocks and tunnel, then exit g-mode."
     },
     {

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -421,6 +421,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "It is possible to save a lot of time by using a Super to knock the clockwise Zeela off the small platform above."
     },
     {
@@ -866,7 +867,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -1800,6 +1802,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "It is possible to save a lot of time by using a Super to knock the clockwise Zeela off the small platform above."
     },
     {
@@ -2413,7 +2416,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [5, 5],
@@ -3069,7 +3073,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],
@@ -3201,6 +3206,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Bring the Zeela from above. It is not global, so it will need to remain on camera for it to move."
       ]
@@ -3423,6 +3429,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Bring the Zeela from above. It is not global, so it will need to remain on camera for it to move.",
         "Using a Super once it's on the right wall below the door can save 20 seconds."

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -436,6 +436,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "It takes 80 seconds for the global Zeela to make it over here. A Super could speed this up, but it's likely to just get the Zeela stuck."
     },
     {
@@ -881,6 +882,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait for the global Zeela."
     },
     {
@@ -1817,6 +1819,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "It takes 70 seconds for the global Zeela to make it over here. A Super could speed this up, but it's likely to just get the Zeela stuck."
     },
     {
@@ -2430,6 +2433,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "It takes 60 seconds for the global Zeela to make it over here. A Super could speed this up, but it's likely to just get the Zeela stuck."
     },
     {
@@ -3087,6 +3091,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "It takes 50 seconds for the global Zeela to make it over here. A Super could speed this up, but it's likely to just get the Zeela stuck."
     },
     {

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -934,7 +934,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -947,7 +947,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -1006,6 +1007,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "While in g-mode, touch the item, roll out of the pipe, then get to the top right door before exiting g-mode and obtaining the item.",
       "devNote": "FIXME: Need these items without counting the item at 4."
     },
@@ -1043,6 +1045,7 @@
         "canEnterGMode",
         {"obstaclesCleared": ["A"]}
       ],
+      "flashSuitChecked": true,
       "note": "While in g-mode, touch the item, roll out of the pipe, then exit g-mode to obtain the item.",
       "devNote": "This technically goes to 1, but 5->1 is free, and this will make the room diagram cleaner."
     },

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -400,6 +400,7 @@
           "h_canArtificialMorphSpringBallBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Kill or spring ball over the first bug. IBJ or bomb boost spring ball jump up to the door."
     },
     {
@@ -467,6 +468,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Roll under the first bug, wait for the second to spawn before rolling off the ledge. IBJ, bomb boost spring ball jump, or HiJump Spring Fling into the pipe.",
       "devNote": "FIXME: Add springFling tech."
     },
@@ -486,6 +488,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Roll under the first bug, wait for the second to spawn before rolling off the ledge. IBJ or bomb boost spring ball jump into the pipe."
     },
     {
@@ -676,6 +679,7 @@
           "h_canArtificialMorphSpringBallBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Fall past the first bug, wait for the second to spawn before rolling off the ledge. IBJ or bomb boost spring ball jump into the pipe."
     },
     {
@@ -698,6 +702,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Fall past the first bug, wait for the second to spawn before rolling off the ledge. IBJ, bomb boost spring ball jump, or HiJump Spring Fling into the pipe."
     },
     {
@@ -746,7 +751,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -836,6 +842,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a Power Bombs to kill the first three hoppers,",
         "or carefully dodge them by quickly rolling between the first two tall flowers and waiting for the hopper to jump over Samus.",
@@ -968,6 +975,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a Power Bombs to kill the first three hoppers,",
         "or carefully dodge them by quickly rolling between the first two tall flowers and waiting for the hopper to jump over Samus.",

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -138,6 +138,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Wait for the slow global Zeelas. They take almost 4 minutes to get there."
     },
     {
@@ -275,6 +276,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Wait for the slow global Zeelas. They take almost 2 minutes to get there."
     },
     {

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -153,6 +153,7 @@
         "canBeVeryPatient"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait for the slow global Zeelas. They take almost 4 minutes to get there."
     },
     {
@@ -291,6 +292,7 @@
         "canBePatient"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait for the slow global Zeelas. They take almost 2 minutes to get there."
     }
   ]

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -153,7 +153,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -229,7 +230,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -140,7 +140,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -247,6 +247,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": "Quickly jump back through the door to avoid a Kihunter hit."
     },
     {
@@ -287,6 +288,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "With Spring Ball alone, quickly jump over the Kihunter and wait for it to move away, then Spring Ball Bomb Jump through the door.",
         "Alternatively, place a Power Bomb and roll to the left on entry to kill the Kihunter, then quickly IBJ through the door before more arrive."

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -296,6 +296,7 @@
       "requires": [
         "h_canArtificialMorphBombThings"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait for the pirates to move as far right as possible in order to kill them all with a single Power Bomb.",
         "Unmorph and kill Baby Kraid before exiting G-Mode. Run away, exit G-Mode, then jump over the spike projectiles."
@@ -413,6 +414,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Kill all of the enemies with Bombs. Samus will take a Baby Kraid spike hit while rolling through the invisible projectiles.",
         "It is not too difficult to IBJ and then bomb horizontally over the cluster of invisible spikes, but there is some risk because they are invisible.",
@@ -437,6 +439,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Wait on the right side of Baby Kraid for about 10 seconds so that he shoots the maximum amount of projectiles which will move to the right after exiting G-Mode.",
         "Roll through him and kill the left pirates with a Power Bomb. Only one is necessary when placing next to the pirate when it is as far to the left as possible.",

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -128,7 +128,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -449,6 +450,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure a Zeb up from below by freezing it or quickly moving after the Zeb has spawned, but before it becomes visible.",
         "Note that Samus must start on the right side of the Zeb in order for it to move rightwards once it starts moving horizontally."
@@ -624,6 +626,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Lure a Zeb by freezing it or by moving quickly while carefully preventing it from going off screen."
     }
   ]

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -250,6 +250,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The only projectiles that Kraid can hit Samus with through the transition are the spinning talons after he stands up.",
         "This requires Kraid to not be defeated and the door to be open during the second phase."

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -202,7 +202,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -277,6 +277,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Roll in while avoiding the Beetoms. It is possible to kill them all without getting hit; one of the most safe areas is the center of the lower floor.",
       "devNote": [
         "There is no way to avoid all damage in direct g-mode, nor a way to get out of immobile.",

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -189,7 +189,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -223,6 +223,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Overload the PLMs by rolling through the camera scroll blocks which are just above the shot blocks.",
       "devNote": "In immobile, the Kihunters are in a worse location, but Samus starts with i-frames."
     },
@@ -470,6 +471,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Rolling on the ground will overload PLMs by moving through camera scroll blocks.",
         "Lure all of the Kihunters to the top right position, then quickly move left, exit g-mode and retreat to one of the other exits."

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -201,6 +201,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "devNote": "It looks like the only way to remain in the room is by starting on the right side and triggering a turnaround, with or without artificial morph."
     },
     {

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -283,6 +283,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "The camera will be messed up, so you will need to move blindly to get into position.",
@@ -505,6 +506,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Wiggle back and forth to get through the bomb blocks before the Zeela hits Samus.",
       "devNote": "This is off camera, but doesnt require canOffScreenMovement because of its simplicity."
     },
@@ -528,6 +530,7 @@
       "requires": [
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wiggle back and forth to get through the bomb blocks while avoiding the off screen Zeela.",
         "Unmorph and exit G-Mode then quickly run back and forth to fix the camera or go through the door."
@@ -604,7 +607,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -632,7 +636,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -161,7 +161,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -396,7 +397,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -148,7 +148,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -382,7 +383,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -589,7 +591,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2169,6 +2169,7 @@
           "h_canArtificialMorphPowerBomb"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Carefully dodge the Sidehoppers, or kill them with a Power Bomb. Be careful not to hit the bomb block with the Power Bomb or it will remain solid.",
         "With IBJ alone, it is easiest to IBJ from the bug pipe below to the ceiling, luring the Sidehoppers to the left.",
@@ -2197,6 +2198,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Go down and overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers.",
         "Use multiple Power Bomb boost Spring Ball jumps, to climb the room; note that one Power Bomb can be saved by carefully jumping out of this morph passageway.",
@@ -2211,6 +2213,7 @@
         "canMidAirMorph"
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers,",
         "or in front of the bomb block at the top left door. Safely kill the enemies, then mid-air morph and go through the crumble blocks."
@@ -2224,6 +2227,7 @@
         "h_canArtificialMorphIBJ"
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "If there are no Sidehoppers in the bottom right corner of their pen, roll down and carefully place bombs while luring and killing them.",
         "Otherwise, go down into the hallway below and carefully kill the two Reos and lure the Sidehoppers to the left.",
@@ -2240,6 +2244,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "If there are no Sidehoppers in the bottom right corner of their pen, roll down and carefully place bombs while luring and killing them.",
         "Otherwise, go down into the hallway below and carefully kill the two Reos and lure the Sidehoppers to the left.",
@@ -2263,6 +2268,7 @@
         ]}
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "Carefully dodge the Reos to the left of the door leading to the Pink Hopper Room and lure them and the Sidehoppers close to each other.",
         "Place a Power Bomb to kill them and both Sidehoppers above. Go down below and lure the third Reo, below the Zeb pipe, off screen to the left.",
@@ -2287,6 +2293,7 @@
         ]}
       ],
       "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "Carefully dodge the Reos to the left of the door leading to the Pink Hopper Room and lure them and the Sidehoppers close to each other.",
         "Place a Power Bomb to kill them and both Sidehoppers above. Go down below and lure the third Reo, below the Zeb pipe, off screen to the left.",
@@ -2311,6 +2318,7 @@
         "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": [
         "If there are no Sidehoppers in the bottom right corner of their pen, roll down and carefully place bombs while luring and killing them.",
         "Otherwise, go down into the hallway below and carefully kill the two Reos and lure the Sidehoppers to the left.",
@@ -2325,6 +2333,7 @@
         "canEnterGMode",
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers."
     },
     {
@@ -2335,6 +2344,7 @@
         "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphPowerBomb"
       ],
+      "flashSuitChecked": true,
       "clearsObstacles": ["B"],
       "note": [
         "Use a Power Bomb to kill any Sidehoppers in the pit below, then roll off and use a second, while exiting G-Mode to destroy the blocks in front of the door.",

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -444,6 +444,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "Roll through the camera scroll blocks and then through the bomb block.",
         "Avoiding the Sidehoppers can be tricky.",
@@ -475,6 +476,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "Roll through the camera scroll blocks and then through the bomb block.",
         "Avoiding the Sidehoppers can be tricky.",
@@ -505,6 +507,7 @@
         "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphPowerBomb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Roll through the camera scroll blocks and then through the bomb block.",
         "Avoiding the Sidehoppers can be tricky.",
@@ -562,6 +565,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks and then through the bomb block."
     },
     {
@@ -592,6 +596,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Roll through the camera scroll blocks and then through the bomb block.",
         "Avoiding the hoppers can be tricky."
@@ -615,6 +620,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Roll through the camera scroll blocks and then through the bomb block."
     },
     {
@@ -699,6 +705,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the camera scroll blocks in front of the bomb blocks to the top left door.",
         "Avoiding the Sidehoppers can be tricky.",
@@ -730,6 +737,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the camera scroll blocks in front of the bomb blocks to the top left door.",
         "Avoiding the Sidehoppers can be tricky.",
@@ -750,6 +758,7 @@
       "requires": [
         {"ammo": {"type": "PowerBomb", "count": 4}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a Power Bomb to boost horizontally to the Morph tunnel to the left and overload PLMs using the camera scroll blocks in front of the bomb blocks.",
         "Carefully roll through the rest of the room and through the bomb blocks to the lowest item."
@@ -797,6 +806,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Avoiding the hoppers can be tricky."
     },
     {
@@ -871,7 +881,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -922,6 +933,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true,
       "note": "Use a Power Bomb, then exit G-Mode."
     },
     {
@@ -1087,6 +1099,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 4 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1164,7 +1177,8 @@
       },
       "requires": [
         "h_canArtificialMorphMovement"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 12],
@@ -1178,6 +1192,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers."
     },
     {
@@ -1194,6 +1209,7 @@
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Carefully roll off of the edge and land on the platform holding the item. Roll through it until PLMs are overloaded, then roll through the bomb blocks and down below."
     },
     {
@@ -1213,6 +1229,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "If using Bombs, lure and kill the Reo. If using Spring Ball, it's important to release jump before reaching to peak of each jump to outrun the Reo."
     },
     {
@@ -1326,6 +1343,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "While using multiple Power Bomb boost Spring Ball jumps, to climb the room,",
         "overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers.",
@@ -1348,6 +1366,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 6 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1368,6 +1387,7 @@
         "h_additionalBomb"
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "While using multiple Power Bomb boost Spring Ball jumps, to climb the room,",
         "overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers.",
@@ -1393,6 +1413,7 @@
         "h_additionalBomb"
       ],
       "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "While using multiple Power Bomb boost Spring Ball jumps, to climb the room,",
         "overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers.",
@@ -1416,6 +1437,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1454,7 +1476,8 @@
       },
       "requires": [
         "h_canArtificialMorphMovement"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [8, 12],
@@ -1475,6 +1498,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs by moving through the camera scroll blocks in front of the passageway leading to the exit of Spore Spawn Supers.",
       "devNote": "Using a Power Bomb boost into Spring Ball will not work, as it will make the blocks remain solid."
     },
@@ -1492,6 +1516,7 @@
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphSpringBall"
       ],
+      "flashSuitChecked": true,
       "note": "Roll through it until PLMs are overloaded, then roll through the bomb blocks and down below.",
       "devNote": "With more items, the strat with camera scroll blocks will be used."
     },
@@ -1528,7 +1553,8 @@
             "h_additionalBomb"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [9, 4],

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -419,6 +419,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": ["Carefully lure a Zeb from the pipe."]
     },
     {
@@ -680,6 +681,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": ["Lure a Zeb from the pipe."]
     },
     {
@@ -830,6 +832,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Carefully lure a Zeb from the pipe below while freezing it.",
         "Samus must start to the left of the pipe in order for the Zeb to move left at the end."
@@ -960,6 +963,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Carefully lure a Zeb from the pipe below while freezing it.",
         "Samus must start to the left of the pipe in order for the Zeb to move left at the end."
@@ -1164,6 +1168,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": ["Carefully lure a Zeb from the pipe below."]
     },
     {

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -186,7 +186,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -964,6 +965,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Using Speed Booster, run through and break the bomb wall to free the global Zeela.",
         "Break the speed blocks just before the Zeela gets to them in order for it to go down to the bottom half of the room.",
@@ -1023,7 +1025,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -199,7 +199,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -248,6 +248,7 @@
         "ScrewAttack"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Screw Attack through the bomb block wall, to instantly overload PLMs on the other side, and fall through the Speed Blocks."
     },
     {
@@ -412,6 +413,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Use a Power Bomb to destroy the bomb block wall."
     },
     {
@@ -483,6 +485,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 6 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -503,6 +506,7 @@
           "SpaceJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "There are camera scroll blocks just below the speed blocks, so it is easy to overload PLMs by wall jumping or space jumping into them."
     },
     {
@@ -518,6 +522,7 @@
         "h_canArtificialMorphIBJ",
         "canBePatient"
       ],
+      "flashSuitChecked": true,
       "note": [
         "There are camera scroll blocks just below the speed blocks, so it is easy to overload PLMs by bouncing into them.",
         "A single IBJ is slow enough at the top to overload them before Samus can hit the blocks."
@@ -626,6 +631,7 @@
           "SpaceJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "There are camera scroll blocks just below the speed blocks, so it is easy to overload PLMs by wall jumping or space jumping into them."
     },
     {
@@ -641,6 +647,7 @@
         "h_canArtificialMorphIBJ",
         "canBePatient"
       ],
+      "flashSuitChecked": true,
       "note": [
         "There are camera scroll blocks just below the speed blocks, so it is easy to overload PLMs by bouncing into them.",
         "A single IBJ is slow enough at the top to overload them before Samus can hit the blocks."
@@ -799,6 +806,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Use The camera scroll blocks above the speed blocks and by the bomb wall to overload PLMs."
     },
     {
@@ -939,6 +947,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Use The camera scroll blocks above the speed blocks and by the bomb wall to overload PLMs."
     },
     {

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -515,7 +515,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -470,6 +470,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "This is possible to do without taking a second hit:",
         "Enter the room in a jump, then shoot down to open the door and land in the doorsill."
@@ -494,6 +495,7 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "This is possible to do without taking a second hit:",
         "Enter the room in a jump, then shoot down to open the door and land in the doorsill."

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -420,7 +420,8 @@
         }
       },
       "requires": [],
-      "clearsObstacles": ["B", "C"]
+      "clearsObstacles": ["B", "C"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -440,6 +441,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
       "note": "Kill the Sidehoppers with a Power Bomb upon entry."
     },
     {
@@ -555,6 +557,7 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Kill the Sidehoppers with Bombs or a Power Bomb, then IBJ up onto the Grapple block."
     },
     {
@@ -762,6 +765,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Kill the Sidehoppers with Bombs or a Power Bomb, then IBJ up onto the Grapple block. Use Wave to get through."
     },
     {
@@ -1184,6 +1188,7 @@
         "canOffScreenMovement",
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-Mode and use X-Ray to get stuck 9 pixels inside the door.",
         "X-Ray climb to a relatively specific height:",
@@ -1208,7 +1213,8 @@
       "requires": [
         "h_canArtificialMorphIBJ"
       ],
-      "clearsObstacles": ["B"]
+      "clearsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -1223,6 +1229,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Using a power bomb against the left wall will kill the enemies and trigger the elevator."
     },
     {

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -220,7 +220,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -205,6 +205,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It's fastest to kill the first hopper safely from inside the doorway, then lure the second one over."
       ]

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -412,6 +412,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Use 1-3 Power Bombs to kill the Sidehoppers."
     },
     {
@@ -438,6 +439,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -520,6 +522,7 @@
       "requires": [
         "h_canArtificialMorphBombs"
       ],
+      "flashSuitChecked": true,
       "note": "Place Bombs against the side of the crumble block until PLMs are overloaded, then go through."
     },
     {
@@ -547,6 +550,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Place two Power Bombs, precisely on the third tile in the morph tunnel to overload PLMs (watch the right side of the screen).",
       "devNote": [
         "Because of the gates, it costs 2 Power Bombs to get into the tunnel and 2 to get out the other side.",

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -171,7 +171,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -245,7 +246,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -104,7 +104,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -137,6 +137,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 8 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -157,6 +158,7 @@
           "SpaceJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Climb the shaft and overload PLMs with the camera scroll blocks which are against the crumble blocks.",
       "devNote": [
         "This is mostly an alternative to the canBeVeryPatient X-Ray climb.",

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -152,6 +152,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The timing to get hit by these guys is a bit tighter, since they are so slow. Buffering their movement with x-ray can help."
       ]

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -230,6 +230,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Traverse the room while avoiding or killing the Boyons.",
         "If the Chozo item is still there, it is best to exit G-Mode before the final Power Bomb goes off to ensure that PLMs aren't overloaded.",
@@ -289,6 +290,7 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": [
         "Traverse the room with a small number of Power Bombs.",
         "If the Chozo item is still there, it is best to exit G-Mode before the final Power Bomb goes off to ensure that PLMs aren't overloaded.",
@@ -320,6 +322,7 @@
         "h_additionalBomb"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Traverse the room while rolling on the thorns and avoiding the Samus Eaters.",
         "Roll from the first platform onto the thorns under the first set of Boyons.",
@@ -349,6 +352,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Traverse the room while rolling on the thorns and avoiding the Samus Eaters.",
         "Roll from the first platform onto the thorns under the first set of Boyons.",

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -352,6 +352,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -167,7 +167,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -302,7 +302,8 @@
       "requires": [
         "h_canArtificialMorphPowerBomb"
       ],
-      "clearsObstacles": ["A", "B"]
+      "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -317,6 +318,7 @@
         "h_canArtificialMorphBombs"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Samus is safe while morphed and on the ground unless near the door, where the Sidehoppers can jump into the open door and then jump lower",
       "devNote": [
         "This can be done to unlock the door.",

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -154,7 +154,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -369,7 +369,8 @@
             "h_additionalBomb"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 6],
@@ -462,7 +463,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -850,7 +852,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],
@@ -886,7 +889,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 6],
@@ -913,7 +917,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 6],
@@ -931,7 +936,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -1289,7 +1295,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 6],
@@ -1313,7 +1320,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [5, 1],
@@ -1341,7 +1349,8 @@
           "h_canArtificialMorphMovement",
           "h_canArtificialMorphBombThings"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 5],
@@ -1468,7 +1477,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [6, 1],
@@ -1507,7 +1517,8 @@
       },
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -216,6 +216,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It takes around 3 minutes to get the Zero to this door.",
         "The Zero only moves on camera and the camera scrolls when exiting the morph tunnel.",
@@ -241,6 +242,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It takes around 3 minutes to get the Zero to this door.",
         "Let the Zero climb the right wall and jump on top of it in Morph Ball form to bounce up to the Cacatac platform.",
@@ -562,6 +564,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It takes around 4 minutes to get the Zero to this door.",
         "The Zero only moves on camera and the camera scrolls when exiting the morph tunnel.",
@@ -587,6 +590,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It takes around 4 minutes to get the Zero to this door.",
         "Let the Zero climb the right wall and jump on top of it in Morph Ball form to bounce up to the Cacatac platform.",
@@ -975,7 +979,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -1244,6 +1249,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "devNote": "It takes around 50 seconds to get the Zero to this door."
     },
     {
@@ -1264,6 +1270,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Let the Caterpillar climb the right wall and jump on top of it in Morph Ball form to bounce up to the Cacatac platform.",
       "devNote": "It takes around 50 seconds to get the Zero to this door."
     },
@@ -1428,6 +1435,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "It takes around 2 minutes to get the Zero to this door."
     },
     {
@@ -1453,6 +1461,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It takes around 2 minutes to get the Zero to this door.",
         "Let the Zero climb the right wall and jump on top of it in Morph Ball form to bounce up to the Cacatac platform."

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -185,7 +185,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -304,7 +305,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -200,6 +200,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Shoot a Super towards the door while the Zeela is on the side of its platform to knock it off."
     },
     {

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -338,6 +338,7 @@
         "canInsaneJump"
       ],
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "flashSuitChecked": true,
       "note": [
         "This is a very long ceiling bomb jump.",
         "Crossing the room with artificial morph is particularly difficult without a good way to kill the Wavers."
@@ -590,6 +591,7 @@
         "canInsaneJump"
       ],
       "reusableRoomwideNotable": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "flashSuitChecked": true,
       "note": [
         "This is a very long ceiling bomb jump.",
         "Crossing the room with artificial morph is particularly difficult without a good way to kill the Wavers.",

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -176,6 +176,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "It takes 30 seconds after room entry to get hit by a Waver. It is the second Waver that comes nearby."
     },
     {
@@ -678,6 +679,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "It takes 90 seconds after room entry to get hit by a Waver. It is the second Waver that comes nearby."
     },
     {

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -190,6 +190,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 30 seconds for a Waver to come and hit Samus. It is the second Waver that will hit her."
     },
     {
@@ -693,6 +694,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 40 seconds for a Waver to come and hit Samus."
     },
     {

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -382,6 +382,7 @@
           "knockback": false
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Some items may reduce the number of Beetom hits, but it's irrelevant since there is an accesible farm in-room."
     },
     {
@@ -416,6 +417,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Either place a Power Bomb on the ledge with the Geega bug farms, to only break the top row of blocks and not kill the Beetom,",
         "or move the Beetom to safety by shaking it off at a higher platform before breaking the Power Bomb blocks."
@@ -607,6 +609,7 @@
           ]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": "Some tech may reduce the number of Beetom hits, but it's irrelevant since there is an accesible farm in-room."
     },
     {
@@ -746,6 +749,7 @@
           ]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": "Some items may reduce the number of Beetom hits, but it's irrelevant since there is an accesible farm in-room."
     },
     {
@@ -2069,6 +2073,7 @@
           "knockback": false
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Without any suits or tanks, Samus will need to move the Beetom part way up the room, shake it off, and go back and farm multiple times.",
         "While the Beetom is near the top section, by the Rippers, shake the Beetom off, and re-grab it and ascend the shaft.",

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -434,7 +434,8 @@
       "requires": [
         "h_canArtificialMorphPowerBomb"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -1155,6 +1156,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1192,7 +1194,8 @@
       "requires": [
         "h_canArtificialMorphPowerBomb"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],
@@ -1537,6 +1540,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Use two Power Bombs to kill the Rippers, or carefully pass the first two and place a single Power Bomb on the left ledge to kill them all.",
         "Exit G-Mode before the Power Bomb explodes in order to break the wall."
@@ -1559,6 +1563,7 @@
       ],
       "clearsObstacles": ["A"],
       "reusableRoomwideNotable": "Red Tower IBJ Between the Bottom Rippers",
+      "flashSuitChecked": true,
       "note": [
         "Requires switching between single and double IBJs. While Doubles are not techincally necessary, they make the strat more bearable.",
         "Exit G-Mode before the Power Bomb explodes in order to break the wall.",
@@ -1901,6 +1906,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Use two Power Bombs to kill the Rippers, or carefully pass the first two and place a single Power Bomb on the left ledge to kill them all.",
         "Exit G-Mode before the Power Bomb explodes in order to break the wall."
@@ -1923,6 +1929,7 @@
       ],
       "clearsObstacles": ["A"],
       "reusableRoomwideNotable": "Red Tower IBJ Between the Bottom Rippers",
+      "flashSuitChecked": true,
       "note": [
         "Requires switching between single and double IBJs. While Doubles are not techincally necessary, they make the strat more bearable.",
         "Exit G-Mode before the Power Bomb explodes in order to break the wall.",

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -461,6 +461,7 @@
         "canXRayClimb"
       ],
       "reusableRoomwideNotable": "Red Tower R-Mode Frozen Beetom X-Ray Climb",
+      "flashSuitChecked": true,
       "note": [
         "Gain R-mode while entering the room.",
         "Use the respawning bugs to refill reserve energy.",
@@ -1272,6 +1273,7 @@
         "canXRayClimb"
       ],
       "reusableRoomwideNotable": "Red Tower R-Mode Frozen Beetom X-Ray Climb",
+      "flashSuitChecked": true,
       "note": [
         "Gain R-mode while entering the room.",
         "Use the respawning bugs to refill reserve energy.",
@@ -1651,6 +1653,7 @@
         "canXRayClimb"
       ],
       "reusableRoomwideNotable": "Red Tower R-Mode Frozen Beetom X-Ray Climb",
+      "flashSuitChecked": true,
       "note": [
         "Gain R-mode while entering the room.",
         "Use the respawning bugs to refill reserve energy.",
@@ -2011,6 +2014,7 @@
         "canXRayClimb"
       ],
       "reusableRoomwideNotable": "Red Tower R-Mode Frozen Beetom X-Ray Climb",
+      "flashSuitChecked": true,
       "note": [
         "Gain R-mode while entering the room.",
         "Use the respawning bugs to refill reserve energy.",

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -114,6 +114,7 @@
       "requires": [
         "h_canArtificialMorphBombThings"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload the PLMs with Bombs by bombing the crumble block on the ground behind the first moving elevator.",
         "After PLMs are overloaded, go through to the item (through the intended entrance or exit path)."
@@ -137,6 +138,7 @@
           "h_additionalBomb"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs before touching the crumble block in the morph tunnel, then go through it after they are overloaded.",
         "This can be done with 2 Power Bombs by placing them on the center of the rightmost tile inside the ceiling morph tunnel. One tile left of the elevator."

--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -105,6 +105,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -126,6 +127,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -141,6 +143,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -166,7 +169,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -186,7 +190,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -211,7 +216,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -231,7 +237,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -277,6 +284,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -298,6 +306,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -313,6 +322,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]

--- a/region/ceres/main/Dead Scientist Room.json
+++ b/region/ceres/main/Dead Scientist Room.json
@@ -108,6 +108,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -129,6 +130,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -144,6 +146,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -169,7 +172,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -189,7 +193,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -214,7 +219,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -234,7 +240,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -283,6 +290,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -304,6 +312,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -319,6 +328,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]

--- a/region/ceres/main/Falling Tile Room.json
+++ b/region/ceres/main/Falling Tile Room.json
@@ -112,6 +112,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -133,6 +134,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -148,6 +150,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Destroy the left door with a Power Bomb."
     },
     {
@@ -167,6 +170,7 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -192,7 +196,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -217,7 +222,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -242,7 +248,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -267,7 +274,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -315,6 +323,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -336,6 +345,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -351,6 +361,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Destroy the right door with a Power Bomb."
     },
     {
@@ -370,6 +381,7 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]

--- a/region/ceres/main/Magnet Stairs Room.json
+++ b/region/ceres/main/Magnet Stairs Room.json
@@ -110,6 +110,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -131,6 +132,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -146,6 +148,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -171,7 +174,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -191,7 +195,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -216,7 +221,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -238,7 +244,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -285,6 +292,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -306,6 +314,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -321,6 +330,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Destroy the right door with a Power Bomb."
     },
     {
@@ -337,6 +347,7 @@
         "h_canArtificialMorphMovement"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ]

--- a/region/crateria/central/Blue Brinstar Elevator Room.json
+++ b/region/crateria/central/Blue Brinstar Elevator Room.json
@@ -160,7 +160,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -278,7 +278,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -298,7 +299,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -326,6 +328,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using scroll blocks a few tiles in front of the bomb blocks."
     },
     {
@@ -416,6 +419,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using the scroll block next to the bomb blocks.",
       "devNote": "PBs cannot be used, as they will solidify the bomb blocks."
     },
@@ -457,6 +461,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using the scroll block next to the bomb blocks."
     },
     {
@@ -544,6 +549,7 @@
         "h_canArtificialMorphMovement",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll blocks next to the bomb wall",
         "After passing through, you need to go from the bottom to the top of Climb and into the bomb blocks while still in G-mode Morph.",
@@ -606,6 +612,7 @@
         "h_canArtificialMorphMovement",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll blocks next to the bomb wall",
         "Navigate to the lower right bomb blocks while still morphed.",
@@ -770,6 +777,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using the scroll blocks immediately in front of the bomb wall"
     },
     {
@@ -800,6 +808,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs immediately in front of the bomb blocks.",
         "Reach the bottom and pass through the bomb blocks while still in G-mode."
@@ -844,6 +853,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs immediately in front of the bomb blocks.",
         "Fall down to the lower bomb blocks while still in G-mode Morph."
@@ -926,6 +936,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
       "devNote": "PBs cannot be used, as they will solidify the bomb blocks."
     },
@@ -948,6 +959,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "Fall down and pass through bomb wall at the bottom while still in G-mode."
@@ -980,6 +992,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 7 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1000,6 +1013,7 @@
           "Morph"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "If Morph is not available, careful movement is needed with SpringBall to reach the top without taking a hit or unmorphing."
@@ -1020,6 +1034,7 @@
         "canBeExtremelyPatient"
       ],
       "reusableRoomwideNotable": "Climb G-Mode Morph Insane IBJ to Top",
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "A long series of precise bomb jumps and enemy manipulations are required to reach the top without taking a hit."
@@ -1038,6 +1053,7 @@
         "h_canArtificialMorphIBJ",
         {"ammo": {"type": "PowerBomb", "count": 7}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "Place PBs as high as possible to occasionally kill multiple pirates at a time."
@@ -1138,6 +1154,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "PBs cannot be used, as they will solidify the bomb blocks."
     },
     {
@@ -1298,7 +1315,8 @@
           "morphed": false
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 3],
@@ -1350,6 +1368,7 @@
           "Morph"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block next to any of the bomb blocks in the room, allowing passage through the bomb blocks at the top by making them become air.",
         "If Morph is not available, careful movement is needed with SpringBall to reach the top without taking a hit or unmorphing."
@@ -1370,6 +1389,7 @@
         "canBeExtremelyPatient"
       ],
       "reusableRoomwideNotable": "Climb G-Mode Morph Insane IBJ to Top",
+      "flashSuitChecked": true,
       "note": [
         "A long series of precise bomb jumps and enemy manipulations are required to reach the top without taking a hit or unmorphing.",
         "Overload PLMs using the scroll block next to the bomb blocks at the top, allowing passage through them by making them become air."
@@ -1388,6 +1408,7 @@
         "h_canArtificialMorphIBJ",
         {"ammo": {"type": "PowerBomb", "count": 8}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "Place PBs as high as possible to occasionally kill multiple pirates at a time.",
@@ -1461,6 +1482,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block next to the bottom right bomb blocks, allowing passage through them by making them become air.",
         "If Morph is unavailable, then careful movement will be required to get past the Pirates without taking a hit.",

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -214,7 +214,8 @@
       "requires": [
         "h_canArtificialMorphLongCeilingBombJump"
       ],
-      "clearsObstacles": ["C"]
+      "clearsObstacles": ["C"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -246,6 +247,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "This is a softlock unless the item is Morph.",
         "The IBJ strat has 2 extra spike hits added as a leniency."
@@ -354,6 +356,7 @@
           "h_canArtificialMorphLongCeilingBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "The IBJ from spikes has 2 extra spike hits added as a leniency."
     },
     {
@@ -383,6 +386,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Quickly grapple to then release grapple on the grapple blocks a few times until they stop working. Be careful not to fall into the spikes.",
       "devNote": "FIXME: Grapple will quickly overload PLMS.  It is barely possible to cross the gap using short grapples, canResetFallSpeed, and ending with a swing."
     },
@@ -424,6 +428,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Place the PBs exactly two tiles left of the Morph tunnel. Be sure not to touch the item if this strat will be needed again in the future.",
       "devNote": [
         "FIXME Add strat for going down without PBs, by using the uncollected item to overload PLMs. This can only be done once, as it forces item pickup."
@@ -665,6 +670,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 7 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -879,6 +885,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Wall jump up 9 times, placing a PB at the top. Only works in direct g-mode with the item still uncollected.",
       "devNote": "FIXME: Using this strat won't risk canRiskPermanentLossOfAccess if the player could x-ray climb instead. However if the adjacent room is heated and Samus is really low energy, this could be a problem."
     },
@@ -896,6 +903,7 @@
         "h_canArtificialMorphCeilingBombJump",
         "canBeVeryPatient"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Ascend with a long IBJ, then ceiling bomb jump against the speed blocks to overload the PLMs. Falling is very unforgiving.",
         "Note that the boyons can be killed with bombs."

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -992,7 +992,8 @@
       "requires": [
         "canEnterGMode",
         {"obstaclesCleared": ["C"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 5],
@@ -1009,6 +1010,7 @@
         "canEnterGMode",
         {"obstaclesCleared": ["C"]}
       ],
+      "flashSuitChecked": true,
       "note": "Walk through the item or use Bombs to overload PLMs, fall through the speed blocks, then exit G-Mode to remote acquire the item."
     },
     {

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -175,7 +175,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -192,7 +193,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -348,7 +350,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -365,7 +368,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -160,6 +160,7 @@
       "requires": [
         "h_canArtificialMorphBombs"
       ],
+      "flashSuitChecked": true,
       "note": "Repeatedly bomb the crumble blocks until the PLMs are overloaded."
     },
     {

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -201,7 +201,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -365,7 +366,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -1185,6 +1185,7 @@
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphPowerBomb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Using IBJ to reach the Gauntlet entrance bomb blocks, place a Power Bomb and it will hit but not break the blocks.",
         "Then IBJ up to to the left, unmorph and use X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
@@ -1198,6 +1199,7 @@
         "h_canArtificialMorphIBJ",
         "ScrewAttack"
       ],
+      "flashSuitChecked": true,
       "note": "IBJ up to to the top left of the room. Use X-Ray to cancel G-mode, then fall with Screw Attack to break the bomb blocks."
     },
     {
@@ -1206,7 +1208,8 @@
       "requires": [
         "canEnterGMode",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [8, 4],
@@ -1216,6 +1219,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb then quickly exit G-Mode before it explodes to break the bomb blocks."
     },
     {
@@ -1225,6 +1229,7 @@
         "canEnterGMode",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "devNote": "Over the wall."
     }
   ]

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -301,6 +301,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
         "Then pass through the bomb blocks (which will have become air).",
@@ -334,6 +335,7 @@
       "requires": [
         "h_canArtificialMorphBombs"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
         "Then pass through the bomb blocks (which will have become air)."
@@ -416,7 +418,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -632,7 +635,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -912,6 +916,7 @@
         "canXRayClimb",
         "canBePatient"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 3 screens."
     },
     {
@@ -965,6 +970,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 3 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1001,7 +1007,8 @@
       },
       "requires": [
         "h_canArtificialMorphMovement"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 2],

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -457,6 +457,7 @@
       "requires": [
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs one tile to the left of the Terminator bomb blocks which can be used to overload PLMs.",
         "The bomb blocks then become air and can be passed through.",
@@ -488,6 +489,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs one tile to the left of the bomb blocks which can be used to overload PLMs.",
         "The bomb blocks then become air and can be passed through.",
@@ -535,6 +537,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs one tile to the left of the bomb blocks which can be used to overload PLMs.",
         "The bomb blocks then become air and can be passed through."
@@ -550,6 +553,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Use G-Mode Morph to pass through the tunnel as you enter the room.",
         "Then unmorph and get up to the top of the room normally.",
@@ -640,6 +644,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use G-Mode Morph to pass through the tunnel as you enter the room.",
         "Use Bombs or SpringBall to navigate to Alcatraz without unmorphing."
@@ -704,7 +709,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -716,6 +722,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs throughout the room, which will overload PLMs when going through them.",
         "The bomb blocks then become air and can be passed through."
@@ -770,6 +777,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Use Bombs or SpringBall to navigate with artificial morph without unmorphing."
     },
     {
@@ -839,6 +847,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Use Bombs or SpringBall to navigate with artificial morph without unmorphing."
     },
     {
@@ -899,6 +908,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs throughout the room, which will overload PLMs when going through them.",
         "The bomb blocks then become air and can be passed through."
@@ -992,6 +1002,7 @@
           "h_canArtificialMorphBombHorizontally"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "A single Power Bomb, placed precisely and as early as possible, can get you over the Geemers and onto the ledge above Alcatraz without taking a hit.",
         "Alternatively Bombs or SpringBall can be used.",
@@ -1056,6 +1067,7 @@
           "h_ZebesNotAwake"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs one tile to the right of the bomb blocks which can be used to overload PLMs, turning the bomb blocks to air.",
         "However, if Zebes is awake, two Geemers block the way.",
@@ -1083,6 +1095,7 @@
         "canOffScreenMovement",
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing.",
         "There are scroll PLMs next to the bomb blocks and on the ledge below the Alcatraz exit, which will overload PLMs when going through them.",
@@ -1175,6 +1188,7 @@
         "canOffScreenMovement",
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing.",
         "There are scroll PLMs next to the bomb blocks and on the ledge below the Alcatraz exit, which will overload PLMs when going through them.",
@@ -1428,6 +1442,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing.",
         "There are scroll PLMs next to the bomb blocks and on the ledge below the Alcatraz exit, which will overload PLMs when going through them.",
@@ -1476,6 +1491,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs throughout the room, which will overload PLMs when going through them.",
         "The bomb blocks then become air and can be passed through."
@@ -1565,6 +1581,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Use Bombs or SpringBall to navigate with artificial morph without unmorphing."
     },
     {
@@ -1623,6 +1640,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing."
       ]
@@ -1735,6 +1753,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "There are scroll PLMs throughout the room, which will overload PLMs when going through them.",
         "The bomb blocks then become air and can be passed through."
@@ -1753,6 +1772,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Use Bombs or SpringBall to navigate with artificial morph without unmorphing."
     },
     {
@@ -1792,6 +1812,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Bombs or SpringBall to navigate with artificial morph without unmorphing."
       ]

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -380,6 +380,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Destroy the bomb wall to open a path for the Geemer to hit Samus through the transition.",
         "If using a PB be careful not to kill the Geemer. Place the PB far left, next to the door, as the Geemer is leaving the flat part of the ceiling."
@@ -411,6 +412,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "From the left, break the bomb blocks with blue speed from the neighboring room.",
         "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
@@ -439,6 +441,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "From the left, break the bomb blocks by shinesparking from the neighboring room.",
         "After the blocks respawn and the Geemer is near, destroy them again using blue speed from the right.",
@@ -592,6 +595,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Wait 75 seconds for a global Geemer, or use a Super to grab a closer one."
       ]
@@ -818,6 +822,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "There is a Geemer just below the door that only moves while on camera."
     },
     {
@@ -1031,7 +1036,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -1230,6 +1236,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It takes approximately 3.5 minutes for a global Geemer to reach this location,",
         "but this can be reduced by using a Super between 19 and 33 seconds after entering the room, to make a Geemer fall and take a shorter path."
@@ -1691,6 +1698,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Wait 2 minutes for a global Geemer, or use a Super to grab a closer one."
       ]
@@ -1912,6 +1920,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Freeze a Geemer on the bottom of the overhang just below the door to Final Missile Bombway. Freeze a second Geemer on the top left of its platform and setup a moonfall between them.",
         "Fall off the Geemers and clip into the tile left of the door. Press up to get out of crouch and lose the stored vertical speed (so that X-Ray works). Then turn-around, open the door, and go into the door transition as the third Geemer hits you.",
@@ -2048,6 +2057,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Place the Power Bomb below the bomb blocks as the Geemer is leaving the flat part of the ceiling to break it and let the Geemer through.",
         "This opens a path for the Geemer to hit Samus through the transition."
@@ -2071,6 +2081,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "After the Geemer is near, destroy the bomb wall using blue speed from the right.",
         "This opens a path for the Geemer to hit Samus through the transition."

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -612,6 +612,7 @@
         "h_ZebesIsAwake"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 75 seconds for a global Geemer."
     },
     {
@@ -838,6 +839,7 @@
         "canBePatient"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 90 seconds for a global Geemer."
     },
     {
@@ -1050,7 +1052,8 @@
         }},
         "h_ZebesIsAwake"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [4, 5],
@@ -1258,6 +1261,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": [
         "It takes approximately 3.5 minutes for a global Geemer to reach this location.",
         "If using a Super, fire between 19 and 33 seconds after entering the room, then wait approximately 30 more seconds to be hit."
@@ -1719,6 +1723,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 2 minutes for a global Geemer."
     },
     {
@@ -1943,6 +1948,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": [
         "Line up with the far right or left side of doorframe in the room below, to be able to not fall back through after entry, as the door remains open.",
         "Be careful not to fall into the door while being hit by the Geemer."

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -420,6 +420,7 @@
         "Morph"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "The enemies do not spawn in this room unless Missiles and Morph are collected (even if Zebes is awake)."
     },
     {

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -278,6 +278,7 @@
         "h_canArtificialMorphBombs"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",
         "When the bomb blocks turn to air, lay bombs as Samus falls.",
@@ -297,6 +298,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Lay a Power Bomb to break the bomb blocks leading down to the item, then use X-ray to cancel G-mode, to clear the blocks."
     },
     {
@@ -309,6 +311,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",
         "Using X-Ray to cancel G-mode will lead to a soft lock if the item there can't be used to get Samus out."
@@ -469,6 +472,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Be careful not to touch any of the pirates spawned lasers.",
         "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",
@@ -488,6 +492,7 @@
         "h_canArtificialMorphIBJ"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Without Morph, the pirates will not spawn.",
         "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",
@@ -515,6 +520,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Without Morph, the pirates will not spawn.",
         "Use Power Bomb horizontal boosts to move toward the left side of the room in artificial morph.",
@@ -536,6 +542,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Without Morph, the pirates will not spawn.",
         "While near the bomb blocks, use a Power Bomb and then use X-ray to cancel G-mode, which will clear the blocks."

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -97,7 +97,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -204,7 +205,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -289,7 +289,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -912,7 +913,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ],
   "devNote": [

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -276,7 +276,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -898,7 +899,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -168,7 +168,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -185,7 +185,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -205,7 +206,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -234,6 +236,7 @@
           "h_canArtificialMorphIBJ"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Without Springball or Gravity, it is possible to overload PLMs with the crumble blocks with bombs.",
         "Take the first left above the waterline. Place bombs in the single tile nook on the left."
@@ -261,6 +264,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Place bombs at the far right, next to the low underwater ceiling.",
         "To safely bomb the fast crab, wait just left of the crack on the floor where it falls."

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -148,6 +148,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The nearby Global crab can be used to exit on the left side of the door.",
         "Exiting on the right will require travelling the Morph maze to find a local crab or two."
@@ -354,7 +355,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -97,7 +97,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -245,7 +246,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -359,6 +361,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Run from the ledge into the open doorway while hitting the frozen Crab as it thaws and the door transition simultaneously.",
         "Note that this requires a pixel perfect freeze, a small pixel starting window, and has tight timing. It then has a 50% success rate due to collision oscillation."

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -110,7 +110,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -259,7 +260,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -431,7 +431,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],

--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -90,7 +90,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -110,7 +111,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -151,7 +153,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -194,7 +197,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -90,7 +90,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -110,7 +111,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -151,7 +153,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -194,7 +197,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -259,7 +259,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -275,7 +276,8 @@
           "h_canArtificialMorphCeilingBombJump",
           "h_canArtificialMorphHBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -2275,7 +2275,8 @@
         "canEnterGMode",
         "Grapple",
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [15, 16],
@@ -2289,6 +2290,7 @@
           "canBeVeryPatient"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The crumble block is the leftmost flat ceiling tile."
     },
     {
@@ -2299,6 +2301,7 @@
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphCeilingBombJump"
       ],
+      "flashSuitChecked": true,
       "note": "Start the IBJ on the second downward tile from the door. The crumble block is the leftmost flat ceiling tile.",
       "devNote": "Without canCeilingBombJump, this would take more than 10 minutes."
     },
@@ -2319,7 +2322,8 @@
             "HiJump"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [17, 10],
@@ -2339,6 +2343,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "To overload the PLMs, place a PB precisely to the right of the bottom of the second overhang above the door to the Moat.",
         "This is at the max jump height without HiJump. Placing the PB higher or lower will not overload the PLMs without many PBs."
@@ -2365,6 +2370,7 @@
         ]},
         "h_canArtificialMorphPowerBomb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "To overload the PLMs, place a PB precisely to the right of the bottom of the second overhang above the door to the Moat.",
         "This is at the max jump height without HiJump. Placing the PB higher or lower will not overload the PLMs without many PBs."

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -462,7 +462,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 17],
@@ -473,7 +474,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -575,6 +577,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -867,6 +870,7 @@
         "canXRayClimb"
       ],
       "reusableRoomwideNotable": "West Ocean - Get Inside the Bridge",
+      "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
     {
@@ -920,6 +924,7 @@
       ],
       "bypassesDoorShell": true,
       "reusableRoomwideNotable": "West Ocean - Get Inside the Bridge",
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -955,6 +960,7 @@
         ]},
         "canXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 2 screens."
     },
     {
@@ -999,7 +1005,8 @@
           "h_canArtificialMorphHBJ",
           "h_canArtificialMorphDiagonalBombJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 17],
@@ -1028,7 +1035,8 @@
           "h_canArtificialMorphHBJ",
           "h_canArtificialMorphDiagonalBombJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 2],
@@ -1044,6 +1052,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 4 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1062,6 +1071,7 @@
         "canXRayClimb",
         "canBePatient"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 3 screens."
     },
     {
@@ -1094,6 +1104,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 3 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1373,7 +1384,8 @@
           "h_canArtificialMorphHBJ",
           "h_canArtificialMorphDiagonalBombJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 17],
@@ -1402,7 +1414,8 @@
           "h_canArtificialMorphHBJ",
           "h_canArtificialMorphDiagonalBombJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 2],
@@ -1653,6 +1666,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Unmorph and cancel g-mode, shoot the shot block, then x-ray standup, partial floor clip, and down grab to the ledge. Wiggle to escape."
     },
     {
@@ -1667,6 +1681,7 @@
       "requires": [
         "canXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
     {

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1435,6 +1435,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "reusableRoomwideNotable": "West Ocean - G-Mode Setup Lure Zeb from Below",
+      "flashSuitChecked": true,
       "note": [
         "Start from the Middle Right Door next to the Zeb farm.",
         "While standing on the right of the Zeb farm, freeze the Zeb while it is still moving up and facing to the right.",
@@ -1463,6 +1464,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "reusableRoomwideNotable": "West Ocean - G-Mode Setup Lure Zeb from Below",
+      "flashSuitChecked": true,
       "note": [
         "Start from the Middle Right Door next to the Zeb farm.",
         "While standing on the right of the Zeb farm, freeze the Zeb while it is still moving up and facing to the right.",
@@ -1514,7 +1516,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [6, 12],

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -283,7 +283,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -366,6 +366,7 @@
       ],
       "clearsObstacles": ["B", "D"],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note":  [
         "Use R-Mode to get a blue suit to cross the room and get the item, or to leave the right shinecharged.",
         "In R-Mode, fill your Reserves at the farm. Damage down again so that Samus is within 1 Zebbo hit from triggering Reserves.",

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -298,6 +298,7 @@
         "h_canArtificialMorphBombs"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb to the left of the Zebbo, then exit G-Mode, to break the bomb wall to the right."
     },
     {
@@ -313,6 +314,7 @@
         "h_canArtificialMorphBombs"
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": "Carefully kill the Zebbo, then place two bombs against the right wall to break the left half of the wall to slightly increase the length of the runway."
     },
     {

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -184,7 +184,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -200,6 +201,7 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Place a Power Bomb near the door, then wait for the Waver to get into position to hit Samus through the transition.",
         "The Waver only moves while on camera, and needs to move around the region several times before being set up properly."
@@ -222,6 +224,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "Freeing the Waver with a shinespark is not reliable, and depends on when and where the shinespark starts.",
         "Most of these strats kill the Wavers or set up situations where they can't reach the door."
@@ -407,6 +410,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "This is harder when crossing the room and easier if the right door can be used to reset the room, but it will cost one extra Power Bomb.",
         "One method is to place a Power Bomb near the first bomb wall, killing the first Waver, but keeping the second, global Waver.",
@@ -619,6 +623,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "This is harder when crossing the room and easier if the left door can be used to reset the room, but it will cost one extra Power Bomb.",
         "Place a Power Bomb near the first and third bomb walls. One Waver will be alive by the fifth wall, which will only move while on camera.",
@@ -732,7 +737,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -744,6 +750,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Place a Power Bomb near the door, then wait for the Waver to get into position to hit Samus through the transition.",
         "The Waver only moves while on camera, and needs to move around the region several times before being set up properly."
@@ -766,6 +773,7 @@
         "leaveWithGModeSetup": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "Freeing the Waver with a shinespark is not reliable, and depends on when and where the shinespark starts.",
         "Most of these strats kill the Wavers or set up situations where they can't reach the door."

--- a/region/crateria/west/Green Brinstar Elevator Room.json
+++ b/region/crateria/west/Green Brinstar Elevator Room.json
@@ -158,7 +158,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -226,7 +227,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -1489,7 +1489,8 @@
       "name": "Base",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 4],
@@ -1498,7 +1499,8 @@
         "canEnterGMode",
         "h_canArtificialMorphBombThings",
         "h_additionalBomb"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 9],
@@ -1508,6 +1510,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb and exit G-Mode. To prevent freeing the Beetoms, the Power Bomb needs to be placed on the left platform just below the door."
     },
     {
@@ -1527,6 +1530,7 @@
           "h_canArtificialMorphCeilingBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Place bombs against the bottom of the crumble blocks to overload PLMs."
     }
   ],

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -328,7 +328,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 4],
@@ -1207,7 +1208,8 @@
           "knockback": false
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "link": [9, 2],
@@ -1317,6 +1319,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "It is possible to shake the beetom off near the right door, then lure it down to the bottom without taking more hits (or to kill the Pirates with Bombs).",
       "devNote": "If starting the room at the bottom, this requires killing the pirates twice, but it's probably not worth fixing."
     },
@@ -1429,6 +1432,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "It is possible to shake the beetom off near the right door, then lure it down to the bottom without taking more hits (or to kill the Pirates with Bombs).",
       "devNote": "If starting the room at the bottom, this requires killing the pirates twice, but it's probably not worth fixing."
     },

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -432,7 +432,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -669,6 +670,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "With Spring Ball, it is possible to save a Power Bomb by placing it on the descent of the first jump by the bottom corner of the overhang,",
         "then bouncing on it on the ascent of the second.",
@@ -783,6 +785,7 @@
         }}
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct and kill the bottom Pirate.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
@@ -992,6 +995,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "With Spring Ball, it is possible to save a Power Bomb by placing it on the descent of the first jump by the bottom corner of the overhang,",
         "then bouncing on it on the ascent of the second.",

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -99,7 +99,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -250,7 +251,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -210,7 +210,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -335,7 +336,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -127,7 +127,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -268,7 +269,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -114,7 +114,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -254,7 +255,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -466,6 +466,7 @@
         "canXRayClimb",
         {"heatFrames": 1600}
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
     {
@@ -498,6 +499,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -602,6 +604,7 @@
         "canXRayClimb",
         {"heatFrames": 1650}
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
     {
@@ -779,6 +782,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
+++ b/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
@@ -189,7 +189,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -221,6 +222,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": "It is possible to get back up with Spring Ball alone with a foosball off of the crumble block.",
       "devNote": "This is one of the easier foosballs because it is free to retry, because there is no heat damage in G-Mode."
     },

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -246,6 +246,7 @@
       ],
       "clearsObstacles": ["A"],
       "reusableRoomwideNotable": "LN Firefleas G-Mode Morph Blind Top to Bottom",
+      "flashSuitChecked": true,
       "note": [
         "Traversing the room without getting hit requires fairly tricky off-screen movement.",
         "Note that Samus moves freely through the off-screen Funes, but will take damage from the Boulders.",
@@ -276,6 +277,7 @@
         "h_canArtificialMorphSpringBall"
       ],
       "reusableRoomwideNotable": "LN Firefleas G-Mode Morph Blind Top to Bottom",
+      "flashSuitChecked": true,
       "note": [
         "Traversing the room without getting hit requires fairly tricky off-screen movement.",
         "Note that Samus moves freely through the off-screen Funes, but will take damage from the Boulders.",
@@ -361,6 +363,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb then exit G-Mode to kill the Fune."
     },
     {
@@ -518,6 +521,7 @@
       "requires": [
         "h_canArtificialMorphSpringBall"
       ],
+      "flashSuitChecked": true,
       "devNote": "This is only useful if the item is Morph or a way to kill the Fune."
     },
     {
@@ -743,6 +747,7 @@
       ],
       "clearsObstacles": ["A"],
       "reusableRoomwideNotable": "LN Firefleas G-Mode Morph Blind Top to Bottom",
+      "flashSuitChecked": true,
       "note": [
         "Traversing the room without getting hit requires fairly tricky off-screen movement.",
         "Note that Samus moves freely through the off-screen Funes, but will take damage from the Boulders.",
@@ -787,6 +792,7 @@
         "h_canArtificialMorphSpringBall"
       ],
       "reusableRoomwideNotable": "LN Firefleas G-Mode Morph Blind Top to Bottom",
+      "flashSuitChecked": true,
       "note": [
         "Traversing the room without getting hit requires fairly tricky off-screen movement.",
         "Note that Samus moves freely through the off-screen Funes, but will take damage from the Boulders.",

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -225,6 +225,7 @@
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 5 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -382,7 +382,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -402,7 +403,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 8],

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -454,6 +454,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -159,6 +159,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "devNote": "This can only be useful if the door does not connect to the Pants Room."
     },
     {
@@ -338,7 +339,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -145,6 +145,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "devNote": "This can only be useful if the door does not connect to the Pants Room."
     },
     {
@@ -324,7 +325,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -279,6 +279,7 @@
           "canInsaneJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The sand does not impede Samus in G-Mode.",
         "It is possible to jump to the tall pillar with nothing, requiring a subpixel precise jump.",
@@ -617,6 +618,7 @@
           "canSpringBallJumpMidAir"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The sand does not impede Samus in G-Mode.",
       "devNote": "Only the last jump needs any items."
     },
@@ -757,6 +759,7 @@
           "canSpringBallJumpMidAir"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The sand does not impede Samus in G-Mode.",
       "devNote": "Only the last jump needs any items."
     },
@@ -779,6 +782,7 @@
           "canTrickyJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The sand does not impede Samus in G-Mode.",
         "It is possible to jump to the tall pillar with nothing, requiring a subpixel precise jump.",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -144,6 +144,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The easiest way to lure an Evir projectile and get through the door before it is to stand facing and against the door cap, open the door then turn right and run back to the left."
       ]
@@ -652,6 +653,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The Evir won't shoot unless Samus enters the sand falls. Getting to the transition tiles while standing before the projectile can be tricky.",
         "With no movement items besides Gravity, walk off the platform while facing right, turn around spin jump to barely enter the sand fall before landing back on the platform and quickly getting to the door."
@@ -671,6 +673,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The Evir won't shoot unless Samus enters the sand falls. Getting to the transition tiles while standing before the projectile while suitless is very precise.",
         "From the sand, turnaround spinjump towards the right. Turn towards the sandfall about when you're level with the platform. Turn right and shoot as soon as you enter the sandfall. And try to land right next to the transition."

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -525,6 +525,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "This only breaks the bomb blocks but doesnt get up to 6. However the requirements from here to 6 are less than 6->4."
     },
     {
@@ -929,6 +930,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "This only breaks the bomb blocks but doesnt get up to 6. However the requirements from here to 6 are less than 6->4."
     },
     {
@@ -953,7 +955,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -986,7 +989,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -1005,7 +1009,8 @@
       },
       "requires": [
         "h_canArtificialMorphBombThings"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 3],

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -281,7 +281,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -295,6 +295,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "devNote": [
         "This is not possible in vanilla, because there is no way to enter through this door.",
         "FIXME: There is a strat from here to 5 with IBJ (Spring Ball + HiJump or ceiling bomb jump)."

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -140,7 +140,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -304,7 +305,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -316,6 +318,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Shoot a Snail to make it chase Samus."
     },
     {

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -161,6 +161,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "This takes 1 min 40 sec if Shaktool is done digging."
     },
     {
@@ -352,6 +353,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait for Shaktool. If Shaktool's camera is fixed it is possible without Shaktool, by using a Snail (Yard): a Super or any SBA can trigger a Yard to attack."
     },
     {

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -183,7 +183,8 @@
       },
       "requires": [
         "h_canArtificialMorphPowerBomb"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -394,6 +395,7 @@
         ]},
         "h_canArtificialMorphPowerBomb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "The Snails will dig through the sand without showing any visual difference. Each block they pass through gets closer to overloading PLMs.",
         "In order to PB the left wall before PLMs are overloaded, it is necessary to only allow one snail to dig, either by bombing one or by facing one to prevent movement until it is off screen.",

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -119,6 +119,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "The item is inside of a Chozo Ball, so there is no way to use artificial morph on the return."
     },
     {

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -149,7 +149,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -566,7 +567,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -136,7 +136,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -552,7 +553,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -523,7 +523,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -537,6 +538,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The Evir won't shoot unless Samus is on the left tile of the platform. Getting to the transition tiles while standing before the projectile can be tricky.",
         "Either do two quick small spin jumps, one onto it and one back, breaking spin before landing both times,",

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -228,7 +228,8 @@
             "hits": 1
           }}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 5],
@@ -481,7 +482,8 @@
       "requires": [
         "h_canNavigateUnderwater",
         "canCarefulJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -619,7 +621,8 @@
             "hits": 1
           }}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -633,7 +636,8 @@
       },
       "requires": [
         "h_canNavigateUnderwater"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -311,6 +311,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb then exit G-Mode."
     },
     {
@@ -386,6 +387,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Bomb the Power Bomb blocks below to overload PLMs, then go up through the crumble blocks to escape."
     },
     {
@@ -401,6 +403,7 @@
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "Bomb the Power Bomb blocks below to overload PLMs, then IBJ up through the crumble blocks to escape."
     },
     {
@@ -431,6 +434,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Bomb the PB blocks below to overload PLMs, then go up through the crumble blocks to escape."
     },
     {
@@ -494,6 +498,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -932,6 +937,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+      "flashSuitChecked": true,
       "note": [
         "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
         "There is a row of tiles that works, just above and to the left of the right door.",
@@ -971,6 +977,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+      "flashSuitChecked": true,
       "note": [
         "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
         "There is a row of tiles that works, just above and to the left of the right door.",
@@ -1090,7 +1097,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 11],
@@ -1105,6 +1113,7 @@
         "Grapple",
         "h_canNavigateUnderwater"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using the Grapple Blocks."
     },
     {
@@ -1395,6 +1404,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+      "flashSuitChecked": true,
       "note": [
         "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
         "There is a row of tiles that works, just above and to the left of the right door.",
@@ -1434,6 +1444,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+      "flashSuitChecked": true,
       "note": [
         "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
         "There is a row of tiles that works, just above and to the left of the right door.",
@@ -1491,7 +1502,8 @@
             "h_canArtificialMorphIBJ"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 11],
@@ -1512,7 +1524,8 @@
             "h_canArtificialMorphIBJ"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 11],
@@ -1527,6 +1540,7 @@
         "Grapple",
         "h_canNavigateUnderwater"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using the Grapple Blocks."
     },
     {
@@ -1551,6 +1565,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: This is doable with just Bombs and entering on the left side."
     },
     {
@@ -1639,7 +1654,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],
@@ -1672,7 +1688,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],
@@ -1695,6 +1712,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "It is easiest to use a single snail on the bottom of the ceiling to the right of the door.",
         "Use at least a small amount of momentum before jumping over towards the snail."
@@ -1733,6 +1751,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+      "flashSuitChecked": true,
       "note": [
         "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
         "There is a row of tiles that works, just above and to the left of the right door.",
@@ -1773,6 +1792,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+      "flashSuitChecked": true,
       "note": [
         "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
         "There is a row of tiles that works, just above and to the left of the right door.",
@@ -1795,7 +1815,8 @@
         },
         "comesThroughToilet": "any"
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 11],
@@ -1811,6 +1832,7 @@
         "Grapple",
         "h_canNavigateUnderwater"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using the Grapple Blocks."
     },
     {

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -296,7 +296,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -722,7 +723,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1312,6 +1314,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Requires no items or tech if you step on a Snail - canUseEnemies is necessary for G-Mode Setup."
       ]
@@ -1610,6 +1613,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The two snails together can setup G-Mode on either side of the door."
       ]
@@ -1900,7 +1904,8 @@
       },
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [9, 2],

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -736,7 +736,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -1329,7 +1330,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [5, 7],
@@ -1629,6 +1631,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "devNote": "Requires entry on either side of the doorway, but not the center."
     },
     {
@@ -2003,7 +2006,8 @@
         "canEnterGMode",
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 2],
@@ -2013,6 +2017,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb, then exit G-Mode to break the blocks."
     },
     {
@@ -2022,7 +2027,8 @@
         "canEnterGMode",
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 11],
@@ -2031,7 +2037,8 @@
         "canEnterGMode",
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 11],
@@ -2045,6 +2052,7 @@
           "HiJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Bomb the Speed blocks by the right door."
     },
     {
@@ -2056,7 +2064,8 @@
         "HiJump",
         "h_canArtificialMorphSpringBall",
         "canSnailClimb"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 11],
@@ -2068,6 +2077,7 @@
         "canSnailClimb",
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "It is barely possible to start a snail climb with just Spring Ball.",
         "Get a snail positioned such that it is on the bottom of an overhang above, and sticking out a bit to be usable as a platform.",
@@ -2090,6 +2100,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "After PLMs are overloaded, climb to the top left door and fall through the Bomb Blocks."
     },
     {
@@ -2110,6 +2121,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "After PLMs are overloaded, use a snail to help climb to the top right items."
     }
   ]

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -223,7 +223,8 @@
           "morphed": false
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -272,7 +273,8 @@
         },
         "comesThroughToilet": "any"
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -194,6 +194,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure the Zoas. Jump so that they start moving horizontally higher, use spin jumps to move horizontally faster while keeping them on screen."
       ]

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -244,7 +244,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -296,7 +297,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -320,7 +322,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -377,7 +380,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -489,6 +493,7 @@
       "requires": [
         "canSuitlessMaridia"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs by touching the sand, then move through the speed blocks. Avoiding the sand pits is easier without Gravity or HiJump."
     },
     {
@@ -673,6 +678,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Be careful not to touch or bomb the sand in order to grab the item before PLMs are overloaded."
     },
     {
@@ -702,7 +708,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 5],
@@ -911,6 +918,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs by touching the sand, then move through the speed blocks.",
         "Shoot the Puyo while crouching to increase accuracy.",
@@ -996,6 +1004,7 @@
           "morphed": false
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs by touching the sand, then move through the speed blocks.",
         "Shoot the Puyo while crouching to increase accuracy.",
@@ -1041,6 +1050,7 @@
           "morphed": true
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "With Gravity, or Spring Ball and HiJump, it is easiest to go through the Morph maze at the top of the room and fall into the the sand.",
         "Otherwise, the overload PLMs by touching the sand, or by bombing the speed blocks, to be able to go through to the left.",
@@ -1063,6 +1073,7 @@
           "morphed": false
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs by touching the sand, then move through the speed blocks.",
         "Shoot the Puyo while crouching to increase accuracy."
@@ -1105,6 +1116,7 @@
           "morphed": true
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "With Gravity, or Spring Ball and HiJump, it is easiest to go through the Morph maze at the top of the room and fall into the the sand.",
         "Otherwise, the overload PLMs by touching the sand, or by bombing the speed blocks, to be able to go through to the left.",
@@ -1195,6 +1207,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Be careful not to touch or bomb the sand in order to grab the item before PLMs are overloaded.",
         "With bombs, kill the Zoas and they will stop spawning."
@@ -1224,6 +1237,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "With bombs, kill the Zoas and they will stop spawning."
     },
     {

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -222,7 +222,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -1178,6 +1179,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure the Zoas. Jump so that they start moving horizontally while higher, use spin jumps to move horizontally faster while keeping them on screen."
       ]

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -452,7 +452,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -129,7 +129,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -147,7 +148,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -174,7 +176,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 5],
@@ -247,7 +250,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -282,7 +286,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -300,7 +305,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 5],

--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -106,7 +106,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -263,7 +264,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -938,6 +938,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -964,6 +965,7 @@
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "Place bombs without moving horizontally, such that multiple hit the Mochtroid immediately as it attaches without being boosted into the doorway or sand."
     },
     {

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -174,7 +174,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -762,7 +763,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -1415,7 +1417,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -155,7 +155,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -751,7 +752,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -864,6 +866,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "The Global crab in the upper section can be knocked off the wall to enter the left side of the above door.",
         "Otherwise, there are more crabs in the lower section of the room."

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -169,7 +169,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -765,7 +766,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -884,6 +886,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "devNote": "Requires entering on either side of the doorway, but not in the center."
     },
     {

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -522,7 +522,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -908,7 +909,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -941,7 +943,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -494,7 +494,8 @@
         "f_DefeatedDraygon",
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -510,6 +511,7 @@
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "There is enough time to IBJ to the top door before Draygon appears."
     },
     {

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -242,7 +242,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
@@ -70,7 +70,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
@@ -93,7 +93,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -111,7 +112,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -232,6 +232,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Hug the right wall after killing the first Cacatac in order to avoid its invisible, stationary projectiles.",
         "After getting to the small island platform, diagonal IBJ up while avoiding the top Cacatac.",
@@ -276,6 +277,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Hug the right wall after killing the first Cacatac in order to avoid its invisible, stationary projectiles."
     },
     {
@@ -293,6 +295,7 @@
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphHBJ"
       ],
+      "flashSuitChecked": true,
       "note": "This requires multiple HBJ to get over spike pits. The first one, by the right door, must be started at the top of an IBJ."
     },
     {

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -102,7 +102,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -120,7 +121,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -465,6 +467,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "IBJ or Spring Ball Bomb Jump through two sets of Crumble Blocks.",
       "devNote": [
         "Without this being Morph, there is no way to escape. PLMs are already overloaded from the sand.",

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -197,7 +197,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -1017,7 +1018,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1924,7 +1926,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -428,7 +428,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -666,6 +667,7 @@
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "To avoid the Mochtroids, it is possible to place bombs near them while in the Morph Tunnel below to the right."
     },
     {
@@ -882,6 +884,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to exactly 8 pixels away from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up a little less than 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door.",
@@ -1136,7 +1139,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 4],
@@ -1329,6 +1333,7 @@
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "To avoid the Mochtroids, it is possible to place bombs near them while in the Morph Tunnel to the right."
     },
     {
@@ -1601,7 +1606,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -1709,7 +1715,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -1851,7 +1858,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -181,6 +181,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -309,7 +310,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],

--- a/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
@@ -70,7 +70,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
@@ -93,7 +93,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -111,7 +112,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -151,7 +151,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -169,7 +170,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 7],
@@ -368,6 +370,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Get to the left side of the room while avoiding the hole in the ground, jump up through the Morph tunnel.",
         "Jump up to the ledge with either Gravity, HiJump and a Crouch Jump Down Grab, or a maximum height Spring Ball Jump."

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -211,7 +211,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -228,7 +229,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -519,7 +521,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -536,7 +539,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -195,7 +195,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -600,7 +601,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [3, 5],

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -182,7 +182,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -586,7 +587,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -197,7 +197,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -551,7 +552,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -184,7 +184,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -537,7 +538,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -111,7 +111,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -203,6 +203,7 @@
         "canBePatient",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Climb up 2.5 screens.",
         "Stop when about half of Samus (or less) is visible at the top of the screen.",
@@ -234,6 +235,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "IBJ up the climb. This is a lot easier with PBs or Spring Ball to help kill the enemies.",
         "With PBs, use one on entry to deal with the Puyos, then IBJ up the right side and use another to kill the middle Choot.",

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -124,7 +124,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -210,7 +210,8 @@
           ]},
           "h_canArtificialMorphSpringBallBombJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -260,7 +261,8 @@
             "canStaggeredWalljump"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -296,6 +298,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "It is possible to kill the Rippers with a single Power Bomb by placing it at least 2 tiles above the lowest Ripper inside the narrow section of the shaft."
     },
     {
@@ -321,6 +324,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The Rippers can be killed with two Power Bombs, or one carefully placed Power Bomb and a careful dodge of the top-most Ripper.",
         "With a single Power Bomb, use Spring Ball to avoid the first Ripper, then place the Power Bomb at least two tiles above the next. This can be achieved with a Staggered IBJ or a Spring Ball Bomb Boost.",
@@ -359,6 +363,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The Rippers can be killed with three Power Bombs, or one carefully placed Power Bomb, Gravity, and a careful dodge of the top-most Ripper.",
         "With a single Power Bomb, IBJ from the water to avoid the first Ripper, then place the Power Bomb at least two tiles above the next. This can be achieved with a Staggered IBJ.",
@@ -554,7 +559,8 @@
             "canStaggeredWalljump"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 4],
@@ -590,6 +596,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "It is possible to kill the Rippers with a single Power Bomb by placing it at least 2 tiles above the lowest Ripper inside the narrow section of the shaft."
     },
     {
@@ -614,6 +621,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The Rippers can be killed with two Power Bombs, or one carefully placed Power Bomb and a careful dodge of the top-most Ripper.",
         "With a single Power Bomb, place it at least two tiles above the first Ripper. This can be achieved with a Staggered IBJ or a Spring Ball Bomb Boost.",

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -659,7 +659,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -646,7 +646,8 @@
       "name": "Base",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 3],

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -149,6 +149,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The off screen portion can be simple with Spring Ball or two short IBJs."
     },
     {
@@ -166,6 +167,7 @@
         "h_canArtificialMorphBombThings",
         "h_additionalBomb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use one bomb to get to the off-screen region. After going a full screen to the right, when Samus is partially visible in the left wall, bomb to the middle platform on the right.",
         "Bomb again to the right, note that these small platforms are one tile left of the ones that are on camera. Exit G-Mode and get to the right door."
@@ -193,6 +195,7 @@
           "Gravity"
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "Spring Ball and Gravity wouldn't be required with some risky off-screen horizontal bomb jumps.",
         "This strat is only useful for avoiding a wall jump. A simpler variant exits G-Mode after the morph tunnel."
@@ -429,7 +432,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -127,6 +127,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME Add details on how this works and check if it actually requires canBeVeryPatient."
       ]
@@ -351,7 +352,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/maridia/inner-yellow/Plasma Beach Quicksand Room.json
+++ b/region/maridia/inner-yellow/Plasma Beach Quicksand Room.json
@@ -88,7 +88,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -106,7 +107,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-yellow/Plasma Beach Quicksand Room.json
+++ b/region/maridia/inner-yellow/Plasma Beach Quicksand Room.json
@@ -65,7 +65,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -224,7 +224,8 @@
           "h_canArtificialMorphSpringBallBombJump",
           "h_canArtificialMorphBombHorizontally"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 5],
@@ -308,7 +309,8 @@
             "h_additionalBomb"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -404,7 +406,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -483,6 +486,7 @@
       "requires": [
         "canXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 2 screens."
     },
     {
@@ -513,6 +517,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -606,7 +611,8 @@
           ]}
         ]},
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],
@@ -627,7 +633,8 @@
           ]}
         ]},
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],
@@ -776,7 +783,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 5],
@@ -899,7 +907,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 6],
@@ -981,7 +990,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 1],

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -122,6 +122,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "It takes between 1-2 minutes for the Puyos to wake up and get to the doorway."
       ]
@@ -485,6 +486,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "It takes approximately 3 minutes for the Puyos to wake up and get to the doorway."
       ]

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -139,6 +139,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "It takes between 1-2 minutes for the Puyos to wake up and get to the doorway."
     },
     {
@@ -503,6 +504,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "It takes approximately 3 minutes for the Puyos to wake up and get to the doorway."
     }
   ]

--- a/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
@@ -153,6 +153,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": [
         "This link doesn't accomplish anything, other than enabling Samus to return with Artificial Morph.",
         "Samus does not obtain the item until returning and exiting G-Mode, so all the requirements must be here."
@@ -379,7 +380,8 @@
           "h_canArtificialMorphIBJ",
           "h_canArtificialMorphSpringBallBombJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -153,7 +153,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -439,7 +440,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -453,7 +453,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -152,7 +152,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -269,6 +269,7 @@
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "The gate will not spawn in indirect g-mode and is freely passable."
     },
     {
@@ -291,6 +292,7 @@
         ]},
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "The gate will not spawn in indirect g-mode and is freely passable."
     },
     {
@@ -353,7 +355,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -562,6 +565,7 @@
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "The gate will not spawn in indirect g-mode and is freely passable."
     },
     {
@@ -584,6 +588,7 @@
         ]},
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "The gate will not spawn in indirect g-mode and is freely passable."
     },
     {
@@ -623,7 +628,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "canOffScreenMovement"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 4],
@@ -803,6 +809,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "The gate will not spawn in indirect g-mode and is freely passable."
     },
     {

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -788,6 +788,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It is easier to use the middle Zebbo farm than the right one."
       ]

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -219,6 +219,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Roll over the two crabs before the first gets to Samus. This is easier with Gravity Suit turned off.",
         "It is possible but difficult to roll from the doorway onto the platform with Gravity turned off.",
@@ -283,7 +284,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -323,6 +325,7 @@
           "morphed": true
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "To save a bomb, it is possible but difficult to roll from the doorway onto the platform with Gravity turned off.",
         "This requires backing up slightly after entering the room then quickly rolling before the crabs. It is a bit tighter in direct G-Mode."
@@ -783,7 +786,8 @@
             "canOffScreenMovement"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],
@@ -799,6 +803,7 @@
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": [
         "One method to kill the crabs is to wait on the central platform until a crab comes near, then move with it laying bombs in its path.",
         "Another is to wait in the doorway and place three bombs to hit it while bouncing over it.",
@@ -819,6 +824,7 @@
         "canGravityJump",
         "h_canArtificialMorphSpringBall"
       ],
+      "flashSuitChecked": true,
       "note": [
         "The shaft will be clear of crabs on room entry. Quickly gravity jump before the bottom crab enters the shaft and exit the left morph tunnel to be safe.",
         "This is a bit tighter when entering in G-Mode Immobile."
@@ -1095,7 +1101,8 @@
             "canOffScreenMovement"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 5],
@@ -1111,6 +1118,7 @@
         "Gravity",
         "h_canArtificialMorphIBJ"
       ],
+      "flashSuitChecked": true,
       "note": [
         "One method to kill the crabs is to wait on the central platform until a crab comes near, then move with it laying bombs in its path.",
         "Another is to wait in the doorway and place three bombs to hit it while bouncing over it.",
@@ -1131,6 +1139,7 @@
         "canGravityJump",
         "h_canArtificialMorphSpringBall"
       ],
+      "flashSuitChecked": true,
       "note": [
         "The shaft will be clear of crabs on room entry. Quickly gravity jump before the bottom crab enters the shaft and exit the left morph tunnel to be safe.",
         "The same strategy works when entering in G-Mode Immobile. Move to the center platform and gravity jump shortly after getting hit."
@@ -1194,7 +1203,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -1225,6 +1235,7 @@
           "morphed": true
         }
       },
+      "flashSuitChecked": true,
       "note": "To save a bomb, it is possible to roll from the doorway onto the platform with Gravity turned off."
     },
     {
@@ -1290,7 +1301,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 2],

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -173,7 +173,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -665,7 +666,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1013,7 +1015,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -1399,7 +1402,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -1430,7 +1434,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [5, 4],
@@ -1442,7 +1447,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -186,7 +186,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -679,7 +680,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -1028,7 +1030,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -1415,14 +1418,16 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [5, 1],
       "name": "Exit G-Mode",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 1],

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -184,7 +184,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -413,7 +414,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -206,6 +206,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "The gate will not spawn in indirect g-mode, and can be freely passed."
     },
     {
@@ -274,6 +275,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "The gate will not spawn in indirect g-mode, and can be freely passed."
     },
     {

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -171,7 +171,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -399,7 +400,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -241,7 +241,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -499,6 +499,7 @@
         "h_canArtificialMorphIBJ",
         "Gravity"
       ],
+      "flashSuitChecked": true,
       "note": "Kill the first fish with bombs then dodge or kill the second one."
     },
     {
@@ -865,7 +866,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -899,7 +901,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 7],
@@ -970,7 +973,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -997,7 +1001,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 5],
@@ -1126,6 +1131,7 @@
         "h_canArtificialMorphIBJ",
         "Gravity"
       ],
+      "flashSuitChecked": true,
       "note": "Kill or dodge the fish by the top left door."
     },
     {

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -333,7 +333,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -369,6 +370,7 @@
           "morphed": true
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Bomb jumping across the broken tube uses a second bomb to climb up to the tube.",
         "FIXME: Moving before the bomb explodes gives enough momentum to only need one power bomb."
@@ -473,6 +475,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
     },
     {
@@ -504,7 +507,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -534,7 +538,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -670,6 +675,7 @@
       "requires": [
         "canXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
     {
@@ -704,7 +710,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -734,7 +741,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 4],
@@ -869,6 +877,7 @@
         "h_canArtificialMorphMovement"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
     },
     {
@@ -929,7 +938,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -965,6 +975,7 @@
           "morphed": true
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Bomb jumping across the broken tube uses a second bomb to climb up to the tube.",
         "FIXME: Moving before the bomb explodes gives enough momentum to only need one power bomb."
@@ -1231,6 +1242,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later."
     },
     {
@@ -1287,7 +1299,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -1307,7 +1320,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 3],
@@ -1327,7 +1341,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 3],
@@ -1347,7 +1362,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -1375,7 +1391,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -1416,7 +1433,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 6],
@@ -1438,6 +1456,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "The tube will break when exiting G-Mode or when the Power Bomb finishes detonating, whichever is later.",
         "Be sure not to overload PLMs with the camera scroll blocks which are next to the tube.",

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -642,7 +642,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 6],
@@ -719,6 +720,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
         "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
@@ -758,6 +760,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
         "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
@@ -789,6 +792,7 @@
         {"ammo": {"type": "PowerBomb", "count": 2}}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
         "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
@@ -822,6 +826,7 @@
         "h_canUsePowerBombs"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
         "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
@@ -1127,7 +1132,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 6],
@@ -1224,6 +1230,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
         "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
@@ -1262,6 +1269,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
         "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
@@ -1293,6 +1301,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
         "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
@@ -1325,6 +1334,7 @@
         "h_canUsePowerBombs"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
         "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
@@ -1676,6 +1686,7 @@
           "canBeVeryPatient"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "This is a long climb, and getting around the fish under the missiles can be tricky or slow."
     },
     {
@@ -1832,6 +1843,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
         "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
@@ -1870,6 +1882,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
         "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
@@ -1901,6 +1914,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
         "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
@@ -1933,6 +1947,7 @@
         "h_canUsePowerBombs"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
         "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
@@ -2349,6 +2364,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
         "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
@@ -2378,6 +2394,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "flashSuitChecked": true,
       "note": [
         "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
         "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
@@ -2476,6 +2493,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "There is a camera scroll block inside of the morph tunnel, so it is best to go through the tunnel quickly and not backtrack.",
         "The crab will not come through the whole tunnel, so as Samus gets close to the vertical portion, wait for the crab to pass.",
@@ -2501,6 +2519,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The crab will not come through the whole tunnel, so wait for it to pass before going through the vertical portion."
     },
     {
@@ -2522,6 +2541,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The crab will not come through the whole tunnel, so wait for it to pass before going through the vertical portion."
     },
     {

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -305,6 +305,7 @@
         "never"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Start on the right side and carefully land on the right edge. If in artificial morph, use spring ball or quickly bomb or bomb over the crab to avoid a second hit.",
       "devNote": "FIXME: It may be possible to get hit on the left side, but it would be dependent on the strats coming in, sometimes you're immobilized too high to get hit."
     },
@@ -971,7 +972,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -1667,6 +1669,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "The global crab takes 37 seconds to get to Samus."
     },
     {
@@ -2271,7 +2274,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [4, 6],

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -958,7 +958,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1652,7 +1653,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -2256,7 +2258,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -2441,6 +2444,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Get to the item while avoiding the crab, note that it doesn't go all the way through the tunnel.",
         "Use a super to knock it off, while it is on the right wall, in order to knock it off so it will go down the morph tunnel."

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -331,6 +331,7 @@
         "h_canArtificialMorphBombHorizontally"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Get into position as close to the center of the room as possible while not being too close to any baby turtles.",
         "Start an IBJ without hiting any baby turtles otherwhise Mama Turtle will wake up."
@@ -351,6 +352,7 @@
         "h_canArtificialMorphIBJ"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": [
         "Place a bomb next to one of the baby turtles, then use spring ball to get on Mama Turtle's back.",
         "Start an IBJ above the waterline to get to the item."
@@ -523,6 +525,7 @@
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphBombHorizontally"
       ],
+      "flashSuitChecked": true,
       "note": "IBJ up a bit, then bomb over Mama Turtle and her babies to prevent her from waking. Then IBJ to the high right ledge before exiting g-mode."
     },
     {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -2341,7 +2341,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [6, 7],
@@ -3491,6 +3492,7 @@
       "requires": [
         "canEnterGMode"
       ],
+      "flashSuitChecked": true,
       "devNote": "This technically requires h_EverestMorphTunnelExpanded or going through the transition while in G-Mode, but that shouldn't cause a problem."
     },
     {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -489,6 +489,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Follow the crab from the bottom right door to the top left door. This takes approximately 90 seconds.",
         "It is also possible to knock the crab off of the middle peak with a super and follow it to the left which may save time."
@@ -524,6 +525,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Follow the crab from the bottom right door to the top left door with Gravity or Grapple.",
         "It is also possible to knock the crab off of the middle peak with a super and follow it to the left with Ice or HiJump and Spring Ball."
@@ -1830,6 +1832,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Follow the crab from the bottom right door to the top right door. Depending on the item setup, this takes 30-50 seconds."
       ],
@@ -2186,7 +2189,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [5, 9],
@@ -2323,7 +2327,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],
@@ -3498,7 +3503,8 @@
         "leaveWithGMode": {
           "morphed": true
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ],
   "devNote": [

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -573,7 +573,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 9],
@@ -616,7 +617,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 11],
@@ -660,7 +662,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 12],
@@ -683,6 +686,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Bounce from the right peak into the morph tunnel.",
         "Samus can't bounce twice in a single fall, so start from the right ground, not the raised scaffolding by the door."
@@ -795,7 +799,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],
@@ -954,7 +959,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 7],
@@ -970,6 +976,7 @@
         "Gravity",
         "h_canArtificialMorphSpringBallBombJump"
       ],
+      "flashSuitChecked": true,
       "note": "This requires one spring ball bomb jump."
     },
     {
@@ -1176,7 +1183,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 11],
@@ -1292,6 +1300,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: Add strats to get here with Morph."
     },
     {
@@ -1911,7 +1920,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 10],
@@ -1956,6 +1966,7 @@
           "h_canArtificialMorphSpringBallBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: Add strats to get here with Morph, suitless."
     },
     {
@@ -2070,7 +2081,8 @@
       "requires": [
         "h_canArtificialMorphIBJ",
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 5],
@@ -2110,6 +2122,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": "Note that it is possible to get up with Grapple alone by using the Powamps. Fling from the Powamp into the side of the top platform to align horizontally."
     },
     {
@@ -2137,7 +2150,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [5, 5],
@@ -2202,7 +2216,8 @@
             "h_canArtificialMorphBombHorizontally"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 12],
@@ -2231,6 +2246,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Bounce from the right peak into the morph tunnel.",
         "Samus can't bounce twice in a single fall, so come to a stop on the top platform or avoid it completely."
@@ -2257,6 +2273,7 @@
         "h_canArtificialMorphIBJ",
         "Gravity"
       ],
+      "flashSuitChecked": true,
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {
@@ -2272,6 +2289,7 @@
         "h_canArtificialMorphIBJ",
         "Gravity"
       ],
+      "flashSuitChecked": true,
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {
@@ -2337,6 +2355,7 @@
           "h_canArtificialMorphSpringBallBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {
@@ -2355,6 +2374,7 @@
           "h_canArtificialMorphSpringBallBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {
@@ -2380,6 +2400,7 @@
         "canInsaneJump",
         "h_canArtificialMorphSpringBall"
       ],
+      "flashSuitChecked": true,
       "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
     },
     {
@@ -2395,6 +2416,7 @@
         "canInsaneJump",
         "h_canArtificialMorphSpringBall"
       ],
+      "flashSuitChecked": true,
       "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
     },
     {
@@ -2411,6 +2433,7 @@
         "h_canArtificialMorphIBJ",
         "Gravity"
       ],
+      "flashSuitChecked": true,
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {
@@ -2426,6 +2449,7 @@
         "h_canArtificialMorphIBJ",
         "Gravity"
       ],
+      "flashSuitChecked": true,
       "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
     },
     {

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -140,7 +140,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -279,6 +279,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "In order to not fall back into the room below, enter on the far left and face and hold left while getting hit, or enter on the far right side while facing left and turn around and hold right white getting hit."
     },
     {

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -169,6 +169,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Use spring ball to cross the room, or use bombs to kill the Zebbos so they stop respawning. One PB can be placed at the first plant on the ground to bomb across the farm while killing the Zebbos."
     },
     {
@@ -234,6 +235,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Enter the room on the far right or left side in order to not fall back through the open doorway."
     },
     {

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -302,7 +302,8 @@
         "f_DefeatedCrocomire",
         "canBePatient"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 5],
@@ -371,7 +372,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -397,7 +399,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -414,7 +417,8 @@
         "f_DefeatedCrocomire",
         "canBePatient"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -185,6 +185,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -201,7 +202,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -223,6 +225,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Get to the top of the room with Spring Ball Bomb Jumps.",
         "To cross the room, perform a Spring Ball Bomb Jump after hitting the bomb with momentum to get a larger horizontal boost, then unmorph on the descent to reset fall speed."

--- a/region/norfair/crocomire/Grapple Tutorial Room 2.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 2.json
@@ -140,7 +140,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -184,6 +184,7 @@
       },
       "requires": [],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Cross the room while in indirect G-Mode and the gate will not be there.",
         "Note that if any of the Gamets are killed, none of them will respawn, but they can still be frozen and used as a platform.",
@@ -284,7 +285,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -390,7 +392,8 @@
       "requires": [
         "Gravity",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -610,7 +613,8 @@
         }
       },
       "requires": [],
-      "clearsObstacles": ["B"]
+      "clearsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -169,6 +169,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "It is possible to lure the Gamets out of the water with nothing but ledge grabs."
       ]
@@ -265,6 +266,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
       ],

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -275,7 +275,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -387,7 +388,8 @@
         },
         "comesThroughToilet": "no"
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -747,6 +749,7 @@
       "requires": [
         "canXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
     {
@@ -762,6 +765,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -781,7 +785,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -974,7 +979,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 1],

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -1345,7 +1345,8 @@
       "requires": [
         "canEnterGMode",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 4],
@@ -1353,7 +1354,8 @@
       "requires": [
         "canEnterGMode",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 4],
@@ -1363,6 +1365,7 @@
         "canTrickyJump",
         "h_canArtificialMorphSpringBallBombJump"
       ],
+      "flashSuitChecked": true,
       "note": "It is possible to perform a Spring Ball Bomb Jump from the Kamer, but it is rarely useful.",
       "devNote": "The Spring Ball Bomb Jump is likely only useful for avoiding a crouch jump to preserve a blue suit."
     }

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -208,6 +208,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure the Gamets to the top left door with Ice and Space Jump, Grapple, or HiJump.",
         "First lure the Gamets vertically using the Kamer platform and Ice, which is much easier with HiJump disabled.",
@@ -587,7 +588,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -959,6 +961,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Lure the Gamets while using the Kamer, then get up to the doorway with a quick crouch jump + down grab or by other means.",
       "devNote": [
         "A crouch jump + down grab should always be usable except when preserving a blue suit.",

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -856,7 +856,8 @@
       "requires": [
         "canEnterGMode",
         {"obstaclesCleared": ["C", "D"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -864,7 +865,8 @@
       "requires": [
         "canEnterGMode",
         {"obstaclesCleared": ["D"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 5],
@@ -1192,14 +1194,16 @@
       "requires": [
         "canEnterGMode",
         {"obstaclesCleared": ["C"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 2],
       "name": "G-Mode Morph",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 2],
@@ -1208,7 +1212,8 @@
         "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 3],
@@ -1216,14 +1221,16 @@
       "requires": [
         "canEnterGMode",
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 5],
       "name": "Base",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],
@@ -1232,7 +1239,8 @@
         "canEnterGMode",
         "h_canArtificialMorphJumpIntoIBJ"
       ],
-      "clearsObstacles": ["C"]
+      "clearsObstacles": ["C"],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],
@@ -1241,7 +1249,8 @@
         "canEnterGMode",
         "h_canArtificialMorphDiagonalBombJump"
       ],
-      "clearsObstacles": ["C"]
+      "clearsObstacles": ["C"],
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],
@@ -1255,6 +1264,7 @@
         {"acidFrames": 150}
       ],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "Cross the solid platforms then horizontally boost into the acid and begin an IBJ.",
         "With more limited Energy, it is possible to IBJ high into the room and boost horizontally to fall into the acid a bit further to the left."

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -365,7 +365,8 @@
       },
       "requires": [
         "h_canArtificialMorphSpringBall"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 6],
@@ -379,7 +380,8 @@
       "requires": [
         "h_canArtificialMorphSpringBall"
       ],
-      "clearsObstacles": ["D"]
+      "clearsObstacles": ["D"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 6],
@@ -395,6 +397,7 @@
         "h_canArtificialMorphDiagonalBombJump"
       ],
       "reusableRoomwideNotable": "PCJR G-Mode Morph Long Diagonal Bomb Jump",
+      "flashSuitChecked": true,
       "note": "Perform a long diagonal bomb jump from the left door to the solid platforms above the acid."
     },
     {
@@ -412,6 +415,7 @@
       ],
       "clearsObstacles": ["D"],
       "reusableRoomwideNotable": "PCJR G-Mode Morph Long Diagonal Bomb Jump",
+      "flashSuitChecked": true,
       "note": "Perform a long diagonal bomb jump from the left door to the solid platforms above the acid."
     },
     {
@@ -441,6 +445,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Bomb boost horizontally at the top of an IBJ and land in the acid, then roll to the right and bomb out to safety.",
         "To save some Energy, it is possible to IBJ or double IBJ out of the acid onto the first solid platform."
@@ -640,6 +645,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb then exit G-Mode to break the blocks."
     },
     {
@@ -658,7 +664,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -678,7 +685,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 4],
@@ -795,6 +803,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "A single horizontal Power Bomb boost can get Samus on top of the blocks and kill most of the Mellas.",
         "With Bombs, killing the Mellas can be a bit tricky; it is recommended to use one to boost and place some midair before luring a Mella to more easily kill it."
@@ -824,6 +833,7 @@
         ]}
       ],
       "clearsObstacles": ["D"],
+      "flashSuitChecked": true,
       "note": [
         "A single horizontal Power Bomb boost can get Samus on top of the blocks and kill most of the Mellas.",
         "With Bombs, killing the Mellas can be a bit tricky; it is recommended to use one to boost and place some midair before luring a Mella to more easily kill it."

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -1058,6 +1058,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Lure a Mella from the right by breaking the speed blocks or using Morph.",
         "Then manipulate it to go high enough to be used in the left doorway.",

--- a/region/norfair/crocomire/Post Crocomire Missile Room.json
+++ b/region/norfair/crocomire/Post Crocomire Missile Room.json
@@ -100,6 +100,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure the Gamets while preventing them from going off camera.",
         "Spawn them when the acid is high and rising to avoid running through it."

--- a/region/norfair/crocomire/Post Crocomire Missile Room.json
+++ b/region/norfair/crocomire/Post Crocomire Missile Room.json
@@ -122,6 +122,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Wait for the acid to lower then quickly roll part way forward to trigger the Metarees and return. Then go again without any difficulty.",
       "devNote": "This is only useful if the item is Morph."
     },
@@ -152,6 +153,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Wait for the acid to lower then quickly roll part way forward to trigger the Metarees and return. Then go again without any difficulty.",
         "Killing any of the Gamets will prevent them from respawning.",

--- a/region/norfair/crocomire/Post Crocomire Missile Room.json
+++ b/region/norfair/crocomire/Post Crocomire Missile Room.json
@@ -184,7 +184,8 @@
       "requires": [
         "canEnterGMode",
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -240,6 +240,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a Super to knock off a nearby Viola, then lure it to the top.",
         "To avoid a wall jump, it is possible to use the Viola as a frozen platform."
@@ -374,6 +375,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off the lowest Viola."
     },
     {
@@ -475,6 +477,7 @@
       "unlocksDoors": [
         {"types": ["ammo"], "requires": []}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Knock a Viola off of its platform and keep it on camera as it climbs to the top of the room."
       ]

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -216,7 +216,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -489,7 +490,8 @@
       },
       "requires": [
         "h_canArtificialMorphIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -557,7 +559,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -584,7 +587,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -522,7 +522,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -549,7 +550,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -497,6 +497,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Freeze the stack of Gammets together a few times to try and raise them as high as possible.",
         "Run with them to the door and freeze the top two such that Samus can stand on the lower and take damage from the higher Gammet when it unfreezes."

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -310,7 +310,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -828,7 +829,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1308,6 +1310,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure a Sova from the bomb maze, or from just below the Power Bomb blocks.",
         "Using a Power Bomb while avoiding killing the Sova can be done by placing the Power Bomb on the lowest stair on the ledge above,",
@@ -1516,6 +1519,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Starting from the top of the room will require careful manipulation of the Sovas.",
         "If going through the Power Bomb blocks, place the Power Bomb on the lowest stair on the ledge above,",
@@ -1899,6 +1903,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Wait 50 seconds for a Waver to get to this door."
     },
     {
@@ -2438,6 +2443,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Wait 40 seconds for a Waver to get to this door."
     },
     {

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -324,6 +324,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 20 seconds for a Waver to come and hit Samus."
     },
     {
@@ -842,7 +843,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -1917,6 +1919,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 50 seconds for a Waver to come and hit Samus."
     },
     {
@@ -2457,6 +2460,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Wait 40 seconds for a Waver to come and hit Samus."
     },
     {
@@ -2727,6 +2731,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Carefully dodge the Wavers while being prepared to abort the IBJ and start over if necessary."
     },
     {
@@ -2734,7 +2739,8 @@
       "name": "Base",
       "requires": [
         "canEnterGMode"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 3],
@@ -2743,7 +2749,8 @@
         "canEnterGMode",
         "h_canArtificialMorphPowerBomb"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [10, 7],
@@ -2763,6 +2770,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Carefully dodge the Wavers while being prepared to abort the IBJ and start over if necessary.",
         "It may be best to first IBJ to the top left side and kill the top Waver with Bombs;",

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -549,7 +549,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -575,6 +576,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1085,7 +1087,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -1111,6 +1114,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1365,7 +1369,8 @@
           "morphed": true
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -1393,6 +1398,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 3 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1411,6 +1417,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1440,6 +1447,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1531,6 +1539,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb high enough to reach the blocks above."
     },
     {
@@ -1547,6 +1556,7 @@
         {"ammo": {"type": "PowerBomb", "count": 3}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "The blocks are breakable with 4 Power Bombs.",
         "Horizontally bomb over the vertical door then up two ledges before placing a Power Bomb that can reach the blocks above."
@@ -1696,6 +1706,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb high enough to reach the blocks above."
     },
     {
@@ -1921,6 +1932,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -2038,6 +2050,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Lower the camera to watch the Wavers and to help avoid them.",
         "With Bombs alone, it may be helpful to kill the top Waver; this can be done by placing Bombs in a vertical line and then moving out of the way as it approaches."
@@ -2469,6 +2482,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Lower the camera to watch the Wavers and to help avoid them.",
         "With Bombs alone, it may be helpful to kill the top Waver; this can be done by placing Bombs in a vertical line and then moving out of the way as it approaches."
@@ -2488,6 +2502,7 @@
         "h_canArtificialMorphPowerBomb",
         "h_additionalBomb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use one Power Bomb to jump towards the Cacatac then a second to jump over it and down below.",
         "Do not land where the Cacatac was, or Samus will get hit by its invisible spikes."

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -375,6 +375,7 @@
         "h_heatProof",
         "canXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
     {
@@ -391,6 +392,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -170,6 +170,7 @@
           "knockback": false
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "To save Energy, it is possible to lure a Beetom to the door without taking any extra hits and without any items.",
         "Get close enough to it to get it to hop towards Samus, then walk and occasionally run to the door with it following.",
@@ -879,6 +880,7 @@
           "knockback": false
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Carefully run through the blocks without killing all of the Beetoms or getting attacked by one.",
         "To save Energy, it is possible to lure a Beetom to the door without taking any extra hits and without any items.",

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -308,6 +308,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Carefully kill the Beetoms with Bombs, then overload PLMs by placing many bombs next to the speed blocks.",
         "An easy way to do this is to stay just out of range to avoid luring them and spam bombs in a vertical line until they wander close enough to jump into the blasts.",
@@ -537,6 +538,7 @@
       "requires": [
         "h_canArtificialMorphBombs"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Overload PLMs by placing many bombs next to the speed blocks.",
         "Safely kill the Beetoms from inside the speed blocks."
@@ -571,6 +573,7 @@
         ]}
       ],
       "reusableRoomwideNotable": "Frog Speedway Shot Block Overload (Speedless Speedway)",
+      "flashSuitChecked": true,
       "note": [
         "Shoot diagonal up-left shots into the ceiling while pressed against the speed blocks to hit all of the shot blocks and overload PLMs.",
         "Note that G-Mode makes it possible with Wave alone (no Spazer or Plasma necessary), and the speed blocks do not resolidify, so the Beetoms can be safely killed while inside of the speed blocks."

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -117,7 +117,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -144,7 +145,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -565,6 +567,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -203,6 +203,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off a Geemer and follow it to the top door."
     }
   ]

--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -101,6 +101,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off the Geemer when it is directly above Samus to regain mobility.",
       "devNote": "FIXME: There is likely a downward G-Mode setup using a Geemer."
     },

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -229,6 +229,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off a Sova and follow it to this door. The fastest Sova is just above the shot blocks, which takes 30 seconds."
     },
     {
@@ -881,6 +882,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off a Sova and follow it to this door. The fastest Sova is just above the shot blocks, which takes 20 seconds."
     },
     {
@@ -1493,6 +1495,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off a nearby Sova."
     },
     {
@@ -1881,6 +1884,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off the nearby Sova while it is on the right side of its platform."
     },
     {
@@ -2470,6 +2474,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off a nearby Sova."
     },
     {
@@ -2906,6 +2911,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Use a Super to knock off a Sova and follow it to this door.",
         "The fastest Sova is just above the middle left door, while it is on the left side of the platform, which takes 45 seconds."

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -1510,6 +1510,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off the Sova to regain mobility."
     },
     {
@@ -2489,6 +2490,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off the Sova to regain mobility."
     },
     {
@@ -2929,6 +2931,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off the Sova to regain mobility."
     },
     {

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -578,7 +578,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 8],
@@ -598,6 +599,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1232,7 +1234,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 8],
@@ -1252,6 +1255,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1292,6 +1296,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1758,7 +1763,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 8],
@@ -1890,6 +1896,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1997,6 +2004,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 3 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -2491,6 +2499,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -2563,7 +2572,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [5, 8],
@@ -3106,7 +3116,8 @@
         "leaveWithGMode": {
           "morphed": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [6, 8],

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -352,6 +352,7 @@
         "canBePatient"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 3 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -185,6 +185,7 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "It takes the Sova about 25 seconds to hit Samus."
     },
     {
@@ -605,7 +606,8 @@
       "requires": [
         "canEnterGMode",
         {"obstaclesCleared": ["D"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 3],
@@ -626,6 +628,7 @@
         "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs by rolling through the item, then go through the bomb block and exit G-Mode to obtain the item.",
       "devNote": "This does not include canRiskPermanentLossOfAccess as every strat that gets here could instead overload PLMs in the bottom morph tunnel."
     },

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -217,6 +217,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Roll through the camera scroll block in the morph tunnel at the bottom of the room to overload PLMs,",
         "then get to the right side through the crumble blocks or bomb blocks near the left item.",
@@ -300,6 +301,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Artificial morph IBJ or use two bomb boost spring ball jumps.",
       "devNote": "This is only useful if the item is Morph."
     },
@@ -331,6 +333,7 @@
         ]}
       ],
       "clearsObstacles": ["D"],
+      "flashSuitChecked": true,
       "note": "Get to the item without overloading PLMs by avoiding entering the morph tunnel at the bottom of the room or using Power Bombs near the items."
     },
     {
@@ -371,6 +374,7 @@
         "h_canArtificialMorphMovement",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using scroll blocks in the morph tunnel. The camera will not scroll to the left side of the room."
     },
     {
@@ -388,6 +392,7 @@
         "h_canArtificialMorphPowerBomb",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Placing a Power Bomb a 0.5 to 1 tile away from the item plinth to bounce Samus onto it (where the right item usually is) while also overloading PLMs as the explosion hits the left item.",
         "Wait for the explosion to completely finish before touching the crumble blocks or they will remain solid.",
@@ -413,6 +418,7 @@
         ]},
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs by rolling through the item then go through the crumble blocks. The camera will not scroll to the left side of the room.",
       "devNote": "FIXME: This item will be remote acquired, but it is ignored here since will require an obstacle and the strat is canRiskPermanentLossOfAccess."
     },
@@ -541,6 +547,7 @@
         "h_canArtificialMorphMovement",
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Overload PLMs using scroll blocks in the morph tunnel. The camera will not scroll to the left side of the room.",
       "devNote": "This is only useful morphless if the item is Morph."
     },

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -167,6 +167,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Note that breaking the left bomb blocks and either the crumble blocks or the other bomb blocks could make the Sova go in a loop without ever getting to the door (unless using a Super).",
         "Because of this it is advised not to break the bomb blocks. But if breaking them is necessary, it is possible to do so, even with a Power Bomb.",
@@ -522,6 +523,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Release the Sova by breaking the crumble blocks. The Sova will then take 40 seconds to get to the door.",
         "Note that breaking the left bomb blocks and either the crumble blocks or the other bomb blocks could make the Sova go in a loop without ever getting to the door (unless using a Super).",

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -578,7 +578,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [3, 7],

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -307,6 +307,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Release the ceiling Sova while being careful not to kill it if using Power Bombs.",
         "The Sova takes 90 seconds to get to the door if the Power Bomb blocks are broken and 45 seconds if they are not.",
@@ -390,6 +391,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Release the ceiling Sova while being careful not to kill it if using Power Bombs.",
         "Go through the ceiling morph tunnel and wait for the Sova on the other side."
@@ -563,6 +565,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": "Either enemy type can be used, so it may be best to kill one and use the other."
     },
     {

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -216,6 +216,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -325,6 +326,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
       "note": "Place a Power Bomb and exit G-Mode in order to break the blocks."
     },
     {
@@ -660,6 +662,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "It is tricky but possible to cross the room without any damage by rolling through the room.",
         "The enemies can be killed with extra Power Bombs, but without them, it's arguably easier to roll through the room without the use a Spring Ball or Bombs.",
@@ -693,6 +696,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "It is tricky but possible to cross the room without any damage by jumping over the Small Dessgeega on room entry then using a Power Bomb to kill several enemies.",
         "Note that crossing the room damageless is easier in indirect G-Mode.",
@@ -780,6 +784,7 @@
           "h_canArtificialMorphCeilingBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Place Bombs against the crumble block to overload PLMs, then go through it and through the bomb blocks at the left."
     },
     {
@@ -801,6 +806,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
       "note": [
         "Place Bombs against the crumble block to overload PLMs, then go through it and through the bomb blocks at the left.",
         "Place a Power Bomb and quuickly exit G-Mode before it goes off in order to break the blocks."

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -374,7 +374,8 @@
             "hits": 1
           }}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -410,6 +411,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: add a Toilet entry version of this"
     },
     {
@@ -604,7 +606,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -634,7 +637,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -99,7 +99,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -650,7 +651,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -117,7 +117,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -139,6 +140,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "devNote": "FIXME: This could be possible with Bombs by luring the hoppers to the left."
     },
     {
@@ -162,6 +164,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": "Immediately on entry Spring Ball Bomb Jump. Be sure not to land left of the pillar below the door or it is harder to get up in time.",
       "devNote": "FIXME: This could be possible with Bombs by luring the hoppers to the left."
     },

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -281,7 +281,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -642,6 +643,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Wait for the Rinka to spawn, then jump, so the trajectory is as high as possible. Space jump makes this a bit easier.",
         "If the Metroids are alive, lure them off screen to the left."
@@ -659,7 +661,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -310,6 +310,7 @@
         {"ammo": {"type": "PowerBomb", "count": 4}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Kill the Metroids while artificially morphed with just Spring Ball to avoid them.",
         "A Metroid (or a Rinka) must be completely on screen while a Power Bomb explodes in order for it to lure the other Metroids.",
@@ -396,7 +397,8 @@
         "f_KilledMetroidRoom1",
         "h_canArtificialMorphLongCeilingBombJump",
         "canBePatient"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -470,7 +472,8 @@
       "requires": [
         "f_KilledMetroidRoom1",
         "h_canArtificialMorphCeilingBombJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 1],
@@ -673,6 +676,7 @@
         {"ammo": {"type": "PowerBomb", "count": 4}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Kill the Metroids while artificially morphed with just Spring Ball to avoid them.",
         "A Metroid (or a Rinka) must be completely on screen while a Power Bomb explodes in order for it to lure the other Metroids.",

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -294,7 +294,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -133,7 +133,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -936,6 +937,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "If alive, the Metroids do 90 damage before the Rinka hits."
     },
     {

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -150,6 +150,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "This is easiest by staying on the top floating platform with the two Metroids stuck below it.",
         "Note that it is necessary to exit G-Mode before exiting the room in order for the Metroids to remain killed."
@@ -456,6 +457,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter immobile with G-mode direct, with the Metroids having been killed previously.",
         "Take a Rinka hit to regain mobility.",
@@ -484,6 +486,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, and quickly freeze the Metroids (if still alive) and Rinkas.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
@@ -950,6 +953,7 @@
         "h_canArtificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Quickly artificial morph and roll off to the bottom before being grabbed by the Metroids.",
         "This is much easier in indirect artificial morph.",

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -120,7 +120,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -900,6 +901,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "If the Metroids are alive, lure them off screen."
       ]
@@ -916,7 +918,8 @@
         "leaveWithGModeSetup": {
           "knockback": false
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -155,7 +155,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -549,7 +550,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -142,7 +142,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -535,7 +536,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -171,6 +171,7 @@
         {"ammo": {"type": "PowerBomb", "count": 4}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Kill the Metroids while artificially morphed with just Spring Ball to avoid them.",
         "A Metroid (or a Rinka) must be completely on screen while a Power Bomb explodes in order for it to lure the other Metroids.",
@@ -564,6 +565,7 @@
         {"ammo": {"type": "PowerBomb", "count": 3}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Kill the Metroids while artificially morphed with just Spring Ball to avoid them.",
         "A Metroid (or a Rinka) must be completely on screen while a Power Bomb explodes in order for it to lure the other Metroids.",

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -178,6 +178,7 @@
         {"ammo": {"type": "PowerBomb", "count": 5}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Kill the Metroids while artificially morphed without any movement items.",
         "With just 5 Power Bombs, place one on the first platform to kill some Rinkas and to lure a second Metroid.",

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -163,7 +163,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -537,6 +538,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "If alive, the Metroids do up to 78 damage before the Rinka hits. Entering through the middle of the door will require less damage."
     }
   ]

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -150,7 +150,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -412,7 +412,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -478,7 +479,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -425,7 +425,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],
@@ -446,7 +447,8 @@
         "comeInWithRMode": {}
       },
       "requires": [],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -492,7 +494,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -101,6 +101,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure a Rinka to the top door without letting it go off screen.",
         "The bottom right Rinka can be lured at the correct angle by standing on the central platform then jumping slightly before it moves."
@@ -413,7 +414,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1016,7 +1018,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -427,7 +427,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -1031,7 +1032,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -171,6 +171,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, moving quickly to avoid Rinka hits, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -493,6 +494,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter immobile with G-mode direct, taking a Rinka hit to regain mobility.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
@@ -520,6 +522,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, and freeze the bottom Rinka near the door.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
@@ -624,6 +627,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter immobile with G-mode direct, taking a Rinka hit to regain mobility.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
@@ -651,6 +655,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, and freeze the bottom Rinka near the door.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -114,7 +114,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -134,7 +135,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -251,7 +251,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -256,6 +256,7 @@
         ]},
         {"ammo": {"type": "PowerBomb", "count": 5}}
       ],
+      "flashSuitChecked": true,
       "note": "IBJ or spring ball bomb jump to avoid the wall jump. The first pirate takes 2 PBs, the next 3 can be killed with 3 total PBs if they are placed under the middle pirate."
     },
     {
@@ -277,6 +278,7 @@
         "h_canArtificialMorphPowerBomb",
         "canHitbox"
       ],
+      "flashSuitChecked": true,
       "note": "IBJ or spring ball bomb jump to avoid the wall jump. Using a total of 3 PBs will allow Samus to roll through the bottom 4 pirates."
     },
     {
@@ -299,6 +301,7 @@
           "hits": 3
         }}
       ],
+      "flashSuitChecked": true,
       "note": "Tank 3 pirate hits then IBJ or spring ball bomb jump to avoid the wall jump."
     },
     {
@@ -317,6 +320,7 @@
           "canBeVeryPatient"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Take the bottom path and place many bombs near the speed blocks to overload PLMs and go through them."
     },
     {

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -177,6 +177,7 @@
         "h_canArtificialMorphIBJ",
         {"ammo": {"type": "PowerBomb", "count": 10}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "IBJ and use 10 PBs to kill the pirates and get to the top. Exit gmode and fall to the bottom.",
         "Note that there is a path up to the right that doesn't need wall jumps, but a crouch jump down grab is needed to get to the final platform."

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -133,7 +133,8 @@
           "hits": 1
         }}
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 3],

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -289,7 +289,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -696,7 +697,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -313,6 +313,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "devNote": "The Covern will do more damage than the Atomic, so there is no canRiskPermanentLossOfAccess."
     },
     {
@@ -538,6 +539,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Use a Covern or Kihunter. A flying Kihunter takes about 25 seconds to get to the door.",
       "devNote": "The Kihunter will do more damage than the Covern, so whether Phantoon is dead or not, that strat will be accurate or conservative."
     },
@@ -722,6 +724,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Use a Covern or Kihunter. A flying Kihunter will collide with Samus eventually, which could take up to 30 seconds, based on her positioning.",
       "devNote": "The Kihunter will do more damage than the Covern, so whether Phantoon is dead or not, that strat will be accurate or conservative."
     }

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -168,7 +168,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -321,6 +322,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Stand on one frozen Atomic to bring a second Atomic to the correct height to use as a crouch platform."
       ]
@@ -677,7 +679,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -182,7 +182,8 @@
         }},
         "f_DefeatedPhantoon"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -338,7 +339,8 @@
         }},
         "f_DefeatedPhantoon"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -200,6 +200,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just left of the bomb blocks, in order to overload PLMs and go through them."
     },
     {
@@ -221,6 +222,7 @@
           "h_canArtificialMorphPowerBomb"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "On room entry, place a Power Bomb to kill the Atomic and land on the Workrobot.",
         "Wait for the Workrobot to move across the room until it meets with a second robot.",
@@ -352,7 +354,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -373,6 +376,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": "With Bombs, it may be helpful to roll off the platform and kill the Atomics before safely leaving the room."
     },
     {
@@ -432,6 +436,7 @@
       "requires": [
         "h_canArtificialMorphMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just left of the bomb blocks, in order to overload PLMs and go through them."
     },
     {
@@ -452,6 +457,7 @@
           "h_canArtificialMorphPowerBomb"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "On room entry, dodge the atomic and quickly place a Power Bomb to kill both Atomics.",
         "It is tricky but possible to kill them both with a single Power Bomb placed on the right half of the platform.",
@@ -557,6 +563,7 @@
       "requires": [
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them. Cancel g-mode and return into the morph tunnel to fix the camera."
     },
     {
@@ -571,6 +578,7 @@
       "requires": [
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them. Dodge the enemies while getting to the door."
     },
     {

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -181,6 +181,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -158,6 +158,7 @@
         "canRiskPermanentLossOfAccess"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": "Only works when Phantoon opens his eye while on the far left side.",
       "devNote": "This would only be useful to leave in g-mode."
     },

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -140,6 +140,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Not likely to be possible, as it requires canRiskPermanentLossOfAccess and Phantoon alive with the door unlocked."
       ]

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -183,7 +183,8 @@
         }},
         "f_DefeatedPhantoon"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],
@@ -808,7 +809,8 @@
         }},
         "f_DefeatedPhantoon"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     }
   ]
 }

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -354,6 +354,7 @@
       "requires": [
         "h_canArtificialMorphCeilingBombJump"
       ],
+      "flashSuitChecked": true,
       "note": "Kill the Bull with bombs, by switching between the high and low ground. Rapidly place bombs while rolling slowly.",
       "devNote": "It is possible with a low vertical diagonal bomb jump, or a double HBJ, but those aren't tech yet."
     },

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -169,7 +169,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -793,7 +794,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -155,7 +155,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -179,6 +179,7 @@
         ]}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "devNote": "The Covern will do more damage than the Bull, so there is no canRiskPermanentLossOfAccess."
     },
     {
@@ -188,7 +189,8 @@
         "comeInWithRMode": {}
       },
       "requires": [],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -374,7 +374,8 @@
         "h_canArtificialMorphLongCeilingBombJump",
         "canBePatient"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -329,6 +329,7 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Bring two atomics to the top of the room.",
         "Stand on one frozen Atomic to bring a second Atomic to the correct height to use as a crouch platform."
@@ -387,7 +388,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -601,7 +603,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -1064,7 +1067,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -1294,7 +1298,8 @@
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [5, 5],
@@ -1527,7 +1532,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [6, 6],

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -347,7 +347,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
@@ -403,7 +404,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [2, 4],
@@ -618,7 +620,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [3, 5],
@@ -1082,7 +1085,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [4, 5],
@@ -1313,7 +1317,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [5, 6],
@@ -1547,7 +1552,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [7, 3],
@@ -1659,6 +1665,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note":  [
         "In R-Mode, kill the Coverns until there is Energy in Samus's Reserves. Get into the Morph tunnel and go to the far left.",
         "Wait for Coverns to damage Samus down until Reserves trigger, forcing a stand up and enabling her to shoot the shot blocks and escape."
@@ -1751,6 +1758,7 @@
         "canRiskPermanentLossOfAccess"
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true,
       "note": [
         "Line up with the far right or left side of doorframe in the room below, to be able to not fall back through after entry, as the door remains open.",
         "Be careful not to fall into the door while being hit by the Covern."

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -287,7 +287,8 @@
           "morphed": false
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -307,7 +308,8 @@
           "morphed": true
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -500,6 +502,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just left of the bomb blocks, in order to overload PLMs and go through them."
     },
     {
@@ -514,6 +517,7 @@
       "requires": [
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Cancel g-mode, morph and move back towards the bomb blocks in order to fix the camera."
@@ -531,6 +535,7 @@
       "requires": [
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Exit g-mode and travel to the item and back while off screen."
@@ -716,6 +721,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just left of the bomb blocks, in order to overload PLMs and go through them."
     },
     {
@@ -859,6 +865,7 @@
       "requires": [
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Cancel g-mode, morph and move back towards the bomb blocks in order to fix the camera."
@@ -884,6 +891,7 @@
         ]},
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Exit g-mode and travel to the item and back while off screen."
@@ -1131,6 +1139,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just left of the bomb blocks, in order to overload PLMs and go through them."
     },
     {
@@ -1145,6 +1154,7 @@
       "requires": [
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Cancel g-mode, morph and move back towards the bomb blocks in order to fix the camera."
@@ -1162,6 +1172,7 @@
       "requires": [
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Exit g-mode and travel to the item and back while off screen."
@@ -1228,6 +1239,7 @@
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door.",
@@ -1308,6 +1320,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Use the camera scroll blocks just left of the bomb blocks, in order to overload PLMs and go through them."
     },
     {
@@ -1412,6 +1425,7 @@
       "requires": [
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Cancel g-mode, morph and move back towards the bomb blocks in order to fix the camera."
@@ -1429,6 +1443,7 @@
       "requires": [
         "canOffScreenMovement"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
         "Exit g-mode and travel to the item and back while off screen."

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -111,7 +111,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -126,7 +126,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -127,7 +127,8 @@
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
-      "gModeRegainMobility": {}
+      "gModeRegainMobility": {},
+      "flashSuitChecked": true
     },
     {
       "link": [1, 2],

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -112,7 +112,8 @@
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],


### PR DESCRIPTION
This includes all things G-Mode: Setups, Uses, Immobile, R-Mode

Currently none of these are modeled as able to carry a flash suit. Uses where G-Mode plus a flash suit can be combined would be very niche and not currently a priority, as you must use x-ray to enter and exit G-Mode. Given that G-Mode is typically modeled from the door to the destination, basically all of these strats wouldn't be useful with a flash suit anyways.