### PR TITLE
Bombway temp blue

### DIFF
--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -122,7 +122,8 @@
           "runway": {
             "length": 3,
             "openEnd": 0  
-          }
+          },
+          "maxExtraRunSpeed": "$3.8"
         }
       },
       "requires": [
@@ -136,6 +137,9 @@
           "types": ["ammo"],
           "requires": []
         }
+      ],
+      "devNote": [
+        "Higher speeds could work, up to at least about $4.4, but with greater difficulty."
       ]
     },
     {
@@ -201,8 +205,9 @@
         "comeInSpeedballing": {
           "runway": {
             "length": 3,
-            "openEnd": 0  
-          }
+            "openEnd": 0
+          },
+          "maxExtraRunSpeed": "$3.8"
         }
       },
       "requires": [
@@ -216,6 +221,9 @@
           "types": ["ammo"],
           "requires": []
         }
+      ],
+      "devNote": [
+        "Higher speeds could work, up to at least about $4.4, but with greater difficulty."
       ]
     },
     {

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -115,6 +115,64 @@
       "devNote": "There doesn't appear to be enough time to spark out in a 'top' position."
     },
     {
+      "link": [1, 2],
+      "name": "Come in Speedballing, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInSpeedballing": {
+          "runway": {
+            "length": 3,
+            "openEnd": 0  
+          }
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Spring Ball Bounce)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canSpringBallBounce",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Unmorph immediately after exiting the tunnel while still descending, to continue chaining temporary blue.",
+        "The frame window for the unmorph depends on the alignment of Samus' bounces;",
+        "in the worst case where Samus bounces upward while exiting, this method will unavoidably fail."
+      ],
+      "devNote": [
+        "FIXME: The canInsaneJump is for difficulty placement for the unmorph while exiting the tunnel;",
+        "it may be better to introduce a specific tech for this?",
+        "Doing a 'canPauseRemorphTemporaryBlue' is technically an alternative, but it seems to be significantly harder."
+      ]
+    },
+    {
       "id": 5,
       "link": [2, 1],
       "name": "Base",
@@ -135,6 +193,30 @@
         }
       },
       "requires": []
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Speedballing, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInSpeedballing": {
+          "runway": {
+            "length": 3,
+            "openEnd": 0  
+          }
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ]
     },
     {
       "id": 7,
@@ -178,6 +260,40 @@
         "canSpringBallBounce"
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Spring Ball Bounce)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canSpringBallBounce",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Unmorph immediately after exiting the tunnel while still descending, to continue chaining temporary blue.",
+        "The frame window for the unmorph depends on the alignment of Samus' bounces;",
+        "in the worst case where Samus bounces upward while exiting, this method will unavoidably fail."
+      ],
+      "devNote": [
+        "FIXME: The canInsaneJump is for difficulty placement for the unmorph while exiting the tunnel;",
+        "it may be better to introduce a specific tech for this?",
+        "Doing a 'canPauseRemorphTemporaryBlue' is technically an alternative, but it seems to be significantly harder."
+      ]
     },
     {
       "id": 10,

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -465,6 +465,18 @@
                   "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInSpeedballing/properties/runway",
                   "$ref": "#/definitions/runway",
                   "description": "Runway in the current room that is available to complete the speedball."
+                },
+                "minExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInSpeedballing/properties/minExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) while morphed which will satisfy this condition."
+                },
+                "maxExtraRunSpeed": {
+                  "$id": "#/definitions/strat/properties/entranceCondition/properties/comeInSpeedballing/properties/maxExtraRunSpeed",
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Maximum extra run speed (in hexadecimal) while morphed which will satisfy this condition."
                 }
               }
             },

--- a/strats.md
+++ b/strats.md
@@ -948,9 +948,12 @@ A `comeInWithDoorStuckSetup` condition must match with a `leaveWithRunway` condi
 
 ### Come In Speedballing
 
-A `comeInSpeedballing` entrance condition indicates that Samus must enter the room either in a speedball from the previous room, or in a process of running, jumping, or falling into a speedball. It has the following property:
+A `comeInSpeedballing` entrance condition indicates that Samus must enter the room either in a speedball from the previous room, or in a process of running, jumping, or falling into a speedball. It has the following properties:
 
 - _runway_: A [runway geometry](#runway-geometry) object describing the tiles available in the current room to complete the speedball. The end of this runway represents the point by which the speedball must be complete (i.e. when Samus must be morphed and on the ground with blue speed). A runway length of 0 would represent that the speedball must be completed before the transition.
+- _minExtraRunSpeed_: The minimum extra run speed (as a hexadecimal string) needed while in speedball. This can be specified if something would prevent the strat from working at too low of a speed.
+- _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) needed while in speedball. This can be specified if something would prevent the strat from working at too high of a speed.
+
 
 It is assumed that the runway in the current room is level or sloping up; adjustments would be needed to handle a case where it sloped down.
 


### PR DESCRIPTION
This adds some `leaveWithTemporaryBlue` strats that were missed on the first pass.

Videos:
- left-to-right speedball: https://videos.maprando.com/video/622
- right-to-left speedball: https://videos.maprando.com/video/621
- left-to-right bounce: https://videos.maprando.com/video/343
- right-to-left bounce: https://videos.maprando.com/video/344
