### PR TITLE
Underwater Wall Jump Break Free

### DIFF
--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -752,6 +752,13 @@
       ]
     },
     {
+      "link": [5, 2],
+      "name": "Underwater Walljump Break Free",
+      "requires": [
+        "canUnderwaterWalljumpBreakFree"
+      ]
+    },
+    {
       "id": 35,
       "link": [5, 4],
       "name": "Base",

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1207,6 +1207,14 @@
       ]
     },
     {
+      "link": [2, 3],
+      "name": "Underwater Walljump Break Free",
+      "requires": [
+        "canUnderwaterWalljumpBreakFree"
+      ],
+      "devNote": "FIXME: Crossing the room with just HiJump should be possible but terrible."
+    },
+    {
       "id": 55,
       "link": [2, 3],
       "name": "Come in Shinecharging, Leave With Temporary Blue (Gravity Jump HiJump)",

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -787,6 +787,15 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Underwater Walljump Break Free",
+      "requires": [
+        "canUnderwaterWalljumpBreakFree",
+        {"spikeHits": 2}
+      ],
+      "devNote": "Two spike hits for leniency."
+    },
+    {
       "id": 35,
       "link": [3, 1],
       "name": "Base",
@@ -1022,6 +1031,14 @@
         "Press pause just after placing the bomb, to disable Spring Ball (a 'spring fling', to reset fall speed).",
         "Place the second bomb soon after regaining control, while the game is fading back in."
       ]
+    },
+    {
+      "link": [5, 4],
+      "name": "Underwater Walljump Break Free",
+      "requires": [
+        "canUnderwaterWalljumpBreakFree"
+      ],
+      "note": "It is recommended to do this on the left wall to the right of the two lower Cacatacs, so that Samus can avoid the spikes on a fail."
     },
     {
       "id": 52,

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -846,6 +846,13 @@
       }
     },
     {
+      "link": [1, 4],
+      "name": "Underwater Walljump Break Free",
+      "requires": [
+        "canUnderwaterWalljumpBreakFree"
+      ]
+    },
+    {
       "id": 37,
       "link": [2, 1],
       "name": "Base",

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -439,6 +439,13 @@
       }
     },
     {
+      "link": [1, 2],
+      "name": "Underwater Walljump Break Free",
+      "requires": [
+        "canUnderwaterWalljumpBreakFree"
+      ]
+    },
+    {
       "id": 25,
       "link": [2, 1],
       "name": "Base",

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -439,13 +439,6 @@
       }
     },
     {
-      "link": [1, 2],
-      "name": "Underwater Walljump Break Free",
-      "requires": [
-        "canUnderwaterWalljumpBreakFree"
-      ]
-    },
-    {
       "id": 25,
       "link": [2, 1],
       "name": "Base",

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -367,7 +367,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "canCarefulJump",
+        "canTrickyJump",
         "canTrickyUseFrozenEnemies",
         "h_canCrouchJumpDownGrab"
       ]

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -566,7 +566,8 @@
         "3- Move to make the Gamets spawn. Moonwalking while facing the stairs is useful here.",
         "4- Quickly climb up to the last ledge before the door.",
         "5- Run, jump, dboost off a Gamet."
-      ]
+      ],
+      "devNote": "FIXME: There could be another strat added that then kills the Gamets at 4 to refill."
     },
     {
       "id": 24,
@@ -578,6 +579,15 @@
         "h_canMaxHeightSpringBallJump"
       ],
       "note": "Wait for the water to be rising and perform a max height SpringBall Jump."
+    },
+    {
+      "link": [1, 4],
+      "name": "Underwater Walljump Break Free",
+      "requires": [
+        "canUnderwaterWalljumpBreakFree"
+      ],
+      "note": "This may be easier by starting with a flatley jump from the lowest ledge.",
+      "devNote": "This is likely never useful unless the Gamets are gone or Samus can't take a hit from them for some reason."
     },
     {
       "id": 25,

--- a/tech.json
+++ b/tech.json
@@ -1091,6 +1091,18 @@
                     "The movement requires using the unintuitive behaviour of turning around in water in order to return Samus to a walljump position.",
                     "Each walljump provides very little height gain so they must be performed very quickly to make progress.",
                     "This tech assumes Samus has HiJump and only expects gaining about 1 tile of height through consecutive walljumping."
+                  ],
+                  "extensionTechs": [
+                    {
+                      "name": "canUnderwaterWalljumpBreakFree",
+                      "techRequires": [
+                        "canUnderwaterWalljump"
+                      ],
+                      "otherRequires": [],
+                      "note": [
+                        "The ability to underwater wall jump against a single wall and break the water line with HiJump but without Space Jump."
+                      ]
+                    }
                   ]
                 }
               ]


### PR DESCRIPTION
I never actually tested any of these, other than seeing how close I could jump to the water line (they were all reasonable, within ~1 tile).

There are ~~three~~ *two* tidal ones, which I would think would be easier, but I'm not sure: ~~West Cac Alley,~~ Pants, Grapple Tutorial 3

~~I am especially unsure about West Cac, as the wall doesnt go above the water line.~~ Also unsure on the lenience needed in East Cac above the spikes.

~~I could also ask Eddie to test the tidal difficulty and West Cac specifically if you think that would be worthwhile.~~

Edit: @blkerby tested it with tidal water in Pants Room, also let me know that West Cac can be done without Break Free, and is already in logic. 