### PR TITLE
Magdollite Tunnel temp blue

### DIFF
--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -251,6 +251,29 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 760}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ]
+    },
+    {
       "id": 11,
       "link": [2, 1],
       "name": "Base",
@@ -400,6 +423,30 @@
       ],
       "note": ["The Magdollite flames can be killed for drops."],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$0.A"
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 790}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ]
     },
     {
       "id": 18,

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -446,6 +446,11 @@
           "types": ["ammo"],
           "requires": []
         }
+      ],
+      "devNote": [
+        "A run speed of $0.7 would be enough to make the first jump (and even less could work with an additional jump).",
+        "The slightly higher speed of $0.A saves a few heat frames, making it reasonable enough to get through on 1 tank.",
+        "This constraint is mostly a technicality since these speeds are all lower than a human player would use."
       ]
     },
     {


### PR DESCRIPTION
Videos:
- left to right: https://videos.maprando.com/video/826
- right to left: https://videos.maprando.com/video/827

Heat frames account for the possibility of entering with very low speed (e.g. with a TAS-level shortcharge), though this isn't shown in the videos.