### PR TITLE
More Logic Updates

### DIFF
--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -102,7 +102,7 @@
                 {"or": [
                   {"ammo": {"type": "Missile", "count": 1}},
                   {"ammo": {"type": "Super", "count": 1}},
-                  {"ammo": {"type": "PowerBomb", "count": 1}}
+                  {"resourceAvailable": [ {"type": "PowerBomb", "count": 1} ]}
                 ]},
                 "h_canUsePowerBombs"
               ]}

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -102,8 +102,9 @@
                 {"or": [
                   {"ammo": {"type": "Missile", "count": 1}},
                   {"ammo": {"type": "Super", "count": 1}},
-                  {"resourceAvailable": [ {"type": "PowerBomb", "count": 1} ]}
+                  {"ammo": {"type": "PowerBomb", "count": 1}}
                 ]},
+                {"partialRefill": {"type": "PowerBomb", "limit": 1}},
                 "h_canUsePowerBombs"
               ]}
             ]}

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -88,16 +88,33 @@
           {"and": [
             {"or": [
               "Ice",
-              "canCarefulJump"
+              "canTrickyJump",
+              {"enemyDamage": {
+                "enemy": "Beetom",
+                "type": "contact",
+                "hits": 1
+              }}
             ]},
-            "h_canUseMorphBombs"
+            {"or": [
+              "h_canUseMorphBombs",
+              {"and": [
+                {"resourceAvailable": [ {"type": "Energy", "count": 50} ]},
+                {"or": [
+                  {"ammo": {"type": "Missile", "count": 1}},
+                  {"ammo": {"type": "Super", "count": 1}},
+                  {"ammo": {"type": "PowerBomb", "count": 1}}
+                ]},
+                "h_canUsePowerBombs"
+              ]}
+            ]}
           ]}
         ]},
-        {"refill": ["Energy", "PowerBomb"]}
+        {"refill": ["PowerBomb"]}
       ],
       "note": "Kill the Beetoms with Screw Attack or by freezing or carefully avoiding them and using Bombs or Power Bombs.",
       "devNote": [
-        "FIXME: Using a Missile, Super, or Power Bomb at the start could be added to the logic to get the first Power Bombs to use for further farming, but this needs a way to express that we're not in health-bomb energy range."
+        "Health Bomb ends at 50 energy.",
+        "One ammo can be used to gain a power bomb and then power bombs can be used to farm more power bombs."
       ]
     },
     {

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -239,7 +239,15 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "HiJump",
-        {"heatFrames": 130}
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Yellow Space Pirate (wall)",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"heatFrames": 120}
       ]
     },
     {
@@ -248,7 +256,15 @@
       "requires": [
         "h_canNavigateHeatRooms",
         "canPreciseWalljump",
-        {"heatFrames": 150}
+        {"or": [
+          "canTrickyJump",
+          {"enemyDamage": {
+            "enemy": "Yellow Space Pirate (wall)",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"heatFrames": 120}
       ],
       "note": "Walljump from directly above the door to avoid the left wall pirate."
     },
@@ -261,6 +277,14 @@
           "canSpringBallJumpMidAir",
           "canWalljump",
           "SpaceJump"
+        ]},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Yellow Space Pirate (standing)",
+            "type": "contact",
+            "hits": 1
+          }}
         ]},
         {"heatFrames": 420}
       ],
@@ -823,7 +847,22 @@
       "name": "Base",
       "requires": [
         "h_canNavigateHeatRooms",
-        {"heatFrames": 150}
+        {"or": [
+          "canCarefulJump",
+          {"enemyDamage": {
+            "enemy": "Yellow Space Pirate (wall)",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"or": [
+          "canTrickyJump",
+          {"heatFrames": 20}
+        ]},
+        {"heatFrames": 115}
+      ],
+      "note": [
+        "Falling to the right of the floating platform is faster."
       ]
     },
     {

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -145,6 +145,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Stun the bottom Pirate by shooting it."
     },
     {
@@ -160,7 +161,8 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -178,7 +180,8 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -196,7 +199,8 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [1, 1],
@@ -228,6 +232,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "The Power Bombs must be placed carefully to hit the Pirate without destroying the PB blocks.",
         "This strat requires heatproof because it's pretty chaotic to execute."
@@ -235,29 +240,30 @@
     },
     {
       "link": [1, 4],
-      "name": "HiJump",
+      "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "HiJump",
+        "ScrewAttack",
         {"or": [
-          "canDodgeWhileShooting",
-          {"enemyDamage": {
-            "enemy": "Yellow Space Pirate (wall)",
-            "type": "contact",
-            "hits": 1
-          }}
-        ]},
-        {"heatFrames": 120}
-      ]
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 155}
+          ]},
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 135}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 4],
-      "name": "Quick Walljump",
+      "name": "HiJump",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "canPreciseWalljump",
+        "HiJump",
         {"or": [
-          "canTrickyJump",
+          "canDodgeWhileShooting",
+          "ScrewAttack",
           {"enemyDamage": {
             "enemy": "Yellow Space Pirate (wall)",
             "type": "contact",
@@ -266,13 +272,31 @@
         ]},
         {"heatFrames": 120}
       ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Quick Walljump",
+      "requires": [
+        "canPreciseWalljump",
+        {"or": [
+          "canTrickyJump",
+          "ScrewAttack",
+          {"enemyDamage": {
+            "enemy": "Yellow Space Pirate (wall)",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"heatFrames": 120}
+      ],
+      "flashSuitChecked": true,
       "note": "Walljump from directly above the door to avoid the left wall pirate."
     },
     {
       "link": [1, 4],
       "name": "Avoid Pirates",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canSpringBallJumpMidAir",
           "canWalljump",
@@ -288,6 +312,7 @@
         ]},
         {"heatFrames": 420}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Shoot the standing pirate with beam shots to prevent it from attacking.",
         "Let the wall pirate climb down a little bit to make passing it easier."
@@ -297,7 +322,6 @@
       "link": [1, 4],
       "name": "Kill Pirates",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           {"and": [
             {"enemyKill": {
@@ -355,6 +379,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Kill the pirates to free up the full runway for a speedy jump, or to start an IBJ.",
         "If the wall pirate jumps over a Samus who is not crouched, it will climb offscreen on its own.  But may still need to be killed after."
@@ -364,7 +389,6 @@
       "link": [1, 4],
       "name": "Freeze a Pirate",
       "requires": [
-        "h_canNavigateHeatRooms",
         "Charge",
         "canUseFrozenEnemies",
         {"or": [
@@ -377,6 +401,7 @@
         ]},
         {"heatFrames": 550}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Crouch in front of the standing pirate to freely shoot charge shots.",
         "Shoot upon entering the room to interupt the pirate lazer attack.",
@@ -393,7 +418,6 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
         {"shinespark": {"frames": 21, "excessFrames": 5}},
         {"heatFrames": 250}
       ],
@@ -424,6 +448,7 @@
         }},
         {"heatFrames": 1260}
       ],
+      "flashSuitChecked": true,
       "note": [
         "X-Ray climb up the left wall in order to jump to the center platform.",
         "Quickly kill the pirates using ammo before beginning the X-Ray climb.",
@@ -434,7 +459,6 @@
       "link": [1, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 200},
         {"or": [
           {"and": [
@@ -444,7 +468,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [1, 5],
@@ -458,6 +483,7 @@
         "canMoonfall",
         {"heatFrames": 180}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Shoot at the Standing Pirate to prevent it from attacking.",
         "Then clip through the Power Bomb blocks with a moonfall."
@@ -543,7 +569,8 @@
           "gentleUpTiles": 2,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -572,7 +599,8 @@
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 3],
@@ -593,15 +621,16 @@
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -662,7 +691,8 @@
       },
       "requires": [
         {"heatFrames": 105}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -673,7 +703,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -689,7 +720,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[2, 28]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 1],
@@ -705,7 +737,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[2, 29]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -726,7 +759,8 @@
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -747,7 +781,8 @@
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -758,7 +793,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [3, 2],
@@ -774,7 +810,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },    
     {
       "link": [3, 3],
@@ -787,7 +824,8 @@
           "gentleUpTiles": 2,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [3, 3],
@@ -829,6 +867,7 @@
         "canOffScreenMovement",
         {"heatFrames": 125}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The camera will not follow Samus so beams and missiles despawn instantly and the Pirates are inactive.",
         "The Grapple Beam still fully extends and Power Bombs turn the Pirates active."
@@ -838,15 +877,14 @@
       "link": [3, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canCarefulJump",
           {"enemyDamage": {
@@ -861,6 +899,7 @@
         ]},
         {"heatFrames": 115}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Falling to the right of the floating platform is faster."
       ]
@@ -875,7 +914,8 @@
       },
       "requires": [
         {"heatFrames": 105}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -886,7 +926,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -902,7 +943,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[2, 28]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -918,7 +960,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[2, 29]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 2],
@@ -929,7 +972,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "link": [4, 2],
@@ -945,7 +989,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },    
     {
       "link": [4, 4],
@@ -956,7 +1001,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [4, 4],
@@ -976,7 +1022,6 @@
       "link": [5, 1],
       "name": "HiJump",
       "requires": [
-        "h_canNavigateHeatRooms",
         "HiJump",
         {"heatFrames": 250},
         {"or": [
@@ -991,13 +1036,13 @@
         {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 1],
       "name": "HiJumpless",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "canPreciseWalljump",
           "canSpringBallJumpMidAir",
@@ -1014,6 +1059,7 @@
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": [
         "Destroying the obstacle isn't seen to take extra time for two reasons.",
         "1- It destroys the shot blocks as well which are assumed to be manually destroyed each time since they respawn.",
@@ -1024,7 +1070,6 @@
       "link": [5, 1],
       "name": "Ice Assist",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canUseFrozenEnemies",
         "h_canCrouchJumpDownGrab",
         {"heatFrames": 700},
@@ -1040,13 +1085,13 @@
         {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 1],
       "name": "IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
         "canIBJ",
         {"or": [
           {"and": [
@@ -1083,6 +1128,7 @@
         {"types": ["missiles"], "requires": [{"heatFrames": 30}]},
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The shot block may respawn while bomb jumping and can be cleared by weaving a Power Bomb into the IBJ, or with a bomb placed overhead while bomb jumping.",
         "The Power Bomb can be placed one tile higher than the doors to also clear the Power Bomb Blocks above at the same time."
@@ -1093,6 +1139,7 @@
       "link": [5, 1],
       "name": "Jump into Respawning Block",
       "requires": [
+        {"noFlashSuit": {}},
         "canJumpIntoRespawningBlock",
         "canTrickyJump",
         {"or": [
@@ -1110,6 +1157,7 @@
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Run from the right door and jump at the very end of the raised flat ground.",
         "Aim down any time before the peak of the jump in order to not fall out of the block.",
@@ -1120,23 +1168,23 @@
       "link": [5, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
       ],
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 30}]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"heatFrames": 50}
       ],
       "unlocksDoors": [
         {"types": ["missiles"], "requires": [{"heatFrames": 30}]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 5],
@@ -1148,7 +1196,8 @@
           "mustStayPut": false
         }},
         {"refill": ["PowerBomb"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [5, 5],

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -1139,7 +1139,6 @@
       "link": [5, 1],
       "name": "Jump into Respawning Block",
       "requires": [
-        {"noFlashSuit": {}},
         "canJumpIntoRespawningBlock",
         "canTrickyJump",
         {"or": [

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1042,11 +1042,14 @@
         "h_canNavigateHeatRooms",
         {"or": [
           {"obstaclesCleared": ["F"]},
-          {"enemyDamage": {
-            "enemy": "Dessgeega",
-            "type": "contact",
-            "hits": 1
-          }}
+          {"and": [
+            "canHitbox",
+            {"enemyDamage": {
+              "enemy": "Dessgeega",
+              "type": "contact",
+              "hits": 1
+            }}
+          ]}
         ]},
         {"canShineCharge": {
           "usedTiles": 23,
@@ -1372,12 +1375,10 @@
       "name": "Plasma Hitbox Run-Through",
       "requires": [
         "h_canNavigateHeatRooms",
+        "canDodgeWhileShooting",
         "Plasma",
         "canHitbox",
-        {"canShineCharge": {
-          "usedTiles": 33,
-          "openEnd": 2
-        }},
+        "SpeedBooster",
         {"heatFrames": 145}
       ],
       "clearsObstacles": ["C", "E", "F"],

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -203,7 +203,15 @@
       "requires": [
         "h_canNavigateUnderwater",
         "canCeilingClip",
-        "canUseFrozenEnemies"
+        "canUseFrozenEnemies",
+        {"or": [
+          "canTrickyJump",
+          {"enemyDamage": {
+            "enemy": "Mochtroid",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
       ],
       "reusableRoomwideNotable": "Botwoon Hallway Mochtroid Ice Clip",
       "note": [
@@ -324,14 +332,23 @@
           ]},
           "HiJump",
           "Gravity",
-          "canSpringBallJumpMidAir"
+          "canTrickySpringBallJump"
+        ]},
+        {"or": [
+          "canTrickyJump",
+          {"enemyDamage": {
+            "enemy": "Mochtroid",
+            "type": "contact",
+            "hits": 1
+          }}
         ]}
       ],
       "reusableRoomwideNotable": "Botwoon Hallway Mochtroid Ice Clip",
       "note": [
         "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
         "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling.",
-        "With no jump assists, use a frozen Mochtroid as a platform to get to the ledge above the door."
+        "Use the middle section of pipes as a platform to reach the top level, above the Mocktroid.",
+        "A crouch jump and down grab is enough if the jump begins on the farthest pixel out."
       ]
     },
     {

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -347,7 +347,7 @@
       "note": [
         "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
         "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling.",
-        "Use the middle section of pipes as a platform to reach the top level, above the Mocktroid.",
+        "Use the middle section of pipes as a platform to reach the top level, above the Mochtroid.",
         "A crouch jump and down grab is enough if the jump begins on the farthest pixel out."
       ]
     },

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -69,6 +69,13 @@
         "Then use Grapple on the blocks to be pushed a precise amount into the wall above the door.",
         "From there, use grapple again to be pushed diagonally down into the transition behind the Green shell."
       ]
+    },
+    {
+      "name": "Colosseum Full Halfie Shinespark",
+      "note": [
+        "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
+        "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
+      ]
     }
   ],
   "links": [
@@ -83,7 +90,10 @@
     {
       "from": 2,
       "to": [
-        {"id": 1},
+        {
+          "id": 1,
+          "devNote": "FIXME: A crossroom jump into water can be used to shinespark across to 1."
+        },
         {"id": 2},
         {"id": 3}
       ]
@@ -327,25 +337,47 @@
       "link": [1, 3],
       "name": "Space Jump",
       "requires": [
-        "SpaceJump"
+        "SpaceJump",
+        {"or": [
+          {"ammo": {"type": "Missile", "count": 3}},
+          {"ammo": {"type": "Super", "count": 3}},
+          "canUseGrapple",
+          "canTrickyJump",
+          "canDodgeWhileShooting",
+          "Spazer",
+          "Wave",
+          "Plasma",
+          "ScrewAttack",
+          {"enemyDamage": {
+            "enemy": "Mochtroid",
+            "type": "contact",
+            "hits": 2
+          }}
+        ]}
       ],
       "devNote": "No water involved here, so no need for Gravity or canSuitlessMaridia."
     },
     {
       "link": [1, 3],
-      "name": "Shinespark",
+      "name": "Colosseum Full Halfie Shinespark (Forward)",
+      "notable": true,
+      "reusableRoomwideNotable": "Colosseum Full Halfie Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 60
         }
       },
       "requires": [
-        "canShinechargeMovement",
+        "canShinechargeMovementComplex",
         "canMidairShinespark",
-        "canCarefulJump",
+        "canTrickyJump",
         {"shinespark": {"frames": 125, "excessFrames": 6}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
+        "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
+      ]
     },
     {
       "link": [1, 3],
@@ -376,10 +408,15 @@
       "name": "Suitless Grapple Only",
       "requires": [
         "canSuitlessMaridia",
-        "canCarefulJump",
+        "canDodgeWhileShooting",
+        "canPreciseGrapple",
         {"or": [
-          "canPreciseGrapple",
-          "canGrappleJump"
+          "canInsaneJump",
+          "canPlayInSand"
+        ]},
+        {"or": [
+          "HiJump",
+          "canTrickyJump"
         ]}
       ],
       "note": [
@@ -978,9 +1015,11 @@
       "name": "Base",
       "requires": [
         "Gravity",
-        "canWalljump",
         {"or": [
-          "HiJump",
+          {"and": [
+            "canWalljump",
+            "HiJump"
+          ]},
           "canConsecutiveWalljump",
           "Grapple"
         ]}
@@ -990,25 +1029,47 @@
       "link": [3, 1],
       "name": "Space Jump",
       "requires": [
-        "SpaceJump"
+        "SpaceJump",
+        {"or": [
+          {"ammo": {"type": "Missile", "count": 3}},
+          {"ammo": {"type": "Super", "count": 3}},
+          "canUseGrapple",
+          "canTrickyJump",
+          "canDodgeWhileShooting",
+          "Spazer",
+          "Wave",
+          "Plasma",
+          "ScrewAttack",
+          {"enemyDamage": {
+            "enemy": "Mochtroid",
+            "type": "contact",
+            "hits": 2
+          }}
+        ]}
       ],
       "devNote": "No water involved here, so no need for Gravity or canSuitlessMaridia."
     },
     {
       "link": [3, 1],
-      "name": "Shinespark",
+      "name": "Colosseum Full Halfie Shinespark (Reverse)",
+      "notable": true,
+      "reusableRoomwideNotable": "Colosseum Full Halfie Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 60
         }
       },
       "requires": [
-        "canShinechargeMovement",
+        "canShinechargeMovementComplex",
         "canMidairShinespark",
-        "canCarefulJump",
+        "canTrickyJump",
         {"shinespark": {"frames": 125}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
+        "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
+      ]
     },
     {
       "link": [3, 1],
@@ -1033,10 +1094,15 @@
       "name": "Suitless Grapple Only",
       "requires": [
         "canSuitlessMaridia",
-        "Grapple",
+        "canDodgeWhileShooting",
+        "canPreciseGrapple",
         {"or": [
-          "canPlayInSand",
-          "canPreciseGrapple"
+          "canInsaneJump",
+          "canPlayInSand"
+        ]},
+        {"or": [
+          "HiJump",
+          "canTrickyJump"
         ]}
       ]
     },

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -405,7 +405,7 @@
     },
     {
       "link": [1, 3],
-      "name": "Suitless Grapple Only",
+      "name": "Suitless Grapple",
       "requires": [
         "canSuitlessMaridia",
         "canDodgeWhileShooting",
@@ -1091,7 +1091,7 @@
     },
     {
       "link": [3, 1],
-      "name": "Suitless Grapple Only",
+      "name": "Suitless Grapple",
       "requires": [
         "canSuitlessMaridia",
         "canDodgeWhileShooting",

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -610,12 +610,19 @@
     {
       "link": [2, 1],
       "name": "Crab Shaft Bottom Frozen Falling Crab",
+      "notable": true,
       "requires": [
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
+        "canDodgeWhileShooting",
         {"ammo": {"type": "Super", "count": 1}}
       ],
-      "note": "Involves a Super to freeze a crab in midair."
+      "reusableRoomwideNotable": "Crab Shaft Ice Only Crab Climb",
+      "note": [
+        "Use a Super to knock a crab off of the wall so that it falls through the opening above.",
+        "Use it to either jump directly to the blocks above, or onto a second crab.",
+        "Then wait for a crab to come around and climb it up to the next section of the room."
+      ]
     },
     {
       "link": [2, 1],
@@ -624,7 +631,8 @@
       "requires": [
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
-        "canCrouchJump"
+        "canCrouchJump",
+        "canTrickyJump"
       ],
       "reusableRoomwideNotable": "Crab Shaft Ice Only Crab Climb",
       "note": [

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -484,7 +484,7 @@
     },
     {
       "link": [1, 4],
-      "name": "Full Run Speed Jump",
+      "name": "Some Run Speed Jump",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 4,
@@ -498,6 +498,19 @@
           "canWalljump",
           "canLateralMidAirMorph"
         ]}
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Full Run Speed Jump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 6,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canCarefulJump"
       ]
     },
     {

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -352,10 +352,10 @@
     },
     {
       "link": [1, 3],
-      "name": "Careful SpringBall Bounce",
+      "name": "Lenient SpringBall Bounce",
       "entranceCondition": {
         "comeInRunning": {
-          "minTiles": 4,
+          "minTiles": 6,
           "speedBooster": "any"
         }
       },
@@ -364,14 +364,17 @@
         "canMockball",
         "canSpringBallBounce"
       ],
-      "note": "With enough run speed, jump over the first moat and MockBall into a regular springball jump over the second moat."
+      "note": [
+        "With at least 6 tiles of run speed, jump over the first moat and MockBall into a regular springball jump over the second moat.",
+        "Aim down before reaching the ceiling to increase the jump distance."
+      ]
     },
     {
       "link": [1, 3],
       "name": "Tricky SpringBall Bounce",
       "entranceCondition": {
         "comeInRunning": {
-          "minTiles": 2,
+          "minTiles": 4,
           "speedBooster": "any"
         }
       },
@@ -380,7 +383,28 @@
         "canMockball",
         "canSpringBallBounce"
       ],
-      "note": "With enough run speed, jump over the first moat and MockBall into a regular springball jump over the second moat."
+      "note": [
+        "With around four tiles of run speed, jump over the first moat and MockBall into a regular springball jump over the second moat.",
+        "SpeedBooster makes the jump possible with a shorter runway, but the trajectory is less predictable."
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Insane SpringBall Bounce",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canMockball",
+        "canSpringBallBounce"
+      ],
+      "note": [
+        "With at least two tiles of run speed, jump over the first moat by maximizing the jump distance and then MockBall into a regular springball to jump over the second moat."
+      ]
     },
     {
       "link": [1, 3],
@@ -468,7 +492,12 @@
         }
       },
       "requires": [
-        "canCarefulJump"
+        "canCarefulJump",
+        {"or": [
+          "canTrickyJump",
+          "canWalljump",
+          "canLateralMidAirMorph"
+        ]}
       ]
     },
     {


### PR DESCRIPTION
- Remove Kraid Beetoms as energy farm
- Make Crab Shaft Ice+Supers notable
- Grapple3 springball bounce add version with more leniency
- Top of PrePillar room a little friendlier
- Colosseum add HiJump or Trickyjump to grapple strats
- Full halfie Notable
- Reverse Botwoon hall ice clip note 

Maybe its too early to put flashSuitChecked on non-trivial and grapple teleport strats?