### PR TITLE
Bowling Alley temp blue break bomb blocks

### DIFF
--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -956,13 +956,30 @@
       "requires": [
         "ScrewAttack",
         "Morph",
-        "canCameraManip"
+        "canCameraManip",
+        "canHeroShot"
       ],
       "note": [
         "Break the shot blocks with Power Beam by first rolling into the morph tunnel to unlock camera scroll for this room.",
         "The blocks can now be cleared from the left side by shooting and quickly scrolling the camera to the right a small amount.",
         "A shot from crouch will reach the bottom block by following the shot as a ball, or wave beam works from the stairs.",
         "Screw Attack is still needed to clear the bomb blocks."
+      ]
+    },
+    {
+      "link": [3, 4],
+      "name": "Temporary Blue Break Bomb Blocks",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canCameraManip",
+        "canHeroShot"
+      ],
+      "note": [
+        "Land on the crumble blocks while unmorphing, in order to retain temporary blue while falling, breaking the bomb blocks",
+        "Roll most of the way into the morph tunnel to unlock the camera scroll, then roll back left, crouch, fire a shot, and follow it to the right, to clear the shot blocks."
       ]
     },
     {


### PR DESCRIPTION
Video for this strat: https://videos.maprando.com/video/308. The ability to retain temporary blue while falling through crumbles could maybe be a separate tech, but it's same kind of soft unmorph as in `canChainTemporaryBlue` so it may be ok to just be assumed as part of that?

This also adds a `canHeroShot` requirement to the existing notable strat "Bowling Alley Missile Chozo Camera Unlock". This won't affect the difficulty level of the strat in Map Rando, since it's already a Very Hard notable.
