### PR TITLE
Lava Dive thread the needle entry

### DIFF
--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -186,6 +186,30 @@
       ]
     },
     {
+      "link": [1, 5],
+      "name": "Lava Dive Thread the Needle Entry",
+      "notable": true,
+      "requires": [
+        {"or": [
+          "canSuitlessLavaDive",
+          "Gravity"
+        ]},
+        "canInsaneJump",
+        {"heatFrames": 200},
+        {"lavaFrames": 60}
+      ],
+      "note": [
+        "Gain a specifc amount of speed by running from a standstill, starting slightly more than 3 tiles from the edge of the Ridley statue jaw.",
+        "Jump on the last possible frame (second-to-last frame may also work, depending on subpixels).",
+        "If successful, Samus will avoid bonking the wall and will land directly in front of the Namihe."
+      ],
+      "devNote": [
+        "Starting horizontal positions between $F2 and $FB will work consistently with a last-frame jump.",
+        "Positions further left can also work but may require an earlier jump.",
+        "Gravity only makes about 1 or 2 frames of difference here, which we ignore."
+      ]
+    },
+    {
       "id": 5,
       "link": [2, 1],
       "name": "Grapple Teleport",
@@ -802,7 +826,7 @@
           {"and": [
             "canDisableEquipment",
             {"heatFrames": 270},
-            {"lavaFrames": 230}
+            {"lavaFrames": 220}
           ]},
           {"and": [
             "canDisableEquipment",


### PR DESCRIPTION
This is a more efficient way to enter the lava from left-to-right.

Videos:
- With Varia: https://videos.maprando.com/video/4
- With Gravity: https://videos.maprando.com/video/592
- Suitless: https://videos.maprando.com/video/591

Probably the most significant thing is that with Gravity this puts left-to-right in logic with 1 tank. It could already be done without the new entry (with a few energy to spare), but it wasn't quite in logic because the 5->2 strat had just enough extra lenience in the lava frames that it was making it require 201 energy. So those lava frames also get slightly tightened in this PR.