### PR TITLE
Check horizontal doors without leaveWithRunway

### DIFF
--- a/scripts/check_runways.py
+++ b/scripts/check_runways.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+for path in sorted(Path("../region/").glob("**/*.json")):
+    room_json = json.load(path.open("r"))
+    if room_json.get("$schema") != "../../../schema/m3-room.schema.json":
+        continue
+
+    runway_nodes = set()
+    for strat_json in room_json["strats"]:
+        from_node = strat_json["link"][0]
+        to_node = strat_json["link"][1]
+        if from_node != to_node:
+            continue
+        if "exitCondition" in strat_json and "leaveWithRunway" in strat_json["exitCondition"]:
+            runway_nodes.add(from_node)
+    
+    for node_json in room_json["nodes"]:
+        node_id = node_json["id"]
+        if node_id not in runway_nodes and node_json.get("doorOrientation") in ["left", "right"]:
+            print("Missing leaveWithRunway at {}: {} ({})".format(room_json["name"], node_json["name"], node_id))


### PR DESCRIPTION
This is just a standalone script to list horizontal door nodes that are lacking a leaveWithRunway strat at the door (i.e. from the door node to itself). If we wanted to enforce this as a check, it could be added to the tests after fixing the existing cases.