### PR TITLE
Add speedBooster to comeInSpinning, comeInWithMockball, comeInWithSpringBallBounce

### DIFF
--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -841,6 +841,7 @@
       "name": "Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[34, 1]],
           "movementType": "any"
         }
@@ -1288,6 +1289,7 @@
       "name": "Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[42, 0]],
           "movementType": "any"
         }
@@ -1302,6 +1304,7 @@
       "name": "Spring Ball Bounce (Tricky Dash Jump)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[32, 0]],
           "movementType": "any"
         }

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -354,6 +354,7 @@
       "name": "Spring Ball Bounce Spring Fling",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[30, 1]],
           "movementType": "controlled"
         }

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -278,6 +278,7 @@
       "notable": true,
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[19.3625, 1]],
           "movementType": "controlled"
         }
@@ -778,6 +779,7 @@
       "notable": true,
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[19.3625, 1]],
           "movementType": "controlled"
         }

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -567,6 +567,7 @@
       "name": "Cross Room Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[18.4375, 1]],
           "movementType": "any"
         }
@@ -587,6 +588,7 @@
       "name": "Tricky Cross Room Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[6.4375, 1]],
           "movementType": "any"
         }

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1594,6 +1594,7 @@
       "name": "Cross Room Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[39, 1]],
           "movementType": "any"
         }
@@ -1608,6 +1609,7 @@
       "name": "Tricky Cross Room Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[34, 1]],
           "movementType": "any"
         }
@@ -1626,6 +1628,7 @@
       "name": "Tricky Cross Room Spring Ball Bounce into Spring Ball Jump",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[6.4375, 1]],
           "movementType": "any"
         }

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -388,12 +388,12 @@
       "name": "Cross Room Spring Ball Bounce (Lenient)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[17, 1]],
           "movementType": "any"
         }
       },
       "requires": [
-        "SpeedBooster",
         "canCrossRoomJumpIntoWater"
       ]
     },
@@ -403,12 +403,12 @@
       "name": "Cross Room Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[9, 1]],
           "movementType": "any"
         }
       },
       "requires": [
-        "SpeedBooster",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater"
       ]
@@ -419,6 +419,7 @@
       "name": "Tricky Cross Room Spring Ball Bounce",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[6.4375, 1]],
           "movementType": "any"
         }

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -287,6 +287,7 @@
       "name": "Cross Room Spring Ball Bounce (Uncontrolled)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[2.5625, 1]],
           "movementType": "uncontrolled"
         }
@@ -302,6 +303,7 @@
       "name": "Cross Room Spring Ball Bounce (Controlled)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[3.5625, 1]],
           "movementType": "controlled"
         }
@@ -316,6 +318,7 @@
       "name": "Cross Room Tricky Spring Ball Bounce (Uncontrolled)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": false,
           "remoteAndLandingMinTiles": [[1.5625, 1]],
           "movementType": "uncontrolled"
         }
@@ -333,6 +336,7 @@
       "name": "Cross Room Tricky Spring Ball Bounce (Controlled)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[2.5625, 1]],
           "movementType": "controlled"
         }

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -1236,6 +1236,7 @@
       "name": "Spring Ball (Come in With Mockball)",
       "entranceCondition": {
         "comeInWithMockball": {
+          "speedBooster": true,
           "adjacentMinTiles": 20,
           "remoteAndLandingMinTiles": [[18.4375, 0]]
         }

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -819,12 +819,12 @@
       "reusableRoomwideNotable": "Crab Hole Cross Room Jump Morph",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[3, 1]],
           "movementType": "uncontrolled"
         }
       },
       "requires": [
-        "SpeedBooster",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -847,6 +847,7 @@
       "reusableRoomwideNotable": "Crab Hole Cross Room Jump Morph",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[3.5625, 1]],
           "movementType": "uncontrolled"
         }
@@ -869,6 +870,7 @@
       "reusableRoomwideNotable": "Crab Hole Cross Room Jump Morph",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[4.5625, 1]],
           "movementType": "controlled"
         }
@@ -1732,12 +1734,12 @@
       "reusableRoomwideNotable": "Crab Hole Cross Room Jump Morph",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[3, 1]],
           "movementType": "any"
         }
       },
       "requires": [
-        "SpeedBooster",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -1757,6 +1759,7 @@
       "reusableRoomwideNotable": "Crab Hole Cross Room Jump Morph",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[3.5625, 1]],
           "movementType": "uncontrolled"
         }
@@ -1779,6 +1782,7 @@
       "reusableRoomwideNotable": "Crab Hole Cross Room Jump Morph",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[4.5625, 1]],
           "movementType": "controlled"
         }

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -1286,6 +1286,7 @@
       "name": "Cross Room Spring Ball Bounce (Come in Spinning)",
       "entranceCondition": {
         "comeInSpinning": {
+          "speedBooster": true,
           "unusableTiles": 2,
           "minExtraRunSpeed": "$4.0"
         }
@@ -1305,6 +1306,7 @@
       "name": "Cross Room Spring Ball Bounce (Come in With Spring Ball Bounce)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[19, 0]],
           "movementType": "any"
         }
@@ -1323,6 +1325,7 @@
       "name": "Cross Room Tricky Spring Ball Bounce (Come in Spinning)",
       "entranceCondition": {
         "comeInSpinning": {
+          "speedBooster": true,
           "unusableTiles": 1,
           "minExtraRunSpeed": "$2.0",
           "maxExtraRunSpeed": "$2.3"
@@ -1347,6 +1350,7 @@
       "name": "Cross Room Tricky Spring Ball Bounce (Come in With Spring Ball Bounce)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[6.4375, 0]],
           "movementType": "any"
         }

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -771,6 +771,7 @@
       "notable": true,
       "entranceCondition": {
         "comeInSpinning": {
+          "speedBooster": false,
           "unusableTiles": 3,
           "minExtraRunSpeed": "$1.D",
           "maxExtraRunSpeed": "$1.D"
@@ -2491,6 +2492,7 @@
       "reusableRoomwideNotable": "Mt. Everest Spring Ball Bounce Right to Left",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": false,
           "remoteAndLandingMinTiles": [[6.4375, 0]],
           "movementType": "controlled"
         }
@@ -2582,6 +2584,7 @@
       "reusableRoomwideNotable": "Mt. Everest Spring Ball Bounce Right to Left",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[4.4375, 2]],
           "adjacentMinTiles": 8,
           "movementType": "controlled"
@@ -2612,6 +2615,7 @@
       "reusableRoomwideNotable": "Mt. Everest Spring Ball Bounce Right to Left",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": "any",
           "remoteAndLandingMinTiles": [[0.4375, 1]],
           "adjacentMinTiles": 4,
           "movementType": "controlled"
@@ -2661,6 +2665,7 @@
       "name": "Tricky Spring Ball Bounce (Come in With Spring Ball Bounce)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[6.4375, 0]],
           "movementType": "controlled"
         }

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -388,6 +388,7 @@
       "name": "Mockball",
       "entranceCondition": {
         "comeInWithMockball": {
+          "speedBooster": "any",
           "adjacentMinTiles": 11.4375,
           "remoteAndLandingMinTiles": [
             [8, 2],
@@ -403,12 +404,11 @@
       "name": "Mockball (Speed Booster, Short Landing)",
       "entranceCondition": {
         "comeInWithMockball": {
+          "speedBooster": true,
           "remoteAndLandingMinTiles": [[9, 1]]
         }
       },
-      "requires": [
-        "SpeedBooster"
-      ]
+      "requires": []
     },
     {
       "id": 17,
@@ -416,6 +416,7 @@
       "name": "Tricky Mockball",
       "entranceCondition": {
         "comeInWithMockball": {
+          "speedBooster": "any",
           "adjacentMinTiles": 10.4375,
           "remoteAndLandingMinTiles": [
             [7, 1],
@@ -434,6 +435,7 @@
       "name": "Insane Mockball",
       "entranceCondition": {
         "comeInWithMockball": {
+          "speedBooster": "any",
           "adjacentMinTiles": 9.4375,
           "remoteAndLandingMinTiles": [[5, 1]]
         }

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -489,9 +489,20 @@
               "type": "object",
               "title": "Come In Spinning",
               "description": "Represents that Samus must come in with a spin jump through the doorway while having a certain amount of speed.",
-              "required": ["unusableTiles"],
+              "required": ["speedBooster", "unusableTiles"],
               "additionalProperties": false,
               "properties": {
+                "speedBooster": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInSpinning/properties/speedBooster",
+                  "type": ["boolean", "string"],
+                  "title": "Speed Booster",
+                  "description": "Whether or not Speed Booster should be equipped when entering the room.",
+                  "enum": [
+                    true,
+                    false,
+                    "any"
+                  ]
+                },
                 "unusableTiles": {
                   "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInSpinning/properties/unusableTiles",
                   "type": "number",
@@ -545,9 +556,20 @@
               "type": "object",
               "title": "Come In With Mockball",
               "description": "Represents that Samus must roll into the room in a mockball with a certain amount of speed.",
-              "required": [],
+              "required": ["speedBooster"],
               "additionalProperties": false,
               "properties": {
+                "speedBooster": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithMockball/properties/speedBooster",
+                  "type": ["boolean", "string"],
+                  "title": "Speed Booster",
+                  "description": "Whether or not Speed Booster should be equipped when entering.",
+                  "enum": [
+                    true,
+                    false,
+                    "any"
+                  ]
+                },
                 "adjacentMinTiles": {
                   "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithMockball/properties/adjacentMinTiles",
                   "type": "number",
@@ -580,9 +602,20 @@
               "type": "object",
               "title": "Come In With Spring Ball Bounce",
               "description": "Represents that Samus must jump into the room with a spring ball bounce in the doorway of the previous room.",
-              "required": ["movementType"],
+              "required": ["speedBooster", "movementType"],
               "additionalProperties": false,
               "properties": {
+                "speedBooster": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithSpringBallBounce/properties/speedBooster",
+                  "type": ["boolean", "string"],
+                  "title": "Speed Booster",
+                  "description": "Whether or not Speed Booster should be equipped when entering.",
+                  "enum": [
+                    true,
+                    false,
+                    "any"
+                  ]
+                },
                 "movementType": {
                   "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInWithSpringBallBounce/properties/movementType",
                   "type": "string",

--- a/strats.md
+++ b/strats.md
@@ -983,6 +983,7 @@ A `comeInWithTemporaryBlue` entrance condition must match with one of the follow
 
 A `comeInSpinning` entrance condition indicates that Samus must come in with a spin jump through the doorway, with speed in a certain range, applicable to horizontal transitions. It has the following properties:
 
+- _speedBooster_: If true, then Speed Booster must be equipped while entering the room. If false, then Speed Booster must not be equipped. If "any", then Speed Booster may or may not be equipped.
 - _unusableTiles_: For a runway connected to the door, the number of tiles before the door that are unusable for gaining speed, because of needing to jump.
 - _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) needed. This only needs to be specified if something would prevent the strat from working at too low of a speed.
 - _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) needed. This only needs to be specified if something would prevent the strat from working at too high of a speed.
@@ -1047,6 +1048,7 @@ A `comeInBlueSpinning` entrance condition must match with a `leaveSpinning` or `
 
 A `comeInWithMockball` entrance condition indicates that Samus must roll into the room in a mockball with a certain amount of momentum, applicable to horizontal transitions. It has the following properties:
 
+- _speedBooster_: If true, then Speed Booster must be equipped while entering the room. If false, then Speed Booster must not be equipped. If "any", then Speed Booster may or may not be equipped.
 - _adjacentMinTiles_: This is the minimum effective runway length in case an adjacent runway (connected to the door) is used to gain speed, jump, and enter a mockball.
 - _remoteAndLandingMinTiles_: When entering a mockball, it takes some time to accelerate up to full speed, which means that even when using a remote runway (i.e. one not connected to the door) to gain speed for the jump, the amount of landing space in front of the door still matters. Depending on the strat, different combinations of remote runway and landing lengths may work (e.g. with shorter landing lengths possibly requiring longer remote runways to compensate). This property is a list of pairs, where in each pair the first value gives a minimal remote runway used to gain speed, and the second value gives the corresponding minimal amount of landing tiles in front of the door usable to gain speed at the start of the mockball. 
 
@@ -1080,6 +1082,7 @@ A `comeInWithMockball` entrance condition must match with one of the following c
 
 A `comeInWithSpringBallBounce` entrance condition indicates that Samus must enter the room by spring ball bouncing in from the previous room, applicable to horizontal transitions. It has the following properties:
 
+- _speedBooster_: If true, then Speed Booster must be equipped while entering the room. If false, then Speed Booster must not be equipped. If "any", then Speed Booster may or may not be equipped.
 - _adjacentMinTiles_: This is the minimum effective runway length in case an adjacent runway (connected to the door) is used to gain speed, jump, and bounce.
 - _remoteAndLandingMinTiles_: A list of pairs, where in each pair the first value gives a minimal remote runway used to gain speed, and the second value gives the corresponding minimal amount of landing tiles in front of the door usable for the bounce.
 - _movementType_: This takes one of three possible values, "controlled", "uncontrolled", and "any", indicating the type of bounce that is required.


### PR DESCRIPTION
When I was first setting up the schema for these, I was thinking that any Speedbooster requirement could just go in the `requires`. But seeing how this is playing out, it seems too error-prone because it's too easy to forget about it. So this adds `speedBooster` as a required property to `comeInSpinning`, `comeInWithMockball`, and `comeInWithSpringBallBounce` entrance conditions, similar to what we already have for `comeInRunning`, `comeInJumping`, and `comeInSpaceJumping`.