### PR TITLE
Refine some Crateria Supers cross-room strats

### DIFF
--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -481,56 +481,54 @@
     },
     {
       "link": [1, 6],
-      "name": "Springball Speedball",
+      "name": "Blue Spring Ball Bounce (Come in Getting Blue Speed)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
-          "length": 3,
-          "openEnd": 1
+          "length": 5,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$2.0",
+          "maxExtraRunSpeed": "$3.F"
         }
       },
       "requires": [
-        "canSpeedball",
-        "canTemporaryBlue",
-        "canCarefulJump",
-        "canSpringBallBounce",
+        "canTrickySpringBallBounce",
         {"or": [
-          "canTrickyDashJump",
+          "canInsaneJump",
           "canChainTemporaryBlue"
         ]},
         {"spikeHits": 1}
       ],
       "note": [
         "Use Springball on the spikes to cross the room with a Speedball.",
-        "It helps to not be at full run speed when bouncing through the spike pit, but is still possible with very tight jumps.",
         "Then bounce into the Morph tunnel and use Springball to bounce all of the way through.",
-        "Unmorphing before the Morph tunnel to better control the bounce can help."
+        "It can help to unmorph before the Morph tunnel and use temporary blue to start the bounce into the tunnel."
       ],
-      "devNote": "There are 2 unusable tiles in this runway."
+      "devNote": "Higher and lower run speeds can also work but may need to jump earlier or take additional spike hits."
     },
     {
       "link": [1, 6],
-      "name": "Speedy Jump Spring Fling Temporary Blue",
+      "name": "Spring Fling Temporary Blue (Come in Getting Blue Speed)",
       "entranceCondition": {
-        "comeInRunning": {
-          "minTiles": 28,
-          "speedBooster": true
+        "comeInGettingBlueSpeed": {
+          "length": 5,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$5.8"
         }
       },
       "requires": [
         "canTrickyJump",
-        "canLateralMidAirMorph",
+        "canMomentumConservingMorph",
         "canSpringFling",
         "canTemporaryBlue"
       ],
-      "note": "Run and jump into an airball, pressing pause just as Samus hits the ceiling, in order to unequip Spring Ball to reset fall speed.",
-      "devNote": "This can be done with 26 tiles of other-room runway, but it would probably require a higher movement tech."
+      "note": "Run and jump into an airball, pressing pause just as Samus hits the ceiling, in order to unequip Spring Ball to reset fall speed."
     },
     {
       "link": [1, 6],
-      "name": "Spring Ball Bounce Spring Fling Temporary Blue",
+      "name": "Spring Fling Temporary Blue (Come in With Blue Spring Ball Bounce)",
       "entranceCondition": {
-        "comeInWithSpringBallBounce": {
-          "remoteAndLandingMinTiles": [[30, 1]],
+        "comeInWithBlueSpringBallBounce": {
+          "minExtraRunSpeed": "$5.8",
           "movementType": "controlled"
         }
       },
@@ -543,7 +541,7 @@
     },
     {
       "link": [1, 6],
-      "name": "Temporary Blue Springball",
+      "name": "Temporary Blue Springball Bounce",
       "entranceCondition": {
         "comeInWithTemporaryBlue": {}
       },

--- a/tech.json
+++ b/tech.json
@@ -456,7 +456,7 @@
                           "name": "canTrickySpringBallBounce",
                           "techRequires": ["canSpringBallBounce"],
                           "otherRequires": [],
-                          "note": "Performing spring ball bounces in tricky situations, such as squeezing into a Morph tunnel while bouncing to keep blue speed."
+                          "note": "Performing spring ball bounces in tricky situations, such as precisely platforming while bouncing to keep blue speed."
                         }
                       ]
                     },

--- a/tech.json
+++ b/tech.json
@@ -450,7 +450,15 @@
                       "name": "canSpringBallBounce",
                       "techRequires": ["canLateralMidAirMorph"],
                       "otherRequires": ["SpringBall"],
-                      "note": "Using a lateral mid-air morph to bounce off a surface with Spring Ball while retaining previous momentum."
+                      "note": "Using a lateral mid-air morph to bounce off a surface with Spring Ball while retaining previous momentum.",
+                      "extensionTechs": [
+                        {
+                          "name": "canTrickySpringBallBounce",
+                          "techRequires": ["canSpringBallBounce"],
+                          "otherRequires": [],
+                          "note": "Performing spring ball bounces in tricky situations, such as squeezing into a Morph tunnel while bouncing to keep blue speed."
+                        }
+                      ]
                     },
                     {
                       "name": "canStationaryLateralMidAirMorph",


### PR DESCRIPTION
I'm envisioning "canTrickySpringBallBounce" here as maybe an Expert tech, for cases requiring a high degree of precision like bouncing into morph tunnels? We could put canInsaneJump on ones that are even more difficult, e.g. where you have to do it while moving with significant speed and possibly from another room (vs. doing it from a stop in temporary blue)? For cases that aren't too precise but are tricky I assume we can use "canTrickyJump" (combined with "canSpringBallBounce") to put them in Very Hard, an example being bouncing across a whole room like the bottom of West Ocean?