### PR TITLE
More Pink Maridia remote runways

### DIFF
--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -33,6 +33,13 @@
       "doorOrientation": "up"
     }
   ],
+  "obstacles": [
+    {
+      "id": "A",
+      "name": "Owtch",
+      "obstacleType": "enemies"
+    }
+  ],
   "enemies": [
     {
       "id": "e1",
@@ -157,20 +164,35 @@
     },
     {
       "link": [1, 1],
-      "name": "Leave Charged",
+      "name": "Kill the Owtch",
       "requires": [
-        "Gravity",
-        "canShinechargeMovement",
         {"or": [
-          "canShinechargeMovement",
+          "h_canUsePowerBombs",
           "Plasma",
           "Charge",
-          {"resourceCapacity": [{"type": "Super", "count": 1}]},
+          {"ammo": {"type": "Super", "count": 1}},
           {"and": [
-            "Morph",
-            {"resourceCapacity": [{"type": "PowerBomb", "count": 1}]}
+            "Gravity",
+            {"getBlueSpeed": {
+              "usedTiles": 16,
+              "openEnd": 1,
+              "gentleDownTiles": 2,
+              "gentleUpTiles": 2,
+              "steepUpTiles": 1
+            }}  
           ]}
-        ]},
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "note": "The Owtch can be killed with a Power Bomb or blue speed, or while it is moving leftward with a Super, Charge, or Plasma."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Shinecharged",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity",
+        "canShinechargeMovement",
         {"canShineCharge": {
           "usedTiles": 23,
           "openEnd": 1,
@@ -184,8 +206,110 @@
           "framesRemaining": 120
         }
       },
-      "flashSuitChecked": true,
-      "note": "Dodge or kill the Owtch. The Owtch can be killed with a Power Bomb or while it is moving leftward with a Super, Charge, or Plasma."
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity"        
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 22,
+            "openEnd": 1,
+            "gentleDownTiles": 2,
+            "gentleUpTiles": 2,
+            "steepUpTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity"        
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 21,
+            "openEnd": 1,
+            "gentleDownTiles": 2,
+            "gentleUpTiles": 2,
+            "steepUpTiles": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity"        
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 18,
+            "openEnd": 1,
+            "gentleDownTiles": 2,
+            "gentleUpTiles": 2,
+            "steepUpTiles": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity"        
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 20,
+            "openEnd": 1,
+            "gentleDownTiles": 2,
+            "gentleUpTiles": 2,
+            "steepUpTiles": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity",
+        {"canShineCharge": {
+          "usedTiles": 23,
+          "openEnd": 1,
+          "gentleDownTiles": 2,
+          "gentleUpTiles": 2,
+          "steepUpTiles": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     },
     {
       "link": [1, 1],

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1732,6 +1732,22 @@
     },
     {
       "link": [4, 6],
+      "name": "Cross Room Space Jump Airball",
+      "entranceCondition": {
+        "comeInSpaceJumping": {
+          "minTiles": 22,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canMomentumConservingMorph"
+      ],
+      "devNote": [
+        "With high enough speed this could be done without morphing, but it would be more difficult, and Morph is needed to get through the maze anyway."
+      ]
+    },
+    {
+      "link": [4, 6],
       "name": "Bomb Grapple Jump",
       "requires": [
         "canSuitlessMaridia",

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -745,6 +745,7 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Bounce through the Speed blocks.",
         "Then unmorph and chain temporary blue into the next room."
@@ -1281,6 +1282,7 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Bounce through the Speed blocks.",
         "Then unmorph and chain temporary blue into the next room."

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -219,6 +219,182 @@
     },
     {
       "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 35,
+            "openEnd": 1
+          },
+          "minExtraRunSpeed": "$1.2"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning (Across Room)",
+      "requires": [
+        "Gravity",
+        {"getBlueSpeed": {
+          "usedTiles": 22,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "blue": "yes"
+        }
+      },
+      "note": "Use Speed Booster to break the Speed blocks, and run from the right side of the room, using blue speed to run on top of the sand."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 34,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball (Across Room)",
+      "requires": [
+        "Gravity",
+        {"getBlueSpeed": {
+          "usedTiles": 22,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Use Speed Booster to break the Speed blocks, and run from the right side of the room, using blue speed to run on top of the sand."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 27,
+            "openEnd": 0
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce (Across Room)",
+      "requires": [
+        "Gravity",
+        {"getBlueSpeed": {
+          "usedTiles": 22,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "note": "Use Speed Booster to break the Speed blocks, and run from the right side of the room, using blue speed to run on top of the sand."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 35,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping (Across Room)",
+      "requires": [
+        "Gravity",
+        {"getBlueSpeed": {
+          "usedTiles": 22,
+          "openEnd": 1
+        }}        
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          }
+        }
+      },
+      "note": "Use Speed Booster to break the Speed blocks, and run from the right side of the room, using blue speed to run on top of the sand."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "Gravity",
+        {"canShineCharge": {
+          "usedTiles": 35,
+          "gentleUpTiles": 2,
+          "openEnd": 1
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
+    },
+    {
+      "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Puyo",
       "notable": false,
       "requires": [],
@@ -462,7 +638,7 @@
     },
     {
       "link": [1, 4],
-      "name": "Speedball",
+      "name": "Speedball (Come in Getting Blue Speed)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 0,
@@ -476,6 +652,102 @@
       ],
       "note": [
         "Enter the room with blue speed, and jump into a speedball."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Speedball (Come in Blue Spinning)",
+      "entranceCondition": {
+        "comeInBlueSpinning": {
+          "unusableTiles": 0
+        }
+      },
+      "requires": [
+        "canSpeedball"
+      ],
+      "note": [
+        "Enter the room in a spin jump with blue speed, and enter a speedball."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Speedball, Leave With Temporary Blue (Come in Getting Blue Speed)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canWaterShineCharge",
+        "canSpeedball",
+        "canTrickyJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Enter the room with blue speed, and jump into a speedball.",
+        "Then chain temporary blue into the next room."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Speedball, Leave With Temporary Blue (Come in Blue Spinning)",
+      "entranceCondition": {
+        "comeInBlueSpinning": {
+          "unusableTiles": 0
+        }
+      },
+      "requires": [
+        "canSpeedball",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Enter the room in a spin jump with blue speed, and enter a speedball.",
+        "Then chain temporary blue into the next room."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Blue Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [],
+      "note": [
+        "Bounce through the Speed blocks."
+      ],
+      "devNote": [
+        "With a mid-air spring ball jump it would be possible to go through the morph tunnel.",
+        "This strat exists mainly as a way to avoid collecting the item."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Blue Spring Ball Bounce, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "note": [
+        "Bounce through the Speed blocks.",
+        "Then unmorph and chain temporary blue into the next room."
       ]
     },
     {
@@ -549,7 +821,8 @@
             "canBombHorizontally"
           ]}
         ]}
-      ]
+      ],
+      "collectsItems": [5]
     },
     {
       "link": [1, 5],
@@ -567,7 +840,8 @@
             "canMidAirMorph"
           ]}
         ]}
-      ]
+      ],
+      "collectsItems": [5]
     },
     {
       "link": [1, 5],
@@ -576,7 +850,8 @@
         "canSuitlessMaridia",
         "Morph",
         "canTrickyUseFrozenEnemies"
-      ]
+      ],
+      "collectsItems": [5]
     },
     {
       "link": [1, 5],
@@ -593,6 +868,7 @@
         "canMidairShinespark",
         {"shinespark": {"frames": 55}}
       ],
+      "collectsItems": [5],
       "flashSuitChecked": true
     },
     {
@@ -610,6 +886,7 @@
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
+      "collectsItems": [5],
       "note": [
         "Needs near max horizontal speed coming from about 40 runway tiles in the adjacent room.",
         "Jump after the transition.",
@@ -644,6 +921,7 @@
           ]}
         ]}
       ],
+      "collectsItems": [5],
       "note": [
         "Needs a runway of 7 tiles with no open end in the adjacent room, to get enough height. This is a peak of height with speed booster, no hjb, while underwater.",
         "Jump before the transition with SpeedBooster off and then SpeedBooster back on after reaching the ceiling and Morphing."
@@ -913,6 +1191,100 @@
         "canStutterWaterShineCharge"
       ],
       "clearsObstacles": ["A"]
+    },
+    {
+      "link": [4, 1],
+      "name": "Suitless Stutter Water Shinecharge, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "canStutterWaterShineCharge"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [4, 1],
+      "name": "Speedball",
+      "entranceCondition": {
+        "comeInSpeedballing": {
+          "runway": {
+            "length": 6,
+            "openEnd": 1
+          }
+        }
+      },
+      "requires": [
+        "canSpeedball"
+      ],
+      "note": [
+        "This is just a rough estimate of the minimum number of tiles that this runway can represent."
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Speedball, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInSpeedballing": {
+          "runway": {
+            "length": 6,
+            "openEnd": 1
+          }
+        }
+      },
+      "requires": [
+        "canSpeedball",
+        "canChainTemporaryBlue"
+      ],
+      "note": [
+        "This is just a rough estimate of the minimum number of tiles that this runway can represent."
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [4, 1],
+      "name": "Blue Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [],
+      "note": [
+        "Bounce through the Speed blocks."
+      ],
+      "devNote": [
+        "With a mid-air spring ball jump it would be possible to go through the morph tunnel.",
+        "This strat exists mainly as a way to avoid collecting the item."
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Blue Spring Ball Bounce, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "note": [
+        "Bounce through the Speed blocks.",
+        "Then unmorph and chain temporary blue into the next room."
+      ]
     },
     {
       "link": [4, 1],
@@ -1336,20 +1708,24 @@
     },
     {
       "link": [4, 6],
-      "name": "Cross Room Jump with Speedbooster",
+      "name": "Speedy Jump",
       "entranceCondition": {
-        "comeInJumping": {
+        "comeInRunning": {
           "speedBooster": true,
           "minTiles": 6.4375
         }
       },
       "requires": [
-        "canDisableEquipment",
         "canCrossRoomJumpIntoWater"
       ],
       "note": [
-        "Requires running 7 tiles with no open end in the adjacent room, as this is a peak in jump speed.",
-        "Run with Speedbooster off, and turn it on after entering the room."
+        "If using at least 8 tiles of runway, jump before going down the first slope.",
+        "If using 7 tiles of runway, Samus will get a higher jump; in this case, jump later, after going down the first slope"
+      ],
+      "devNote": [
+        "We don't require 'canTrickyDashJump' here, since any speed of at least $2.0 works;",
+        "a different jump timing is needed for run speed between $2.0 and $2.3 compared to higher speeds,",
+        "but there is a very large window in both cases, making it not difficult for the player to find a timing that works."
       ]
     },
     {
@@ -1463,7 +1839,8 @@
             "h_additionalBomb"
           ]}
         ]}
-      ]
+      ],
+      "collectsItems": [5]
     },
     {
       "link": [6, 5],
@@ -1473,6 +1850,7 @@
         "canMidAirMorph",
         "canDisableEquipment"
       ],
+      "collectsItems": [5],
       "note": "Jump and mid-air morph. This is much easier with Gravity and HiJump turned off."
     },
     {

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -233,12 +233,16 @@
             "canSpringBallBounce",
             {"or": [
               {"ammo": {"type": "PowerBomb", "count": 2}},
-              "canLongChainTemporaryBlue"
+              {"and": [
+                "canLongChainTemporaryBlue",
+                "can4HighMidAirMorph"
+              ]}
             ]}
           ]},
           {"and": [
             "canLongChainTemporaryBlue",
             "canStationaryLateralMidAirMorph",
+            "can4HighMidAirMorph",
             "canBeVeryPatient"
           ]}
         ]}

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -229,6 +229,11 @@
       "requires": [
         "canChainTemporaryBlue",
         {"or": [
+          "HiJump",
+          "canTrickySpringBallJump",
+          "canInsaneJump"
+        ]},
+        {"or": [
           {"and": [
             "canSpringBallBounce",
             {"or": [
@@ -266,16 +271,25 @@
         "canChainTemporaryBlue",
         "canXRayTurnaround",
         {"or": [
+          "HiJump",
+          "canTrickySpringBallJump",
+          "canInsaneJump"
+        ]},
+        {"or": [
           {"and": [
             "canSpringBallBounce",
             {"or": [
               {"ammo": {"type": "PowerBomb", "count": 2}},
-              "canLongChainTemporaryBlue"
+              {"and": [
+                "canLongChainTemporaryBlue",
+                "can4HighMidAirMorph"
+              ]}
             ]}
           ]},
           {"and": [
             "canLongChainTemporaryBlue",
             "canStationaryLateralMidAirMorph",
+            "can4HighMidAirMorph",
             "canBeVeryPatient"
           ]}
         ]}
@@ -470,11 +484,15 @@
             "canSpringBallBounce",
             {"or": [
               {"ammo": {"type": "PowerBomb", "count": 2}},
-              "canLongChainTemporaryBlue"
+              {"and": [
+                "canLongChainTemporaryBlue",
+                "can4HighMidAirMorph"
+              ]}
             ]}
           ]},
           {"and": [
             "canLongChainTemporaryBlue",
+            "can4HighMidAirMorph",
             "canBeVeryPatient"
           ]}
         ]}
@@ -500,7 +518,8 @@
         "canLongChainTemporaryBlue",
         "canStationaryLateralMidAirMorph",
         "canSpringBallBounce",
-        "canSpringBallJumpMidAir"
+        "canSpringBallJumpMidAir",
+        "can4HighMidAirMorph"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -219,6 +219,71 @@
     },
     {
       "link": [1, 2],
+      "name": "Temporary Blue Chain",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {
+          "direction": "right"
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "canSpringBallBounce",
+            {"or": [
+              {"ammo": {"type": "PowerBomb", "count": 2}},
+              "canLongChainTemporaryBlue"
+            ]}
+          ]},
+          {"and": [
+            "canLongChainTemporaryBlue",
+            "canStationaryLateralMidAirMorph",
+            "canBeVeryPatient"
+          ]}
+        ]}
+      ],
+      "note": [
+        "Chain temporary blue across the room in order to break the Speed blocks.",
+        "If available, bouncing using Spring Ball can help speed this up significantly.",
+        "If two Power Bombs are also available, they can be used to break the shot blocks along the way without needing to stop bouncing."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Temporary Blue Chain (X-Ray Turnaround)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {
+          "direction": "left"
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canXRayTurnaround",
+        {"or": [
+          {"and": [
+            "canSpringBallBounce",
+            {"or": [
+              {"ammo": {"type": "PowerBomb", "count": 2}},
+              "canLongChainTemporaryBlue"
+            ]}
+          ]},
+          {"and": [
+            "canLongChainTemporaryBlue",
+            "canStationaryLateralMidAirMorph",
+            "canBeVeryPatient"
+          ]}
+        ]}
+      ],
+      "note": [
+        "Chain temporary blue across the room in order to break the Speed blocks.",
+        "If available, bouncing using Spring Ball can help speed this up significantly.",
+        "If two Power Bombs are also available, they can be used to break the shot blocks along the way without needing to stop bouncing."
+      ]
+    },
+    {
+      "link": [1, 2],
       "name": "CF Clip with Bombs (Left to Right)",
       "requires": [
         "h_canBombIntoCrystalFlashClip",
@@ -389,6 +454,69 @@
     },
     {
       "link": [2, 1],
+      "name": "Temporary Blue Chain",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canStationaryLateralMidAirMorph",
+        {"or": [
+          {"and": [
+            "canSpringBallBounce",
+            {"or": [
+              {"ammo": {"type": "PowerBomb", "count": 2}},
+              "canLongChainTemporaryBlue"
+            ]}
+          ]},
+          {"and": [
+            "canLongChainTemporaryBlue",
+            "canBeVeryPatient"
+          ]}
+        ]}
+      ],
+      "note": [
+        "Chain temporary blue across the room in order to break the Speed blocks.",
+        "If available, bouncing using Spring Ball can help speed this up significantly.",
+        "If two Power Bombs are also available, they can be used to break the shot blocks along the way without needing to stop bouncing;",
+        "the first Power Bomb must be placed at a specific time, about 1 tile to the left of the first set of Speed blocks;",
+        "the second Power Bomb should be placed as early as possible after coming off cooldown."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Temporary Blue Chain, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canStationaryLateralMidAirMorph",
+        "canSpringBallBounce",
+        "canSpringBallJumpMidAir"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "left"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Chain temporary blue across the room in order to break the Speed blocks, using Spring Ball to speed up the process.",
+        "If two Power Bombs are also available, they can be used to break the shot blocks along the way without needing to stop bouncing;",
+        "the first Power Bomb must be placed at a specific time, about 1 tile to the left of the first set of Speed blocks;",
+        "the second Power Bomb should be placed as early as possible after coming off cooldown."
+      ],
+      "devNote": [
+        "The slower version of this strat (with HiJump instead of Spring Ball) is not included;",
+        "it could require too much patience, considering that the chain continues into the next room."
+      ]
+    },
+    {
+      "link": [2, 1],
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
@@ -425,7 +553,7 @@
     },
     {
       "link": [2, 2],
-      "name": "Leave Charged",
+      "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
         "Gravity",
@@ -437,6 +565,109 @@
         }
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning (Short Runway Across Gap, Space Jump)",
+      "requires": [
+        "Gravity",
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 6,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning (Long Runway Below, Space Jump)",
+      "requires": [
+        "Gravity",
+        "SpaceJump",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 42,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball (Short Runway Across Gap)",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 6,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball (Long Runway Below)",
+      "requires": [
+        "Gravity",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 42,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping (Short Runway Across Gap)",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 6,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping (Long Runway Below)",
+      "requires": [
+        "Gravity",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 42,
+            "openEnd": 1
+          }
+        }
+      }
     },
     {
       "link": [2, 2],

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -322,22 +322,106 @@
     },
     {
       "link": [1, 1],
-      "name": "Leave Charged",
+      "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
         "Gravity",
         "f_DefeatedBotwoon",
         {"canShineCharge": {
-          "usedTiles": 16,
-          "openEnd": 0
+          "usedTiles": 15,
+          "openEnd": 1
         }}
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 125
+          "framesRemaining": 145
         }
       },
-      "devNote": "FIXME: Removing Gravity for a water stutter shinecharge may be helpful here."
+      "note": "Achieve a shinecharge before running into the wall, to be able to make it to the door faster."
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 12,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Mockball",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 12,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 11,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 12,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "Gravity",
+        "canChainTemporaryBlue",
+        {"canShineCharge": {
+          "usedTiles": 15,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     },
     {
       "link": [1, 1],
@@ -351,6 +435,24 @@
       "link": [1, 3],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],
@@ -402,7 +504,7 @@
     },
     {
       "link": [2, 2],
-      "name": "Leave Charged",
+      "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
         "Gravity",
@@ -414,10 +516,89 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 55
+          "framesRemaining": 70
         }
-      },
-      "devNote": "FIXME: Removing Gravity for a water stutter shinecharge may be helpful here."
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "Gravity",
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Mockball",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 14,
+            "openEnd": 2
+          }
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "Gravity",
+        "canChainTemporaryBlue",
+        {"canShineCharge": {
+          "usedTiles": 15,
+          "openEnd": 1
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     },
     {
       "link": [2, 2],


### PR DESCRIPTION
A few noteworthy changes:
- Added `collectsItems` to strats in Botwoon Energy Tank Room, as collecting the item is unavoidable when passing through the Morph maze (except while in G-mode if PLMs are already overloaded, though this doesn't really matter since taking the bottom path through the speed blocks would also be an option in that case).
- Clarified details about the "Speedy Jump" strat to get on top of the ledge on the right side of Botwoon Energy Tank Room using run speed from the previous room. Disabling Speed Booster as a way to get a normalized extra run speed of $2.0 seems unnecessary as a logical requirement, since higher speeds also work fine.
- Added an obstacle in Below Botwoon Energy Tank Room for the Owtch being killed. This reduces duplication since many strats need the runway clear.
- Tightened the shinecharge frames remaining in Botwoon's Room.
