### PR TITLE
Bat Cave temporary blue

### DIFF
--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -184,6 +184,31 @@
     },
     {
       "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "HiJump",
+        {"or": [
+          {"heatFrames": 575},
+          {"and": [
+            "canXRayCancelShinecharge",
+            {"heatFrames": 415}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 2],
       "name": "Grapple Teleport",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
@@ -302,6 +327,30 @@
       ],
       "flashSuitChecked": true,
       "note": "Fall through the shot blocks and shoot around the Skree to open the door without falling into the lava to shinespark out of the room."
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"heatFrames": 550},
+          {"and": [
+            "canXRayCancelShinecharge",
+            {"heatFrames": 390}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "link": [2, 1],

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -195,10 +195,10 @@
         "canLongChainTemporaryBlue",
         "HiJump",
         {"or": [
-          {"heatFrames": 575},
+          {"heatFrames": 570},
           {"and": [
             "canXRayCancelShinecharge",
-            {"heatFrames": 415}
+            {"heatFrames": 420}
           ]}
         ]}
       ],
@@ -343,7 +343,7 @@
           {"heatFrames": 550},
           {"and": [
             "canXRayCancelShinecharge",
-            {"heatFrames": 390}
+            {"heatFrames": 380}
           ]}
         ]}
       ],


### PR DESCRIPTION
The `canXRayCancelShinecharge` doesn't help quite as much going from bottom to top, since you have the wait a bit anyway for the path to become clear of Skree projectiles. Videos for these are up already on https://videos.maprando.com. I can associate them to the new strats after strat IDs are added; going to work on a GitHub Action workflow for that soon.
