### PR TITLE
Add lower Bowling Alley leave with temp blue

### DIFF
--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -999,9 +999,6 @@
       "name": "Temporary Blue Bounce and SpringBall",
       "requires": [
         {"obstaclesNotCleared": ["B"]},
-        "h_canUseSpringBall",
-        "canTemporaryBlue",
-        "canCarefulJump",
         {"or": [
           {"and": [
             "f_DefeatedPhantoon",
@@ -1018,10 +1015,12 @@
             }},
             {"or": [
               "f_DefeatedPhantoon",
-              "canMockball"
+              "canSpeedball"
             ]}
           ]}
-        ]}
+        ]},
+        "canTemporaryBlue",
+        "canSpringBallBounce"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1032,6 +1031,49 @@
       "devNote": [
         "Killing phantoon only removes requirements for the strat.",
         "The runway is a bit longer with Phantoon killed and the Power Bomb blocks broken, but it shouldn't matter at this difficulty."
+      ]
+    },
+    {
+      "link": [4, 3],
+      "name": "Leave With Temporary Blue (Spring Ball Bounce, Pause Remorph)",
+      "requires": [
+        {"obstaclesNotCleared": ["B"]},
+        {"or": [
+          {"and": [
+            "f_DefeatedPhantoon",
+            {"canShineCharge": {
+              "usedTiles": 16,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"obstaclesCleared": ["A"]},
+            {"canShineCharge": {
+              "usedTiles": 35,
+              "openEnd": 1
+            }},
+            {"or": [
+              "f_DefeatedPhantoon",
+              "canSpeedball"
+            ]}
+          ]}
+        ]},
+        "canSpringBallBounce",
+        "canPauseRemorphTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Gain temporary blue, and bounce into the morph tunnel, using Spring Ball to reach the left side while retaining temporary blue.",
+        "After bouncing up out of the tunnel, unmorph, aim down, and use a pause buffer to remorph and land or bounce on the door frame, chaining temporary blue into the next room."
       ]
     },
     {

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -996,7 +996,7 @@
     {
       "id": 46,
       "link": [4, 3],
-      "name": "Temporary Blue Bounce and SpringBall",
+      "name": "Temporary Blue Spring Ball Bounce",
       "requires": [
         {"obstaclesNotCleared": ["B"]},
         {"or": [


### PR DESCRIPTION
Videos:
- Power on: https://videos.maprando.com/video/696
- Power off: https://videos.maprando.com/video/697
 
This also touches up the way that the existing in-room strat "Temporary Blue Spring Ball Bounce" is written, though none of the changes should be significant.
