### PR TITLE
Crab Hole temp blue

### DIFF
--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -1112,6 +1112,37 @@
       "devNote": "Jump low through the door with at least $1.D extra run speed."
     },
     {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canGravityJump",
+        "canSpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Perform a gravity jump and use Spring Ball to bounce through the top of the hole.",
+        "Use a pause buffer to remorph, also taking the opportunity to equip Gravity again.",
+        "Then chain temporary blue into the next room."
+      ]
+    },
+    {
       "id": 44,
       "link": [2, 2],
       "name": "Leave with Runway",
@@ -1317,6 +1348,83 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"enemyKill": {
+            "enemies": [["Sciser"]],
+            "explicitWeapons": [
+              "Missile",
+              "Super",
+              "Grapple",
+              "Wave",
+              "Spazer",
+              "Plasma",
+              "Ice Shield"
+            ]
+          }}
+        ]},
+        "canGravityJump",
+        "canSpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Gain a shinecharge while entering, and either kill the crab before it touches Samus, or use X-Ray to cancel the shinecharge.",
+        "Perform a gravity jump and use Spring Ball to bounce through the top of the hole.",
+        "Use a pause buffer to remorph, also taking the opportunity to equip Gravity again.",
+        "Then chain temporary blue into the next room."
+      ]
+    },
+    {
+      "link": [2, 4],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canSpeedball",
+        "canGravityJump",
+        "canSpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Jump through the transition with blue speed.",
+        "Perform a very short speedball to kill the bottom crab and get into position below the hole.",
+        "Perform a gravity jump and use Spring Ball to bounce through the top of the hole.",
+        "Use a pause buffer to remorph, also taking the opportunity to equip Gravity again.",
+        "Then chain temporary blue into the next room."
+      ]
+    },
+    {
       "id": 57,
       "link": [2, 4],
       "name": "Grapple Teleport",
@@ -1450,6 +1558,35 @@
       "note": [
         "The shaft will be clear of crabs on room entry. Quickly gravity jump before the bottom crab enters the shaft and exit the left morph tunnel to be safe.",
         "This is a bit tighter when entering in G-Mode Immobile."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canGravityJump",
+        "canSpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Perform a gravity jump and use Spring Ball to bounce through the top of the hole.",
+        "Use a pause buffer to remorph, also taking the opportunity to equip Gravity again.",
+        "Then chain temporary blue into the next room."
       ]
     },
     {
@@ -1962,6 +2099,36 @@
         "Then morph and go through the tunnel to the right."
       ],
       "devNote": "Jump low through the door with at least $1.5 extra run speed."
+    },
+    {
+      "link": [3, 4],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canGravityJump",
+        "canSpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Perform a gravity jump and use Spring Ball to bounce through the top of the hole.",
+        "Use a pause buffer to remorph, also taking the opportunity to equip Gravity again.",
+        "Then chain temporary blue into the next room."
+      ]
     },
     {
       "id": 91,

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -1398,7 +1398,8 @@
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 0,
-          "openEnd": 1
+          "openEnd": 1,
+          "maxExtraRunSpeed": "$1.A"
         }
       },
       "requires": [
@@ -1422,6 +1423,9 @@
         "Perform a gravity jump and use Spring Ball to bounce through the top of the hole.",
         "Use a pause buffer to remorph, also taking the opportunity to equip Gravity again.",
         "Then chain temporary blue into the next room."
+      ],
+      "devNote": [
+        "This can be done at higher run speeds, with greater precision or an earlier jump through the door."
       ]
     },
     {

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -79,6 +79,7 @@
       "to": [
         {"id": 1},
         {"id": 2},
+        {"id": 3},
         {"id": 4}
       ]
     },
@@ -110,6 +111,7 @@
       "to": [
         {"id": 1},
         {"id": 2},
+        {"id": 3},
         {"id": 4}
       ]
     },
@@ -242,6 +244,65 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Suitless Spring Ball Bounce, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canTrickySpringBallBounce",
+        "canPauseRemorphTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use Spring Ball to bounce into the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        "Morph",
+        "canPauseRemorphTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use a neutral bounce to enter the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ],
+      "devNote": "FIXME: add a tech for bouncing into the tunnel."
+    },
+    {
       "id": 10,
       "link": [1, 2],
       "name": "G-Mode Morph",
@@ -273,6 +334,63 @@
         "It is possible but difficult to roll from the doorway onto the platform with Gravity turned off.",
         "This requires backing up slightly after entering the room then quickly rolling before the crabs. It is a bit tighter in direct G-Mode."
       ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Suitless Spring Ball Bounce, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canTrickySpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use Spring Ball to bounce into the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        "Morph",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use a neutral bounce to enter the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ],
+      "devNote": "FIXME: add a tech for bouncing into the tunnel."
     },
     {
       "id": 11,
@@ -2098,6 +2216,63 @@
       }
     },
     {
+      "link": [4, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Suitless Spring Ball Bounce, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canTrickySpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use Spring Ball to bounce into the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        "Morph",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use a neutral bounce to enter the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ],
+      "devNote": "FIXME: add a tech for bouncing into the tunnel."
+    },
+    {
       "id": 103,
       "link": [4, 2],
       "name": "G-Mode Morph",
@@ -2194,6 +2369,65 @@
           "blockPositions": [[2, 29]]
         }
       }
+    },
+    {
+      "link": [4, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Suitless Spring Ball Bounce, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canTrickySpringBallBounce",
+        "canPauseRemorphTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use Spring Ball to bounce into the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ]
+    },
+    {
+      "link": [4, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity, Pause Remorph)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        "Morph",
+        "canPauseRemorphTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Use a neutral bounce to enter the hole, then unmorph to descend.",
+        "Use a pause buffer to remorph, then chain temporary blue into the next room."
+      ],
+      "devNote": "FIXME: add a tech for bouncing into the tunnel."
     },
     {
       "id": 109,


### PR DESCRIPTION
Strats for taking temporary blue from the top of Crab Hole (either door) to the bottom (either door). These can be done either with Gravity (neutral bounce) or suitless (with a spring ball bounce), with every case using a pause remorph.

Videos:
- suitless top-left to bottom-right: https://videos.maprando.com/video/670
- suitless top-left to bottom-left: https://videos.maprando.com/video/671
- Gravity top-left to bottom-right: https://videos.maprando.com/video/672
- Gravity top-left to bottom-left: https://videos.maprando.com/video/673
- suitless top-right to bottom-left: https://videos.maprando.com/video/674
- suitless top-right to bottom-right: https://videos.maprando.com/video/675
- Gravity top-right to bottom-left: https://videos.maprando.com/video/676
- Gravity top-right to bottom-right: https://videos.maprando.com/video/677