### PR TITLE
Etecoon ETank small fixes

### DIFF
--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -344,28 +344,6 @@
       }
     },
     {
-      "id": 73,
-      "link": [1, 3],
-      "name": "Leave With Temporary Blue (Pause Remorph)",
-      "requires": [
-        "canPauseRemorphTemporaryBlue",
-        "canXRayTurnaround"
-      ],
-      "exitCondition": {
-        "leaveWithTemporaryBlue": {}
-      },
-      "unlocksDoors": [
-        {
-          "types": ["ammo"],
-          "requires": []
-        }
-      ],
-      "note": [
-        "Land on the crumble blocks while unmorphing, to retain temporary blue.",
-        "Then aim down and use a pause buffer to remorph and chain temporary blue."
-      ]
-    },
-    {
       "id": 8,
       "link": [1, 5],
       "name": "Base",
@@ -610,6 +588,10 @@
       "link": [2, 3],
       "name": "Leave With Temporary Blue (Pause Remorph)",
       "requires": [
+        {"canShineCharge": {
+          "usedTiles": 20,
+          "openEnd": 0
+        }},
         "canPauseRemorphTemporaryBlue"
       ],
       "exitCondition": {


### PR DESCRIPTION
There is no purpose to the 1->3 temp blue strat, as the 2->3 strat already covers it, using the in-room runway and without needing X-Ray. The 2->3 strat was missing a shinecharge requirement though, which is added here.

In theory, alternatives like 1->3 this could still matter for speed purposes (e.g. in case the room becomes heated) but I don't think we're at a point of caring about that yet.