### PR TITLE
Acid Snakes Tunnel carry temp blue

### DIFF
--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -119,9 +119,9 @@
   "strats": [
     {
       "link": [1, 2],
-      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 13,
           "openEnd": 1
         }
@@ -202,9 +202,9 @@
     },
     {
       "link": [2, 1],
-      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 13,
           "openEnd": 1
         }

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -84,6 +84,8 @@
       "from": 1,
       "to": [
         {"id": 1},
+        {"id": 2},
+        {"id": 3},
         {"id": 4}
       ]
     },
@@ -116,10 +118,123 @@
   ],
   "strats": [
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "canSpeedball",
+            "canSpringBallBounce",
+            {"heatFrames": 490}  
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 420}
+          ]},
+          {"and": [
+            "canSpeedball",
+            "canLongChainTemporaryBlue",
+            {"heatFrames": 780}
+          ]}  
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Use Space Jump, Spring Ball, to carry blue speed across the room;",
+        "alternatively, use a long series of temporary blue chains."
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "canSpeedball",
+            "canSpringBallBounce",
+            {"heatFrames": 400}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 420}  
+          ]},
+          {"and": [
+            "canSpeedball",
+            "canLongChainTemporaryBlue",
+            {"heatFrames": 670}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "right"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Use Space Jump, Spring Ball, to carry blue speed across the room;",
+        "alternatively, use a long series of temporary blue chains."
+      ]
+    },
+    {
       "link": [1, 4],
       "name": "Base",
       "requires": [
         {"heatFrames": 70}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "canSpeedball",
+            "canSpringBallBounce",
+            {"heatFrames": 490}  
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 420}
+          ]},
+          {"and": [
+            "canSpeedball",
+            "canLongChainTemporaryBlue",
+            {"heatFrames": 790}            
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Use Space Jump, Spring Ball, to carry blue speed across the room;",
+        "alternatively, use a long series of temporary blue chains."
       ]
     },
     {
@@ -388,6 +503,56 @@
         "This includes time to moonwalk back against the right door, without shooting it open.",
         "An additional tile could be used by opening the right door but there is not yet any known application."
       ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Short Runway)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 5,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"or": [
+          {"heatFrames": 245},
+          {"and": [
+            {"heatFrames": 85},
+            "canXRayCancelShinecharge"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "left"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Gain the shinecharge below the right edge of the door above to avoid bringing the Dragon on-camera."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Full Runway)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canXRayCancelShinecharge",
+        "canChainTemporaryBlue",
+        {"heatFrames": 240}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "any"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 4],

--- a/tech.json
+++ b/tech.json
@@ -1706,6 +1706,18 @@
           ]
         },
         {
+          "name": "canXRayCancelShinecharge",
+          "techRequires": [],
+          "otherRequires": [
+            "XRayScope",
+            {"noFlashSuit": {}}
+          ],
+          "note": [
+            "Using X-Ray to cancel a shinecharge to avoid having to wait for the 180-frame shinecharge timer to expire.",
+            "This allows moving more quickly after gaining temporary blue."
+          ]
+        },
+        {
           "name": "canXRayStandUp",
           "techRequires": [],
           "otherRequires": [


### PR DESCRIPTION
For these strats, the amount of heat damage would depend on the amount of run speed, which depends in a complicated way on the amount of runway available in the other room and on shortcharge skill. The heat frames that I put in are based on a conservative assumption of very low run speed. At some point we could add variant strats with lower heat frames by assuming a higher run speed, but I don't think that's too important right now.

Someday I still think it would be neat to add schema support for interpolating heat frames in a continuous way based on runway length, which could be useful in many situations in heated rooms. But that's a problem for another day.