### PR TITLE
Add comeInWithBlueSpringBallBounce in Final Missile Bombway

### DIFF
--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -139,6 +139,18 @@
     },
     {
       "link": [2, 1],
+      "name": "Temporary Blue Bounce (Come in With Spring Ball Bounce)",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ]
+    },
+    {
+      "link": [2, 1],
       "name": "Temporary Blue Bounce (Come in With Temporary Blue)",
       "entranceCondition": {
         "comeInWithTemporaryBlue": {}


### PR DESCRIPTION
Normally a temporary blue into spring ball bounce could be used here instead. By bouncing all the way instead of using temporary blue, it allows keeping a flash suit, so it seemed worth adding.