### PR TITLE
Add more leniencies and trickyjump requirements

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -374,7 +374,8 @@
               "canTrickyJump",
               {"spikeHits": 2}
             ]}
-          ]
+          ],
+          "devNote": "2 extra attempts for leniency."
         },
         {
           "name": "h_HeatedSpringwall",
@@ -384,7 +385,8 @@
               "canTrickyJump",
               {"heatFrames": 500}
             ]}
-          ]
+          ],
+          "devNote": "2 extra attempts for leniency."
         }
       ]
     },

--- a/helpers.json
+++ b/helpers.json
@@ -365,6 +365,26 @@
               ]}
             ]}
           ]
+        },
+        {
+          "name": "h_SpringwallOverSpikes",
+          "requires": [
+            "canSpringwall",
+            {"or":[
+              "canTrickyJump",
+              {"spikeHits": 2}
+            ]}
+          ]
+        },
+        {
+          "name": "h_HeatedSpringwall",
+          "requires": [
+            "canSpringwall",
+            {"or":[
+              "canTrickyJump",
+              {"heatFrames": 500}
+            ]}
+          ]
         }
       ]
     },

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -884,8 +884,16 @@
             "canTrickyDashJump",
             "h_canBackIntoCorner",
             "canInsaneJump"
+          ]},
+          {"and": [
+            "canTrickyDashJump",
+            {"spikeHits": 1}
           ]}
         ]}
+      ],
+      "note": [
+        "Run and jump from the safe stair to just reach the door ledge.",
+        "To avoid walljumping, use a full speed jump or jump from on top of the spikes (stairs or floor)."
       ]
     },
     {

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -794,7 +794,7 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        {"spikeHits": 4}
+        {"spikeHits": 5}
       ]
     },
     {
@@ -804,7 +804,21 @@
         "canIframeSpikeJump",
         {"or": [
           {"and": [
-            "canTrickyJump",
+            "canInsaneJump",
+            {"spikeHits": 2}
+          ]},
+          {"spikeHits": 3}
+        ]}
+      ]
+    },
+    {
+      "link": [3, 4],
+      "name": "Spike Damage Boost",
+      "requires": [
+        "canHorizontalDamageBoost",
+        {"or": [
+          {"and": [
+            "canInsaneJump",
             {"spikeHits": 2}
           ]},
           {"spikeHits": 3}
@@ -832,8 +846,11 @@
       "link": [4, 1],
       "name": "X-Ray Access Springwall",
       "requires": [
-        "canSpringwall",
-        {"spikeHits": 1}
+        "h_SpringwallOverSpikes",
+        {"or": [
+          {"spikeHits": 1},
+          "canInsaneJump"
+        ]}
       ]
     },
     {
@@ -856,8 +873,18 @@
         "HiJump",
         "SpeedBooster",
         {"or": [
-          "canTrickyJump",
-          "canWalljump"
+          {"and": [
+            "canWalljump",
+            {"or": [
+              "canTrickyJump",
+              {"spikeHits": 1}
+            ]}
+          ]},
+          {"and": [
+            "canTrickyDashJump",
+            "h_canBackIntoCorner",
+            "canInsaneJump"
+          ]}
         ]}
       ]
     },
@@ -891,6 +918,7 @@
           ]},
           {"and": [
             {"spikeHits": 1},
+            "canHorizontalDamageBoost",
             "canPreciseWalljump",
             "canIframeSpikeJump"
           ]}

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -1211,7 +1211,7 @@
       "name": "Writg Springwall",
       "requires": [
         "h_canNavigateHeatRooms",
-        "canSpringwall",
+        "h_HeatedSpringwall",
         "canConsecutiveWalljump",
         {"heatFrames": 300},
         {"or": [

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -1100,8 +1100,7 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUseMorphBombs",
-        "canSpringwall",
-        "canTrickySpringBallJump",
+        "h_HeatedSpringwall",
         {"heatFrames": 900}
       ],
       "note": [

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -638,8 +638,7 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUseMorphBombs",
-        "canSpringwall",
-        "canTrickySpringBallJump",
+        "h_HeatedSpringwall",
         {"heatFrames": 300}
       ],
       "clearsObstacles": ["A"],
@@ -1061,8 +1060,8 @@
       "name": "Springwall",
       "requires": [
         "h_canNavigateHeatRooms",
-        "canSpringwall",
-        {"heatFrames": 400}
+        "h_HeatedSpringwall",
+        {"heatFrames": 245}
       ]
     },
     {

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -705,7 +705,6 @@
       "requires": [
         "Gravity",
         "canSpringwall",
-        "canTrickySpringBallJump",
         {"resetRoom": {
           "nodes": [1]
         }}

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -714,7 +714,20 @@
         "canSuitlessMaridia",
         "HiJump",
         {"or": [
-          "canCarefulJump",
+          "canTrickyJump",
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Pink Space Pirate (standing)",
+            "type": "contact",
+            "hits": 1
+          }},
+          {"enemyKill": {
+            "enemies": [["Pink Space Pirate (standing)"]],
+            "explicitWeapons": ["Plasma"]
+          }}
+        ]},
+        {"or": [
+          "canTrickyJump",
           "canSpringBallJumpMidAir",
           {"enemyDamage": {
             "enemy": "Pink Space Pirate (standing)",
@@ -726,7 +739,8 @@
             "explicitWeapons": ["Plasma"]
           }}
         ]}
-      ]
+      ],
+      "note": "Shooting towards Pirates will cause them to stop in place and not fire back."
     },
     {
       "link": [2, 6],
@@ -737,6 +751,19 @@
         {"or": [
           "canStationaryLateralMidAirMorph",
           "canSpringFling"
+        ]},
+        {"or": [
+          "canTrickyJump",
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Pink Space Pirate (standing)",
+            "type": "contact",
+            "hits": 1
+          }},
+          {"enemyKill": {
+            "enemies": [["Pink Space Pirate (standing)"]],
+            "explicitWeapons": ["Plasma"]
+          }}
         ]},
         {"or": [
           "canTrickyJump",
@@ -754,7 +781,8 @@
       "note": [
         "The second jump is harder than a normal mid-air springball jump.",
         "Use either a stationary lateral mid air morph, to gain enough horizontal momentum,",
-        "or a SpringFling to reduce Samus' fall speed as soon as it begins to build up."
+        "or a SpringFling to reduce Samus' fall speed as soon as it begins to build up.",
+        "Shooting towards Pirates will cause them to stop in place and not fire back."
       ]
     },
     {
@@ -1370,13 +1398,24 @@
     },
     {
       "link": [6, 7],
-      "name": "Suitless",
+      "name": "Suitless HiJump",
       "requires": [
         "canSuitlessMaridia",
         "canCarefulJump",
+        "HiJump"
+      ]
+    },
+    {
+      "link": [6, 7],
+      "name": "Suitless Springball",
+      "requires": [
+        "canSuitlessMaridia",
+        "canCarefulJump",
+        "canSpringBallJumpMidAir",
         {"or": [
-          "HiJump",
-          "canSpringBallJumpMidAir"
+          "canTrickyJump",
+          "canStationaryLateralMidAirMorph",
+          "canSpringFling"
         ]}
       ]
     },

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2869,7 +2869,13 @@
             "Spazer",
             "Wave"
           ]},
-          "h_canMaxHeightSpringBallJump",
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            {"or": [
+              "Wave",
+              "Spazer"
+            ]}
+          ]},
           "Plasma"
         ]},
         {"or": [

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -374,7 +374,11 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "note": "Requires getting back on Mama Turtle while she is at the right."
+      "note": [
+        "Requires getting back on Mama Turtle while she is at the right.",
+        "The safest way is to have a normalized fall speed with either a full height jump or falling from the ledge above.",
+        "Shrinking Samus' hitbox after touching the turtles back will also usually help."
+      ]
     },
     {
       "link": [1, 3],
@@ -628,7 +632,6 @@
         "canSuitlessMaridia",
         "canTrickyJump",
         {"or": [
-          "HiJump",
           "canSpringBallJumpMidAir",
           "h_canCrouchJumpDownGrab",
           "canUseEnemies"
@@ -636,7 +639,7 @@
       ],
       "note": [
         "Jump over or on to Mama Turtle.",
-        "The easiest method is to jump over her by jumping on her babies."
+        "The easiest method is to jump over her by jumping on her babies, or to Morph under her."
       ]
     },
     {
@@ -708,6 +711,16 @@
         {"or": [
           "Wave",
           "Spazer",
+          {"and":[
+            "canTrickyJump",
+            "canDodgeWhileShooting",
+            {"ammo": {"type": "Missile", "count": 5}}
+          ]},
+          {"and":[
+            "canTrickyJump",
+            "canResetFallSpeed",
+            "canDownBack"
+          ]},
           "canInsaneJump"
         ]}
       ],

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -618,16 +618,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canCarefulJump",
-        {"or": [
-          "HiJump",
-          "Morph"
-        ]},
-        {"or": [
-          "HiJump",
-          "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab",
-          "canUseEnemies"
-        ]}
+        "HiJump"
       ]
     },
     {
@@ -636,18 +627,27 @@
       "requires": [
         "canSuitlessMaridia",
         "canTrickyJump",
-        "canUseEnemies"
+        {"or": [
+          "HiJump",
+          "canSpringBallJumpMidAir",
+          "h_canCrouchJumpDownGrab",
+          "canUseEnemies"
+        ]}
       ],
       "note": [
         "Jump over or on to Mama Turtle.",
-        "The easiest method is to jump over her by jumping on her babies, spin jumping off of them and over her, then breaking spin before landing."
+        "The easiest method is to jump over her by jumping on her babies."
       ]
     },
     {
       "link": [4, 2],
       "name": "Grapple",
       "requires": [
-        "Grapple"
+        "Grapple",
+        {"or": [
+          "HiJump",
+          "canPreciseGrapple"
+        ]}
       ],
       "clearsObstacles": ["B"],
       "note": [
@@ -700,6 +700,20 @@
       ]
     },
     {
+      "link": [4, 3],
+      "name": "Reveal Item while Jumping",
+      "requires": [
+        "canDodgeWhileShooting",
+        "canCarefulJump",
+        {"or": [
+          "Wave",
+          "Spazer",
+          "canInsaneJump"
+        ]}
+      ],
+      "note": "Reveal the item while jumping to the right wall and collect it as Samus falls past."
+    },
+    {
       "link": [4, 5],
       "name": "Base",
       "requires": []
@@ -714,8 +728,7 @@
     },
     {
       "link": [5, 2],
-      "name": "Mama Turtle Wall Jump Bomb Boost",
-      "notable": true,
+      "name": "Wall Jump Bomb Boost",
       "requires": [
         "canWallJumpBombBoost"
       ],
@@ -787,7 +800,6 @@
         "HiJump",
         "canInsaneJump",
         "canStationarySpinJump",
-        "canConsecutiveWalljump",
         "canInsaneWalljump",
         "canCWJ"
       ],

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1398,6 +1398,16 @@
       "requires": [
         "h_canNavigateUnderwater",
         "canTrickyUseFrozenEnemies",
+        {"or": [
+          "canInsaneJump",
+          "Spazer",
+          "Wave",
+          "Plasma",
+          {"and": [
+            "canTrickyJump",
+            {"ammo": {"type": "Super", "count": 1}}
+          ]}
+        ]},
         {"ammo": {"type": "Super", "count": 1}},
         {"resetRoom": {
           "nodes": [3],

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1400,20 +1400,27 @@
         "h_canNavigateUnderwater",
         "canTrickyUseFrozenEnemies",
         {"or": [
+          {"resetRoom": {
+            "nodes": [3],
+            "mustStayPut": true
+          }},
+          "canPrepareForNextRoom"
+        ]},
+        {"or": [
           "canInsaneJump",
           "Spazer",
           "Wave",
           "Plasma",
           {"and": [
-            "canTrickyJump",
+            "canDodgeWhileShooting",
             {"ammo": {"type": "Super", "count": 1}}
+          ]},
+          {"and": [
+            "canDodgeWhileShooting",
+            "HiJump"
           ]}
         ]},
-        {"ammo": {"type": "Super", "count": 1}},
-        {"resetRoom": {
-          "nodes": [3],
-          "mustStayPut": true
-        }}
+        {"ammo": {"type": "Super", "count": 1}}
       ],
       "note": "Knock the crab off the wall immediately and then freeze.",
       "devNote": "Kinda tough with no other beam/missile/super/movement."

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1079,6 +1079,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
+        "canTrickyJump",
         "canCrossRoomJumpIntoWater"
       ],
       "note": "Wall jump relatively high off either side of the door frame in the room below."

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -478,6 +478,11 @@
         "h_canNavigateUnderwater",
         "canHorizontalDamageBoost",
         "canCarefulJump",
+        {"or": [
+          "Gravity",
+          "HiJump",
+          "canTrickyJump"
+        ]},
         {"enemyDamage": {
           "enemy": "Gamet",
           "type": "contact",
@@ -487,7 +492,7 @@
       "note": [
         "1- Stand near the farm point, on the edge of where you make Gamets spawn.",
         "2- Wait for the water position to be high.",
-        "3- Move to make the Gamets spawn. Moonwalk is useful here.",
+        "3- Move to make the Gamets spawn. Moonwalking while facing the stairs is useful here.",
         "4- Quickly climb up to the last ledge before the door.",
         "5- Run, jump, dboost off a Gamet."
       ]

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -82,6 +82,16 @@
       "dropRequires": ["h_heatProof", "h_lavaProof"]
     }
   ],
+  "reusableRoomwideNotable": [
+    {
+      "name": "Lava Dive with HiJump",
+      "note": [
+        "Climb through the Lava by walljumping off of the Namihes with HiJump.",
+        "This can be done by jumping from the left side Namihes to the hanging ceiling in the center of the room and climbing further from there.",
+        "By Spring Ball jumping after the Namihe walljump, it is possible to avoid the center structure and conserve some energy."
+      ]
+    }
+  ],
   "links": [
     {
       "from": 1,
@@ -556,7 +566,9 @@
     },
     {
       "link": [4, 3],
-      "name": "Lava Dive with HiJump",
+      "name": "Lava Dive with HiJump (Criss Cross Walljumps)",
+      "notable": true,
+      "reusableRoomwideNotable": "Lava Dive with HiJump",
       "requires": [
         "HiJump",
         "canSuitlessLavaDive",
@@ -573,20 +585,37 @@
     },
     {
       "link": [4, 3],
-      "name": "Springwall",
+      "name": "Lava Dive with HiJump and Springwall",
+      "notable": true,
+      "reusableRoomwideNotable": "Lava Dive with HiJump",
       "requires": [
         {"or": [
           "h_lavaProof",
           "canSuitlessLavaDive"
         ]},
-        "h_HeatedSpringwall",
+        "canSpringwall",
         "HiJump",
         "canUseEnemies",
+        {"or": [
+          "canTrickyJump",
+          {"and": [
+            {"heatFrames": 400},
+            {"lavaFrames": 400}
+          ]}
+        ]},
         {"heatFrames": 195},
         {"lavaFrames": 180}
       ],
-      "note": "Lava physics will reduce Samus' horizontal momentum.",
-      "devNote": "Works with or without Gravity"
+      "note": [
+        "Walljump off of the Upper-Left Namihe and then Spring Ball jump up and out of the Lava.",
+        "Delay the pause until in position to perform the Spring Ball jump because Lava physics will reduce Samus' horizontal momentum.",
+        "It may help to also delay the Morph."
+      ],
+      "devNote": [
+        "Works with or without Gravity",
+        "Leniency added to keep the strat balanced with the normal HiJump Lava Dive as that requires canTrickyJump.",
+        "Leniency is worth 1 extra attempt.  This Springwall is easier than regular SpringWalls because the lava slows down the required inputs."
+      ]
     },
     {
       "link": [4, 3],

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -580,7 +580,6 @@
           "canSuitlessLavaDive"
         ]},
         "canSpringwall",
-        "canTrickySpringBallJump",
         "HiJump",
         "canUseEnemies",
         {"heatFrames": 195},

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -573,7 +573,7 @@
         "HiJump",
         "canSuitlessLavaDive",
         "canUseEnemies",
-        "canTrickyJump",
+        "canPreciseWalljump",
         "canStaggeredWalljump",
         {"heatFrames": 270},
         {"lavaFrames": 240}
@@ -596,13 +596,6 @@
         "canSpringwall",
         "HiJump",
         "canUseEnemies",
-        {"or": [
-          "canTrickyJump",
-          {"and": [
-            {"heatFrames": 400},
-            {"lavaFrames": 400}
-          ]}
-        ]},
         {"heatFrames": 195},
         {"lavaFrames": 180}
       ],
@@ -613,8 +606,7 @@
       ],
       "devNote": [
         "Works with or without Gravity",
-        "Leniency added to keep the strat balanced with the normal HiJump Lava Dive as that requires canTrickyJump.",
-        "Leniency is worth 1 extra attempt.  This Springwall is easier than regular SpringWalls because the lava slows down the required inputs."
+        "This Springwall is easier than regular SpringWalls because the lava slows down the required inputs."
       ]
     },
     {

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -579,7 +579,7 @@
           "h_lavaProof",
           "canSuitlessLavaDive"
         ]},
-        "canSpringwall",
+        "h_HeatedSpringwall",
         "HiJump",
         "canUseEnemies",
         {"heatFrames": 195},

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -157,10 +157,10 @@
     },
     {
       "link": [1, 3],
-      "name": "Crumble Shaft Top Item Precise Walljump",
-      "notable": true,
+      "name": "Precise Walljump",
       "requires": [
         "canPreciseWalljump",
+        "canTrickyJump",
         "canCameraManip",
         {"heatFrames": 300}
       ],
@@ -176,6 +176,7 @@
       "notable": true,
       "requires": [
         "canUseFrozenEnemies",
+        "canCarefulJump",
         "canCameraManip",
         {"heatFrames": 350}
       ],
@@ -540,6 +541,19 @@
         {"heatFrames": 175}
       ],
       "note": "Must have grabbed the item with a spinjump still active."
+    },
+    {
+      "link": [3, 1],
+      "name": "Precise Walljump",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "canPreciseWalljump",
+        "canTrickyJump",
+        {"heatFrames": 300}
+      ],
+      "note": [
+        "Walljump off the sides of the crumble block platforms to reach the door."
+      ]
     },
     {
       "link": [3, 2],

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -218,18 +218,25 @@
             {"heatFrames": 80}
           ]}
         ]},
-        "canUseFrozenEnemies",
+        {"or": [
+          "canTrickyUseFrozenEnemies",
+          {"and": [
+            "canUseFrozenEnemies",
+            "Wave"
+          ]}
+        ]},
         {"heatFrames": 300}
       ],
-      "note": "An ice shot through the morph tunnel can freeze the Boyon even without Wave."
+      "note": "An ice shot can shoot through the wall below the Morph tunnel and can freeze the Boyon even without Wave."
     },
     {
       "link": [2, 1],
-      "name": "Impressive Damage Boost",
+      "name": "Ice Beam Tutorial Room Impressive Damage Boost",
+      "notable": true,
       "requires": [
         "canHorizontalDamageBoost",
         "canTrivialMidAirMorph",
-        "canCarefulJump",
+        "canTrickyJump",
         {"enemyDamage": {
           "enemy": "Boyon",
           "type": "contact",

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -247,14 +247,11 @@
         {"or": [
           "canTrickyJump",
           "SpaceJump",
-          {"and": [
-            "canCameraManip",
-            "canPrepareForNextRoom"
-          ]},
-          {"and": [
-            "canCameraManip",
-            "canMoonwalk"
-          ]}
+          {"enemyDamage": {
+            "enemy": "Blue Sidehopper",
+            "type": "contact",
+            "hits": 1
+          }}
         ]}
       ],
       "unlocksDoors": [
@@ -327,9 +324,10 @@
           "hits": 1
         }},
         {"or": [
-          "canHorizontalDamageBoost",
-          "canTrickyJump",
-          "canHitbox",
+          {"and": [
+            "canTrickyJump",
+            "canHitbox"
+          ]},
           {"enemyDamage": {
             "enemy": "Blue Sidehopper",
             "type": "contact",
@@ -529,7 +527,15 @@
           "enemy": "Blue Sidehopper",
           "type": "contact",
           "hits": 1
-        }}
+        }},
+        {"or": [
+          "canCarefulJump",
+          {"enemyDamage": {
+            "enemy": "Blue Sidehopper",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
       ]
     },
     {

--- a/tech.json
+++ b/tech.json
@@ -717,6 +717,18 @@
               ],
               "extensionTechs": [
                 {
+                  "name": "canSpringwall",
+                  "techRequires": [
+                    "canTrickySpringBallJump",
+                    "canWallJumpInstantMorph"
+                  ],
+                  "otherRequires": [],
+                  "note": [
+                    "A mid-air Spring Ball jump that starts with a wall jump to gain more height.",
+                    "It often benefits from the momentum change when equipping Spring Ball while morphed and moving horizontally after a WallJump."
+                  ]
+                },
+                {
                   "name": "canDoubleSpringBallJumpMidAir",
                   "techRequires": ["canTrickySpringBallJump"],
                   "otherRequires": [],
@@ -741,33 +753,21 @@
                   "devNote": "Similar to an underwater walljump into springballjump, but that has no applications yet since double springballjump is easier for similar requirements."
                 }
               ]
-            },
-            {
-              "name": "canSpringwall",
-              "techRequires": [
-                "canSpringBallJumpMidAir",
-                "canWallJumpInstantMorph"
-              ],
-              "otherRequires": [],
-              "note": [
-                "A mid-air Spring Ball jump that starts with a wall jump to gain more height.",
-                "It often benefits from the momentum change when equipping Spring Ball while morphed and moving horizontally after a WallJump."
-              ]
-            },
-          {
-            "name": "canSpringFling",
-            "techRequires": ["canDisableEquipment"],
-            "otherRequires": [
-              "Morph",
-              "SpringBall"
-            ],
-            "note": [
-              "The ability to gain extra distance meerly by turning Springball on or off.",
-              "When equipping or unequipping Springball while Morphed, Samus' speed is reset.",
-              "If rising (and not in liquid physics), the horizontal speed is set to full roll speed.",
-              "If falling, the vertical speed is set to zero and horizontal speed is reset unless SpeedBooster is equipped."
-            ]
-          }
+            }
+          ]
+        },
+        {
+          "name": "canSpringFling",
+          "techRequires": ["canDisableEquipment"],
+          "otherRequires": [
+            "Morph",
+            "SpringBall"
+          ],
+          "note": [
+            "The ability to gain extra distance merely by turning Springball on or off.",
+            "When equipping or unequipping Springball while Morphed, Samus' speed is reset.",
+            "If rising (and not in liquid physics), the horizontal speed is set to full roll speed.",
+            "If falling, the vertical speed is set to zero and horizontal speed is reset unless SpeedBooster is equipped."
           ]
         },
         {


### PR DESCRIPTION
- freezing crabs before they move too far
- Impressive damage boost
- Grapple tutorial gamet boost to vh
- Everest crossroomjumpintowater to veryhard
- Crumble Shaft Top Item Precise Walljump -- add trickyjump
- mama turtle grapple no hijump to precisegrapple
- Fish Tank standing next to pirates=tricky jump.  You can shoot the bottom one to avoid doing anything tricky.  Springballing to the fish from bottom left still seems fine as it was.
- canSpringwall moved to extension of canTrickySpringballJump
- Added heat and spike leniency helpers for canSpringwall.  They look different from the IBJ helpers since the initial walljump setup depends on the strat.  Sometimes there is a forced spikehit and sometimes there isn't.