### PR TITLE
Refine Moat shinespark strats and item collection

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -237,7 +237,7 @@ A `shineChargeFrames` object represents the need for Samus to have the given amo
 
 For this requirement to be satisfied, one of the following must be true:
 - It must be preceded by a `canShineCharge` requirement in the same strat.
-- The start must have `startsWithShineCharge` set to true, and connect with an immediately preceding strat with `endsWithShineCharge` set to true.
+- The strat must have `startsWithShineCharge` set to true, and connect with an immediately preceding strat with `endsWithShineCharge` set to true.
 - The strat must have a `comeInShinecharged` or `comeInShinechargedJumping` entrance condition.
 
 #### hibashiHits object

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -231,6 +231,15 @@ __Example:__
 {"gravitylessHeatFrames": 70}
 ```
 
+#### shineChargeFrames object
+
+A `shineChargeFrames` object represents the need for Samus to have the given amount of shinecharge frames remaining; after this requirement, the new amount of shinecharge frames remaining is updated by subtracting away the given amount of frames.
+
+For this requirement to be satisfied, one of the following must be true:
+- It must be preceded by a `canShinecharge` requirement in the same strat.
+- It must be preceded by a strat with `keepsShinecharge` set to true.
+- The strat must have a `comeInShinecharged` or `comeInShinechargedJumping` entrance condition.
+
 #### hibashiHits object
 A `hibashiHits` object represents the need for Samus to intentionally take a number of hits from the Norfair flame bursts (also called hibashi). This is meant to be converted to a flat health value based on item loadout. The vanilla damage per hibashi hit is 30 with Power Suit, 15 with Varia, and 7 with Gravity Suit.
 

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -236,8 +236,8 @@ __Example:__
 A `shineChargeFrames` object represents the need for Samus to have the given amount of shinecharge frames remaining; after this requirement, the new amount of shinecharge frames remaining is updated by subtracting away the given amount of frames.
 
 For this requirement to be satisfied, one of the following must be true:
-- It must be preceded by a `canShinecharge` requirement in the same strat.
-- It must be preceded by a strat with `keepsShinecharge` set to true.
+- It must be preceded by a `canShineCharge` requirement in the same strat.
+- The start must have `startsWithShineCharge` set to true, and connect with an immediately preceding strat with `endsWithShineCharge` set to true.
 - The strat must have a `comeInShinecharged` or `comeInShinechargedJumping` entrance condition.
 
 #### hibashiHits object

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -40,7 +40,17 @@
     {
       "id": "A",
       "obstacleType": "abstract",
-      "name": "Shinespark Left"
+      "name": "Shinesparking Left Through Item"
+    },
+    {
+      "id": "B",
+      "obstacleType": "abstract",
+      "name": "Shinesparking Right Through Item"
+    },
+    {
+      "id": "C",
+      "obstacleType": "abstract",
+      "name": "Hero Shot to Open Door"
     }
   ],
   "reusableRoomwideNotable": [
@@ -116,14 +126,27 @@
     },
     {
       "link": [1, 2],
-      "name": "Shinespark",
+      "name": "Base",
+      "requires": [
+        {"or": [
+          "Grapple",
+          "SpaceJump"
+        ]}
+      ],
+      "devNote": "This avoids collecting the item."
+    },
+    {
+      "link": [1, 2],
+      "name": "Shinespark Above Item",
       "entranceCondition": {
-        "comeInWithSpark": {}
+        "comeInWithSpark": {
+          "position": "top"
+        }
       },
       "requires": [
-        {"shinespark": {"frames": 42, "excessFrames": 7}}
+        {"shinespark": {"frames": 42, "excessFrames": 9}}
       ],
-      "devNote": "To avoid making another obstacle, it is assumed the item at 3 is collected by other means."
+      "devNote": "Sparking in top position means the item will be avoided."
     },
     {
       "link": [1, 2],
@@ -193,9 +216,9 @@
         {"or": [
           "canTrickyJump",
           "h_canUseMorphBombs"
-        ]},
-        {"obstaclesNotCleared": ["A"]}
+        ]}
       ],
+      "collectsItems": [3],
       "reusableRoomwideNotable": "Moat SpringBall Bounce",
       "note": "Run, jump, lateral midair morph on the way down, then bounce off the pedestal to get to the other side."
     },
@@ -210,9 +233,9 @@
         {"or": [
           "canTrickyJump",
           "h_canUseMorphBombs"
-        ]},
-        {"obstaclesNotCleared": ["A"]}
+        ]}
       ],
+      "collectsItems": [3],
       "reusableRoomwideNotable": "Moat SpringBall Bounce",
       "note": "Open the door and step as close to the transition as possible. Run, jump, lateral midair morph on the way down, then bounce off the pedestal to get to the other side."
     },
@@ -227,9 +250,9 @@
       },
       "requires": [
         "canCWJ",
-        "canDisableEquipment",
-        {"obstaclesNotCleared": ["A"]}
+        "canDisableEquipment"
       ],
+      "collectsItems": [3],
       "note": [
         "Aligning against the closed door shell on the other side of the transition.",
         "Run towards the water and jump on the last possible frame.",
@@ -247,9 +270,9 @@
           "canMoonwalk",
           "Morph",
           "canXRayTurnaround"
-        ]},
-        {"obstaclesNotCleared": ["A"]}
+        ]}
       ],
+      "collectsItems": [3],
       "note": [
         "Stand on the farthest pixel into the door possible using moonwalk, X-Ray, or morphball turn around.",
         "Run towards the water and jump on the last possible frame.",
@@ -290,53 +313,7 @@
     },
     {
       "link": [1, 2],
-      "name": "Diagonal Spark (Come In Shinecharged)",
-      "entranceCondition": {
-        "comeInShinecharged": {
-          "framesRequired": 130
-        }
-      },
-      "requires": [
-        "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 7}}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Run and jump onto the pedestal.",
-        "Jump again to the right, and shinespark diagonally to make it past the water."
-      ]
-    },
-    {
-      "link": [1, 2],
-      "name": "Leave With Spark (Come In Shinecharged)",
-      "entranceCondition": {
-        "comeInShinecharged": {
-          "framesRequired": 140
-        }
-      },
-      "requires": [
-        "canShinechargeMovementComplex",
-        "canHeroShot",
-        {"shinespark": {"frames": 19}}
-      ],
-      "exitCondition": {
-        "leaveWithSpark": {}
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Run and jump onto the pedestal.",
-        "Jump again to the right to bring the door on-camera.",
-        "Fire a shot mid-air, and activate the shinespark wind-up.",
-        "Wait until the shot hits the door before sparking."
-      ]
-    },
-    {
-      "link": [1, 2],
-      "name": "Hero Shot Spark",
+      "name": "Hero Shot Spark Above Item",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 40
@@ -348,7 +325,9 @@
         {"shinespark": {"frames": 38}}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -361,7 +340,8 @@
         "Sparking too late will cause the shot to despawn before reaching the door.",
         "Sparking too early will cause Samus to bonk the door as it will not yet be open.",
         "A beam shot, Missile, or Super can be used."
-      ]
+      ],
+      "devNote": "Sparking in top position means the item will be avoided."
     },
     {
       "link": [1, 2],
@@ -398,7 +378,7 @@
     },
     {
       "link": [1, 2],
-      "name": "Come in Shinecharging, Leave With Temporary Blue (Speedy Jump)",
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue (Speedy Jump)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 2,
@@ -422,7 +402,7 @@
     },
     {
       "link": [1, 2],
-      "name": "Come in Shinecharging, Leave With Temporary Blue (Insane Speedy Jump)",
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue (Insane Speedy Jump)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 2,
@@ -451,6 +431,7 @@
       "requires": [
         "canDisableEquipment"
       ],
+      "collectsItems": [3],
       "note": "This jump is much easier without HiJump or Speedbooster equipped."
     },
     {
@@ -462,7 +443,8 @@
           "SpaceJump",
           "Gravity"
         ]}
-      ]
+      ],
+      "collectsItems": [3]
     },
     {
       "link": [1, 3],
@@ -473,91 +455,68 @@
           "minTiles": 3
         }
       },
-      "requires": []
+      "requires": [],
+      "collectsItems": [3]
+    },
+    {
+      "link": [1, 3],
+      "name": "Carry Shinecharge to Item",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 85
+        }
+      },
+      "requires": [],
+      "collectsItems": [3],
+      "endsWithShineCharge": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Hero Shot Spark Through Item",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 40
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canHeroShot",
+        {"shinespark": {"frames": 38}}
+      ],
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "clearsObstacles": ["B", "C"],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "Run and jump, fire a shot mid-air, and activate the shinespark wind-up.",
+        "Wait until the shot is at a specific position before sparking.",
+        "Sparking too late will cause the shot to despawn before reaching the door.",
+        "Sparking too early will cause Samus to bonk the door as it will not yet be open.",
+        "A beam shot, Missile, or Super can be used."
+      ],
+      "devNote": "Sparking in bottom position means the item will be collected along the way."
+    },
+    {
+      "link": [2, 1],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          "Grapple",
+          "SpaceJump"
+        ]}
+      ],
+      "collectsItems": [3],
+      "note": "This avoids collecting the item.",
+      "devNote": "Several other strats would also be possible for avoiding the item."
     },
     {
       "link": [2, 1],
       "name": "Pass Below",
       "requires": [
         "h_canBombThings"
-      ]
-    },
-    {
-      "link": [2, 1],
-      "name": "Leave With Spark (Come In Shinecharged)",
-      "entranceCondition": {
-        "comeInShinecharged": {
-          "framesRequired": 90
-        }
-      },
-      "requires": [
-        "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 23}}
-      ],
-      "exitCondition": {
-        "leaveWithSpark": {}
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Come into the room with a shinecharge, run and jump to the left, firing a shot just before landing on the pedestal.",
-        "Activate the shinespark either just before landing on the pedestal or just afterward (depending on the vertical position needed for the spark)."
-      ]
-    },
-    {
-      "link": [2, 1],
-      "name": "Leave With Spark (Come In Shinecharging)",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 4,
-          "openEnd": 0
-        }
-      },
-      "requires": [
-        "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 23}}
-      ],
-      "exitCondition": {
-        "leaveWithSpark": {}
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "note": [
-        "After gaining a shinecharge, run back to the door to make space for a running jump to the left, firing a shot just before landing on the pedestal.",
-        "Activate the shinespark either just before landing on the pedestal or just afterward (depending on the vertical position needed for the spark)."
-      ]
-    },
-    {
-      "link": [2, 1],
-      "name": "Hero Shot Spark",
-      "entranceCondition": {
-        "comeInShinecharged": {
-          "framesRequired": 25
-        }
-      },
-      "requires": [
-        "canShinechargeMovementTricky",
-        "canHeroShot",
-        {"shinespark": {"frames": 39}}
-      ],
-      "exitCondition": {
-        "leaveWithSpark": {}
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Run, fire a shot mid-air, jump, and activate a mid-air shinespark to the left.",
-        "Sparking too late will cause the shot to despawn before reaching the door.",
-        "Sparking too early will cause Samus to bonk the door as it will not yet be open.",
-        "A beam shot, Missile, or Super can be used."
       ]
     },
     {
@@ -576,6 +535,7 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
+      "collectsItems": [3],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Enter with enough speed to jump onto or over the item pedestal, morphing mid-air and then unmorphing into temporary blue."
@@ -665,17 +625,14 @@
     },
     {
       "link": [2, 3],
-      "name": "Grapple",
+      "name": "Base",
       "requires": [
-        "Grapple"
-      ]
-    },
-    {
-      "link": [2, 3],
-      "name": "Space Jump",
-      "requires": [
-        "SpaceJump"
-      ]
+        {"or": [
+          "Grapple",
+          "SpaceJump"
+        ]}
+      ],
+      "collectsItems": [3]
     },
     {
       "link": [2, 3],
@@ -690,7 +647,8 @@
             "HiJump"
           ]}
         ]}
-      ]
+      ],
+      "collectsItems": [3]
     },
     {
       "link": [2, 3],
@@ -705,6 +663,7 @@
           "SpeedBooster"
         ]}
       ],
+      "collectsItems": [3],
       "note": [
         "Execution of this strat is non-trivial, and failing will lead to falling into the pit.",
         "Depending on item loadout, that could be a softlock."
@@ -724,6 +683,7 @@
         "canDisableEquipment",
         "canCarefulJump"
       ],
+      "collectsItems": [3],
       "note": [
         "Execution of this strat is non-trivial, and failing will lead to falling into the pit.",
         "Depending on item loadout, that could be a softlock."
@@ -731,38 +691,142 @@
     },
     {
       "link": [2, 3],
-      "name": "Shinespark",
+      "name": "Shinespark Through Item",
       "entranceCondition": {
-        "comeInWithSpark": {}
+        "comeInWithSpark": {
+          "position": "bottom"
+        }
       },
       "requires": [
-        {"shinespark": {"frames": 23, "excessFrames": 0}}
+        {"shinespark": {"frames": 23, "excessFrames": 1}}
       ],
+      "collectsItems": [3],
       "clearsObstacles": ["A"],
       "devNote": "This will grab the item and continue the spark to the left door. If this is an E-Tank, Samus will not maintain full Energy after the next strat."
+    },
+    {
+      "link": [2, 3],
+      "name": "Carry Shinecharge to Item (Come in Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 130}
+      ],
+      "collectsItems": [3],
+      "endsWithShineCharge": true,
+      "note": [
+        "After gaining a shinecharge, run back to the door to make space for a running jump to the left."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Carry Shinecharge to Item (Come in Shinecharged)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 85
+        }
+      },
+      "requires": [],
+      "collectsItems": [3],
+      "endsWithShineCharge": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Hero Shot Spark Through Item",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 25
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canHeroShot",
+        {"shinespark": {"frames": 17}}
+      ],
+      "clearsObstacles": ["A", "C"],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "Run, fire a shot mid-air, jump, and activate a mid-air shinespark to the left.",
+        "Sparking too late will cause the shot to despawn before reaching the door.",
+        "Sparking too early will cause Samus to bonk the door as it will not yet be open.",
+        "A beam shot, Missile, or Super can be used."
+      ]
     },
     {
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
       "link": [3, 1],
       "name": "Continue Shinespark Left",
       "requires": [
-        {"shinespark": {"frames": 19, "excessFrames": 19}},
-        {"obstaclesCleared": ["A"]}
+        {"obstaclesCleared": ["A"]},
+        {"obstaclesNotCleared": ["B", "C"]},
+        {"shinespark": {"frames": 19, "excessFrames": 19}}
+      ],
+      "resetsObstacles": ["A"],
+      "devNote": "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark."
+    },
+    {
+      "link": [3, 1],
+      "name": "Continue Hero Shot Shinespark Left",
+      "requires": [
+        {"obstaclesCleared": ["A", "C"]},
+        {"obstaclesNotCleared": ["B"]},
+        {"shinespark": {"frames": 21, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "devNote": "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark."
+    },
+    {
+      "link": [3, 1],
+      "name": "Continue Shinecharge, Leave With Spark",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"obstaclesNotCleared": ["A", "B", "C"]},
+        "canShinechargeMovementComplex",
+        "canHeroShot",
+        {"shineChargeFrames": 15},
+        {"shinespark": {"frames": 21}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "From the pedestal, fire a shot to the left to open the door.",
+        "If needed, jump slightly to the left to follow the shot, then activate the shinespark wind-up.",
+        "Wait until the shot hits the door before sparking."
+      ],
+      "devNote": "If approaching from the right, the camera will be scrolled further, making it unnecessary to jump and follow the shot."
     },
     {
       "link": [3, 2],
       "name": "Grapple",
       "requires": [
         "Grapple",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
@@ -770,7 +834,7 @@
       "name": "Space Jump",
       "requires": [
         "SpaceJump",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
@@ -793,7 +857,7 @@
             "SpeedBooster"
           ]}
         ]},
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
@@ -802,7 +866,7 @@
       "requires": [
         "Gravity",
         "canIBJ",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
@@ -811,7 +875,7 @@
       "requires": [
         "canGravityJump",
         "canSuitlessMaridia",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
@@ -819,7 +883,7 @@
       "name": "Moat Horizontal Bomb Jump",
       "requires": [
         "canHBJ",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
@@ -828,7 +892,7 @@
       "requires": [
         "canSuitlessMaridia",
         "h_canDoubleSpringBallJumpWithHiJump",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
     {
@@ -836,8 +900,78 @@
       "name": "Moat Ceiling Bomb Jump",
       "requires": [
         "canCeilingBombJump",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Continue Shinespark Right",
+      "requires": [
+        {"obstaclesCleared": ["B"]},
+        {"obstaclesNotCleared": ["A", "C"]},
+        {"shinespark": {"frames": 23, "excessFrames": 7}}
+      ],
+      "resetsObstacles": ["B"]
+    },
+    {
+      "link": [3, 2],
+      "name": "Continue Hero Shot Shinespark Right",
+      "requires": [
+        {"obstaclesCleared": ["B", "C"]},
+        {"obstaclesNotCleared": ["A"]},
+        {"shinespark": {"frames": 23, "excessFrames": 7}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Continue Shinecharge into Diagonal Spark",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"obstaclesNotCleared": ["A", "B", "C"]},
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 45},
+        {"shinespark": {"frames": 7}}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Jump from the pedestal to the right, and shinespark diagonally to make it past the water."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Continue Shinecharge, Leave With Spark",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"obstaclesNotCleared": ["A", "B", "C"]},
+        "canShinechargeMovementComplex",
+        "canHeroShot",
+        {"shineChargeFrames": 45},
+        {"shinespark": {"frames": 22}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "From the pedestal, jump to the right to bring the door on-camera.",
+        "Fire a shot mid-air, and activate the shinespark wind-up.",
+        "Wait until the shot hits the door before sparking."
+      ],
+      "devNote": "If approaching from the right, the camera will be scrolled further, requiring a larger jump to prevent the shot from despawning."
     }
   ]
 }

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -968,7 +968,6 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
       "note": [
         "From the pedestal, jump to the right to bring the door on-camera.",

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -521,6 +521,22 @@
     },
     {
       "link": [2, 1],
+      "name": "Gravity",
+      "requires": [
+        "Gravity",
+        {"or": [
+          "canWalljump",
+          "canGravityJump",
+          {"and": [
+            "canSpringBallJumpMidAir",
+            "HiJump"
+          ]}
+        ]}
+      ],
+      "collectsItems": [3]
+    },
+    {
+      "link": [2, 1],
       "name": "Come in Shinecharging, Leave With Temporary Blue (Speedy Jump)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
@@ -630,22 +646,6 @@
         {"or": [
           "Grapple",
           "SpaceJump"
-        ]}
-      ],
-      "collectsItems": [3]
-    },
-    {
-      "link": [2, 3],
-      "name": "Gravity",
-      "requires": [
-        "Gravity",
-        {"or": [
-          "canWalljump",
-          "canGravityJump",
-          {"and": [
-            "canSpringBallJumpMidAir",
-            "HiJump"
-          ]}
         ]}
       ],
       "collectsItems": [3]

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -508,7 +508,6 @@
           "SpaceJump"
         ]}
       ],
-      "collectsItems": [3],
       "note": "This avoids collecting the item.",
       "devNote": "Several other strats would also be possible for avoiding the item."
     },

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -322,6 +322,7 @@
       "requires": [
         "canShinechargeMovementTricky",
         "canHeroShot",
+        "canMidairShinespark",
         {"shinespark": {"frames": 38}}
       ],
       "exitCondition": {
@@ -466,7 +467,9 @@
           "framesRequired": 85
         }
       },
-      "requires": [],
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
       "collectsItems": [3],
       "endsWithShineCharge": true
     },
@@ -481,11 +484,8 @@
       "requires": [
         "canShinechargeMovementTricky",
         "canHeroShot",
+        "canHorizontalShinespark",
         {"shinespark": {"frames": 38}}
-      ],
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "clearsObstacles": ["B", "C"],
       "collectsItems": [3],
@@ -698,6 +698,7 @@
         }
       },
       "requires": [
+        "canHorizontalShinespark",
         {"shinespark": {"frames": 23, "excessFrames": 1}}
       ],
       "collectsItems": [3],
@@ -731,7 +732,9 @@
           "framesRequired": 85
         }
       },
-      "requires": [],
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
       "collectsItems": [3],
       "endsWithShineCharge": true
     },
@@ -746,6 +749,7 @@
       "requires": [
         "canShinechargeMovementTricky",
         "canHeroShot",
+        "canHorizontalShinespark",
         {"shinespark": {"frames": 17}}
       ],
       "clearsObstacles": ["A", "C"],

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -244,7 +244,7 @@
       "name": "Moat Continuous Walljump, Run Through the Door",
       "entranceCondition": {
         "comeInRunning": {
-          "speedBooster": "any",
+          "speedBooster": false,
           "minTiles": 1.4
         }
       },
@@ -531,8 +531,7 @@
             "HiJump"
           ]}
         ]}
-      ],
-      "collectsItems": [3]
+      ]
     },
     {
       "link": [2, 1],

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -238,6 +238,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/shineChargeFrames",
             "type": "integer",
             "minimum": 1,
+            "maximum": 180,
             "title": "Shinecharge Frames",
             "description": "Fulfilled by spending the given amount of frames with an active shinecharge."
           },

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -234,6 +234,13 @@
             "title": "Draygon Electricity Frames",
             "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames grapples to a broken Draygon turret."
           },
+          "shineChargeFrames": {
+            "$id": "#/definitions/logicalRequirement/items/properties/shineChargeFrames",
+            "type": "integer",
+            "minimum": 1,
+            "title": "Shinecharge Frames",
+            "description": "Fulfilled by spending the given amount of frames with an active shinecharge."
+          },
           "enemyDamage": {
             "$id": "#/definitions/logicalRequirement/items/properties/enemyDamage",
             "type": "object",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -807,6 +807,12 @@
             {"required": ["comeInWithGrappleTeleport"]}
           ]
         },
+        "startsWithShineCharge": {
+          "$id": "#/definitions/strat/properties/startsWithShineCharge",
+          "type": "boolean",
+          "title": "Starts With Shinecharge",
+          "description": "If true, indicates that this strat must start with shinecharge frames remaining from an earlier strat."
+        },
         "requires": {
           "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
           "$id": "#/definitions/strat/properties/requires",
@@ -1321,6 +1327,12 @@
             "type": "string",
             "pattern": "^(.*)$"
           }
+        },
+        "endsWithShineCharge": {
+          "$id": "#/definitions/strat/properties/endsWithShineCharge",
+          "type": "boolean",
+          "title": "Keeps Shinecharge",
+          "description": "If true, indicates that this strat ends with shinecharge frames remaining, which can be used in a subsequent strat."
         },
         "flashSuitChecked": {
           "$id": "#/definitions/strat/properties/flashSuitChecked",

--- a/strats.md
+++ b/strats.md
@@ -1510,6 +1510,18 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
 }
 ```
 
+## Starts With Shinecharge
+
+The `startsWithShineCharge` property indicates that a strat must start while in a shinecharge state, from a shinecharge obtained in an earlier strat. The amount of frames required is determined by `shineChargeFrames` requirements in this strat.
+
+This property should not be combined with a `leaveShinecharged` exit condition.
+
+## Ends With Shinecharge
+
+The `endsWithShineCharge` property indicates that a strat ends while in a shinecharge state, allowing a shinespark to be used in a subsequent strat. The amount of frames remaining is determined by `shineChargeFrames` requirements coming after the most recent `canShineCharge` requirement.
+
+This property should not be combined with a `leaveShinecharged` exit condition.
+
 ## Run Speed
 
 There are many kinds of cross-room strats that require Samus to enter the room with a certain amount of speed. For easier interpretation, these requirements are usually specified in terms of runway tiles required. In certain situations, however, it is necessary to directly reference speed values. There are several types of Samus horizontal speed:


### PR DESCRIPTION
This PR was prompted by insomniaspeed mentioning a strat where you come in from the right of Moat with a shinecharge, jump across, grab the item, and spark back to the right: https://discord.com/channels/1053421401354285129/1053436236628496454/1247939732776812565. It turns out to be fairly complicated in that there are a lot of possible combinations of whether you carry the shinecharge into the room vs. gain it while running in, and whether you spark back to the door vs. spark through the door (left or right door). Also you can enter from either the left or right side of the room; the left-side entry is less significant but could still be useful as a way to grab the item on the way while sparking right, rather than having to make another trip back into the left room (which might be heated) after grabbing the item.

In general, the room wasn't accurately modeling which strats are required to grab the item. There can be scenarios where you could want to skip picking up an ETank, in order to save the refill for a later time. It's not applicable to Map Rando logic but still seems worth representing accurately. We can do this now that we have the "collectsItems" strat property. There would still be more strats that could be added for skipping past the item; I'm not trying to be complete with them in this PR, just trying to make sure the existing strats are accurate and that the most basic ones are included.

The other thing added here is a new "shineChargeFrames" logical requirement. For a while now, Map Rando has been treating shinecharge frames as a resource type like energy, missiles, etc., so the capability has been there to support something like this. It allows us to represent shinecharges that span multiple strats, a generalization of what we were already able to do with cross-room strats. Strats that use this should also use the new boolean strat properties "startsWithShineCharge" / "endsWithShineCharge" also added in this PR, as a way to mark whether the strat is expected to start with an active shinecharge and/or end with one. In this room, the "shineChargeFrames" helps us avoid a blowup in complexity in terms of amount of obstacles and/or nodes required to represent things accurately. It should be useful in many other situations too.

Technically, the required shinecharge frames for a through-door spark from the item pedestal probably could be a little less if you are going through to the opposite door (as the camera scroll is more favorable) vs. doubling back through the door you came in. This could be represented using one more obstacle, but I didn't think it was necessarily worth the extra complexity to try to model that. Shinecharge frames can already be minimized even further by initiating the spark with a hero shot before collecting the item, just with a slightly higher shinespark energy cost; so that seems to make it not matter very much.