### PR TITLE
Fix East Sand Hall blue spring ball bounce notables

### DIFF
--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -73,6 +73,21 @@
         "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
         "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
       ]
+    },
+    {
+      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)",
+      "note": [
+        "Use a 3-tap or 4-tap to gain a speedball with a specific amount of speed in the other room (between $2.1 and $2.3 extra run speed), and either roll in or do a controlled bounce to enter while descending close to the ground.",
+        "Bounce on the platform in front of the door, then bounce on the second-to-last pillar."
+      ]
+    },
+    {
+      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
+      "note": [
+        "Gain a speedball in the other room, and either roll in or do a controlled bounce to enter while descending close to the ground.",
+        "Bounce anywhere on the platform in front of the door, clearing the whole room at once.",
+        "If needed, blue speed will destroy any Evirs along the way and allow bouncing on the sand at the end to make it onto the ledge."
+      ]
     }
   ],
   "links": [
@@ -295,8 +310,9 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Cross-Room Blue Spring Ball Bounce",
+      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)",
       "notable": true,
+      "reusableRoomwideNotable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.1",
@@ -357,6 +373,7 @@
       "link": [1, 2],
       "name": "Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
       "notable": true,
+      "reusableRoomwideNotable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.1",
@@ -717,6 +734,7 @@
       "link": [2, 1],
       "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
       "notable": true,
+      "reusableRoomwideNotable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.0",
@@ -740,6 +758,7 @@
       "link": [2, 1],
       "name": "Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
       "notable": true,
+      "reusableRoomwideNotable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.1",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -371,7 +371,7 @@
     {
       "id": 13,
       "link": [1, 2],
-      "name": "Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
+      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
       "notable": true,
       "reusableRoomwideNotable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)",
       "entranceCondition": {
@@ -756,7 +756,7 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
+      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
       "notable": true,
       "reusableRoomwideNotable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
       "entranceCondition": {


### PR DESCRIPTION
These had wrong names (didn't include the room name) and needed to be grouped into reusables. The left-to-right vs. right-to-left strats seem different enough to keep separate from each other, but the temp blue chain variants should be ok not being separate notables.