### PR TITLE
Add script to populate tech IDs

### DIFF
--- a/.github/workflows/run_scripts.yml
+++ b/.github/workflows/run_scripts.yml
@@ -58,9 +58,12 @@ jobs:
           python ./resources/ci/common/list_actions.py
       # Run Strat ID validator
       # Run Autoformatter
-      - name: Run Strat ID Validator & Autoformatter
+      - name: Run Strat ID Generator & Autoformatter
         working-directory: scripts
         run: python populate_strat_ids.py
+      - name: Run Tech ID Generator & Autoformatter
+        working-directory: scripts
+        run: python populate_tech_ids.py
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6.1.0
         with:

--- a/schema/m3-tech.schema.json
+++ b/schema/m3-tech.schema.json
@@ -52,6 +52,12 @@
               ],
               "additionalProperties": false,
               "properties": {
+                "id": {
+                  "$id": "#/properties/techCategories/items/properties/techs/items/properties/id",
+                  "type": "integer",
+                  "title": "Tech ID",
+                  "description": "Identifier for this tech, unique across all tech."
+                },
                 "name": {
                   "$id": "#/properties/techCategories/items/properties/techs/items/properties/name",
                   "type": "string",

--- a/scripts/format_json.py
+++ b/scripts/format_json.py
@@ -3,7 +3,7 @@
 import json
 
 # Keys whose values should always be expanded to separate lines
-non_one_line_keys = {"requires", "and", "or", "to"}
+non_one_line_keys = {"requires", "techRequires", "otherRequires", "and", "or", "to"}
 
 
 def is_one_liner_dict(obj, nesting_allowed=True):

--- a/scripts/populate_tech_ids.py
+++ b/scripts/populate_tech_ids.py
@@ -1,0 +1,43 @@
+# Tool to assign tech IDs where they are missing.
+# This also performs auto-formatting.
+#
+# To use, run "python populate_tech_ids.py" from a working directory of "sm-json-data/scripts".
+
+import json
+from pathlib import Path
+
+import format_json
+
+path = Path("../tech.json")
+all_tech_str = path.open("r").read()
+all_tech_json = json.loads(all_tech_str)
+
+next_id = all_tech_json.get("nextTechId", 1)
+orig_next_id = next_id
+
+def process_tech(tech_json):
+    global next_id
+    if "id" not in tech_json:
+        new_tech_json = {"id": next_id, **tech_json}
+        tech_json.clear()
+        tech_json.update(new_tech_json)
+        next_id += 1
+    for t in tech_json.get("extensionTechs", []):
+        process_tech(t)
+
+for category_json in all_tech_json["techCategories"]:
+    for t in category_json["techs"]:
+        process_tech(t)
+
+all_tech_json["nextTechId"] = next_id
+    
+new_tech_str = format_json.format(all_tech_json, indent=2)
+
+if next_id != orig_next_id:
+    print("Added {} tech IDs".format(next_id - orig_next_id))
+elif new_tech_str != all_tech_str:
+    print("Formatted tech")
+    
+# Write the auto-formatted output:
+if new_tech_str != all_tech_str:
+    path.write_text(new_tech_str)


### PR DESCRIPTION
This also sets up autoformatting on `tech.json`.

Having IDs on tech will be useful in Map Rando in at least a couple ways:
- preserving tech settings (and exporting/importing them) in a more robust way, e.g. so that it can keep working if a tech is renamed.
- associating videos to tech on the new video site, with the same kind of robustness.