### PR TITLE
Replace event nodes with junctions, unlockStrats with regular strats

### DIFF
--- a/region/brinstar/green/Spore Spawn Room.json
+++ b/region/brinstar/green/Spore Spawn Room.json
@@ -29,73 +29,9 @@
     {
       "id": 3,
       "name": "Spore Spawn",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Spore Spawn Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Charge",
-              "notable": false,
-              "requires": [
-                "Charge",
-                {"or": [
-                  {"and": [
-                    "Ice",
-                    "Wave"
-                  ]},
-                  {"and": [
-                    "Ice",
-                    "Spazer"
-                  ]},
-                  {"and": [
-                    "Spazer",
-                    "Wave"
-                  ]},
-                  {"and": [
-                    "canBePatient",
-                    {"or": [
-                      "Ice",
-                      "Wave",
-                      "Spazer"
-                    ]}
-                  ]},
-                  "Plasma",
-                  "canBeVeryPatient"
-                ]}
-              ]
-            },
-            {
-              "name": "Missiles",
-              "notable": false,
-              "requires": [
-                {"resourceCapacity": [{"type": "Missile", "count": 1}]},
-                {"or": [
-                  "canDodgeWhileShooting",
-                  "canBePatient"
-                ]}
-              ],
-              "devNote": "No ammo count because Missiles are farmable here."
-            },
-            {
-              "name": "Supers",
-              "notable": false,
-              "requires": [
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"resourceCapacity": [{"type": "Missile", "count": 1}]},
-                  {"ammo": {"type": "Super", "count": 2}}
-                ]},
-                {"ammo": {"type": "Super", "count": 4}}
-              ],
-              "note": "Spore Spawn's pollen does not drop Supers. The fight requires 4 Supers, where many misses could lead to a softlock."
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedSporeSpawn"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     }
   ],
   "enemies": [
@@ -128,7 +64,8 @@
       "from": 3,
       "to": [
         {"id": 1},
-        {"id": 2}
+        {"id": 2},
+        {"id": 3}
       ]
     }
   ],
@@ -249,6 +186,66 @@
       "name": "Base",
       "requires": [],
       "flashSuitChecked": true
+    },
+    {
+      "link": [3, 3],
+      "name": "Charge",
+      "requires": [
+        "Charge",
+        {"or": [
+          {"and": [
+            "Ice",
+            "Wave"
+          ]},
+          {"and": [
+            "Ice",
+            "Spazer"
+          ]},
+          {"and": [
+            "Spazer",
+            "Wave"
+          ]},
+          {"and": [
+            "canBePatient",
+            {"or": [
+              "Ice",
+              "Wave",
+              "Spazer"
+            ]}
+          ]},
+          "Plasma",
+          "canBeVeryPatient"
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedSporeSpawn"]
+    },
+    {
+      "link": [3, 3],
+      "name": "Missiles",
+      "requires": [
+        {"resourceCapacity": [{"type": "Missile", "count": 1}]},
+        {"or": [
+          "canDodgeWhileShooting",
+          "canBePatient"
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedSporeSpawn"],
+      "devNote": "No ammo count because Missiles are farmable here."
+    },
+    {
+      "link": [3, 3],
+      "name": "Supers",
+      "notable": false,
+      "requires": [
+        {"or": [
+          "canDodgeWhileShooting",
+          {"resourceCapacity": [{"type": "Missile", "count": 1}]},
+          {"ammo": {"type": "Super", "count": 2}}
+        ]},
+        {"ammo": {"type": "Super", "count": 4}}
+      ],
+      "setsFlags": ["f_DefeatedSporeSpawn"],
+      "note": "Spore Spawn's pollen does not drop Supers. The fight requires 4 Supers, where many misses could lead to a softlock."
     }
   ],
   "nextStratId": 11,

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -59,108 +59,9 @@
     {
       "id": 3,
       "name": "Kraid",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Kraid Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Charge",
-              "notable": false,
-              "requires": [
-                "Charge",
-                {"or": [
-                  "Wave",
-                  "Spazer",
-                  "Plasma",
-                  "canBePatient"
-                ]},
-                {"or": [
-                  "HiJump",
-                  "canWalljump",
-                  "SpaceJump",
-                  "canSpringBallJumpMidAir",
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    {"or": [
-                      "canCarefulJump",
-                      "h_canCrouchJumpDownGrab"
-                    ]}
-                  ]}
-                ]}
-              ],
-              "note": "Getting up during Phase 2 can be done by jumping on Kraid's projectile platforms or a well timed crouch jump + down grab."
-            },
-            {
-              "name": "Missiles",
-              "notable": false,
-              "requires": [
-                {"ammo": {"type": "Missile", "count": 2}},
-                {"or": [
-                  "HiJump",
-                  "canWalljump",
-                  "SpaceJump",
-                  "canSpringBallJumpMidAir",
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    {"or": [
-                      "canCarefulJump",
-                      "h_canCrouchJumpDownGrab"
-                    ]}
-                  ]}
-                ]}
-              ],
-              "note": [
-                "Only 2 Missiles are needed to get Kraid to stand up, after which they are farmable.",
-                "Getting up during Phase 2 can be done by jumping on Kraid's projectile platforms or a well timed crouch jump + down grab."
-              ]
-            },
-            {
-              "name": "Supers",
-              "notable": false,
-              "requires": [
-                {"or": [
-                  {"ammo": {"type": "Super", "count": 5}},
-                  {"and": [
-                    {"ammo": {"type": "Super", "count": 4}},
-                    "canDodgeWhileShooting"
-                  ]},
-                  {"and": [
-                    {"ammo": {"type": "Super", "count": 3}},
-                    "canDodgeWhileShooting",
-                    "canBePatient"
-                  ]},
-                  {"and": [
-                    {"ammo": {"type": "Super", "count": 1}},
-                    "canDodgeWhileShooting",
-                    "canBeVeryPatient"
-                  ]}
-                ]},
-                {"or": [
-                  "HiJump",
-                  "canWalljump",
-                  "SpaceJump",
-                  "canSpringBallJumpMidAir",
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    {"or": [
-                      "canCarefulJump",
-                      "h_canCrouchJumpDownGrab"
-                    ]}
-                  ]}
-                ]}
-              ],
-              "note": [
-                "4 supers are required to kill Kraid. Only 1 is needed to get him to stand up, after which they are farmable, even though the drop rate is low.",
-                "Getting up during Phase 2 can be done by jumping on Kraid's projectile platforms or a well timed crouch jump + down grab."
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedKraid"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated"
     }
   ],
   "enemies": [
@@ -193,7 +94,8 @@
       "from": 3,
       "to": [
         {"id": 1},
-        {"id": 2}
+        {"id": 2},
+        {"id": 3}
       ]
     }
   ],
@@ -617,6 +519,100 @@
         "f_DefeatedKraid"
       ],
       "note": "Door is not reachable mid-fight"
+    },
+    {
+      "link": [3, 3],
+      "name": "Charge",
+      "requires": [
+        "Charge",
+        {"or": [
+          "Wave",
+          "Spazer",
+          "Plasma",
+          "canBePatient"
+        ]},
+        {"or": [
+          "HiJump",
+          "canWalljump",
+          "SpaceJump",
+          "canSpringBallJumpMidAir",
+          {"and": [
+            "canDodgeWhileShooting",
+            {"or": [
+              "canCarefulJump",
+              "h_canCrouchJumpDownGrab"
+            ]}
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedKraid"],
+      "note": "Getting up during Phase 2 can be done by jumping on Kraid's projectile platforms or a well timed crouch jump + down grab."
+    },
+    {
+      "link": [3, 3],
+      "name": "Missiles",
+      "requires": [
+        {"ammo": {"type": "Missile", "count": 2}},
+        {"or": [
+          "HiJump",
+          "canWalljump",
+          "SpaceJump",
+          "canSpringBallJumpMidAir",
+          {"and": [
+            "canDodgeWhileShooting",
+            {"or": [
+              "canCarefulJump",
+              "h_canCrouchJumpDownGrab"
+            ]}
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedKraid"],
+      "note": [
+        "Only 2 Missiles are needed to get Kraid to stand up, after which they are farmable.",
+        "Getting up during Phase 2 can be done by jumping on Kraid's projectile platforms or a well timed crouch jump + down grab."
+      ]
+    },
+    {
+      "link": [3, 3],
+      "name": "Supers",
+      "requires": [
+        {"or": [
+          {"ammo": {"type": "Super", "count": 5}},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 4}},
+            "canDodgeWhileShooting"
+          ]},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 3}},
+            "canDodgeWhileShooting",
+            "canBePatient"
+          ]},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            "canDodgeWhileShooting",
+            "canBeVeryPatient"
+          ]}
+        ]},
+        {"or": [
+          "HiJump",
+          "canWalljump",
+          "SpaceJump",
+          "canSpringBallJumpMidAir",
+          {"and": [
+            "canDodgeWhileShooting",
+            {"or": [
+              "canCarefulJump",
+              "h_canCrouchJumpDownGrab"
+            ]}
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedKraid"],
+      "note": [
+        "4 supers are required to kill Kraid. Only 1 is needed to get him to stand up, after which they are farmable, even though the drop rate is low.",
+        "Getting up during Phase 2 can be done by jumping on Kraid's projectile platforms or a well timed crouch jump + down grab."
+      ]
     }
   ],
   "nextStratId": 29,

--- a/region/ceres/main/Ceres Ridley's Room.json
+++ b/region/ceres/main/Ceres Ridley's Room.json
@@ -35,27 +35,9 @@
     {
       "id": 2,
       "name": "Ceres Ridley",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Ceres Ridley Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                {"resourceAtMost": [{"type": "RegularEnergy", "count": 29}]}
-              ],
-              "note": "Just taking damage is enough to finish the fight.",
-              "devNote": "It is possible to finish the fight with more Reserve Energy."
-            }
-          ],
-          "note": "It's also possible to get through this fight without losing energy, but it is pointless, difficult, and very time-consuming."
-        }
-      ],
-      "yields": ["f_DefeatedCeresRidley"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated"
     }
   ],
   "enemies": [
@@ -79,7 +61,8 @@
     {
       "from": 2,
       "to": [
-        {"id": 1}
+        {"id": 1},
+        {"id": 2}
       ]
     }
   ],
@@ -131,6 +114,16 @@
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 2],
+      "name": "Base",
+      "requires": [
+        {"resourceAtMost": [{"type": "RegularEnergy", "count": 29}]}
+      ],
+      "setsFlags": ["f_DefeatedCeresRidley"],
+      "note": "Just taking damage is enough to finish the fight.",
+      "devNote": "It is possible to finish the fight with more Reserve Energy."
     }
   ],
   "nextStratId": 6,

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -59,56 +59,16 @@
     {
       "id": 3,
       "name": "Bomb Torizo",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Bomb Torizo Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "h_canActivateBombTorizo",
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"ammo": {"type": "Super", "count": 2}},
-                  {"enemyDamage": {
-                    "enemy": "Bomb Torizo",
-                    "type": "contact",
-                    "hits": 3
-                  }}
-                ]}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedBombTorizo"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 4,
       "name": "Save the Animals",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Animal Wall Lock",
-          "lockType": "cutscene",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "f_ZebesSetAblaze"
-              ],
-              "devNote": "Technically this also requires opening the wall."
-            }
-          ]
-        }
-      ],
-      "yields": ["f_AnimalsSaved"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     }
   ],
   "enemies": [
@@ -146,13 +106,15 @@
       "from": 3,
       "to": [
         {"id": 1},
-        {"id": 2}
+        {"id": 2},
+        {"id": 3}
       ]
     },
     {
       "from": 4,
       "to": [
-        {"id": 1}
+        {"id": 1},
+        {"id": 4}
       ]
     }
   ],
@@ -366,10 +328,37 @@
       "requires": []
     },
     {
+      "link": [3, 3],
+      "name": "Fight Bomb Torizo",
+      "requires": [
+        "h_canActivateBombTorizo",
+        {"or": [
+          "canDodgeWhileShooting",
+          {"ammo": {"type": "Super", "count": 2}},
+          {"enemyDamage": {
+            "enemy": "Bomb Torizo",
+            "type": "contact",
+            "hits": 3
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedBombTorizo"]
+    },
+    {
       "id": 17,
       "link": [4, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [4, 4],
+      "name": "Save the Animals",
+      "notable": false,
+      "requires": [
+        "f_ZebesSetAblaze"
+      ],
+      "setsFlags": ["f_AnimalsSaved"],
+      "devNote": "Technically this also requires opening the wall."
     }
   ],
   "nextStratId": 18,

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -41,54 +41,16 @@
     {
       "id": 3,
       "name": "Statues Event",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Statues Above Lock",
-          "lockType": "gameFlag",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "f_DefeatedKraid",
-                "f_DefeatedPhantoon",
-                "f_DefeatedDraygon",
-                "f_DefeatedRidley"
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_TourianOpen"],
-      "note": "Represents the statues actually sinking and opening up the path to Tourian"
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 4,
       "name": "Underwater Statues Event",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Statues Below Lock",
-          "lockType": "gameFlag",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "f_DefeatedKraid",
-                "f_DefeatedPhantoon",
-                "f_DefeatedDraygon",
-                "f_DefeatedRidley"
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_TourianOpen"],
-      "note": "Represents the statues actually sinking and opening up the path to Tourian, but coming from below"
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     }
   ],
   "enemies": [],
@@ -120,6 +82,7 @@
       "from": 3,
       "to": [
         {"id": 1},
+        {"id": 3},
         {"id": 4}
       ]
     },
@@ -133,6 +96,9 @@
             "If Tourian is locked, coming in from below results in glitched graphics.",
             "You can reach the elevator to go back down again or sit through the unlock to get up which in turn can result in persisting glitched graphics."
           ]
+        },
+        {
+          "id": 4
         }
       ]
     }
@@ -462,6 +428,19 @@
       "requires": []
     },
     {
+      "link": [3, 3],
+      "name": "Statues Cutscene",
+      "notable": false,
+      "requires": [
+        "f_DefeatedKraid",
+        "f_DefeatedPhantoon",
+        "f_DefeatedDraygon",
+        "f_DefeatedRidley"
+      ],
+      "setsFlags": ["f_TourianOpen"],
+      "note": "Represents the statues sinking and opening up the path to Tourian"
+    },
+    {
       "id": 18,
       "link": [3, 4],
       "name": "Base",
@@ -538,6 +517,19 @@
           ]}
         ]}
       ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Statues Cutscene",
+      "notable": false,
+      "requires": [
+        "f_DefeatedKraid",
+        "f_DefeatedPhantoon",
+        "f_DefeatedDraygon",
+        "f_DefeatedRidley"
+      ],
+      "setsFlags": ["f_TourianOpen"],
+      "note": "Represents the statues sinking and opening up the path to Tourian, but coming from below"
     }
   ],
   "nextStratId": 25,

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -61,38 +61,9 @@
     {
       "id": 3,
       "name": "Ridley",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Ridley Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Heat Proof Ridley",
-              "notable": false,
-              "requires": [
-                "h_heatProof",
-                {"enemyKill": {
-                  "enemies": [["Ridley"]]
-                }}
-              ]
-            },
-            {
-              "name": "Ridley without Heat Protection",
-              "notable": true,
-              "requires": [
-                "canHeatRun",
-                {"enemyKill": {
-                  "enemies": [["Ridley"]]
-                }}
-              ],
-              "note": "Fight Ridley without immunity to heat damage."
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedRidley"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 4,
@@ -307,6 +278,29 @@
         "h_heatProof",
         "canIBJ"
       ]
+    },
+    {
+      "link": [3, 3],
+      "name": "Heat Proof Ridley",
+      "requires": [
+        "h_heatProof",
+        {"enemyKill": {
+          "enemies": [["Ridley"]]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedRidley"]
+    },
+    {
+      "link": [3, 3],
+      "name": "Ridley without Heat Protection",
+      "requires": [
+        "canHeatRun",
+        {"enemyKill": {
+          "enemies": [["Ridley"]]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedRidley"],
+      "note": "Fight Ridley without immunity to heat damage."
     },
     {
       "id": 13,

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -38,28 +38,9 @@
     {
       "id": 3,
       "name": "Acid Chozo Statue",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "yields": ["f_UsedAcidChozoStatue"],
-      "locks": [
-        {
-          "name": "Acid Statue Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "h_canActivateAcidChozo",
-                {"obstaclesNotCleared": ["A"]},
-                "h_canUsePowerBombs",
-                {"heatFrames": 1000}
-              ]
-            }
-          ]
-        }
-      ],
-      "note": "This node represents the ledge the statue is on. This is why it can be reached without breaking the PB blocks, but not unlocked."
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 4,
@@ -534,6 +515,17 @@
         "f_UsedAcidChozoStatue",
         {"heatFrames": 300}
       ]
+    },
+    {
+      "link": [3, 3],
+      "name": "Use Acid Statue",
+      "requires": [
+        "h_canActivateAcidChozo",
+        {"obstaclesNotCleared": ["A"]},
+        "h_canUsePowerBombs",
+        {"heatFrames": 1000}
+      ],
+      "setsFlags": ["f_UsedAcidChozoStatue"]
     },
     {
       "id": 25,

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -61,412 +61,9 @@
     {
       "id": 5,
       "name": "Golden Torizo",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "yields": ["f_DefeatedGoldenTorizo"],
-      "locks": [
-        {
-          "name": "Golden Torizo Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Safe Spot Heatproof Supers",
-              "notable": true,
-              "requires": [
-                "h_heatProof",
-                "Super"
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": "Farm supers to use throughout the fight.",
-              "devNote": "Supers are farmable here, so no ammo requirement."
-            },
-            {
-              "name": "Safe Spot Heatproof Charge",
-              "notable": true,
-              "requires": [
-                "h_heatProof",
-                "Charge",
-                "canBeVeryPatient"
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": "Stand in the safe spot and fire Charge shots into GT."
-            },
-            {
-              "name": "Safe Spot Supers",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                {"heatFrames": 1200},
-                {"ammo": {"type": "Super", "count": 30}}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": [
-                "This strat is assuming no farming. It requires 30 supers, but can be done with 29.",
-                "This requires a very steady fire rate so that for every Super Missile caught by GT, the next 4 Supers do damage."
-              ],
-              "devNote": [
-                "No farming expected because that would change the heat frames.",
-                "Supers count hard-coded because of GT's inherent 'dodging' ability.",
-                "We could use an enemyKill if this were integrated into the enemy definition.",
-                "It actually takes 29 supers but giving 1 extra in leniency since it's easy to miss."
-              ]
-            },
-            {
-              "name": "Safe Spot Supers (Farming)",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                "canTrickyJump",
-                {"ammo": {"type": "Super", "count": 15}},
-                {"or": [
-                  {"and": [
-                    "Plasma",
-                    {"heatFrames": 2700}
-                  ]},
-                  {"and": [
-                    "canPreciseGrapple",
-                    {"heatFrames": 2700}
-                  ]},
-                  {"heatFrames": 3200}
-                ]}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": [
-                "This strat requires some farming. It assumes starting with 15 supers for one session of farming.",
-                "A safe farming method is to face left while standing in the safe spot.  Then fire straight up to shoot the orbs as they appear.",
-                "Jump up while GT's beak is not open to collect the drops.",
-                "Plasma allows all of the orbs to be broken at once.",
-                "Grapple allows for more drops to be collected by shooting diagonally, and collecting the items using Grapple.",
-                "Keep the number of current Missiles below 31 so that GT will be guaranteed to use the attack which creates drops.",
-                "Firing Supers requires a very steady fire rate so that for every Super Missile caught by GT, the next 4 Supers do damage."
-              ],
-              "devNote": "Listed Heat frames have been reduced by accounting for health drops."
-            },
-            {
-              "name": "Safe Spot Supers (Farming, Few Supers)",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                "canTrickyJump",
-                "canBePatient",
-                {"ammo": {"type": "Super", "count": 5}},
-                {"or": [
-                  {"and": [
-                    "Plasma",
-                    {"heatFrames": 3100}
-                  ]},
-                  {"and": [
-                    "canPreciseGrapple",
-                    {"heatFrames": 3200}
-                  ]},
-                  {"heatFrames": 4500}
-                ]}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": [
-                "This strat requires much farming. It assumes a capacity of and starting with only 5 supers for five sessions of farming.",
-                "A safe farming method is to face left while standing in the safe spot.  Then fire straight up to shoot the orbs as they appear.",
-                "Jump up while GT's beak is not open to collect the drops.",
-                "Plasma allows all of the orbs to be broken at once.",
-                "Grapple allows for more drops to be collected by shooting diagonally, and collecting the items using Grapple.",
-                "Keep the number of current Missiles below 31 so that GT will be guaranteed to use the attack which creates drops.",
-                "Firing Supers requires a very steady fire rate so that for every Super Missile caught by GT, the next 4 Supers do damage."
-              ],
-              "devNote": "Listed Heat frames have been reduced by accounting for health drops."
-            },
-            {
-              "name": "Golden Torizo Crystal Flash",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                {"or": [
-                  {"ammo": {"type": "Super", "count": 30}},
-                  {"and": [
-                    "Charge",
-                    "Ice",
-                    "Wave",
-                    "Plasma"
-                  ]}
-                ]},
-                {"heatFrames": 800},
-                "h_canHeatedCrystalFlash",
-                {"heatFrames": 800}
-              ],
-              "flashSuitChecked": true,
-              "note": [
-                "Midway through the fight, use a Crystal Flash to refill Samus' energy.",
-                "Crystal Flashing while standing in the safe spot at GT's feet is safe."
-              ],
-              "devNote": [
-                "FIXME: Other resource combinations can work; fewer supers + farm, weaker beam + more health, 2nd crystal flash.",
-                "FIXME: Add heavy pause abuse strats for GT."
-              ]
-            },
-            {
-              "name": "Safe Spot Full Combo",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                "Charge",
-                "Ice",
-                "Wave",
-                "Plasma",
-                {"heatFrames": 1250}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": "Stand in the safe spot and fire Charge shots into GT."
-            },
-            {
-              "name": "Safe Spot Almost Full Combo",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                "Charge",
-                "Wave",
-                "Plasma",
-                {"heatFrames": 1400}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": "Stand in the safe spot and fire Charge shots into GT."
-            },
-            {
-              "name": "Safe Spot Charge Plasma",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                "Charge",
-                "Plasma",
-                {"heatFrames": 2000}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": "Stand in the safe spot and fire Charge shots into GT."
-            },
-            {
-              "name": "Safe Spot Full Spazer",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                "Charge",
-                "Ice",
-                "Wave",
-                "Spazer",
-                {"heatFrames": 4000}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": "Stand in the safe spot and fire Charge shots into GT."
-            },
-            {
-              "name": "Safe Spot Two Beam Charge",
-              "notable": true,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                "Charge",
-                {"heatFrames": 6500},
-                {"or": [
-                  {"and": [
-                    "Ice",
-                    "Wave"
-                  ]},
-                  {"and": [
-                    "Ice",
-                    "Spazer"
-                  ]},
-                  {"and": [
-                    "Wave",
-                    "Spazer"
-                  ]}
-                ]}
-              ],
-              "reusableRoomwideNotable": "Golden Torizo Safe Spot",
-              "note": "Stand in the safe spot and fire Charge shots into GT."
-            },
-            {
-              "name": "Supers",
-              "notable": false,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                {"heatFrames": 1200},
-                {"ammo": {"type": "Super", "count": 30}},
-                {"enemyDamage": {
-                  "enemy": "Golden Torizo",
-                  "type": "super",
-                  "hits": 4
-                }},
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"ammo": {"type": "Super", "count": 5}},
-                  {"and": [
-                    {"enemyDamage": {
-                      "enemy": "Golden Torizo",
-                      "type": "super",
-                      "hits": 2
-                    }},
-                    {"heatFrames": 200}
-                  ]}
-                ]}
-              ],
-              "devNote": [
-                "No farming expected because that would change the heat frames.",
-                "Supers count hard-coded because of GT's inherent 'dodging' ability.",
-                "We could use an enemyKill if this were integrated into the enemy definition.",
-                "It actually takes 29 supers but giving 1 extra in leniency since it's easy to miss"
-              ]
-            },
-            {
-              "name": "Golden Torizo Missiles Only",
-              "notable": true,
-              "requires": [
-                "h_heatProof",
-                "Morph",
-                {"resourceCapacity": [{"type": "Missile", "count": 15}]},
-                {"or": [
-                  {"resourceCapacity": [{"type": "RegularEnergy", "count": 199}]},
-                  {"resourceCapacity": [{"type": "ReserveEnergy", "count": 100}]}
-                ]},
-                "canBeVeryPatient"
-              ],
-              "note": [
-                "Killing Golden Torizo only with missiles using enemy state manipulation to get missiles to connect.",
-                "This can be done by rolling under GT, triggering the sit attack, and then shooting missiles during the stand up animation.",
-                "By pushing GT to the door and rolling into the door during a jump back, the sit can reliably be manipulated.",
-                "But this setup is subpixel dependant and harder to setup again if GT moves unexpectidly.",
-                "Use of the safe spot is expected. Keep missiles below 31 to control the fight. This fight takes multiple minutes.",
-                "(A cheeky Missile can hit GT the moment it becomes active)"
-              ],
-              "devNote": "It is easy to make mistakes with this strat, so some capacity is given for leniency.  You can farm up resources readily enough."
-            },
-            {
-              "name": "Full Combo",
-              "notable": false,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                {"heatFrames": 1800},
-                "Charge",
-                "Ice",
-                "Wave",
-                "Plasma",
-                {"enemyDamage": {
-                  "enemy": "Golden Torizo",
-                  "type": "contact",
-                  "hits": 1
-                }},
-                {"or": [
-                  {"enemyDamage": {
-                    "enemy": "Golden Torizo",
-                    "type": "contact",
-                    "hits": 3
-                  }},
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    {"or": [
-                      "ScrewAttack",
-                      "Morph"
-                    ]}
-                  ]}
-                ]}
-              ],
-              "note": "This is an estimate of the net damage taken, including farmed energy."
-            },
-            {
-              "name": "Almost Full Combo",
-              "notable": false,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                {"heatFrames": 2150},
-                "Charge",
-                "Wave",
-                "Plasma",
-                {"enemyDamage": {
-                  "enemy": "Golden Torizo",
-                  "type": "contact",
-                  "hits": 2
-                }},
-                {"or": [
-                  {"enemyDamage": {
-                    "enemy": "Golden Torizo",
-                    "type": "contact",
-                    "hits": 3
-                  }},
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    {"or": [
-                      "ScrewAttack",
-                      "Morph"
-                    ]}
-                  ]}
-                ]}
-              ],
-              "note": "This is an estimate of the net damage taken, including farmed energy."
-            },
-            {
-              "name": "Charge Plasma",
-              "notable": false,
-              "requires": [
-                "h_canNavigateHeatRooms",
-                {"heatFrames": 3600},
-                "Charge",
-                "Plasma",
-                {"enemyDamage": {
-                  "enemy": "Golden Torizo",
-                  "type": "contact",
-                  "hits": 2
-                }},
-                {"or": [
-                  {"enemyDamage": {
-                    "enemy": "Golden Torizo",
-                    "type": "contact",
-                    "hits": 6
-                  }},
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    {"or": [
-                      "ScrewAttack",
-                      "Morph"
-                    ]}
-                  ]}
-                ]}
-              ],
-              "note": "This is an estimate of the net damage taken, including farmed energy."
-            },
-            {
-              "name": "Full Spazer",
-              "notable": false,
-              "requires": [
-                "h_heatProof",
-                "Charge",
-                "Ice",
-                "Wave",
-                "Spazer",
-                {"enemyDamage": {
-                  "enemy": "Golden Torizo",
-                  "type": "contact",
-                  "hits": 4
-                }},
-                {"or": [
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    {"or": [
-                      "Morph",
-                      "ScrewAttack",
-                      {"enemyDamage": {
-                        "enemy": "Golden Torizo",
-                        "type": "contact",
-                        "hits": 6
-                      }}
-                    ]}
-                  ]},
-                  {"enemyDamage": {
-                    "enemy": "Golden Torizo",
-                    "type": "contact",
-                    "hits": 13
-                  }}
-                ]}
-              ],
-              "note": "This is an estimate of the net damage taken, including farmed energy."
-            }
-          ]
-        }
-      ]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 6,
@@ -566,7 +163,8 @@
       "from": 5,
       "to": [
         {"id": 2},
-        {"id": 4}
+        {"id": 4},
+        {"id": 5}
       ]
     },
     {
@@ -1140,6 +738,420 @@
       ]
     },
     {
+      "link": [5, 5],
+      "name": "Safe Spot Heatproof Supers",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_heatProof",
+        "Super"
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "Farm supers to use throughout the fight.",
+      "devNote": "Supers are farmable here, so no ammo requirement."
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Heatproof Charge",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_heatProof",
+        "Charge",
+        "canBeVeryPatient"
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "Stand in the safe spot and fire Charge shots into GT."
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Supers",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        {"heatFrames": 1200},
+        {"ammo": {"type": "Super", "count": 30}}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": [
+        "This strat is assuming no farming. It requires 30 supers, but can be done with 29.",
+        "This requires a very steady fire rate so that for every Super Missile caught by GT, the next 4 Supers do damage."
+      ],
+      "devNote": [
+        "No farming expected because that would change the heat frames.",
+        "Supers count hard-coded because of GT's inherent 'dodging' ability.",
+        "We could use an enemyKill if this were integrated into the enemy definition.",
+        "It actually takes 29 supers but giving 1 extra in leniency since it's easy to miss."
+      ]
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Supers (Farming)",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        "canTrickyJump",
+        {"ammo": {"type": "Super", "count": 15}},
+        {"or": [
+          {"and": [
+            "Plasma",
+            {"heatFrames": 2700}
+          ]},
+          {"and": [
+            "canPreciseGrapple",
+            {"heatFrames": 2700}
+          ]},
+          {"heatFrames": 3200}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": [
+        "This strat requires some farming. It assumes starting with 15 supers for one session of farming.",
+        "A safe farming method is to face left while standing in the safe spot.  Then fire straight up to shoot the orbs as they appear.",
+        "Jump up while GT's beak is not open to collect the drops.",
+        "Plasma allows all of the orbs to be broken at once.",
+        "Grapple allows for more drops to be collected by shooting diagonally, and collecting the items using Grapple.",
+        "Keep the number of current Missiles below 31 so that GT will be guaranteed to use the attack which creates drops.",
+        "Firing Supers requires a very steady fire rate so that for every Super Missile caught by GT, the next 4 Supers do damage."
+      ],
+      "devNote": "Listed Heat frames have been reduced by accounting for health drops."
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Supers (Farming, Few Supers)",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        "canTrickyJump",
+        "canBePatient",
+        {"ammo": {"type": "Super", "count": 5}},
+        {"or": [
+          {"and": [
+            "Plasma",
+            {"heatFrames": 3100}
+          ]},
+          {"and": [
+            "canPreciseGrapple",
+            {"heatFrames": 3200}
+          ]},
+          {"heatFrames": 4500}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": [
+        "This strat requires much farming. It assumes a capacity of and starting with only 5 supers for five sessions of farming.",
+        "A safe farming method is to face left while standing in the safe spot.  Then fire straight up to shoot the orbs as they appear.",
+        "Jump up while GT's beak is not open to collect the drops.",
+        "Plasma allows all of the orbs to be broken at once.",
+        "Grapple allows for more drops to be collected by shooting diagonally, and collecting the items using Grapple.",
+        "Keep the number of current Missiles below 31 so that GT will be guaranteed to use the attack which creates drops.",
+        "Firing Supers requires a very steady fire rate so that for every Super Missile caught by GT, the next 4 Supers do damage."
+      ],
+      "devNote": "Listed Heat frames have been reduced by accounting for health drops."
+    },
+    {
+      "link": [5, 5],
+      "name": "Golden Torizo Crystal Flash",
+      "requires": [
+        {"notable": "Golden Torizo Crystal Flash"},
+        "h_canNavigateHeatRooms",
+        {"or": [
+          {"ammo": {"type": "Super", "count": 30}},
+          {"and": [
+            "Charge",
+            "Ice",
+            "Wave",
+            "Plasma"
+          ]}
+        ]},
+        {"heatFrames": 800},
+        "h_canHeatedCrystalFlash",
+        {"heatFrames": 800}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "flashSuitChecked": true,
+      "note": [
+        "Midway through the fight, use a Crystal Flash to refill Samus' energy.",
+        "Crystal Flashing while standing in the safe spot at GT's feet is safe."
+      ],
+      "devNote": [
+        "FIXME: Other resource combinations can work; fewer supers + farm, weaker beam + more health, 2nd crystal flash.",
+        "FIXME: Add heavy pause abuse strats for GT."
+      ]
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Full Combo",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        "Charge",
+        "Ice",
+        "Wave",
+        "Plasma",
+        {"heatFrames": 1250}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "Stand in the safe spot and fire Charge shots into GT."
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Almost Full Combo",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        "Charge",
+        "Wave",
+        "Plasma",
+        {"heatFrames": 1400}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "Stand in the safe spot and fire Charge shots into GT."
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Charge Plasma",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        "Charge",
+        "Plasma",
+        {"heatFrames": 2000}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "Stand in the safe spot and fire Charge shots into GT."
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Full Spazer",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        "Charge",
+        "Ice",
+        "Wave",
+        "Spazer",
+        {"heatFrames": 4000}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "Stand in the safe spot and fire Charge shots into GT."
+    },
+    {
+      "link": [5, 5],
+      "name": "Safe Spot Two Beam Charge",
+      "requires": [
+        {"notable": "Golden Torizo Safe Spot"},
+        "h_canNavigateHeatRooms",
+        "Charge",
+        {"heatFrames": 6500},
+        {"or": [
+          {"and": [
+            "Ice",
+            "Wave"
+          ]},
+          {"and": [
+            "Ice",
+            "Spazer"
+          ]},
+          {"and": [
+            "Wave",
+            "Spazer"
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "Stand in the safe spot and fire Charge shots into GT."
+    },
+    {
+      "link": [5, 5],
+      "name": "Golden Torizo Fight (Supers)",
+      "requires": [
+        "h_canNavigateHeatRooms",
+        {"heatFrames": 1200},
+        {"ammo": {"type": "Super", "count": 30}},
+        {"enemyDamage": {
+          "enemy": "Golden Torizo",
+          "type": "super",
+          "hits": 4
+        }},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"ammo": {"type": "Super", "count": 5}},
+          {"and": [
+            {"enemyDamage": {
+              "enemy": "Golden Torizo",
+              "type": "super",
+              "hits": 2
+            }},
+            {"heatFrames": 200}
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "devNote": [
+        "No farming expected because that would change the heat frames.",
+        "Supers count hard-coded because of GT's inherent 'dodging' ability.",
+        "We could use an enemyKill if this were integrated into the enemy definition.",
+        "It actually takes 29 supers but giving 1 extra in leniency since it's easy to miss"
+      ]
+    },
+    {
+      "link": [5, 5],
+      "name": "Golden Torizo Missiles Only",
+      "requires": [
+        {"notable": "Golden Torizo Missiles Only"},
+        "h_heatProof",
+        "Morph",
+        {"resourceCapacity": [{"type": "Missile", "count": 15}]},
+        {"or": [
+          {"resourceCapacity": [{"type": "RegularEnergy", "count": 199}]},
+          {"resourceCapacity": [{"type": "ReserveEnergy", "count": 100}]}
+        ]},
+        "canBeVeryPatient"
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": [
+        "Killing Golden Torizo only with missiles using enemy state manipulation to get missiles to connect.",
+        "This can be done by rolling under GT, triggering the sit attack, and then shooting missiles during the stand up animation.",
+        "By pushing GT to the door and rolling into the door during a jump back, the sit can reliably be manipulated.",
+        "But this setup is subpixel dependant and harder to setup again if GT moves unexpectidly.",
+        "Use of the safe spot is expected. Keep missiles below 31 to control the fight. This fight takes multiple minutes.",
+        "(A cheeky Missile can hit GT the moment it becomes active)"
+      ],
+      "devNote": "It is easy to make mistakes with this strat, so some capacity is given for leniency.  You can farm up resources readily enough."
+    },
+    {
+      "link": [5, 5],
+      "name": "Golden Torizo Fight (Full Combo)",
+      "requires": [
+        "h_canNavigateHeatRooms",
+        {"heatFrames": 1800},
+        "Charge",
+        "Ice",
+        "Wave",
+        "Plasma",
+        {"enemyDamage": {
+          "enemy": "Golden Torizo",
+          "type": "contact",
+          "hits": 1
+        }},
+        {"or": [
+          {"enemyDamage": {
+            "enemy": "Golden Torizo",
+            "type": "contact",
+            "hits": 3
+          }},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"or": [
+              "ScrewAttack",
+              "Morph"
+            ]}
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "This is an estimate of the net damage taken, including farmed energy."
+    },
+    {
+      "link": [5, 5],
+      "name": "Golden Torizo Fight (Almost Full Combo)",
+      "requires": [
+        "h_canNavigateHeatRooms",
+        {"heatFrames": 2150},
+        "Charge",
+        "Wave",
+        "Plasma",
+        {"enemyDamage": {
+          "enemy": "Golden Torizo",
+          "type": "contact",
+          "hits": 2
+        }},
+        {"or": [
+          {"enemyDamage": {
+            "enemy": "Golden Torizo",
+            "type": "contact",
+            "hits": 3
+          }},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"or": [
+              "ScrewAttack",
+              "Morph"
+            ]}
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "This is an estimate of the net damage taken, including farmed energy."
+    },
+    {
+      "link": [5, 5],
+      "name": "Golden Torizo Fight (Charge Plasma)",
+      "requires": [
+        "h_canNavigateHeatRooms",
+        {"heatFrames": 3600},
+        "Charge",
+        "Plasma",
+        {"enemyDamage": {
+          "enemy": "Golden Torizo",
+          "type": "contact",
+          "hits": 2
+        }},
+        {"or": [
+          {"enemyDamage": {
+            "enemy": "Golden Torizo",
+            "type": "contact",
+            "hits": 6
+          }},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"or": [
+              "ScrewAttack",
+              "Morph"
+            ]}
+          ]}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "This is an estimate of the net damage taken, including farmed energy."
+    },
+    {
+      "link": [5, 5],
+      "name": "Golden Torizo Fight (Full Spazer)",
+      "requires": [
+        "h_heatProof",
+        "Charge",
+        "Ice",
+        "Wave",
+        "Spazer",
+        {"enemyDamage": {
+          "enemy": "Golden Torizo",
+          "type": "contact",
+          "hits": 4
+        }},
+        {"or": [
+          {"and": [
+            "canDodgeWhileShooting",
+            {"or": [
+              "Morph",
+              "ScrewAttack",
+              {"enemyDamage": {
+                "enemy": "Golden Torizo",
+                "type": "contact",
+                "hits": 6
+              }}
+            ]}
+          ]},
+          {"enemyDamage": {
+            "enemy": "Golden Torizo",
+            "type": "contact",
+            "hits": 13
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedGoldenTorizo"],
+      "note": "This is an estimate of the net damage taken, including farmed energy."
+    },
+    {
       "id": 40,
       "link": [6, 2],
       "name": "Base",
@@ -1274,7 +1286,27 @@
       "id": 4,
       "name": "Golden Torizo Horizontal Bomb Jump",
       "note": "Use a bomb explosion to jump horizontally over the GT crumble blocks."
+    },
+    {
+      "id": 5,
+      "name": "Golden Torizo Crystal Flash",
+      "note": [
+        "Midway through the fight, use a Crystal Flash to refill Samus' energy.",
+        "Crystal Flashing while standing in the safe spot at GT's feet is safe."
+      ]     
+    },
+    {
+      "id": 6,
+      "name": "Golden Torizo Missiles Only",
+      "note": [
+        "Killing Golden Torizo only with missiles using enemy state manipulation to get missiles to connect.",
+        "This can be done by rolling under GT, triggering the sit attack, and then shooting missiles during the stand up animation.",
+        "By pushing GT to the door and rolling into the door during a jump back, the sit can reliably be manipulated.",
+        "But this setup is subpixel dependant and harder to setup again if GT moves unexpectidly.",
+        "Use of the safe spot is expected. Keep missiles below 31 to control the fight. This fight takes multiple minutes.",
+        "(A cheeky Missile can hit GT the moment it becomes active)"
+      ]     
     }
   ],
-  "nextNotableId": 5
+  "nextNotableId": 7
 }

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -45,182 +45,23 @@
     {
       "id": 3,
       "name": "Botwoon Phase 1",
-      "nodeType": "event",
-      "nodeSubType": "boss"
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 4,
       "name": "Back-Side Botwoon",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Back-Side Botwoon Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Back-Side Botwoon Fight - Gravity, Charge, Wave",
-              "notable": true,
-              "requires": [
-                "Gravity",
-                "Charge",
-                "Wave",
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"enemyDamage": {
-                    "enemy": "Botwoon 1",
-                    "type": "acid",
-                    "hits": 2
-                  }}
-                ]}
-              ],
-              "reusableRoomwideNotable": "Back-Side Botwoon Fight with Charge and Wave",
-              "note": [
-                "With Gravity, dodging the acid is pretty trivial.",
-                "Even without knowing about the distance trick expected in the suitless version."
-              ]
-            },
-            {
-              "name": "Back-Side Botwoon Fight - Suitless, Charge, Wave",
-              "notable": true,
-              "requires": [
-                "canSuitlessMaridia",
-                "Charge",
-                "Wave",
-                "canDodgeWhileShooting",
-                {"or": [
-                  "Morph",
-                  {"enemyDamage": {
-                    "enemy": "Botwoon 1",
-                    "type": "acid",
-                    "hits": 2
-                  }}
-                ]}
-              ],
-              "reusableRoomwideNotable": "Back-Side Botwoon Fight with Charge and Wave",
-              "note": [
-                "Even when suitless, it's possible to stand far enough that the acid attack doesn't spawn.",
-                "Botwoon still gets hit. So there's a safe way to take no damage."
-              ]
-            },
-            {
-              "name": "Back-Side Botwoon Microwave",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                "Charge",
-                "Plasma",
-                "canXRayWaitForIFrames"
-              ],
-              "reusableRoomwideNotable": "Back-Side Botwoon Magic Pixel Beam Fight",
-              "flashSuitChecked": true,
-              "note": [
-                "Stand on the appropriate pixel for shooting diagonally through the wall and use the microwave trick to defeat Botwoon.",
-                "Using angle up, it is where Samus' front foot is on the seam in the floor.",
-                "There is not proper spacing for landing an angle down shot and xraying.",
-                "Waiting for Botwoon to peak their head through the wall works too but is less safe."
-              ]
-            },
-            {
-              "name": "Back-Side Botwoon Magic Pixel",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                {"enemyKill": {
-                  "enemies": [
-                    ["Reverse Botwoon 1"],
-                    ["Reverse Botwoon 2"]
-                  ],
-                  "explicitWeapons": ["Charge+Plasma", "Charge+Ice+Spazer"]
-                }}
-              ],
-              "reusableRoomwideNotable": "Back-Side Botwoon Magic Pixel Beam Fight",
-              "note": [
-                "A charge beam shot will pass right through the dividing wall if fired from the correct 2pixel window.",
-                "Using angle down the spot is where Samus' front toe touches the wall.",
-                "Using angle up, it is where Samus' front foot is on the seam in the floor."
-              ]
-            },
-            {
-              "name": "Back-Side Botwoon Plasma Shield Microwave",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                "canSpecialBeamAttack",
-                "Plasma",
-                "canXRayWaitForIFrames",
-                {"ammo": {"type": "PowerBomb", "count": 2}}
-              ],
-              "flashSuitChecked": true,
-              "note": [
-                "Wait for Botwoon to spawn then use a Plasma Special Beam Attack.",
-                "Use XRay to slow time and watch for a particle to overlap Botwoons head, then proceed to Microwave."
-              ],
-              "devNote": "Killing in 1 SBA takes some luck."
-            },
-            {
-              "name": "Back-Side Botwoon Plasma Shield Fight",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                {"enemyKill": {
-                  "enemies": [
-                    ["Reverse Botwoon 1"],
-                    ["Reverse Botwoon 2"]
-                  ],
-                  "explicitWeapons": ["Plasma Shield"]
-                }}
-              ],
-              "note": "Stand near the dividing wall and unleash the Plasma Special Beam Attack!"
-            },
-            {
-              "name": "Back-Side Botwoon Super Only Fight",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                "canBeExtremelyPatient",
-                {"enemyKill": {
-                  "enemies": [
-                    ["Reverse Botwoon 1"],
-                    ["Reverse Botwoon 2"]
-                  ],
-                  "explicitWeapons": ["Super"]
-                }}
-              ],
-              "note": [
-                "Wait for the one pattern (bottom->right) where Botwoon's head passes through the dividing barrier briefly and fire a Super Missile.",
-                "This takes a long time, averaging one super per minute."
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedBotwoon"],
-      "note": "This represents fighting Botwoon from behind the wall."
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 5,
       "name": "Botwoon Phase 2",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Botwoon Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                {"enemyKill": {
-                  "enemies": [["Botwoon 2"]]
-                }}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedBotwoon"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     }
   ],
   "enemies": [
@@ -283,6 +124,7 @@
       "from": 4,
       "to": [
         {"id": 2},
+        {"id": 4},
         {"id": 5}
       ]
     },
@@ -290,7 +132,8 @@
       "from": 5,
       "to": [
         {"id": 1},
-        {"id": 4}
+        {"id": 4},
+        {"id": 5}
       ]
     }
   ],
@@ -670,6 +513,152 @@
       "requires": []
     },
     {
+      "link": [4, 4],
+      "name": "Back-Side Botwoon Fight - Gravity, Charge, Wave",
+      "requires": [
+        {"notable": "Back-Side Botwoon Fight with Charge and Wave"},
+        "Gravity",
+        "Charge",
+        "Wave",
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Botwoon 1",
+            "type": "acid",
+            "hits": 2
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "note": [
+        "Fight Botwoon from behind the wall."
+      ],
+      "devNote": [
+        "With Gravity, dodging the acid is pretty trivial.",
+        "Even without knowing about the distance trick expected in the suitless version."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Back-Side Botwoon Fight - Suitless, Charge, Wave",
+      "requires": [
+        {"notable": "Back-Side Botwoon Fight with Charge and Wave"},
+        "canSuitlessMaridia",
+        "Charge",
+        "Wave",
+        "canDodgeWhileShooting",
+        {"or": [
+          "Morph",
+          {"enemyDamage": {
+            "enemy": "Botwoon 1",
+            "type": "acid",
+            "hits": 2
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "note": [
+        "Even when suitless, it's possible to stand far enough that the acid attack doesn't spawn.",
+        "Botwoon still gets hit. So there's a safe way to take no damage."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Back-Side Botwoon Microwave",
+      "requires": [
+        {"notable": "Back-Side Botwoon Magic Pixel Beam Fight"},
+        "h_canNavigateUnderwater",
+        "Charge",
+        "Plasma",
+        "canXRayWaitForIFrames"
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "flashSuitChecked": true,
+      "note": [
+        "Stand on the appropriate pixel for shooting diagonally through the wall and use the microwave trick to defeat Botwoon.",
+        "Using angle up, it is where Samus' front foot is on the seam in the floor.",
+        "There is not proper spacing for landing an angle down shot and xraying.",
+        "Waiting for Botwoon to peak their head through the wall works too but is less safe."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Back-Side Botwoon Magic Pixel",
+      "requires": [
+        {"notable": "Back-Side Botwoon Magic Pixel Beam Fight"},
+        "h_canNavigateUnderwater",
+        {"enemyKill": {
+          "enemies": [
+            ["Reverse Botwoon 1"],
+            ["Reverse Botwoon 2"]
+          ],
+          "explicitWeapons": ["Charge+Plasma", "Charge+Ice+Spazer"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "note": [
+        "A charge beam shot will pass right through the dividing wall if fired from the correct 2-pixel window.",
+        "Using angle down the spot is where Samus' front toe touches the wall.",
+        "Using angle up, it is where Samus' front foot is on the seam in the floor."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Back-Side Botwoon Plasma Shield Microwave",
+      "requires": [
+        "h_canNavigateUnderwater",
+        "canSpecialBeamAttack",
+        "Plasma",
+        "canXRayWaitForIFrames",
+        {"ammo": {"type": "PowerBomb", "count": 2}}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "flashSuitChecked": true,
+      "note": [
+        "Wait for Botwoon to spawn then use a Plasma Special Beam Attack.",
+        "Use XRay to slow time and watch for a particle to overlap Botwoons head, then proceed to Microwave."
+      ],
+      "devNote": "Killing in 1 SBA takes some luck."
+    },
+    {
+      "link": [4, 4],
+      "name": "Back-Side Botwoon Plasma Shield Fight",
+      "requires": [
+        {"notable": "Back-Side Botwoon Plasma Shield Fight"},
+        "h_canNavigateUnderwater",
+        {"enemyKill": {
+          "enemies": [
+            ["Reverse Botwoon 1"],
+            ["Reverse Botwoon 2"]
+          ],
+          "explicitWeapons": ["Plasma Shield"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "note": "Stand near the dividing wall and unleash the Plasma Special Beam Attack!"
+    },
+    {
+      "link": [4, 4],
+      "name": "Back-Side Botwoon Super Only Fight",
+      "requires": [
+        {"notable": "Back-Side Botwoon Super Only Fight"},
+        "h_canNavigateUnderwater",
+        "canBeExtremelyPatient",
+        {"enemyKill": {
+          "enemies": [
+            ["Reverse Botwoon 1"],
+            ["Reverse Botwoon 2"]
+          ],
+          "explicitWeapons": ["Super"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "note": [
+        "Wait for the one pattern (bottom->right) where Botwoon's head passes through the dividing barrier briefly and fire a Super Missile.",
+        "This takes a long time, averaging one super per minute."
+      ]
+    },
+    {
       "id": 27,
       "link": [4, 5],
       "name": "Base",
@@ -690,6 +679,17 @@
       "requires": [
         "f_DefeatedBotwoon"
       ]
+    },
+    {
+      "link": [5, 5],
+      "name": "Defeat Botwoon Phase 2",
+      "notable": false,
+      "requires": [
+        {"enemyKill": {
+          "enemies": [["Botwoon 2"]]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"]
     }
   ],
   "nextStratId": 30,
@@ -715,7 +715,22 @@
         "Fight Botwoon without Gravity suit.",
         "The left corner can be used to avoid most attacks and may be worth using even in the opening of the fight for safety."
       ]
-    }
+    },
+    {
+      "id": 4,
+      "name": "Back-Side Botwoon Plasma Shield Fight",
+      "note": [
+        "Stand near the dividing wall and unleash the Plasma Special Beam Attack!"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "Back-Side Botwoon Super Only Fight",
+      "note": [
+        "Wait for the one pattern (bottom->right) where Botwoon's head passes through the dividing barrier briefly and fire a Super Missile.",
+        "This takes a long time, averaging one Super per minute."
+      ]
+   }
   ],
-  "nextNotableId": 4
+  "nextNotableId": 6
 }

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -60,112 +60,9 @@
     {
       "id": 3,
       "name": "Draygon",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Draygon Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Draygon Grapple Kill",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                "canUseGrapple",
-                {"draygonElectricityFrames": 240},
-                {"enemyDamage": {
-                  "enemy": "Draygon",
-                  "type": "contact",
-                  "hits": 5
-                }}
-              ],
-              "note": [
-                "Kill Draygon by grappling to the top left turret.",
-                "Number of Draygon hits seems to vary, taking a worst case guess at 5."
-              ]
-            },
-            {
-              "name": "Draygon Grapple Quick Kill",
-              "notable": true,
-              "requires": [
-                "h_canNavigateUnderwater",
-                "canPreciseGrapple",
-                "h_canBreakOneDraygonTurret",
-                {"draygonElectricityFrames": 240}
-              ],
-              "note": [
-                "Kill Draygon by grappling to a bottom turret as you get grabbed.",
-                "Avoids taking all the hits from Draygon."
-              ]
-            },
-            {
-              "name": "Draygon Shinespark Kill",
-              "notable": true,
-              "requires": [
-                "Gravity",
-                "canMidairShinespark",
-                "canShinechargeMovementComplex",
-                {"or": [
-                  "canShinechargeMovementTricky",
-                  "h_canBreakThreeDraygonTurrets"
-                ]},
-                {"canShineCharge": {
-                  "usedTiles": 22,
-                  "openEnd": 0
-                }},
-                {"enemyDamage": {
-                  "enemy": "Draygon",
-                  "type": "contact",
-                  "hits": 2
-                }},
-                {"or": [
-                  "HiJump",
-                  {"enemyDamage": {
-                    "enemy": "Draygon",
-                    "type": "contact",
-                    "hits": 1
-                  }}
-                ]},
-                {"shinespark": {"frames": 150}}
-              ],
-              "note": [
-                "Shinecharge in-room, then horizontally spark through Draygon multiple times.",
-                "It takes 3 Shinesparks if that is the only source of damage onto Draygon.",
-                "Be careful of taking damage at the end of a Shinespark when near walls and on the killing Shinespark."
-              ],
-              "devNote": "150 frames is an approximate sum of all required shinesparks."
-            },
-            {
-              "name": "Gravity Draygon",
-              "notable": false,
-              "requires": [
-                "Gravity",
-                {"enemyKill": {
-                  "enemies": [["Draygon"]],
-                  "farmableAmmo": ["Missile", "Super"]
-                }}
-              ]
-            },
-            {
-              "name": "Suitless Draygon",
-              "notable": true,
-              "requires": [
-                "canSuitlessMaridia",
-                "Morph",
-                "h_canBreakThreeDraygonTurrets",
-                {"enemyKill": {
-                  "enemies": [["Draygon"]],
-                  "farmableAmmo": ["Missile", "Super"]
-                }}
-              ],
-              "note": "Fight Draygon without gravity, but with morph.",
-              "devNote": "This will require coming into the fight with ammo to kill the turrets. Although that ammo could instead be farmed in the fight."
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedDraygon"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     }
   ],
   "enemies": [
@@ -202,7 +99,8 @@
       "from": 3,
       "to": [
         {"id": 1},
-        {"id": 2}
+        {"id": 2},
+        {"id": 3}
       ]
     }
   ],
@@ -940,6 +838,110 @@
         }
       ],
       "note": "Charge a shinespark in the bottom of Draygon's room, then Gravity jump up in order to shinespark out of the right door."
+    },
+    {
+      "link": [3, 3],
+      "name": "Draygon Grapple Kill",
+      "requires": [
+        {"notable": "Draygon Grapple Kill"},
+        "h_canNavigateUnderwater",
+        "canUseGrapple",
+        {"draygonElectricityFrames": 240},
+        {"enemyDamage": {
+          "enemy": "Draygon",
+          "type": "contact",
+          "hits": 5
+        }}
+      ],
+      "setsFlags": ["f_DefeatedDraygon"],
+      "note": [
+        "Kill Draygon by grappling to the top left turret.",
+        "Number of Draygon hits varies; 5 hits are assumed, which is close to a worst-case scenario."
+      ]
+    },
+    {
+      "link": [3, 3],
+      "name": "Draygon Grapple Quick Kill",
+      "requires": [
+        {"notable": "Draygon Grapple Quick Kill"},
+        "h_canNavigateUnderwater",
+        "canPreciseGrapple",
+        "h_canBreakOneDraygonTurret",
+        {"draygonElectricityFrames": 240}
+      ],
+      "setsFlags": ["f_DefeatedDraygon"],
+      "note": [
+        "Kill Draygon by grappling to a bottom turret as you get grabbed.",
+        "Avoids taking all the hits from Draygon."
+      ]
+    },
+    {
+      "link": [3, 3],
+      "name": "Draygon Shinespark Kill",
+      "requires": [
+        {"notable": "Draygon Shinespark Kill"},
+        "Gravity",
+        "canMidairShinespark",
+        "canShinechargeMovementComplex",
+        {"or": [
+          "canShinechargeMovementTricky",
+          "h_canBreakThreeDraygonTurrets"
+        ]},
+        {"canShineCharge": {
+          "usedTiles": 22,
+          "openEnd": 0
+        }},
+        {"enemyDamage": {
+          "enemy": "Draygon",
+          "type": "contact",
+          "hits": 2
+        }},
+        {"or": [
+          "HiJump",
+          {"enemyDamage": {
+            "enemy": "Draygon",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"shinespark": {"frames": 150}}
+      ],
+      "setsFlags": ["f_DefeatedDraygon"],
+      "note": [
+        "Shinecharge in-room, then horizontally spark through Draygon multiple times.",
+        "It takes 3 Shinesparks if that is the only source of damage onto Draygon.",
+        "Be careful of taking damage at the end of a Shinespark when near walls and on the killing Shinespark."
+      ],
+      "devNote": "150 frames is an approximate sum of all required shinesparks."
+    },
+    {
+      "link": [3, 3],
+      "name": "Gravity Draygon",
+      "requires": [
+        "Gravity",
+        {"enemyKill": {
+          "enemies": [["Draygon"]],
+          "farmableAmmo": ["Missile", "Super"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedDraygon"]
+    },
+    {
+      "link": [3, 3],
+      "name": "Suitless Draygon",
+      "requires": [
+        {"notable": "Suitless Draygon"},
+        "canSuitlessMaridia",
+        "Morph",
+        "h_canBreakThreeDraygonTurrets",
+        {"enemyKill": {
+          "enemies": [["Draygon"]],
+          "farmableAmmo": ["Missile", "Super"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedDraygon"],
+      "note": "Fight Draygon without gravity, but with morph.",
+      "devNote": "This will require coming into the fight with ammo to kill the turrets. Although that ammo could instead be farmed in the fight."
     }
   ],
   "nextStratId": 44,
@@ -953,7 +955,37 @@
       "id": 2,
       "name": "Draygon Shinespark out the Right with a Gravity Jump",
       "note": "Charge a shinespark in the bottom of Draygon's room, then Gravity jump up in order to shinespark out of the right door."
+    },
+    {
+      "id": 3,
+      "name": "Suitless Draygon",
+      "note": "Fight Draygon without gravity, but with Morph."
+    },
+    {
+      "id": 4,
+      "name": "Draygon Shinespark Kill",
+      "note": [
+        "Shinecharge in-room, then horizontally spark through Draygon multiple times.",
+        "It takes 3 Shinesparks if that is the only source of damage onto Draygon.",
+        "Be careful of taking damage at the end of a Shinespark when near walls and on the killing Shinespark."
+      ]
+    },
+    {
+      "id": 5,
+      "name": "Draygon Grapple Kill",
+      "note": [
+        "Kill Draygon by grappling to the top left turret.",
+        "Number of Draygon hits varies; 5 hits are assumed, which is close to a worst-case scenario."
+      ]
+    },
+    {
+      "id": 6,
+      "name": "Draygon Grapple Quick Kill",
+      "note": [
+        "Kill Draygon by grappling to a bottom turret as you get grabbed.",
+        "Avoids taking all the hits from Draygon."
+      ]     
     }
   ],
-  "nextNotableId": 3
+  "nextNotableId": 7
 }

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -68,74 +68,23 @@
     {
       "id": 5,
       "name": "Inside Maridia Tube",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Inside Maridia Tube Event Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                {"obstaclesCleared": ["A"]}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_MaridiaTubeBroken"],
-      "note": "Represents the inside of the tube; unlocking this node breaks the tube"
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 6,
       "name": "Above Maridia Tube",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Above Maridia Tube Event Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                {"obstaclesCleared": ["A"]}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_MaridiaTubeBroken"],
-      "note": "Represents the area just above the tube; unlocking this node breaks the tube"
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 7,
       "name": "Below Maridia Tube",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Below Maridia Tube Event Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                {"or": [
-                  "h_canUsePowerBombs",
-                  {"obstaclesCleared": ["A"]}
-                ]}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_MaridiaTubeBroken"],
-      "note": "Represents the area just below the tube; unlocking this node breaks the tube"
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     }
   ],
   "enemies": [],
@@ -143,7 +92,8 @@
     {
       "id": "A",
       "obstacleType": "abstract",
-      "name": "Breaking the Tube"
+      "name": "Breaking the Tube",
+      "devNote": "FIXME: This obstacle can be eliminated."
     }
   ],
   "links": [
@@ -220,7 +170,8 @@
       "from": 7,
       "to": [
         {"id": 2},
-        {"id": 5}
+        {"id": 5},
+        {"id": 7}
       ]
     }
   ],
@@ -1710,6 +1661,14 @@
       "clearsObstacles": ["A"]
     },
     {
+      "link": [5, 5],
+      "name": "Break the Tube",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "setsFlags": ["f_MaridiaTubeBroken"]
+    },
+    {
       "id": 74,
       "link": [5, 6],
       "name": "Base",
@@ -1824,6 +1783,14 @@
       "clearsObstacles": ["A"]
     },
     {
+      "link": [6, 6],
+      "name": "Break the Tube",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "setsFlags": ["f_MaridiaTubeBroken"]
+    },
+    {
       "id": 86,
       "link": [7, 2],
       "name": "Base",
@@ -1838,6 +1805,17 @@
       ],
       "resetsObstacles": ["A"],
       "devNote": "The obstacle is reset, as 7 is too low to jump to 4."
+    },
+    {
+      "link": [7, 7],
+      "name": "Break the Tube",
+      "requires": [
+        {"or": [
+          "h_canUsePowerBombs",
+          {"obstaclesCleared": ["A"]}
+        ]}    
+      ],
+      "setsFlags": ["f_MaridiaTubeBroken"]
     }
   ],
   "nextStratId": 88,

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -54,106 +54,9 @@
     {
       "id": 4,
       "name": "Crocomire",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Crocomire Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Charge",
-              "notable": false,
-              "requires": [
-                "Charge",
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"enemyDamage": {
-                    "enemy": "Crocomire",
-                    "type": "contact",
-                    "hits": 5
-                  }}
-                ]}
-              ]
-            },
-            {
-              "name": "Missiles",
-              "notable": false,
-              "requires": [
-                {"ammo": {"type": "Missile", "count": 25}},
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"ammo": {"type": "Missile", "count": 25}}
-                ]}
-              ],
-              "devNote": "Some farming will still be useful, but without dodging efficiently, many of the drops will be energy."
-            },
-            {
-              "name": "Farm Missiles",
-              "notable": false,
-              "requires": [
-                "canDodgeWhileShooting",
-                "canTrickyJump",
-                {"or": [
-                  {"ammo": {"type": "Missile", "count": 2}},
-                  {"ammo": {"type": "Super", "count": 2}}
-                ]},
-                {"resourceCapacity": [{"type": "Missile", "count": 10}]}
-              ],
-              "note": "Farming requires somewhat careful dodging in order to minimize energy drops.",
-              "devNote": [
-                "Crocomire does not have a farming phase until he has been hit twice.",
-                "It is possible to get to the farming phase with 1 PB, but sometimes Croc will just rush Samus into the spikes without ever having farm phases, so it is ignored here."
-              ]
-            },
-            {
-              "name": "Supers",
-              "notable": false,
-              "requires": [
-                {"ammo": {"type": "Super", "count": 8}},
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"ammo": {"type": "Super", "count": 4}}
-                ]},
-                {"or": [
-                  "canFarmWhileShooting",
-                  {"ammo": {"type": "Super", "count": 4}}
-                ]}
-              ],
-              "note": [
-                "The hitbox on Croc's mouth may cause direct hits to miss, so jumping and shooting Supers horizontally is recommended.",
-                "While Crocomire's farmables may drop Supers, the rate is too low to rely on.",
-                "If you run out, Croc will most likely push you into the spikes.",
-                "It takes 8 Supers to kill croc if you don't let it move forward."
-              ],
-              "devNote": "canFarmWhileShooting represents accurate shooting, not the ability to farm drops."
-            },
-            {
-              "name": "Crocomire with 5 Missiles",
-              "notable": true,
-              "requires": [
-                "canFarmWhileShooting",
-                "canBePatient",
-                {"or": [
-                  {"ammo": {"type": "Missile", "count": 2}},
-                  {"ammo": {"type": "Super", "count": 2}}
-                ]},
-                {"resourceCapacity": [{"type": "Missile", "count": 5}]}
-              ],
-              "note": [
-                "This can be a very long fight if Crocomire is stingy with the farming phases.",
-                "Farming requires careful dodging in order to minimize energy drops. Delay grabbing all of the drops until necessary to reduce the chance of running out of ammo."
-              ],
-              "devNote": [
-                "This strat is notable, not because it's harder than its required tech, but because its tedious, RNG heavy, and players might not want to encounter it.",
-                "Crocomire does not have a farming phase until he has been hit twice.",
-                "It is possible to get to the farming phase with 1 PB, but sometimes Croc will just rush Samus into the spikes without ever having farm phases, so it is ignored here."
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedCrocomire"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node can be eliminated."
     },
     {
       "id": 5,
@@ -212,6 +115,7 @@
     {
       "from": 4,
       "to": [
+        {"id": 4},
         {"id": 5},
         {"id": 6}
       ]
@@ -511,6 +415,101 @@
       ],
       "note": "Touch the item while remaining in artificial morph. Ceiling bomb jump back to the left, then use x-ray to cancel g-mode and obtain the item.",
       "devNote": "This strat alone would only require canBePatient, but it is only possible after Ceiling Bomb Jumping there, so it would be a combined 4 minutes."
+    },
+    {
+      "link": [4, 4],
+      "name": "Crocomire Fight (Charge)",
+      "requires": [
+        "Charge",
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Crocomire",
+            "type": "contact",
+            "hits": 5
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedCrocomire"]
+    },
+    {
+      "link": [4, 4],
+      "name": "Crocomire Fight (Missiles)",
+      "requires": [
+        {"ammo": {"type": "Missile", "count": 25}},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"ammo": {"type": "Missile", "count": 25}}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedCrocomire"],
+      "devNote": "Some farming will still be useful, but without dodging efficiently, many of the drops will be energy."
+    },
+    {
+      "link": [4, 4],
+      "name": "Crocomire Fight (Farm Missiles)",
+      "requires": [
+        "canDodgeWhileShooting",
+        "canTrickyJump",
+        {"or": [
+          {"ammo": {"type": "Missile", "count": 2}},
+          {"ammo": {"type": "Super", "count": 2}}
+        ]},
+        {"resourceCapacity": [{"type": "Missile", "count": 10}]}
+      ],
+      "setsFlags": ["f_DefeatedCrocomire"],
+      "note": "Farming requires somewhat careful dodging in order to minimize energy drops.",
+      "devNote": [
+        "Crocomire does not have a farming phase until he has been hit twice.",
+        "It is possible to get to the farming phase with 1 PB, but sometimes Croc will just rush Samus into the spikes without ever having farm phases, so it is ignored here."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Crocomire Fight (Supers)",
+      "requires": [
+        {"ammo": {"type": "Super", "count": 8}},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"ammo": {"type": "Super", "count": 4}}
+        ]},
+        {"or": [
+          "canFarmWhileShooting",
+          {"ammo": {"type": "Super", "count": 4}}
+        ]}
+      ],
+      "setsFlags": ["f_DefeatedCrocomire"],
+      "note": [
+        "The hitbox on Croc's mouth may cause direct hits to miss, so jumping and shooting Supers horizontally is recommended.",
+        "While Crocomire's farmables may drop Supers, the rate is too low to rely on.",
+        "If you run out, Croc will most likely push you into the spikes.",
+        "It takes 8 Supers to kill croc if you don't let it move forward."
+      ],
+      "devNote": "canFarmWhileShooting represents accurate shooting, not the ability to farm drops."
+    },
+    {
+      "link": [4, 4],
+      "name": "Crocomire with 5 Missiles",
+      "requires": [
+        {"notable": "Crocomire with 5 Missiles"},
+        "canFarmWhileShooting",
+        "canBePatient",
+        {"or": [
+          {"ammo": {"type": "Missile", "count": 2}},
+          {"ammo": {"type": "Super", "count": 2}}
+        ]},
+        {"resourceCapacity": [{"type": "Missile", "count": 5}]}
+      ],
+      "setsFlags": ["f_DefeatedCrocomire"],
+      "note": [
+        "This can be a very long fight if Crocomire is stingy with the farming phases.",
+        "Farming requires careful dodging in order to minimize energy drops. Delay grabbing all of the drops until necessary to reduce the chance of running out of ammo."
+      ],
+      "devNote": [
+        "This strat is notable, not because it's harder than its required tech, but because its tedious, RNG heavy, and players might not want to encounter it.",
+        "Crocomire does not have a farming phase until he has been hit twice.",
+        "It is possible to get to the farming phase with 1 PB, but sometimes Croc will just rush Samus into the spikes without ever having farm phases, so it is ignored here."
+      ]
     },
     {
       "id": 21,
@@ -822,6 +821,15 @@
     }
   ],
   "nextStratId": 42,
-  "notables": [],
-  "nextNotableId": 1
+  "notables": [
+    {
+      "id": 1,
+      "name": "Crocomire with 5 Missiles",
+      "note": [
+        "This can be a very long fight if Crocomire is stingy with the farming phases.",
+        "Farming requires careful dodging in order to minimize energy drops. Delay grabbing all of the drops until necessary to reduce the chance of running out of ammo."
+      ]     
+    }
+  ],
+  "nextNotableId": 2
 }

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -48,187 +48,39 @@
     {
       "id": 3,
       "name": "Mother Brain",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Mother Brain 1 Glass Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "h_canPartiallyBreakMotherBrainGlass",
-                "h_canPartiallyBreakMotherBrainGlass",
-                "h_canPartiallyBreakMotherBrainGlass"
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_MotherBrainGlassBroken"],
-      "devNote": [
-        "Requires 18 ammo to fully break the glass, which will remain broken if Samus leaves.",
-        "Or, it takes 6 ammo to partially break the glass, and then 3000 damage is required to kill Mother Brain 1, but the glass also needs to be broken.",
-        "The requirements for finishing Mother Brain 1 is in the 3 to 4 link."
-      ]
+      "nodeType": "junction",
+      "nodeSubType": "junction"
     },
     {
       "id": 4,
       "name": "Mother Brain (Phases 2 and 3)",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "yields": ["f_ZebesSetAblaze", "f_DefeatedMotherBrain"],
-      "locks": [
-        {
-          "name": "Mother Brain 2 and 3 Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                {"enemyKill": {
-                  "enemies": [["Mother Brain 2"]]
-                }},
-                {"enemyDamage": {
-                  "enemy": "Mother Brain 2",
-                  "type": "rainbow",
-                  "hits": 1
-                }},
-                {"ammoDrain": {"type": "Missile", "count": 75}},
-                {"ammoDrain": {"type": "Super", "count": 75}},
-                {"ammoDrain": {"type": "PowerBomb", "count": 300}}
-              ],
-              "note": "The fight also brings Samus down below 100 energy, but then it fills her up"
-            }
-          ]
-        }
-      ]
+      "nodeType": "junction",
+      "nodeSubType": "junction"
     },
     {
       "id": 5,
       "name": "Between First and Second Zebetite",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Second Zebetite Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "h_canOpenZebetites",
-                {"or": [
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    "canInsaneJump"
-                  ]},
-                  {"enemyDamage": {
-                    "enemy": "Rinka",
-                    "type": "contact",
-                    "hits": 1
-                  }}
-                ]}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_KilledZebetites2"]
+      "nodeType": "junction",
+      "nodeSubType": "junction"
     },
     {
       "id": 6,
       "name": "Between Second and Third Zebetite",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Third Zebetite Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "h_canOpenZebetites",
-                {"or": [
-                  {"and": [
-                    "canDodgeWhileShooting",
-                    "canTrickyJump"
-                  ]},
-                  {"enemyDamage": {
-                    "enemy": "Rinka",
-                    "type": "contact",
-                    "hits": 1
-                  }}
-                ]}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_KilledZebetites3"]
+      "nodeType": "junction",
+      "nodeSubType": "junction"
     },
     {
       "id": 7,
       "name": "Between Third and Fourth Zebetite",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "Fourth Zebetite Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "h_canOpenZebetites",
-                {"enemyDamage": {
-                  "enemy": "Rinka",
-                  "type": "contact",
-                  "hits": 1
-                }}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_KilledZebetites4"]
+      "nodeType": "junction",
+      "nodeSubType": "junction"
     },
     {
       "id": 8,
       "name": "Before First Zebetite",
-      "nodeType": "event",
-      "nodeSubType": "flag",
-      "locks": [
-        {
-          "name": "First Zebetite Lock",
-          "lockType": "triggeredEvent",
-          "unlockStrats": [
-            {
-              "name": "Base",
-              "notable": false,
-              "requires": [
-                "h_canOpenZebetites",
-                {"or": [
-                  "canDodgeWhileShooting",
-                  {"enemyDamage": {
-                    "enemy": "Rinka",
-                    "type": "contact",
-                    "hits": 1
-                  }}
-                ]}
-              ]
-            }
-          ]
-        }
-      ],
-      "yields": ["f_KilledZebetites1"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node could be eliminated."
     }
   ],
   "enemies": [
@@ -329,6 +181,7 @@
     {
       "from": 3,
       "to": [
+        {"id": 3},
         {
           "id": 4,
           "note": [
@@ -353,6 +206,7 @@
     {
       "from": 5,
       "to": [
+        {"id": 5},
         {"id": 6},
         {"id": 8}
       ]
@@ -361,6 +215,7 @@
       "from": 6,
       "to": [
         {"id": 5},
+        {"id": 6},
         {"id": 7}
       ]
     },
@@ -368,7 +223,8 @@
       "from": 7,
       "to": [
         {"id": 3},
-        {"id": 6}
+        {"id": 6},
+        {"id": 7}
       ]
     },
     {
@@ -379,7 +235,8 @@
           "id": 3,
           "note": "Direct link to Mother Brain 1 for the Ice Zebetite skip."
         },
-        {"id": 5}
+        {"id": 5},
+        {"id": 8}
       ]
     }
   ],
@@ -615,6 +472,21 @@
       "requires": []
     },
     {
+      "link": [3, 3],
+      "name": "Break Mother Brain Glass",
+      "requires": [
+        "h_canPartiallyBreakMotherBrainGlass",
+        "h_canPartiallyBreakMotherBrainGlass",
+        "h_canPartiallyBreakMotherBrainGlass"
+      ],
+      "setsFlags": ["f_MotherBrainGlassBroken"],
+      "devNote": [
+        "Requires 18 ammo to fully break the glass, which will remain broken if Samus leaves.",
+        "Or, it takes 6 ammo to partially break the glass, and then 3000 damage is required to kill Mother Brain 1, but the glass also needs to be broken.",
+        "The requirements for finishing Mother Brain 1 is in the 3 to 4 link."
+      ]
+    },
+    {
       "id": 14,
       "link": [3, 4],
       "name": "Missiles",
@@ -848,6 +720,26 @@
       ]
     },
     {
+      "link": [4, 4],
+      "name": "Mother Brain 2 and 3 Fight",
+      "notable": false,
+      "requires": [
+        {"enemyKill": {
+          "enemies": [["Mother Brain 2"]]
+        }},
+        {"enemyDamage": {
+          "enemy": "Mother Brain 2",
+          "type": "rainbow",
+          "hits": 1
+        }},
+        {"ammoDrain": {"type": "Missile", "count": 75}},
+        {"ammoDrain": {"type": "Super", "count": 75}},
+        {"ammoDrain": {"type": "PowerBomb", "count": 300}}
+      ],
+      "setsFlags": ["f_ZebesSetAblaze", "f_DefeatedMotherBrain"],
+      "note": "The fight also brings Samus down below 100 energy, but then it fills her up"
+    },
+    {
       "id": 21,
       "link": [4, 4],
       "name": "Mother Brain R-Mode Reduced Tanks",
@@ -902,6 +794,26 @@
         "this is done by using X-Ray, deselecting X-Ray while continuing to hold dash, then briefly releasing dash for one or two frames before repressing dash.",
         "During the rainbow beam attack, release dash while the auto-reserve refill is happening."
       ]
+    },
+    {
+      "link": [5, 5],
+      "name": "Destroy Second Zebetite",
+      "notable": false,
+      "requires": [
+        "h_canOpenZebetites",
+        {"or": [
+          {"and": [
+            "canDodgeWhileShooting",
+            "canInsaneJump"
+          ]},
+          {"enemyDamage": {
+            "enemy": "Rinka",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_KilledZebetites2"]
     },
     {
       "id": 23,
@@ -994,6 +906,26 @@
       ]
     },
     {
+      "link": [6, 6],
+      "name": "Destroy Third Zebetite",
+      "notable": false,
+      "requires": [
+        "h_canOpenZebetites",
+        {"or": [
+          {"and": [
+            "canDodgeWhileShooting",
+            "canTrickyJump"
+          ]},
+          {"enemyDamage": {
+            "enemy": "Rinka",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_KilledZebetites3"]
+    },
+    {
       "id": 26,
       "link": [6, 7],
       "name": "Base",
@@ -1058,6 +990,20 @@
       ]
     },
     {
+      "link": [7, 7],
+      "name": "Destroy Fourth Zebetite",
+      "notable": false,
+      "requires": [
+        "h_canOpenZebetites",
+        {"enemyDamage": {
+          "enemy": "Rinka",
+          "type": "contact",
+          "hits": 1
+        }}
+      ],
+      "setsFlags": ["f_KilledZebetites4"]
+    },
+    {
       "id": 29,
       "link": [8, 2],
       "name": "Base",
@@ -1116,6 +1062,22 @@
           }}
         ]}
       ]
+    },
+    {
+      "link": [8, 8],
+      "name": "Destroy First Zebetite",
+      "requires": [
+        "h_canOpenZebetites",
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Rinka",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]}
+      ],
+      "setsFlags": ["f_KilledZebetites1"]
     }
   ],
   "nextStratId": 33,

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -35,53 +35,9 @@
     {
       "id": 2,
       "name": "Phantoon",
-      "nodeType": "event",
-      "nodeSubType": "boss",
-      "locks": [
-        {
-          "name": "Phantoon Fight",
-          "lockType": "bossFight",
-          "unlockStrats": [
-            {
-              "name": "Charge",
-              "notable": false,
-              "requires": [
-                "Charge",
-                {"enemyKill": {
-                  "enemies": [["Phantoon"]],
-                  "explicitWeapons": ["Charge"]
-                }}
-              ]
-            },
-            {
-              "name": "Missiles",
-              "notable": false,
-              "requires": [
-                {"resourceCapacity": [{"type": "Missile", "count": 1}]},
-                {"enemyKill": {
-                  "enemies": [["Phantoon"]],
-                  "explicitWeapons": ["Missile"]
-                }}
-              ],
-              "note": "No ammo count because Missiles are farmable here."
-            },
-            {
-              "name": "Nintendo Power Phantoon",
-              "notable": false,
-              "requires": [
-                {"resourceCapacity": [{"type": "Super", "count": 1}]},
-                {"enemyKill": {
-                  "enemies": [["Phantoon"]],
-                  "explicitWeapons": ["Super"]
-                }}
-              ],
-              "note": "No ammo count because Supers are farmable here.",
-              "devNote": "FIXME add tech/energy/item requirements to survive flames."
-            }
-          ]
-        }
-      ],
-      "yields": ["f_DefeatedPhantoon"]
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "devNote": "FIXME: This node could be eliminated."
     }
   ],
   "enemies": [
@@ -105,7 +61,8 @@
     {
       "from": 2,
       "to": [
-        {"id": 1}
+        {"id": 1},
+        {"id": 2}
       ]
     }
   ],
@@ -241,6 +198,45 @@
       "link": [2, 1],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 2],
+      "name": "Phantoon Fight (Charge)",
+      "requires": [
+        "Charge",
+        {"enemyKill": {
+          "enemies": [["Phantoon"]],
+          "explicitWeapons": ["Charge"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedPhantoon"]
+    },
+    {
+      "link": [2, 2],
+      "name": "Phantoon Fight (Missiles)",
+      "requires": [
+        {"resourceCapacity": [{"type": "Missile", "count": 1}]},
+        {"enemyKill": {
+          "enemies": [["Phantoon"]],
+          "explicitWeapons": ["Missile"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedPhantoon"],
+      "note": "No ammo count because Missiles are farmable here."
+    },
+    {
+      "link": [2, 2],
+      "name": "Nintendo Power Phantoon",
+      "requires": [
+        {"resourceCapacity": [{"type": "Super", "count": 1}]},
+        {"enemyKill": {
+          "enemies": [["Phantoon"]],
+          "explicitWeapons": ["Super"]
+        }}
+      ],
+      "setsFlags": ["f_DefeatedPhantoon"],
+      "note": "No ammo count because Supers are farmable here.",
+      "devNote": "FIXME add tech/energy/item requirements to survive flames."
     }
   ],
   "nextStratId": 11,

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1743,20 +1743,18 @@
             "$id": "#/properties/nodes/items/properties/nodeType",
             "type": "string",
             "title": "Node Type",
-            "description": "Examples: door, event, item, junction",
+            "description": "Examples: door, item, junction",
             "default": "",
             "examples": [
               "door",
               "entrance",
               "exit",
-              "event",
               "item"
             ],
             "enum": [
               "door",
               "entrance",
               "exit",
-              "event",
               "item",
               "junction",
               "utility"
@@ -1769,15 +1767,12 @@
             "title": "Node SubType",
             "default": "",
             "examples": [
-              "boss",
               "chozo",
               "hidden",
               "visible"
             ],
             "enum": [
-              "boss",
               "chozo",
-              "flag",
               "hidden",
               "visible",
 

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -619,7 +619,7 @@ for r,d,f in os.walk(os.path.join(".","region")):
                             messages["counts"]["reds"] += 1
                         if notable_id >= room["nextNotableId"]:
                             next_notable_id = room["nextNotableId"]
-                            msg = f"🔴ERROR: Notable ID {notable_id} is not less than nextNotableId ({next_notable_id}):{stratRef}"
+                            msg = f"🔴ERROR: Notable ID {notable_id} is not less than nextNotableId ({next_notable_id}):{roomRef}:{notable_name}"
                             messages["reds"].append(msg)
                             messages["counts"]["reds"] += 1                            
                         notable_id_set.add(notable["id"])


### PR DESCRIPTION
This goes through all rooms and changes "event" nodes to "junction" type, moving their "unlockStrats" into regular strats from the node to itself, using a "setsFlags" strat property to indicate the flags getting set.

The "event" node type is also removed from the schema since this is no longer needed.

A couple related things could be done as a follow-up that aren't included in this PR:
- The structure of these rooms could be simplified: in most cases the affected nodes could be deleted, moving their strats to other nodes. But that would require some reworking of the room diagrams and a little more thought room-by-room, whereas this PR is just applying a systematic change.
- Strats for gray doors that unlock a flag (e.g. `f_ZebesAwake`, `f_KilledMetroidRoom1`) could be migrated in a similar way, allowing us to remove the `yields` property (which in Map Rando has historically been a big pain point and source of bugs).