### PR TITLE
Tourian remote runways

### DIFF
--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -113,6 +113,89 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 12,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 12,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 14,
+          "openEnd": 0
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Carry G-Mode Back Through",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -174,6 +257,127 @@
         "Gain a shinecharge by running right-to-left on the leftmost runway.",
         "Then run toward the right, jumping twice before sparking mid-air."
       ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave With Mockball (Space Jump)",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "SpaceJump",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "SpaceJump",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave With Controlled Spring Ball Bounce",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "controlled"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"getBlueSpeed": {
+          "usedTiles": 14,
+          "openEnd": 1
+        }},
+        "canChainTemporaryBlue",
+        {"or": [
+          "canLongChainTemporaryBlue",
+          "canSpringBallBounce",
+          "SpaceJump"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],
@@ -245,6 +449,45 @@
     },
     {
       "link": [2, 1],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 10,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 10,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 1],
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
@@ -304,6 +547,67 @@
         "leaveWithRunway": {
           "length": 1,
           "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 0
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 6,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
         }
       }
     },

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -329,6 +329,101 @@
     },
     {
       "link": [1, 2],
+      "name": "Kill the Enemies, Leave Spinning",
+      "requires": [
+        "canDodgeWhileShooting",
+        "canTrickyJump",
+        "canCameraManip",
+        {"enemyKill": {
+          "enemies": [["Blue Sidehopper", "Blue Sidehopper"]]
+        }}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": "Defining an obstacle for the enemies could help simplify these strats."
+    },
+    {
+      "link": [1, 2],
+      "name": "Kill the Enemies, Leave With Mockball",
+      "requires": [
+        "canDodgeWhileShooting",
+        "canTrickyJump",
+        "canCameraManip",
+        {"enemyKill": {
+          "enemies": [["Blue Sidehopper", "Blue Sidehopper"]]
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Kill the Enemies, Leave With Spring Ball Bounce",
+      "requires": [
+        "canDodgeWhileShooting",
+        "canTrickyJump",
+        "canCameraManip",
+        {"enemyKill": {
+          "enemies": [["Blue Sidehopper", "Blue Sidehopper"]]
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Kill the Enemies, Leave Space Jumping",
+      "requires": [
+        "canDodgeWhileShooting",
+        "canTrickyJump",
+        "canCameraManip",
+        {"enemyKill": {
+          "enemies": [["Blue Sidehopper", "Blue Sidehopper"]]
+        }}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 6,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "For higher speed, use the farther-away runway in the middle of the room.",
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
       "name": "Take the Damage",
       "requires": [
         {"enemyDamage": {

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -90,6 +90,81 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 25,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 25,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 21,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 17,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 27,
+          "openEnd": 0
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"
@@ -176,6 +251,81 @@
         }
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 25,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 25,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 21,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 17,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 27,
+          "openEnd": 0
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     }
   ]
 }

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -231,6 +231,111 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 29,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 28,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 25,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 22,
+            "openEnd": 0
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        {"canShineCharge": {
+          "usedTiles": 30,
+          "openEnd": 1
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "note": "If it not possible to freeze or kill the Metroids, then move quickly enough that they get stuck off-camera to the right, and gain the shinecharge in a position where Samus can angle up and shoot the Rinka while waiting for the shinecharge timer to run out."
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
@@ -412,6 +517,133 @@
         "canBePatient"
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        "canTrickyJump",
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 31,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": [
+        "FIXME: Blue speed can be used to protect against metroid damage, in the canMetroidAvoid case;",
+        "but could there be a scenario where having blue speed is incompatible for what is needed in the next room?",
+        "We made the 'blue' property for this kind of thing; the trouble is that the entrance conditions are written for either blue or not-blue, not either."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave With Mockball (Space Jump)",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 31,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        "canTrickyJump",
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 31,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave With Controlled Spring Ball Bounce",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        "canTrickySpringBallBounce"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 31,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "controlled",
+          "minExtraRunSpeed": "$1.3"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 31,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 3],
@@ -598,6 +830,110 @@
         }
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 21,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 21,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 18,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 15,
+            "openEnd": 0
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        {"canShineCharge": {
+          "usedTiles": 22,
+          "openEnd": 0
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     },
     {
       "link": [2, 2],
@@ -1221,7 +1557,7 @@
     },
     {
       "link": [4, 1],
-      "name": "Inifinite Bomb Jump",
+      "name": "Infinite Bomb Jump",
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"or": [
@@ -1236,5 +1572,8 @@
       "name": "Base",
       "requires": []
     }
+  ],
+  "devNote": [
+    "Doing 'canMetroidAvoid' while using the runway below the left door (e.g. to get a shinecharge) seems pretty tough; maybe it should require something more?"
   ]
 }

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -115,6 +115,72 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Rinka",
       "notable": false,
       "requires": [],
@@ -351,6 +417,27 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "f_KilledMetroidRoom2",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas.",
+      "devNote": "Doing this with Metroids alive is technically possible but seems really bad."
     },
     {
       "link": [2, 1],
@@ -839,6 +926,26 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "f_KilledMetroidRoom2",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas."
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway",
       "requires": [
@@ -880,6 +987,92 @@
         "It may be easiest to stand on a frozen Rinka from the left spawner to position a freeze of the other Rinka.",
         "It is possible maintain a half-tile gap between the Rinka and the runway in order to extend it as far as possible."
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 2,
+            "openEnd": 1
+          }
+        }
+      },
+      "devNote": "There is 1 unusable landing tile here; at low speeds (earlier jump) it could be used but wouldn't serve a purpose."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      }
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -138,6 +138,169 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning (Short Runway)",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning (Long Runway, Space Jump)",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom3"
+        ]},
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 26,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball (Short Runway)",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 2,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball (Long Runway)",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom3"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 29,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "minExtraRunSpeed": "$1.2"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Short Runway)",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Long Runway)",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom3"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 29,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled",
+          "minExtraRunSpeed": "$1.A"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping (Short Runway)",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping (Long Runway)",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom3"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 26,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"getBlueSpeed": {
+          "usedTiles": 29,
+          "openEnd": 2
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Rinka",
       "notable": false,
       "requires": [],
@@ -540,8 +703,133 @@
     },
     {
       "link": [2, 2],
-      "name": "Crystal Flash",
+      "name": "Leave Spinning (Space Jump)",
       "requires": [
+        "canTrickyJump",
+        {"or": [
+          {"and": [
+            "canMetroidAvoid",
+            "canPreciseSpaceJump"
+          ]},
+          "f_KilledMetroidRoom3"
+        ]},
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 29,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom3"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 6,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Controlled Spring Ball Bounce",
+      "requires": [
+        "canTrickyJump",
+        {"or": [
+          {"and": [
+            "canMetroidAvoid",
+            "canTrickySpringBallBounce"
+          ]},
+          "Ice",
+          "f_KilledMetroidRoom3"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 29,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 2
+          },
+          "movementType": "controlled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "f_KilledMetroidRoom3",
+        {"getBlueSpeed": {
+          "usedTiles": 29,
+          "openEnd": 2
+        }},
+        "canChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "canLongChainTemporaryBlue",
+            {"acidFrames": 20},
+            {"enemyDamage": {
+              "enemy": "Rinka",
+              "type": "contact",
+              "hits": 1
+            }}
+          ]},
+          "canSpringBallBounce",
+          "SpaceJump"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "canPreciseSpaceJump",
+        {"or": [
+          {"and": [
+            "canMetroidAvoid",
+            "canInsaneJump"
+          ]},
+          "f_KilledMetroidRoom3"
+        ]},
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 29,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Crystal Flash",
+      "requires": [ 
         {"obstaclesCleared": ["A"]},
         "h_canCrystalFlash"
       ],

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -289,6 +289,11 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom3"
+        ]},
         {"getBlueSpeed": {
           "usedTiles": 29,
           "openEnd": 2
@@ -807,12 +812,9 @@
       "link": [2, 2],
       "name": "Leave Space Jumping",
       "requires": [
-        "canPreciseSpaceJump",
+        "canTrickyJump",
         {"or": [
-          {"and": [
-            "canMetroidAvoid",
-            "canInsaneJump"
-          ]},
+          "canMetroidAvoid",
           "f_KilledMetroidRoom3"
         ]},
         "SpaceJump"

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -322,6 +322,35 @@
       "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage."
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 9,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "f_KilledMetroidRoom4",
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        "canSpringBallBounce"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "any"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas.",
+        "Use spring ball to bounce through the 3-tile-high portion."
+      ],
+      "devNote": [
+        "It might technically be possible to get through the 3-tile-high part without Spring Ball, but this probably isn't really viable?"
+      ]
+    },
+    {
       "link": [2, 1],
       "name": "Already Cleared",
       "requires": [

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -85,6 +85,67 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 2,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 2,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 2,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 2,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"
@@ -369,6 +430,25 @@
     },
     {
       "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        "can4HighMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 1],
       "name": "Come in Shinecharged, Leave With Spark (Platforming)",
       "entranceCondition": {
         "comeInShinecharged": {
@@ -490,6 +570,24 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [3, 1],
@@ -620,6 +718,26 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [3, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 11,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "can4HighMidAirMorph",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas."
     },
     {
       "link": [3, 2],
@@ -1028,6 +1146,25 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 11,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas."
     },
     {
       "link": [3, 3],

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -49,6 +49,7 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3}
       ]
@@ -74,6 +75,41 @@
         }
       },
       "note": "If coming from below, carefully get up on the left side of the room without breaking the runway blocks."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
     },
     {
       "link": [1, 1],
@@ -182,6 +218,41 @@
           "blockPositions": [[2, 29]]
         }
       }
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 3],
@@ -302,6 +373,22 @@
       "note": "Use Wave to clear the seaweed quickly."
     },
     {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
       "link": [2, 2],
       "name": "Leave with Runway, Extended Seaweed Runway",
       "requires": [],
@@ -416,6 +503,94 @@
         "Do one more angle down shot to destroy the last seaweed block at Samus' knees.",
         "Then shinespark through the door."
       ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 3],
+      "name": "Leave Spinning (Space Jump, Door Open)",
+      "requires": [
+        "SpaceJump",
+        {"doorUnlockedAtNode": 3}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 3],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 3],
+      "name": "Leave With Mockball (Door Open)",
+      "requires": [
+        {"doorUnlockedAtNode": 2}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },    
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [3, 1],

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -37,6 +37,14 @@
     }
   ],
   "enemies": [],
+  "reusableRoomwideNotable": [
+    {
+      "name": "Seaweed Room Temporary Blue Chain",
+      "note": [
+        "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
+      ]
+    }
+  ],
   "links": [
     {
       "from": 1,
@@ -83,7 +91,7 @@
       "exitCondition": {
         "leaveWithMockball": {
           "remoteRunway": {
-            "length": 8,
+            "length": 7,
             "openEnd": 1
           },
           "landingRunway": {
@@ -91,7 +99,10 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "devNote": [
+        "There is one unusable remote runway tile here, in order to allow space to reasonably perform the mockball."
+      ]
     },
     {
       "link": [1, 1],
@@ -100,7 +111,7 @@
       "exitCondition": {
         "leaveWithSpringBallBounce": {
           "remoteRunway": {
-            "length": 8,
+            "length": 7,
             "openEnd": 1
           },
           "landingRunway": {
@@ -109,7 +120,10 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "devNote": [
+        "There is one unusable remote runway tile here, in order to allow space to reasonably perform the bounce."
+      ]
     },
     {
       "link": [1, 1],
@@ -222,6 +236,8 @@
     {
       "link": [1, 2],
       "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "notable": true,
+      "reusableRoomwideNotable": "Seaweed Room Temporary Blue Chain",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -234,11 +250,14 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
     },
     {
       "link": [1, 3],
       "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "notable": true,
+      "reusableRoomwideNotable": "Seaweed Room Temporary Blue Chain",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -252,7 +271,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
     },
     {
       "link": [1, 3],
@@ -375,6 +395,8 @@
     {
       "link": [2, 1],
       "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "notable": true,
+      "reusableRoomwideNotable": "Seaweed Room Temporary Blue Chain",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 1,
@@ -386,7 +408,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "note": "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -125,6 +125,21 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 21,
+          "openEnd": 0
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "left"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
       "name": "Leave Normally",
       "exitCondition": {
         "leaveNormally": {}

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -246,6 +246,58 @@
     },
     {
       "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 3,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "minExtraRunSpeed": "$0.E"
+        }
+      },
+      "note": "Use the floating platform near the bottom-left of the room."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 3,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "note": "Use the floating platform near the bottom-left of the room."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Use the floating platform near the bottom-left of the room."
+    },
+    {
+      "link": [2, 2],
       "name": "G-Mode Regain Mobility",
       "requires": [
         {"enemyDamage": {

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -42,6 +42,13 @@
       "doorEnvironments": [{"physics": "air"}]
     }
   ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Top Space Pirates",
+      "obstacleType": "enemies"
+    }
+  ],
   "enemies": [
     {
       "id": "e1",
@@ -58,6 +65,7 @@
       "homeNodes": [2]
     }
   ],
+
   "links": [
     {
       "from": 1,
@@ -102,11 +110,98 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 43,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Use the lower runway."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 43,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 2,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Use the lower runway."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 43,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "note": "Use the upper runway."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 43,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Use the upper runway."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
         "h_canCrystalFlash"
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Pirates Already Dead",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        {"or": [
+          "HiJump",
+          "canWalljump",
+          "h_canFly"
+        ]}
+      ]
     },
     {
       "link": [1, 2],
@@ -170,6 +265,7 @@
           ]}
         ]}
       ],
+      "clearsObstacles": ["A"],
       "note": [
         "Run from or Roll under the pirate lazers.",
         "The Pirates will also not shoot if they come on screen while Samus is crouched."
@@ -208,6 +304,7 @@
           }}
         ]}
       ],
+      "clearsObstacles": ["A"],      
       "note": "Kill the Pirates fast enough that they won't attack, or shoot them from below with Wave."
     },
     {
@@ -216,25 +313,11 @@
       "requires": [
         "h_getBlueSpeedMaxRunway"
       ],
+      "clearsObstacles": ["A"],
       "note": [
         "Run into the pirates with speedbooster to save health over shinesparking.",
         "A speedy jump can reach the top platform."
       ]
-    },
-    {
-      "link": [1, 2],
-      "name": "Leave Shinecharged",
-      "requires": [
-        "h_canShineChargeMaxRunway"
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 120
-        }
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true,
-      "note": "Coming from the left only requires SpeedBooster to kill all the Pirates."
     },
     {
       "link": [1, 2],
@@ -252,6 +335,7 @@
         ]},
         {"ammo": {"type": "PowerBomb", "count": 5}}
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": "IBJ or spring ball bomb jump to avoid the wall jump. The first pirate takes 2 PBs, the next 3 can be killed with 3 total PBs if they are placed under the middle pirate."
     },
@@ -321,6 +405,13 @@
     },
     {
       "link": [2, 1],
+      "name": "Pirates Already Dead",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ]
+    },
+    {
+      "link": [2, 1],
       "name": "Pass Through Pirates",
       "requires": [
         {"or": [
@@ -336,74 +427,6 @@
         ]}
       ],
       "note": "Walk through the pirates either by taking damage or by using Plasma Beam."
-    },
-    {
-      "link": [2, 1],
-      "name": "Fight Pirates Slowly",
-      "requires": [
-        {"or": [
-          {"and": [
-            "canDodgeWhileShooting",
-            "canCameraManip",
-            {"or": [
-              "Plasma",
-              {"and": [
-                "h_hasBeamUpgrade",
-                "canBePatient"
-              ]},
-              "canBeVeryPatient"
-            ]}
-          ]},
-          {"and": [
-            {"or": [
-              "canBePatient",
-              {"enemyDamage": {
-                "enemy": "Tourian Space Pirate (all)",
-                "type": "contact",
-                "hits": 1
-              }}
-            ]},
-            {"or": [
-              "Morph",
-              "canTurnaroundAimCancel",
-              "canXRayTurnaround"
-            ]}
-          ]}
-        ]}
-      ],
-      "note": [
-        "Run from or Roll under the pirate lazers.",
-        "The Pirates will also not shoot if they come on screen while Samus is crouched."
-      ]
-    },
-    {
-      "link": [2, 1],
-      "name": "Kill Pirates Fast",
-      "requires": [
-        {"or": [
-          "Wave",
-          "ScrewAttack",
-          {"and": [
-            "Plasma",
-            "canXRayWaitForIFrames"
-          ]},
-          {"enemyKill": {
-            "enemies": [
-              [
-                "Tourian Space Pirate (all)",
-                "Tourian Space Pirate (all)"
-              ],
-              [
-                "Tourian Space Pirate (all)",
-                "Tourian Space Pirate (all)"
-              ],
-              ["Tourian Space Pirate (all)"]
-            ],
-            "explicitWeapons": ["Missile", "Super", "Ice+Plasma"]
-          }}
-        ]}
-      ],
-      "note": "Kill the Pirates fast enough that they won't attack, or shoot them from above with Wave."
     },
     {
       "link": [2, 1],
@@ -505,30 +528,80 @@
     },
     {
       "link": [2, 2],
-      "name": "Leave Shinecharged",
+      "name": "Fight Pirates Slowly",
       "requires": [
-        "h_canShineChargeMaxRunway",
         {"or": [
-          {"enemyDamage": {
-            "enemy": "Tourian Space Pirate (all)",
-            "type": "contact",
-            "hits": 1
-          }},
-          {"and": [
-            "Plasma",
-            "canHitbox"
-          ]},
-          "Morph",
-          "ScrewAttack",
           {"and": [
             "canDodgeWhileShooting",
             "canCameraManip",
             {"or": [
-              "h_hasBeamUpgrade",
-              "canBePatient"
+              "Plasma",
+              {"and": [
+                "h_hasBeamUpgrade",
+                "canBePatient"
+              ]},
+              "canBeVeryPatient"
+            ]}
+          ]},
+          {"and": [
+            {"or": [
+              "canBePatient",
+              {"enemyDamage": {
+                "enemy": "Tourian Space Pirate (all)",
+                "type": "contact",
+                "hits": 1
+              }}
+            ]},
+            {"or": [
+              "Morph",
+              "canTurnaroundAimCancel",
+              "canXRayTurnaround"
             ]}
           ]}
         ]}
+      ],
+      "clearsObstacles": ["A"],      
+      "note": [
+        "Run from or Roll under the pirate lazers.",
+        "The Pirates will also not shoot if they come on screen while Samus is crouched."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Kill Pirates Fast",
+      "requires": [
+        {"or": [
+          "Wave",
+          "ScrewAttack",
+          {"and": [
+            "Plasma",
+            "canXRayWaitForIFrames"
+          ]},
+          {"enemyKill": {
+            "enemies": [
+              [
+                "Tourian Space Pirate (all)",
+                "Tourian Space Pirate (all)"
+              ],
+              [
+                "Tourian Space Pirate (all)",
+                "Tourian Space Pirate (all)"
+              ],
+              ["Tourian Space Pirate (all)"]
+            ],
+            "explicitWeapons": ["Missile", "Super", "Ice+Plasma"]
+          }}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "note": "Kill the Pirates fast enough that they won't attack, or shoot them from above with Wave."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Shinecharged",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "h_canShineChargeMaxRunway"
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -536,6 +609,76 @@
         }
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 23,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 19,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 37,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "h_canShineChargeMaxRunway",
+        "can4HighMidAirMorph",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "note": [
+        "Gain temporary blue with a shinecharge; then do a tight lateral mid-air morph to jump past the speed blocks.",
+        "Alernatively, start the temporary blue chain by doing a running jump over them rather than doing a shinecharge."
+      ]
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -45,7 +45,7 @@
   "obstacles": [
     {
       "id": "A",
-      "name": "Top Space Pirates",
+      "name": "Space Pirates",
       "obstacleType": "enemies"
     }
   ],
@@ -564,6 +564,10 @@
       "note": [
         "Run from or Roll under the pirate lazers.",
         "The Pirates will also not shoot if they come on screen while Samus is crouched."
+      ],
+      "devNote": [
+        "Technically it's not possible to kill the bottom Pirates while staying at node 2 (not dropping down);",
+        "but if we're not going down, then it doesn't matter that the bottom ones aren't killed."
       ]
     },
     {
@@ -594,7 +598,12 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "note": "Kill the Pirates fast enough that they won't attack, or shoot them from above with Wave."
+      "note": "Kill the Pirates fast enough that they won't attack, or shoot them from above with Wave.",
+      "devNote": [
+        "Technically it's not possible to kill the bottom Pirates while staying at node 2 (not dropping down);",
+        "but if we're not going down, then it doesn't matter that the bottom ones aren't killed.",
+        "FIXME: The enemyKill requirements could be reduced if it is only needed to kill the top ones, which could be modeled as a separate obstacle."
+      ]
     },
     {
       "link": [2, 2],

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -47,6 +47,13 @@
       "nodeType": "junction",
       "nodeSubType": "junction",
       "note": "This node represents being at the bottom of the shaft with the acid just starting to rise."
+    },
+    {
+      "id": 4,
+      "name": "Top of Shaft Without Acid Triggered",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "note": "This node represents being at the top of the shaft without the acid having been triggered to rise."
     }
   ],
   "obstacles": [
@@ -80,7 +87,8 @@
         {
           "id": 3,
           "note": "The acid starts rising when Samus is at the bottom of the long fall"
-        }
+        },
+        {"id": 4}
       ]
     },
     {
@@ -88,7 +96,8 @@
       "to": [
         {"id": 1},
         {"id": 2},
-        {"id": 3}
+        {"id": 3},
+        {"id": 4}
       ]
     },
     {
@@ -99,6 +108,13 @@
           "id": 2,
           "note": "The acid starts rising when Samus is at the bottom of the long fall"
         },
+        {"id": 3}
+      ]
+    },
+    {
+      "from": 4,
+      "to": [
+        {"id": 1},
         {"id": 3}
       ]
     }
@@ -112,6 +128,53 @@
         "leaveWithRunway": {
           "length": 1,
           "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
         }
       }
     },
@@ -137,7 +200,7 @@
       "flashSuitChecked": true
     },
     {
-      "link": [1, 3],
+      "link": [1, 4],
       "name": "Base",
       "requires": [
         {"or": [
@@ -151,7 +214,7 @@
       "note": "The pirates are free to kill, although they take some time."
     },
     {
-      "link": [1, 3],
+      "link": [1, 4],
       "name": "Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
@@ -167,7 +230,7 @@
       "flashSuitChecked": true
     },
     {
-      "link": [1, 3],
+      "link": [1, 4],
       "name": "G-Mode Morph Power Bomb Pirate Kill",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -186,36 +249,11 @@
       ]
     },
     {
-      "link": [1, 3],
+      "link": [1, 4],
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
-        }
-      },
-      "requires": []
-    },
-    {
-      "link": [2, 1],
-      "name": "Crystal Flash Grapple Clip",
-      "requires": [
-        "h_canJumpIntoCrystalFlashClip",
-        "HiJump",
-        "Grapple"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Clear the Pirates near the door.",
-        "Jump into a Crystal Flash clip where the ceiling is a single tile thick.",
-        "Switch to Grappling Beam before the Crystal Flash ends and mash shoot while holding down."
-      ]
-    },
-    {
-      "link": [2, 1],
-      "name": "Grapple Teleport",
-      "entranceCondition": {
-        "comeInWithGrappleTeleport": {
-          "blockPositions": [[5, 3], [7, 2]]
         }
       },
       "requires": []
@@ -394,6 +432,31 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Crystal Flash Grapple Clip",
+      "requires": [
+        "h_canJumpIntoCrystalFlashClip",
+        "HiJump",
+        "Grapple"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Clear the Pirates near the door.",
+        "Jump into a Crystal Flash clip where the ceiling is a single tile thick.",
+        "Switch to Grappling Beam before the Crystal Flash ends and mash shoot while holding down."
+      ]
+    },
+    {
+      "link": [2, 4],
+      "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3], [7, 2]]
+        }
+      },
+      "requires": []
+    },
+    {
       "link": [3, 1],
       "name": "Protected Shaft Climb With Screw Attack",
       "requires": [
@@ -532,6 +595,22 @@
       "note": "Clear the right side Space Pirates and then race the rising acid by bomb jumping."
     },
     {
+      "link": [3, 1],
+      "name": "Leave With Temporary Blue (Race the Acid)",
+      "requires": [
+        "canFastWalljumpClimb",
+        {"canShineCharge": {
+          "usedTiles": 21,
+          "openEnd": 1
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [3, 2],
       "name": "Base",
       "requires": [
@@ -563,6 +642,26 @@
       ],
       "flashSuitChecked": true,
       "devNote": "The Crystal Flash should be performed on a platform away from the acid trigger or any Pirates."
+    },
+    {
+      "link": [4, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 21,
+          "openEnd": 1
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [4, 3],
+      "name": "Base",
+      "requires": []
     }
   ]
 }

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -127,6 +127,95 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 0
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce (Space Jump)",
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Controlled Spring Ball Bounce",
+      "requires": [
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "movementType": "controlled"
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 0
+          }
+        }
+      }
     }
   ]
 }

--- a/region/tourian/main/Tourian First Room.json
+++ b/region/tourian/main/Tourian First Room.json
@@ -245,6 +245,24 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "can4HighMidAirMorph",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [3, 1],
       "name": "Base",
       "requires": []
@@ -378,6 +396,24 @@
       "flashSuitChecked": true
     },
     {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "can4HighMidAirMorph",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "link": [3, 3],
       "name": "Leave with Runway",
       "requires": [],
@@ -388,6 +424,69 @@
         }
       },
       "devNote": "FIXME: Is it possible to leave charged through the elevator."
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave Space Jumping",
+      "requires": [],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Some changes worth nothing:

- In Tourian Escape Room 3: Added an obstacle representing the Space Pirates being cleared, in order to be able to use the runway near the top-right door. This avoids duplicating a bunch of requirements.
- In Tourian Escape Room 4: Added a node for being at the top of the room without the acid being triggered. This again is to avoid duplicating a bunch of strats. The runway up there is used to get temporary blue to carry out the left door.