### PR TITLE
A few temp blue strat adjustments

### DIFF
--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2550,10 +2550,10 @@
           "usedTiles": 22,
           "openEnd": 2
         }},
-        "canTemporaryBlue",
+        "canChainTemporaryBlue",
         "canTrickyJump",
         "canLateralMidAirMorph",
-        "canSpringBallBounce"
+        "canTrickySpringBallBounce"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -400,9 +400,16 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "canChainTemporaryBlue"
+        "canChainTemporaryBlue",
+        "canInsaneJump"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Breaking the bomb blocks is difficult because there is not enough space above them to get a neutral bounce.",
+        "It is best to break them by jumping from the top platform (inside the 3-tile-high space), as this provides a 2-frame window for the morph;",
+        "in comparison, jumping from the platform below requires a frame-perfect morph.",
+        "If Spring Ball is available, it can be used to increase the window by one frame."
+      ]
     },
     {
       "id": 11,
@@ -416,9 +423,16 @@
       },
       "requires": [
         "canChainTemporaryBlue",
-        "canXRayTurnaround"
+        "canXRayTurnaround",
+        "canInsaneJump"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Breaking the bomb blocks is difficult because there is not enough space above them to get a neutral bounce.",
+        "It is best to break them by jumping from the top platform (inside the 3-tile-high space), as this provides a 2-frame window for the morph;",
+        "in comparison, jumping from the platform below requires a frame-perfect morph.",
+        "If Spring Ball is available, it can be used to increase the window by one frame."
+      ]
     },
     {
       "id": 12,
@@ -449,7 +463,8 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "canLongChainTemporaryBlue"
+        "canChainTemporaryBlue",
+        "canInsaneJump"
       ],
       "flashSuitChecked": true
     },
@@ -464,8 +479,9 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "canLongChainTemporaryBlue",
-        "canXRayTurnaround"
+        "canXRayTurnaround",
+        "canChainTemporaryBlue",
+        "canInsaneJump"
       ],
       "flashSuitChecked": true
     },
@@ -2080,7 +2096,7 @@
       "name": "Climb Temporary Blue Chain Through Bomb Blocks to Top",
       "requires": [
         {"notable": "Climb Temporary Blue Chain Through Bomb Blocks"},
-        "canChainTemporaryBlue",
+        "canLongChainTemporaryBlue",
         "canXRayTurnaround",
         "canTrickyJump",
         "canBePatient",
@@ -2088,6 +2104,7 @@
           "usedTiles": 27.5,
           "openEnd": 0
         }},
+        "canInsaneJump",
         {"obstaclesCleared": ["A"]},
         {"or": [
           "h_ClimbWithoutLava",
@@ -2095,7 +2112,13 @@
         ]}
       ],
       "flashSuitChecked": true,
-      "note": "A long Temporary Blue Chain with x-ray turnarounds to climb up and destroy the bomb blocks blocking the top morph tunnel.",
+      "note": [
+        "This is a long temporary blue chain with X-Ray turnarounds to climb up and destroy the bomb blocks blocking the top morph tunnel.",
+        "Breaking the bomb blocks is difficult because there is not enough space above them to get a neutral bounce.",
+        "It is best to break them by jumping from the top platform (inside the 3-tile-high space), as this provides a 2-frame window for the morph;",
+        "in comparison, jumping from the platform below requires a frame-perfect morph.",
+        "If Spring Ball is available, it can be used to increase the window by one frame."
+      ],
       "devNote": "The runway was reduced by 0.5 tiles, as you can't maintain Temporary Blue directly against a wall."
     },
     {

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -501,13 +501,17 @@
       },
       "requires": [
         "canChainTemporaryBlue",
-        "can4HighMidAirMorph"
+        "can4HighMidAirMorph",
+        "canInsaneJump"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
       "note": [
         "Use a temporary blue chain to jump through the bomb blocks and land on the center of the ledge above.",
-        "Break the last block by jumping directly into it as there is not enough height available to get a bounce."
+        "Break the last block by jumping directly into it, as there is not enough height available to get a bounce.",
+        "With this method, there is a 2-frame window for when to morph;",
+        "jumping from the platform below is also possible but requires a frame-perfect morph.",
+        "If Spring Ball is available, it can be used to increase the window by one frame in either case."
       ]
     },
     {
@@ -523,13 +527,17 @@
       "requires": [
         "canChainTemporaryBlue",
         "canXRayTurnaround",
-        "can4HighMidAirMorph"
+        "can4HighMidAirMorph",
+        "canInsaneJump"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
       "note": [
         "Use a temporary blue chain to jump through the bomb blocks and land on the center of the ledge above.",
-        "Break the last block by jumping directly into it as there is not enough height available to get a bounce."
+        "Break the last block by jumping directly into it, as there is not enough height available to get a bounce.",
+        "With this method, there is a 2-frame window for when to morph;",
+        "jumping from the platform below is also possible but requires a frame-perfect morph.",
+        "If Spring Ball is available, it can be used to increase the window by one frame in either case."
       ]
     },
     {
@@ -547,12 +555,13 @@
               "usedTiles": 15,
               "openEnd": 0
             }},
-            "can4HighMidAirMorph",
             {"doorUnlockedAtNode": 2}
           ]}
         ]},
         "canChainTemporaryBlue",
-        "canXRayTurnaround"
+        "canXRayTurnaround",
+        "can4HighMidAirMorph",
+        "canInsaneJump"
       ],
       "clearsObstacles": ["A", "B"],
       "unlocksDoors": [
@@ -565,7 +574,10 @@
       "flashSuitChecked": true,
       "note": [
         "Use a temporary blue chain to jump through the bomb blocks and land on the center of the ledge above.",
-        "Break the last block by jumping directly into it as there is not enough height available to get a bounce."
+        "Break the last block by jumping directly into it, as there is not enough height available to get a bounce.",
+        "With this method, there is a 2-frame window for when to morph;",
+        "jumping from the platform below is also possible but requires a frame-perfect morph.",
+        "If Spring Ball is available, it can be used to increase the window by one frame in either case."
       ]
     },
     {


### PR DESCRIPTION
- Climb temp blue from bottom to the top: This strat was somehow only in Extreme. Added a "canLongChainTemporaryBlue" requirement now which will put it into Insane. We could consider making it notable? Breaking the bomb block at the top is the hardest part, and it's exhausting to retry since you have to start from the bottom of the room every time. Also added some notes and made a video for it here: https://videos.maprando.com/video/839
- Climb temp blue from top through upper bomb blocks: Breaking the bomb blocks is hard enough that I think this deserves to be Extreme, especially given that you have to do a cross-room setup on each attempt and it might not be trivial. So added a "canInsaneJump".
- Climb temp blue from top through lower bomb blocks: This had a "canLongChainTemporaryBlue" requirement which wasn't really necessary. It is awkward because you want to bounce directly from the long fall, but it feels more Extreme level than Insane. So this PR puts "canInsaneJump" on it instead.
- Ice Beam Gate Room breaking bomb blocks with temp blue: This works the same as breaking the Climb upper bomb blocks, so I added notes and a "canInsaneJump" requirement here too. It's maybe less necessary here for the strats where all you're doing is running in from the other room, but the other room could be heated so again the amount of attempts might be limited.
- Big Pink "Leave With Temporary Blue (Spring Ball Bounce)" was in Very Hard which didn't make any sense. Added "canChainTemporaryBlue" and "canTrickySpringBallBounce" which should put it into Expert.
