### PR TITLE
Add schema for strat IDs

### DIFF
--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -84,6 +84,12 @@
         }
       ],
       "properties": {
+        "id": {
+          "$id": "#/definitions/strat/properties/id",
+          "type": "integer",
+          "title": "Strat ID",
+          "description": "Identifier for this strat, unique within the room."
+        },
         "link": {
           "$id": "#/definitions/strat/properties/link",
           "type": "array",
@@ -2382,6 +2388,12 @@
           }
         }
       }
+    },
+    "nextStratId": {
+      "$id": "#/properties/nextStratId",
+      "type": "integer",
+      "title": "Next Strat ID",
+      "description": "Identifier for the next strat ID to be sequentially assigned within the room."
     }
   }
 }


### PR DESCRIPTION
After this I can add a script to auto-assign strat IDs.

The purpose of tracking a "nextStratId" is to ensure that a strat ID isn't ever reassigned to a different strat, in case the strat with the largest ID in the room gets deleted.