### PR TITLE
Colosseum remote runways

### DIFF
--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -655,19 +655,19 @@
         "comeInGettingBlueSpeed": {
           "length": 1,
           "openEnd": 1,
-          "maxExtraRunSpeed": "$2.3"
+          "maxExtraRunSpeed": "$1.9"
         }
       },
       "requires": [
         "HiJump",
-        "canInsaneJump",
         "canPreciseSpaceJump",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": "This can be done at greater speed (at least up to $2.3) but would be more difficult."
     },
     {
       "link": [2, 1],

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1148,7 +1148,7 @@
     },
     {
       "link": [2, 3],
-      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity Jump, Spring Ball Jump, Pause Buffer)",
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity Jump, Spring Ball Jump, Pause Remorph)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -1160,7 +1160,8 @@
         "canGravityJump",
         "canSpringBallJumpMidAir",
         "canInsaneJump",
-        "canChainTemporaryBlue"
+        "canChainTemporaryBlue",
+        "canPauseRemorphTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -76,6 +76,14 @@
         "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
         "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
       ]
+    },
+    {
+      "name": "Colosseum Bomb Jump Water Escape",
+      "note": [
+        "With HiJump, perform a mid-air spring ball jump into an IBJ to escape the water.",
+        "This can be done at the left, the center, and right side of the room.",
+        "Use a spring fling to delay Samus' initial descent in order to get the IBJ started."
+      ]
     }
   ],
   "links": [
@@ -310,6 +318,25 @@
         }}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Blue Space Jump, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 2,
+          "openEnd": 1,
+          "maxExtraRunSpeed": "$2.4"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [1, 3],
@@ -562,6 +589,24 @@
     },
     {
       "link": [1, 3],
+      "name": "Blue Space Jump, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 2,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 3],
       "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
@@ -602,6 +647,27 @@
           "blockPositions": [[108, 13]]
         }
       }
+    },
+    {
+      "link": [2, 1],
+      "name": "Blue Space Jump, Leave With Temporary Blue (Womple Jump)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 1,
+          "openEnd": 1,
+          "maxExtraRunSpeed": "$2.3"
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canInsaneJump",
+        "canPreciseSpaceJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],
@@ -869,6 +935,25 @@
     },
     {
       "link": [2, 3],
+      "name": "Colosseum Bomb Jump Water Escape",
+      "notable": true,
+      "reusableRoomwideNotable": "Colosseum Bomb Jump Water Escape",
+      "requires": [
+        "HiJump",
+        "h_canMaxHeightSpringBallJump",
+        "canSpringFling",
+        "canBombJumpWaterEscape",
+        "canJumpIntoIBJ"
+      ],
+      "note": [
+        "Perform the spring ball jump near max height.",
+        "Place the first bomb between a few frames after the spring ball jump; ideally it should be just above the water line.",
+        "Press pause a few frames after placing the bomb, to disable Spring Ball (a 'spring fling', to reset fall speed).",
+        "Place the second bomb soon after regaining control, while the game is fading back in, then continue into an IBJ."
+      ]
+    },
+    {
+      "link": [2, 3],
       "name": "Cross Room Jump with IBJ",
       "entranceCondition": {
         "comeInJumping": {
@@ -924,6 +1009,48 @@
         "canDownGrab"
       ],
       "note": "Requires running a very precise distance of 7 tiles with no open end in the adjacent room, to hit a peak of the speed vs height graph."
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room Speedy Space Jump",
+      "entranceCondition": {
+        "comeInSpaceJumping": {
+          "speedBooster": true,
+          "minTiles": 18.4375
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canCrossRoomJumpIntoWater",
+        "canMomentumConservingTurnaround"
+      ],
+      "note": [
+        "Gain speed using at least 18 tiles of runway, then Space Jump through the door transition."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room Insane Speedy Space Jump",
+      "entranceCondition": {
+        "comeInSpaceJumping": {
+          "speedBooster": true,
+          "minTiles": 6.4375
+        }
+      },
+      "requires": [
+        "canTrickyDashJump",
+        "canPreciseSpaceJump",
+        "canInsaneJump",
+        "canCrossRoomJumpIntoWater",
+        "canMomentumConservingTurnaround",
+        "canDownGrab"
+      ],
+      "note": [
+        "Requires running a precise distance of 7 tiles with no open end in the adjacent room, to hit a peak of the speed vs height graph (at extra run speed $2.0 or $2.1).",
+        "This needs a last-frame Space Jump in the previous room.",
+        "At the lower of the two possible speeds ($2.0), the jump must be done very low through the door;",
+        "at the higher speed ($2.1) there is a relatively large window of vertical positions that work."
+      ]
     },
     {
       "link": [2, 3],
@@ -996,6 +1123,56 @@
       "requires": [
         "canUnderwaterWalljump",
         "canSpaceJumpWaterBounce"
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity Jump HiJump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canGravityJump",
+        "HiJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity Jump, Spring Ball Jump, Pause Buffer)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canGravityJump",
+        "canSpringBallJumpMidAir",
+        "canInsaneJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Position as far left as possible, hanging over the ledge, and use X-Ray to turn around to the right.",
+        "Perform a gravity jump into a spring ball jump.",
+        "Immediately after the spring ball jump, unmorph to avoid bonking the wall and losing blue speed.",
+        "Use a pause buffer to morph again without losing temporary blue:",
+        "pause as early as possible, and hold angle and aim-down while the pause hits;",
+        "during the black screen, hold only the down input, to buffer a morph;",
+        "coming out of the pause, during the morphing animation roll from down to right, and then hold angle and unmorph to chain temporary blue."
       ]
     },
     {
@@ -1114,11 +1291,12 @@
       "link": [3, 1],
       "name": "Colosseum Bomb Jump Water Escape",
       "notable": true,
+      "reusableRoomwideNotable": "Colosseum Bomb Jump Water Escape",
       "requires": [
         "HiJump",
         "canPreciseWalljump",
         "canIframeSpikeJump",
-        {"spikeHits": 2},
+        {"spikeHits": 1},
         "canNeutralDamageBoost",
         {"or": [
           "canHorizontalDamageBoost",
@@ -1127,7 +1305,10 @@
         "h_canMaxHeightSpringBallJump",
         {"or": [
           "canSpringFling",
-          "canInsaneJump"
+          {"and": [
+            {"spikeHits": 1},
+            "canInsaneJump"
+          ]}
         ]},
         "canBombJumpWaterEscape",
         "canJumpIntoIBJ"
@@ -1139,10 +1320,11 @@
         "Perform the spring ball jump near max height.",
         "Place the first bomb between about 4 and 6 frames after the spring ball jump; ideally it should be just above the water line.",
         "Press pause between about 5 and 10 frames after placing the bomb, to disable Spring Ball (a 'spring fling', to reset fall speed).",
-        "Place the second bomb soon after regaining control, while the game is fading back in."
+        "Place the second bomb soon after regaining control, while the game is fading back in.",
+        "A spike hit in the center of the room can avoided by doing another spring ball jump into IBJ (also with a spring fling)."
       ],
       "devNote": [
-        "This trick can be done without a 'spring fling' but is far more precise:",
+        "The IBJ at the left side of the room can be done without a 'spring fling' but is far more precise:",
         "the first bomb must be placed exactly two frames before the spring ball jump,",
         "and the spring ball jump should be performed just before max height,",
         "during the 4-frame window between 2 and 5 frames before the last possible frame to jump",
@@ -1229,6 +1411,24 @@
     },
     {
       "link": [3, 1],
+      "name": "Blue Space Jump, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 2,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [3, 1],
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
@@ -1303,6 +1503,24 @@
       "link": [3, 2],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [3, 2],

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -659,6 +659,7 @@
         }
       },
       "requires": [
+        "Gravity",
         "HiJump",
         "canPreciseSpaceJump",
         "canChainTemporaryBlue"

--- a/tech.json
+++ b/tech.json
@@ -1634,7 +1634,18 @@
                   "note": [
                     "The ability to move across large distances while maintaining Temporary Blue."
                   ]
-                }    
+                },
+                {
+                  "name": "canPauseRemorphTemporaryBlue",
+                  "techRequires": ["canChainTemporaryBlue"],
+                  "otherRequires": [],
+                  "note": [
+                    "The ability to continue chaining temporary blue after mid-air unmorphing.",
+                    "This is done by pausing while aiming down, then pressing down during the unpause black screen to buffer a morph.",
+                    "Coming out of the pause, roll from down into forward before the morph animation finishes.",
+                    "Alternatively, press diagonally down-forward during the black screen to buffer a stationary lateral morph."
+                  ]
+                }
               ]
             }
           ]


### PR DESCRIPTION
Some things worth noting:
- Updated the "Colosseum Bomb Jump Water Escape" notable to take into account that it can also be used in the middle and right side of the room.
- There's an application of some tech of using a pause buffer to continue chaining temporary blue after unmorphing in the air (i.e. an unmorph other than the soft landing type). I remembered seeing this in a bobbob video a while back but forgot about it until recently. It could probably be made into its own "tech", will start keeping an eye out for other applications.