### PR TITLE
Fix up canChainTemporaryBlue reqs

### DIFF
--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -225,7 +225,9 @@
           "openEnd": 0
         }
       },
-      "requires": [],
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
@@ -388,7 +390,9 @@
           "openEnd": 0
         }
       },
-      "requires": [],
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -198,6 +198,7 @@
         "comeInWithTemporaryBlue": {}
       },
       "requires": [
+        "canChainTemporaryBlue",
         "canSpringBallBounce"
       ],
       "clearsObstacles": ["A"],

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -884,7 +884,8 @@
           "steepUpTiles": 1
         }},
         "canBlueSpaceJump",
-        "canTrickyJump"
+        "canTrickyJump",
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -385,6 +385,7 @@
         "canTrickyDashJump",
         "canTrickySpringBallBounce",
         "canInsaneJump",
+        "canChainTemporaryBlue",
         "canBeVeryPatient"
       ],
       "exitCondition": {

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -295,8 +295,7 @@
           "Plasma",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
-        ]},
-        "canChainTemporaryBlue"
+        ]}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -315,7 +315,8 @@
           "gentleDownTiles": 2,
           "gentleUpTiles": 2,
           "steepUpTiles": 1
-        }}
+        }},
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1271,7 +1271,8 @@
         }
       },
       "requires": [
-        "canStutterWaterShineCharge"
+        "canStutterWaterShineCharge",
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -420,7 +420,6 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        "canChainTemporaryBlue",
         {"canShineCharge": {
           "usedTiles": 15,
           "openEnd": 1

--- a/region/maridia/inner-pink/Draygon Save Room.json
+++ b/region/maridia/inner-pink/Draygon Save Room.json
@@ -187,7 +187,9 @@
           "openEnd": 0
         }
       },
-      "requires": [],
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
@@ -358,7 +360,9 @@
           "openEnd": 0
         }
       },
-      "requires": [],
+      "requires": [
+        "canChainTemporaryBlue"
+      ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1730,7 +1730,8 @@
         "canWaterShineCharge",
         "HiJump",
         "canGravityJump",
-        "canTrickySpringBallJump"
+        "canTrickySpringBallJump",
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
@@ -1810,7 +1811,8 @@
         "canXRayTurnaround",
         "HiJump",
         "canGravityJump",
-        "canTrickySpringBallJump"
+        "canTrickySpringBallJump",
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -201,6 +201,7 @@
           "usedTiles": 20,
           "openEnd": 2
         }},
+        "canChainTemporaryBlue",
         "canXRayTurnaround",
         "HiJump",
         "canTrickySpringBallJump"

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -195,8 +195,7 @@
         {"canShineCharge": {
           "usedTiles": 14,
           "openEnd": 0
-        }},
-        "canChainTemporaryBlue"
+        }}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -163,8 +163,7 @@
         {"canShineCharge": {
           "usedTiles": 27,
           "openEnd": 0
-        }},
-        "canChainTemporaryBlue"
+        }}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
@@ -343,8 +342,7 @@
         {"canShineCharge": {
           "usedTiles": 27,
           "openEnd": 0
-        }},
-        "canChainTemporaryBlue"
+        }}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -868,7 +868,8 @@
           "usedTiles": 19,
           "openEnd": 0,
           "steepDownTiles": 3
-        }}
+        }},
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}


### PR DESCRIPTION
This fixes up several strats that either were missing a needed `canChainTemporaryBlue` requirement or had an unnecessary one. The most important reason this can matter is because `canChainTemporaryBlue` has a Morph requirement while `canTemporaryBlue`, `leaveWithTemporaryBlue`, and `comeInWithTemporaryBlue` do not. There are some cases where you can gain temporary blue near a door and jump through it with temporary blue without morphing; and then, if entering the bottom right of Screw Attack Room, you can use the temporary blue to break the bomb blocks, again without morphing, so those strats don't need a `canChainTemporaryBlue` requirement. But in every other case of cross-room temporary blue, Morph is needed, so we have to make sure those `canChainTemporaryBlue` requirements are there.

It can also make a difference for difficulty placement, e.g. in Map Rando we have  `canTemporaryBlue` in Very Hard while `canChainTemporaryBlue` is Expert.