### PR TITLE
Plasma Spark Room temp blue

### DIFF
--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -198,6 +198,38 @@
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue (Long Chain)",
+      "requires": [
+        "Gravity",
+        "HiJump",
+        {"canShineCharge": {
+          "usedTiles": 42,
+          "startingDownTiles": 2,
+          "gentleDownTiles": 2,
+          "steepUpTiles": 3,
+          "openEnd": 1
+        }},
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Gain a shinecharge by running right-to-left on the long runway at the bottom of the room."
+      ],
+      "devNote": [
+        "FIXME: This is also possible using Spring Ball jumps (with pause remorphs) instead of HiJump."
+      ]
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -795,7 +827,7 @@
     {
       "id": 31,
       "link": [3, 3],
-      "name": "Leave With Temporary Blue",
+      "name": "Leave With Temporary Blue (Kill Owtches)",
       "requires": [
         "Gravity",
         {"enemyKill": {
@@ -814,7 +846,7 @@
         "canXRayTurnaround"
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [
         {
@@ -826,6 +858,34 @@
         "Gain a shinecharge by running right-to-left on the underwater runway on the right side of the room."
       ],
       "devNote": "FIXME: It's technically possible to evade the Owtches without killing them, but it's unclear if this can be done reliably."
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Temporary Blue (Long Chain)",
+      "requires": [
+        "Gravity",
+        {"canShineCharge": {
+          "usedTiles": 42,
+          "startingDownTiles": 2,
+          "gentleDownTiles": 2,
+          "steepUpTiles": 3,
+          "openEnd": 1
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Gain a shinecharge by running right-to-left on the long runway at the bottom of the room."
+      ]
     },
     {
       "id": 32,

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -214,7 +214,9 @@
         "canLongChainTemporaryBlue"
       ],
       "exitCondition": {
-        "leaveWithTemporaryBlue": {}
+        "leaveWithTemporaryBlue": {
+          "direction": "any"
+        }
       },
       "unlocksDoors": [
         {


### PR DESCRIPTION
Videos:
- vertical door on the left: https://videos.maprando.com/video/715
- middle right door (long chain from bottom of room): https://videos.maprando.com/video/717
- middle right door (existing strat, killing the Owtches): https://videos.maprando.com/video/718

This also fixes the existing strat that should have had `leaveWithTemporaryBlue` but accidentally had `leaveWithSpark` (a copy-paste error).