### PR TITLE
LN Elevator temp blue

### DIFF
--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -251,6 +251,32 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 11,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"heatFrames": 120},
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ]
+    },
+    {
       "id": 7,
       "link": [1, 2],
       "name": "Grapple Teleport",
@@ -525,6 +551,32 @@
         }
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 11,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"heatFrames": 120},
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ]
     },
     {
       "id": 19,


### PR DESCRIPTION
Videos:
- left-to-right: https://videos.maprando.com/video/822
- left-to-right with X-Ray: https://videos.maprando.com/video/823
- right-to-left: https://videos.maprando.com/video/824
- right-to-left with X-Ray: https://videos.maprando.com/video/825

The heat frames here may look a little lenient based on the videos, but they're made to account for the worst-case scenario where entering with lower speed, e.g. where the shortcharge is essentially all done in-room.