### PR TITLE
Various logic changes

### DIFF
--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1324,13 +1324,8 @@
       "link": [5, 8],
       "name": "Space Jump Alcatraz Escape",
       "requires": [
-        "canTrivialMidAirMorph",
-        "canCarefulJump",
-        "SpaceJump",
-        {"or": [
-          "HiJump",
-          "canMidAirMorph"
-        ]}
+        "canMidAirMorph",
+        "SpaceJump"
       ]
     },
     {

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1325,6 +1325,7 @@
       "name": "Space Jump Alcatraz Escape",
       "requires": [
         "canMidAirMorph",
+        "canCarefulJump",
         "SpaceJump"
       ]
     },

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -521,7 +521,7 @@
       "link": [1, 8],
       "name": "SpeedBooster",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 13,
           "openEnd": 0,
           "steepUpTiles": 2,
@@ -529,6 +529,32 @@
         }
       },
       "requires": []
+    },
+    {
+      "link": [1, 8],
+      "name": "In Room Shortcharge",
+      "requires": [
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 1},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "steepUpTiles": 2,
+              "steepDownTiles": 2,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 13,
+            "steepUpTiles": 2,
+            "steepDownTiles": 2,
+            "openEnd": 0
+          }}
+        ]}
+      ],
+      "unlocksDoors": [
+        {"nodeId": 1, "types": ["ammo"], "requires": []}
+      ]
     },
     {
       "link": [1, 8],

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1324,8 +1324,13 @@
       "link": [5, 8],
       "name": "Space Jump Alcatraz Escape",
       "requires": [
-        "canMidAirMorph",
-        "SpaceJump"
+        "canTrivialMidAirMorph",
+        "canCarefulJump",
+        "SpaceJump",
+        {"or": [
+          "HiJump",
+          "canMidAirMorph"
+        ]}
       ]
     },
     {

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -190,6 +190,10 @@
       "requires": [
         "canSpringBallBounce",
         "canDisableEquipment",
+        {"or": [
+          "canTrickyJump",
+          "h_canUseMorphBombs"
+        ]},
         {"obstaclesNotCleared": ["A"]}
       ],
       "reusableRoomwideNotable": "Moat SpringBall Bounce",
@@ -203,6 +207,10 @@
         "canSpringBallBounce",
         "canDisableEquipment",
         {"doorUnlockedAtNode": 1},
+        {"or": [
+          "canTrickyJump",
+          "h_canUseMorphBombs"
+        ]},
         {"obstaclesNotCleared": ["A"]}
       ],
       "reusableRoomwideNotable": "Moat SpringBall Bounce",

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -605,19 +605,22 @@
       "link": [1, 5],
       "name": "Cross Room Jump with Speedbooster",
       "entranceCondition": {
-        "comeInJumping": {
+        "comeInRunning": {
           "speedBooster": true,
-          "minTiles": 43
+          "minTiles": 40
         }
       },
       "requires": [
-        "canTrickyJump",
+        "canInsaneJump",
         "canLateralMidAirMorph",
-        "canCrossRoomJumpIntoWater"
+        "canCrossRoomJumpIntoWater",
+        "canMomentumConservingMorph"
       ],
       "note": [
-        "Needs max horizontal speed coming from 43 runway tiles in the adjacent room.",
-        "Jump after the transition."
+        "Needs near max horizontal speed coming from about 43 runway tiles in the adjacent room.",
+        "Jump after the transition.",
+        "Running a longer on the short runway is more difficult at maximum speed, but will increase the success of the jump.",
+        "A crisp momentum conserving morph can also make up for a jump that is buffered through the door."
       ]
     },
     {

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -617,7 +617,7 @@
         "canMomentumConservingMorph"
       ],
       "note": [
-        "Needs near max horizontal speed coming from about 43 runway tiles in the adjacent room.",
+        "Needs near max horizontal speed coming from about 40 runway tiles in the adjacent room.",
         "Jump after the transition.",
         "Running a longer on the short runway is more difficult at maximum speed, but will increase the success of the jump.",
         "A crisp momentum conserving morph can also make up for a jump that is buffered through the door."

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -426,7 +426,13 @@
       "link": [5, 6],
       "name": "West Sand Hole MidAir Morph",
       "requires": [
-        "h_canFourTileJumpMorph"
+        {"or": [
+          "h_canFourTileJumpMorph",
+          {"and": [
+            "canPreciseWalljump",
+            "canWallJumpInstantMorph"
+          ]}
+        ]}
       ]
     },
     {

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -442,14 +442,55 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "HiJump",
+          {"and": [
+            "HiJump",
+            {"or": [
+              "canCrouchJump",
+              "canDownGrab"
+            ]}
+          ]},
           "SpaceJump",
-          "canTrickyDashJump",
-          "canTrickyUseFrozenEnemies",
-          "canPreciseWalljump"
+          "canTrickyDashJump"
         ]}
       ],
       "devNote": "The menus don't really matter with these strats."
+    },
+    {
+      "link": [3, 1],
+      "name": "Tricky Menu Avoid",
+      "requires": [
+        "canTrickyJump",
+        {"or": [
+          "canPreciseWalljump",
+          "canSpringBallJumpMidAir"
+        ]}
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Frozen Menu Platforms",
+      "requires": [
+        "canUseFrozenEnemies",
+        {"or": [
+          "Plasma",
+          "Wave",
+          "Spazer",
+          "canTrickyJump",
+          {"enemyDamage": {
+            "enemy": "Menu",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Menu",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ]
     },
     {
       "link": [3, 1],
@@ -466,8 +507,6 @@
             "explicitWeapons": [
               "PowerBomb",
               "ScrewAttack",
-              "Wave",
-              "Spazer",
               "Plasma",
               "Missile",
               "Super"
@@ -484,16 +523,20 @@
               ]},
               {"and": [
                 "canDodgeWhileShooting",
-                {"enemyDamage": {
-                  "enemy": "Menu",
-                  "type": "contact",
-                  "hits": 1
-                }}
+                {"or": [
+                  "Wave",
+                  "Spazer",
+                  {"enemyDamage": {
+                    "enemy": "Menu",
+                    "type": "contact",
+                    "hits": 1
+                  }}
+                ]}
               ]},
               {"enemyDamage": {
                 "enemy": "Menu",
                 "type": "contact",
-                "hits": 2
+                "hits": 3
               }}
             ]}
           ]}

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -509,7 +509,8 @@
               "ScrewAttack",
               "Plasma",
               "Missile",
-              "Super"
+              "Super",
+              "Grapple"
             ]
           }},
           {"and": [
@@ -517,10 +518,7 @@
               "enemies": [["Menu", "Menu", "Menu"]]
             }},
             {"or": [
-              {"and": [
-                "canDodgeWhileShooting",
-                "canTrickyJump"
-              ]},
+              "canFarmWhileShooting",
               {"and": [
                 "canDodgeWhileShooting",
                 {"or": [

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -446,7 +446,9 @@
             "HiJump",
             {"or": [
               "canCrouchJump",
-              "canDownGrab"
+              "canDownGrab",
+              "canWalljump",
+              "SpeedBooster"
             ]}
           ]},
           "SpaceJump",

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -386,7 +386,11 @@
           "canIBJ",
           {"and": [
             "SpaceJump",
-            "canMidAirMorph"
+            "canTrivialMidAirMorph",
+            {"or": [
+              "HiJump",
+              "canMidAirMorph"
+            ]}
           ]},
           {"and": [
             "HiJump",

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -386,11 +386,7 @@
           "canIBJ",
           {"and": [
             "SpaceJump",
-            "canTrivialMidAirMorph",
-            {"or": [
-              "HiJump",
-              "canMidAirMorph"
-            ]}
+            "canMidAirMorph"
           ]},
           {"and": [
             "HiJump",

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -262,12 +262,29 @@
       "link": [2, 1],
       "name": "Green Gate Glitch",
       "requires": [
+        "Gravity",
         {"or": [
           "h_canGreenGateGlitch",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
       "clearsObstacles": ["A"]
+    },
+    {
+      "link": [2, 1],
+      "name": "Crab Tunnel Suitless Green Gate Glitch",
+      "notable": true,
+      "requires": [
+        {"or": [
+          "h_canGreenGateGlitch",
+          {"obstaclesCleared": ["A"]}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "Perform the Gate Glitch by moving towards the gate and firing the super on the correct frame for it to pass through and reach the button on the other side.",
+        "Due to the water physics, many traditional setups for the glitch will not work."
+      ]
     },
     {
       "link": [2, 1],

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -3536,14 +3536,16 @@
         {"or": [
           "canTrickyJump",
           {"and": [
-            "canLateralMidAirMorph",
-            "canCarefulJump"
+            "can4HighMidAirMorph",
+            "canCarefulJump",
+            "canLateralMidAirMorph"
           ]}
         ]}
       ],
       "note": [
-        "Running does not help. This is most easily done with a late jump at the bottom of the slope.",
-        "It is a bit less precise with an air ball or turning gravity suit back on and wall jumping on the platform at the end."
+        "This is most easily done with a late jump at the bottom of the slope.",
+        "It is a bit less precise with an air ball or turning gravity suit back on and wall jumping on the platform at the end.",
+        "An alternate method is to airball simultaneously with the gravity jump pause."
       ]
     },
     {

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -80,7 +80,11 @@
               "name": "Missiles",
               "notable": false,
               "requires": [
-                {"ammo": {"type": "Missile", "count": 50}}
+                {"ammo": {"type": "Missile", "count": 25}},
+                {"or": [
+                  "canDodgeWhileShooting",
+                  {"ammo": {"type": "Missile", "count": 25}}
+                ]}
               ],
               "devNote": "Some farming will still be useful, but without dodging efficiently, many of the drops will be energy."
             },
@@ -89,13 +93,10 @@
               "notable": false,
               "requires": [
                 "canDodgeWhileShooting",
+                "canTrickyJump",
                 {"or": [
                   {"ammo": {"type": "Missile", "count": 2}},
                   {"ammo": {"type": "Super", "count": 2}}
-                ]},
-                {"or": [
-                  "canTrickyJump",
-                  {"ammo": {"type": "Missile", "count": 25}}
                 ]},
                 {"resourceCapacity": [{"type": "Missile", "count": 10}]}
               ],
@@ -112,25 +113,27 @@
                 {"ammo": {"type": "Super", "count": 8}},
                 {"or": [
                   "canDodgeWhileShooting",
-                  {"ammo": {"type": "Super", "count": 5}}
+                  {"ammo": {"type": "Super", "count": 4}}
                 ]},
                 {"or": [
-                  "canTrickyJump",
-                  {"ammo": {"type": "Super", "count": 2}}
+                  "canFarmWhileShooting",
+                  {"ammo": {"type": "Super", "count": 4}}
                 ]}
               ],
               "note": [
+                "The hitbox on Croc's mouth may cause direct hits to miss, so jumping and shooting Supers horizontally is recommended.",
                 "While Crocomire's farmables may drop Supers, the rate is too low to rely on.",
                 "If you run out, Croc will most likely push you into the spikes.",
                 "It takes 8 Supers to kill croc if you don't let it move forward."
-              ]
+              ],
+              "devNote": "canFarmWhileShooting represents accurate shooting, not the ability to farm drops."
             },
             {
               "name": "Crocomire with 5 Missiles",
               "notable": true,
               "requires": [
-                "canDodgeWhileShooting",
-                "canBeVeryPatient",
+                "canFarmWhileShooting",
+                "canBePatient",
                 {"or": [
                   {"ammo": {"type": "Missile", "count": 2}},
                   {"ammo": {"type": "Super", "count": 2}}

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -638,6 +638,42 @@
       "note": "This strat just waits out the Dragon."
     },
     {
+      "link": [3, 2],
+      "name": "Reverse Shinespark",
+      "requires": [
+        "canHorizontalShinespark",
+        {"or": [
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"heatFrames": 90}
+          ]},
+          {"obstaclesCleared": ["A"]}
+        ]},
+        {"or": [
+          {"and": [
+            {"doorUnlockedAtNode": 1},
+            {"heatFrames": 30},
+            {"canShineCharge": {
+              "usedTiles": 17,
+              "openEnd": 0
+            }}
+          ]},
+          {"canShineCharge": {
+            "usedTiles": 16,
+            "openEnd": 0
+          }}
+        ]},
+        {"shinespark": {"frames": 62, "excessFrames": 20}},
+        {"heatFrames": 450}
+      ],
+      "clearsObstacles": ["A"],
+      "unlocksDoors": [
+        {"nodeId": 1, "types": ["missiles"], "requires": [{"heatFrames": 30}]},
+        {"nodeId": 1, "types": ["super"], "requires": []},
+        {"nodeId": 1, "types": ["powerbomb"], "requires": [{"heatFrames": 60}]}
+      ]
+    },
+    {
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -249,9 +249,19 @@
           "enemies": [["Metroid", "Metroid", "Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBombPeriphery"]
         }},
+        {"or": [
+          "canTrickyJump",
+          {"ammo": {"type": "PowerBomb", "count": 2}}
+        ]},
         {"metroidFrames": 330}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "note": [
+        "Place Power Bombs to kill the Metroids.",
+        "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
+      ],
+      "devNote": "Using 1 pack of PBs isn't intuitive as a way to kill 4 metroids without grouping them."
+      
     },
     {
       "link": [1, 1],
@@ -605,10 +615,18 @@
           "enemies": [["Metroid", "Metroid", "Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBombPeriphery"]
         }},
+        {"or": [
+          "canTrickyJump",
+          {"ammo": {"type": "PowerBomb", "count": 2}}
+        ]},
         {"metroidFrames": 170}
       ],
       "clearsObstacles": ["A"],
-      "note": "Power Bombing the first Metroid will cause the rest to rush towards Samus."
+      "note": [
+        "Place Power Bombs to kill the Metroids.",
+        "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
+      ],
+      "devNote": "Using 1 pack of PBs isn't intuitive as a way to kill 4 metroids without grouping them."
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -213,9 +213,18 @@
           "enemies": [["Metroid", "Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBombPeriphery"]
         }},
+        {"or": [
+          "canTrickyJump",
+          {"ammo": {"type": "PowerBomb", "count": 2}}
+        ]},
         {"metroidFrames": 300}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "note": [
+        "Place Power Bombs to kill the Metroids.",
+        "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
+      ],
+      "devNote": "Using 1 pack of PBs isn't intuitive as a way to kill 3 metroids without grouping them."
     },
     {
       "link": [1, 2],
@@ -339,10 +348,20 @@
           "enemies": [["Metroid", "Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBombPeriphery"]
         }},
+        {"or": [
+          "canTrickyJump",
+          {"ammo": {"type": "PowerBomb", "count": 2}}
+        ]},
         {"metroidFrames": 200}
       ],
-      "clearsObstacles": ["A"],
-      "devNote": "Killing the first Metroid happens to group the other two nearby, and when jumping close to them they derp around."
+      "clearsObstacles": ["A"],"note": [
+        "Place Power Bombs to kill the Metroids.",
+        "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
+      ],
+      "devNote": [
+        "Using 1 pack of PBs isn't intuitive as a way to kill 3 metroids without grouping them.",
+        "Killing the first Metroid happens to group the other two nearby, and when jumping close to them they derp around."
+      ]
     },
     {
       "link": [2, 1],

--- a/tech.json
+++ b/tech.json
@@ -398,7 +398,8 @@
                   "otherRequires": [],
                   "note" : [
                     "A mid-air morph that has to be done in a 4-tile-high space, into a morph tunnel at the top of the space.",
-                    "It's a lot more precise than with more room. Turn off HiJump before attempting this."
+                    "It's a lot more precise than with more room. Turn off HiJump before attempting this.",
+                    "Most applications of this tech are in places where wall jump instant morphing is not possible."
                   ]
                 },
                 {


### PR DESCRIPTION
- 8 Super Croc is stressful on expert and takes practice to avoid hitbox scams; add another super pack for lower difficulties
- can4HighMidAirMorph is fair to move to very hard
- Maridia bug room left side bugs are still really hard to deal with
- Crab Tunnel GGG notable; give the option of turning it off and provide some visibility to it
- Everest gravity jump airball
- Some Metroid Rooms require 2nd PB pack
- parlor break top left blocks with speed
- Spacejump alcatraz escape/crab hole
- Croc escape reverse spark
- Botwoon Etank momentumConservingMorph to speedyjump entry
- Moat Springball Bounce add Bombs.  I'd like to keep the strat at Hard