### PR TITLE
Add more Blue Boulder cross-room jumps

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -249,7 +249,7 @@
       },
       "requires": [
         "canCarefulJump",
-        "canWalljump"
+        "canPreciseWalljump"
       ],
       "note": "A doorsill with an open end is really all the room that's needed on the other side."
     },
@@ -259,7 +259,7 @@
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
-          "minTiles": 1
+          "minTiles": 2
         }
       },
       "requires": [
@@ -280,6 +280,21 @@
         "canTrickyJump"
       ],
       "note": "With two tiles of runway and no wall jump or items, a last-frame jump is needed to make it."
+    },
+    {
+      "link": [2, 1],
+      "name": "Jump Through the Door Tricky Air Ball",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canLateralMidAirMorph"
+      ],
+      "note": "With only one tile of runway, a last-frame jump is needed to make it."
     },
     {
       "link": [2, 1],

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -227,7 +227,20 @@
     },
     {
       "link": [2, 1],
-      "name": "Boulder Room Jump Through the Door",
+      "name": "Jump Through the Door",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 3
+        }
+      },
+      "requires": [
+        "canCarefulJump"
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Jump Through the Door Wall Jump",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -242,7 +255,35 @@
     },
     {
       "link": [2, 1],
-      "name": "Boulder Room Doorsill Jump",
+      "name": "Jump Through the Door Air Ball",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "canCarefulJump",
+        "canLateralMidAirMorph"
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Tricky Jump Through the Door",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "canTrickyJump"
+      ],
+      "note": "With two tiles of runway and no wall jump or items, a last-frame jump is needed to make it."
+    },
+    {
+      "link": [2, 1],
+      "name": "Doorsill Jump",
       "requires": [
         {"doorUnlockedAtNode": 2},
         "canPreciseWalljump",
@@ -258,7 +299,7 @@
     },
     {
       "link": [2, 1],
-      "name": "Boulder Room Naked Walljump",
+      "name": "Naked Walljump",
       "requires": [
         "canSuitlessMaridia",
         "canInsaneWalljump"

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -236,7 +236,8 @@
       },
       "requires": [
         "canCarefulJump"
-      ]
+      ],
+      "devNote": "This is a lenient version of the strat, with an extra tile of runway."
     },
     {
       "link": [2, 1],
@@ -265,7 +266,8 @@
       "requires": [
         "canCarefulJump",
         "canLateralMidAirMorph"
-      ]
+      ],
+      "devNote": "This is a lenient version of the strat, with an extra tile of runway."
     },
     {
       "link": [2, 1],


### PR DESCRIPTION
This adds some cross-room jump strats that were missing (as pointed out by zornor in the Discord). There are also cross-room spring ball bounce strats that should be considered; I figure we can come back to that after (or as part of) the pending Crateria remote runway PR. (**Edit**: On second thought, I guess spring ball bounce wouldn't necessarily be useful since if you have Morph then you can just do the airball instead, as that requires just the 1 tile of runway which is always available, assuming there's an air environment at all)

This room is currently a bit awkward because of not having a node to represent being in the water below the right door. I'm not sure if everything is logically sound if you were down there and not able to unlock the door (e.g. which could happen in Map Rando with Random start). So it could all still use another look later.