### PR TITLE
Update m3-room.schema.json

### DIFF
--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -2339,13 +2339,9 @@
             ],
             "pattern": "^(.*)$"
           },
-          "note": {
-            "$id": "#/properties/reusableRoomwideNotable/items/properties/note",
-            "type": ["string", "array"],
-            "title": "Strat Description",
-            "description": "A common description for all strats that use this reusable strat",
-            "default": "",
-            "pattern": "^(.*)$"
+         "note": {
+            "$ref" : "m3-note.schema.json#/definitions/note",
+            "$id": "#/properties/enemies/items/properties/note"
           },
           "devNote": {
             "$ref" : "m3-note.schema.json#/definitions/devNote",


### PR DESCRIPTION
Fixes the "note" property of "reusableRoomwideNotable" to use the common definition in "m3-note.schema.json#/definitions/note"