### PR TITLE
Reserve Double Damage Boost

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -188,7 +188,7 @@ An `autoReserveTrigger` object represents a logical requirement for "auto" reser
 
 * _minReserveEnergy_: The minimum amount of energy in reserves which will satisfy this requirement (default: 1).
 * _maxReserveEnergy_: The maximum amount of energy in reserves which will satisfy this requirement (default: 400).
-* _environmentalDamage_: The types of environmental damage that are being taken while the refill is occurring. The refill recovers 1 energy per frame and damage is taken on every frame of refill.  `environmentalDamage` can be of the forms `heat`, `lava`, and `acid`.  Each specified type of environment represents a requirement of that "environmentFrames" object where the frame amount is Samus' new energy after the reserve refill has complete. Environmental Damage is applied after the refill has complete.
+* _environmentalDamage_: The types of environmental damage that are being taken while the refill is occurring. The refill recovers 1 energy per frame and damage is taken on every frame of refill.  `environmentalDamage` can be of the forms `heat`, `lava`, and `acid`.  Each specified type of environment represents a requirement of that "environmentFrames" object where the frame amount is applied to Samus' new energy after the reserve refill has completed.
 
 __Example:__
 ```json

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -184,11 +184,10 @@ __Example:__
 
 #### autoReserveTrigger object
 
-An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves (capped to energy capacity), and reserve energy becoming zero.  An `autoReserveTrigger` object has three optional properties:
+An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves (capped to energy capacity), and reserve energy becoming zero. If the `autoReserveTrigger` takes place in a heated room, there is an additional `heatFrames` event with the number of frames being equal to the amount of health recovered by the Reserve refill.  An `autoReserveTrigger` object has two optional properties:
 
 * _minReserveEnergy_: The minimum amount of energy in reserves which will satisfy this requirement (default: 1).
 * _maxReserveEnergy_: The maximum amount of energy in reserves which will satisfy this requirement (default: 400).
-* _environmentalDamage_: The types of environmental damage that are being taken while the refill is occurring. The refill recovers 1 energy per frame and damage is taken on every frame of refill.  `environmentalDamage` can be of the forms `heat`, `lava`, and `acid`.  Each specified type of environment represents a requirement of that "environmentFrames" object where the frame amount is applied to Samus' new energy after the reserve refill has completed.
 
 __Example:__
 ```json

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -184,10 +184,11 @@ __Example:__
 
 #### autoReserveTrigger object
 
-An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves (capped to energy capacity), and reserve energy becoming zero. It has two optional properties:
+An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves (capped to energy capacity), and reserve energy becoming zero.  An `autoReserveTrigger` object has three optional properties:
 
 * _minReserveEnergy_: The minimum amount of energy in reserves which will satisfy this requirement (default: 1).
 * _maxReserveEnergy_: The maximum amount of energy in reserves which will satisfy this requirement (default: 400).
+* _environmentalDamage_: The types of environmental damage that are being taken while the refill is occurring. The refill recovers 1 energy per frame and damage is taken on every frame of refill.  `environmentalDamage` can be of the forms `heat`, `lava`, and `acid`.  Each specified type of environment represents a requirement of that "environmentFrames" object where the frame amount is Samus' new energy after the reserve refill has complete. Environmental Damage is applied after the refill has complete.
 
 __Example:__
 ```json

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -184,7 +184,7 @@ __Example:__
 
 #### autoReserveTrigger object
 
-An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves (capped to energy capacity), and reserve energy becoming zero. If the `autoReserveTrigger` takes place in a heated room, there is an additional `heatFrames` event with the number of frames being equal to the amount of health recovered by the Reserve refill.  An `autoReserveTrigger` object has two optional properties:
+An `autoReserveTrigger` object represents a logical requirement for "auto" reserves to be triggered, which results in Samus' energy becoming equal to the amount of energy in reserves (capped to energy capacity), and reserve energy becoming zero. If the `autoReserveTrigger` takes place in a heated room, there is an implicit `heatFrames` requirement with the number of frames being equal to the amount of health recovered by the Reserve refill.  An `autoReserveTrigger` object has two optional properties:
 
 * _minReserveEnergy_: The minimum amount of energy in reserves which will satisfy this requirement (default: 1).
 * _maxReserveEnergy_: The maximum amount of energy in reserves which will satisfy this requirement (default: 400).

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1448,8 +1448,7 @@
         ]},
         "canCrouchJump",
         "canInsaneJump",
-        "canPauseAbuse",
-        "canNeutralDamageBoost",
+        "canReserveDoubleDamageBoost",
         {"autoReserveTrigger": {"minReserveEnergy": 85}},
         {"enemyDamage": {
           "enemy": "Geemer (blue)",
@@ -1457,6 +1456,7 @@
           "hits": 1
         }}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait 3 minutes for a global Geemer to waddle over, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
         "Damage down until Samus is one Geemer hit away from running out of energy, and set reserves to manual.",

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2910,7 +2910,7 @@
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
         {"or": [
-          "canTrickySpringBallJump",
+          "h_canMaxHeightSpringBallJump",
           "HiJump"
         ]},
         {"autoReserveTrigger": {"minReserveEnergy": 85}},

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2899,6 +2899,33 @@
         "Near the end, use the global crab to get onto the top left corner of the room, then jump towards the walkway leading to the door."
       ],
       "devNote": "The global crab will fall if the speed blocks are broken."
+    },
+    {
+      "link": [9, 4],
+      "name": "Scisor Double Damage Boost",
+      "requires": [
+        "h_canNavigateUnderwater",
+        {"obstaclesNotCleared": ["A"]},
+        "canCrouchJump",
+        "canInsaneJump",
+        "canReserveDoubleDamageBoost",
+        {"or": [
+          "canTrickySpringBallJump",
+          "HiJump"
+        ]},
+        {"autoReserveTrigger": {"minReserveEnergy": 85}},
+        {"enemyDamage": {
+          "enemy": "Scisor",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Jump with either Springball or HiJump onto the global Scisor while it is climbing the section above the Speed locked item.",
+        "Have Reserves set to manual and return them to auto after taking a deadly crab hit in order to gain two damage boosts.",
+        "If the Speed blocks are broken, the global crab will not be able to reach this part of the room."
+      ]
     }
   ]
 }

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2904,7 +2904,7 @@
       "link": [9, 4],
       "name": "Scisor Double Damage Boost",
       "requires": [
-        "h_canNavigateUnderwater",
+        "canSuitlessMaridia",
         {"obstaclesNotCleared": ["A"]},
         "canCrouchJump",
         "canInsaneJump",

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -950,10 +950,7 @@
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
         {"or": [
-          {"and": [
-            "canStationaryLateralMidAirMorph",
-            "h_canMaxHeightSpringBallJump"
-          ]},
+          "h_canMaxHeightSpringBallJump",
           "HiJump"
         ]},
         {"autoReserveTrigger": {"minReserveEnergy": 85}},

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -943,6 +943,35 @@
     },
     {
       "link": [2, 7],
+      "name": "Scisor Double Damage Boost",
+      "requires": [
+        "h_canNavigateUnderwater",
+        "canCrouchJump",
+        "canInsaneJump",
+        "canReserveDoubleDamageBoost",
+        {"or": [
+          {"and": [
+            "canStationaryLateralMidAirMorph",
+            "canTrickySpringBallJump"
+          ]},
+          "HiJump"
+        ]},
+        {"autoReserveTrigger": {"minReserveEnergy": 85}},
+        {"enemyDamage": {
+          "enemy": "Scisor",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Jump with either Springball or HiJump onto a Scisor while it is climbing the right-most mountain.",
+        "Have Reserves set to manual and return them to auto after taking a deadly crab hit in order to gain two damage boosts.",
+        "This gains barely enough height to reach the ledge above."
+      ]
+    },
+    {
+      "link": [2, 7],
       "name": "G-Mode Morph IBJ",
       "entranceCondition": {
         "comeInWithGMode": {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -952,7 +952,7 @@
         {"or": [
           {"and": [
             "canStationaryLateralMidAirMorph",
-            "canTrickySpringBallJump"
+            "h_canMaxHeightSpringBallJump"
           ]},
           "HiJump"
         ]},

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -127,7 +127,15 @@
         "Normalized whole-room movement can be used to manipulate the Sm. Dessgeegas, to be able to do this strat reliably without heat protection.",
         "For details, see the individual strats, as the specific technique depends on whether entering from the left or right side of the room."
       ]
-
+    },
+    {
+      "name": "Cathedral Entrance Sova Boost",
+      "note": [
+        "Wait for the global Sova to begin climbing the wall below the right side door.",
+        "Jump into it just before it reaches the ledge that the door is on to gain height through a neutral damage boost.",
+        "The jump can be either a difficult walljump or a crouch jump combined with a type of Bomb and the refill effect of Reserve tanks.",
+        "Maniputlating the camera can help normalizing the timing of the jump."
+      ]
     }
   ],
   "strats": [
@@ -805,6 +813,113 @@
             {"heatFrames": 300}
           ]}
         ]}
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Walljump into Unmorph Bomb Boost",
+      "requires": [
+        "canInsaneWalljump",
+        "canWallJumpInstantMorph",
+        "canUnmorphBombBoost",
+        "canDownGrab",
+        {"heatFrames": 215}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Use a fully delayed walljump to gain enough horizontal distance to place a bomb past the lip of the overhang.",
+        "Unmorph to hover in the air above the bomb while it explodes.",
+        "Ride the explosion into a down-grab to reach the ledge."
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Cathedral Entrance Sova Boost (Walljump)",
+      "notable": true,
+      "requires": [
+        "canInsaneWalljump",
+        "canWallJumpInstantMorph",
+        "canNeutralDamageBoost",
+        "canCameraManip",
+        {"heatFrames": 830},
+        {"enemyDamage": {
+          "enemy": "Sova",
+          "type": "contact",
+          "hits": 1
+        }},
+        {"heatFrames": 90}
+      ],
+      "reusableRoomwideNotable": "Cathedral Entrance Sova Boost",
+      "flashSuitChecked": true,
+      "note": [
+        "Wait for the global Sova to begin climbing the wall below the door.",
+        "Time a walljump into instant morph where Samus boosts off of the Sova with the right timing to bounce up to the door's ledge.",
+        "The jump must be a fully delayed walljump.",
+        "Normalizing the camera can help with timing the walljump.",
+        "The damage boost can be attempted again when the Sova climbs down the left all, or by knocking it off the wall with a Super Missile."
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Cathedral Entrance Sova Boost (Reserve Double Damage Boost)",
+      "notable": true,
+      "requires": [
+        "canCrouchJump",
+        "canInsaneJump",
+        {"or": [
+          "canMidAirMorph",
+          "canOffScreenMovement"
+        ]},
+        "canPauseAbuse",
+        "canCameraManip",
+        "canNeutralDamageBoost",
+        {"heatFrames": 830},
+        {"autoReserveTrigger": {"minReserveEnergy": 85}},
+        {"enemyDamage": {
+          "enemy": "Sova",
+          "type": "contact",
+          "hits": 1
+        }},
+        {"heatFrames": 90}
+      ],
+      "reusableRoomwideNotable": "Cathedral Entrance Sova Boost",
+      "flashSuitChecked": true,
+      "note": [
+        "Wait for the global Sova to begin climbing the wall below the door.",
+        "Have Reserves set to manual and couch jump up above the Sova as it turns the lip of the ledge.",
+        "Before touching the Sova, pause, so that Samus will recieve a small damage boost followed by pause screen appearing.",
+        "Set Reserves back to auto which will end Samus' IFrames enabling a second damage boost.",
+        "Without Morphball, this requires a blind damage boost."
+      ]
+    },
+    {
+      "link": [5, 2],
+      "name": "Cathedral Entrance Sova Boost (Reserve Delay Bomb Boost and Sova Boost)",
+      "notable": true,
+      "requires": [
+        "h_canBombThings",
+        "canMidAirMorph",
+        "canTrickyJump",
+        "canCrouchJump",
+        "canManageReserves",
+        "canCameraManip",
+        {"heatFrames": 830},
+        {"autoReserveTrigger": {"minReserveEnergy": 85}},
+        {"enemyDamage": {
+          "enemy": "Sova",
+          "type": "contact",
+          "hits": 1
+        }},
+        {"heatFrames": 90}
+      ],
+      "reusableRoomwideNotable": "Cathedral Entrance Sova Boost",
+      "flashSuitChecked": true,
+      "note": [
+        "Wait for the global Sova to begin climbing the wall below the door.",
+        "Time a crouch jump to touch the Sova as it begins to climb lip of the ledge to the door.",
+        "Just before the collision, place a Bomb or Power Bomb.",
+        "Reserves will activate which will suspend Samus in the air on top of the Bomb while it explodes.",
+        "This will give two height boosts, allowing Samus to reach the door."
       ]
     },
     {

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -870,9 +870,8 @@
           "canMidAirMorph",
           "canOffScreenMovement"
         ]},
-        "canPauseAbuse",
         "canCameraManip",
-        "canNeutralDamageBoost",
+        "canReserveDoubleDamageBoost",
         {"heatFrames": 830},
         {"autoReserveTrigger": {
           "minReserveEnergy": 85,

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -856,7 +856,7 @@
         "Time a walljump into instant morph where Samus boosts off of the Sova with the right timing to bounce up to the door's ledge.",
         "The jump must be a fully delayed walljump.",
         "Normalizing the camera can help with timing the walljump.",
-        "The damage boost can be attempted again when the Sova climbs down the left all, or by knocking it off the wall with a Super Missile."
+        "The damage boost can be attempted again when the Sova climbs down the left wall, or by knocking it off the wall with a Super Missile."
       ]
     },
     {

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -874,7 +874,10 @@
         "canCameraManip",
         "canNeutralDamageBoost",
         {"heatFrames": 830},
-        {"autoReserveTrigger": {"minReserveEnergy": 85}},
+        {"autoReserveTrigger": {
+          "minReserveEnergy": 85,
+          "environmentalDamage": ["heat"]
+        }},
         {"enemyDamage": {
           "enemy": "Sova",
           "type": "contact",
@@ -904,7 +907,10 @@
         "canManageReserves",
         "canCameraManip",
         {"heatFrames": 830},
-        {"autoReserveTrigger": {"minReserveEnergy": 85}},
+        {"autoReserveTrigger": {
+          "minReserveEnergy": 85,
+          "environmentalDamage": ["heat"]
+        }},
         {"enemyDamage": {
           "enemy": "Sova",
           "type": "contact",

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -873,10 +873,7 @@
         "canCameraManip",
         "canReserveDoubleDamageBoost",
         {"heatFrames": 830},
-        {"autoReserveTrigger": {
-          "minReserveEnergy": 85,
-          "environmentalDamage": ["heat"]
-        }},
+        {"autoReserveTrigger": {"minReserveEnergy": 85}},
         {"enemyDamage": {
           "enemy": "Sova",
           "type": "contact",
@@ -906,10 +903,7 @@
         "canManageReserves",
         "canCameraManip",
         {"heatFrames": 830},
-        {"autoReserveTrigger": {
-          "minReserveEnergy": 85,
-          "environmentalDamage": ["heat"]
-        }},
+        {"autoReserveTrigger": {"minReserveEnergy": 85}},
         {"enemyDamage": {
           "enemy": "Sova",
           "type": "contact",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -379,17 +379,6 @@
                 "type": "integer",
                 "description": "Maximum energy in reserves which will satisfy this requirement",
                 "default": 400
-              },
-              "environmentalDamage": {
-                "$id": "#/definitions/logicalRequirement/items/properties/autoReserveTrigger/properties/environmentalDamage",
-                "type":"array",
-                "description": "The current environment where this auto reserve is being triggered.",
-                "items": {
-                  "$id": "#/definitions/logicalRequirement/items/properties/autoReserveTrigger/properties/environmentalDamage/items",
-                  "type": "string",
-                  "enum": ["heat", "lava", "acid"],
-                  "description": "Damage is taken per frame of energy refill for each environment using the environment's damage object."
-                }
               }
             }
           },

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -379,6 +379,17 @@
                 "type": "integer",
                 "description": "Maximum energy in reserves which will satisfy this requirement",
                 "default": 400
+              },
+              "environmentalDamage": {
+                "$id": "#/definitions/logicalRequirement/items/properties/autoReserveTrigger/properties/environmentalDamage",
+                "type":"array",
+                "description": "The current environment where this auto reserve is being triggered.",
+                "items": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/autoReserveTrigger/properties/environmentalDamage/items",
+                  "type": "string",
+                  "enum": ["heat", "lava", "acid"],
+                  "description": "Damage is taken per frame of energy refill for each environment using the environment's damage object."
+                }
               }
             }
           },

--- a/tech.json
+++ b/tech.json
@@ -908,7 +908,9 @@
       "techs": [
         {
           "name": "canUnmorphBombBoost",
-          "techRequires": [],
+          "techRequires": [
+            "canResetFallSpeed"
+          ],
           "otherRequires": [
             "Morph",
             {"or": [

--- a/tech.json
+++ b/tech.json
@@ -230,6 +230,25 @@
                 "1) Samus can take an enemy hit as long as her total energy (regular energy + reserve energy) is greater than what the enemy deals.",
                 "2) Samus can be expected to refill twice during a shinespark even with no Energy Tanks.",
                 "When Samus is at low energy, it would be possible with pause abuse to take less damage than what the enemy deals, but in general this is not assumed to be required."
+              ],
+              "extensionTechs": [
+                {
+                  "name": "canReserveDoubleDamageBoost",
+                  "techRequires": [
+                    "canPauseAbuse",
+                    "canNeutralDamageBoost"
+                  ],
+                  "otherRequires": [
+                    "ReserveTank"
+                  ],
+                  "note": [
+                    "The ability to pause abuse through fatal damage and then use the refill time of a Reserve Tank to take another damage boost.",
+                    "The timing of contact with the enemy, and the pause to enable Reserves are very precise because the amount of height gained is not much.",
+                    "Reserves must begin set to Manual and Samus' energy should reach zero with the next enemy hit.",
+                    "Returning from the pause screen with Reserves on auto will instantly trigger a refill followed by a second enemy hit.",
+                    "Then the screen will remain dark until another pause occurs."
+                  ]
+                }
               ]
             }
           ]

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -74,6 +74,7 @@ def process_keyvalue(k, v, metadata):
         "resourceAvailable",# validated by schema
         "refill",           # validated by schema
         "partialRefill",    # validated by schema
+        "autoReserveTrigger",    # validated by schema
         "comeInWithSpark",  # validated by schema
         "comeInWithDoorStuckSetup", # validated by schema
         "comeInRunning",  # validated by schema


### PR DESCRIPTION
autoReserveTrigger needed to account for heat damage during refill.  I don't think there are situations where you would trigger it in acid or lava, but maybe something will come up.  Like soaking a namihe hit in lava dive since that won't break spin.

I'm not aware of other uses for `canReserveDoubleDamageBoost` #1512 , but there are more `autoReserveTrigger` into bomb boost situations.