### PR TITLE
Add canStaggeredWalljump reqs to Bubble Mountain runway walljumps

### DIFF
--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1492,7 +1492,7 @@
       },
       "requires": [
         "canPreciseWalljump",
-        "canConsecutiveWalljump",
+        "canStaggeredWalljump",
         "canTrickyJump"
       ]
     },
@@ -1507,7 +1507,7 @@
         }
       },
       "requires": [
-        "canConsecutiveWalljump",
+        "canStaggeredWalljump",
         "canCarefulJump"
       ]
     },
@@ -1522,7 +1522,7 @@
         }
       },
       "requires": [
-        "canConsecutiveWalljump",
+        "canStaggeredWalljump",
         "canCarefulJump"
       ]
     },

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1502,7 +1502,7 @@
             "canWallJumpInstantMorph",
             {"enemyDamage": {
               "enemy": "Cacatac",
-              "type": "contact",
+              "type": "spike",
               "hits": 1
             }}
           ]}
@@ -1530,7 +1530,7 @@
             "canWallJumpInstantMorph",
             {"enemyDamage": {
               "enemy": "Cacatac",
-              "type": "contact",
+              "type": "spike",
               "hits": 1
             }}
           ]}
@@ -1558,7 +1558,7 @@
             "canWallJumpInstantMorph",
             {"enemyDamage": {
               "enemy": "Cacatac",
-              "type": "contact",
+              "type": "spike",
               "hits": 1
             }}
           ]}

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1492,6 +1492,7 @@
       },
       "requires": [
         "canPreciseWalljump",
+        "canConsecutiveWalljump",
         "canTrickyJump"
       ]
     },
@@ -1506,7 +1507,7 @@
         }
       },
       "requires": [
-        "canWalljump",
+        "canConsecutiveWalljump",
         "canCarefulJump"
       ]
     },
@@ -1521,7 +1522,7 @@
         }
       },
       "requires": [
-        "canWalljump",
+        "canConsecutiveWalljump",
         "canCarefulJump"
       ]
     },

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1497,7 +1497,7 @@
         {"or": [
           "canStaggeredWalljump",
           "ScrewAttack",
-          "canPseudoScrew",
+          "canWalljumpWithCharge",
           {"and": [
             "canWallJumpInstantMorph",
             {"enemyDamage": {
@@ -1525,7 +1525,7 @@
         {"or": [
           "canStaggeredWalljump",
           "ScrewAttack",
-          "canPseudoScrew",
+          "canWalljumpWithCharge",
           {"and": [
             "canWallJumpInstantMorph",
             {"enemyDamage": {
@@ -1553,7 +1553,7 @@
         {"or": [
           "canStaggeredWalljump",
           "ScrewAttack",
-          "canPseudoScrew",
+          "canWalljumpWithCharge",
           {"and": [
             "canWallJumpInstantMorph",
             {"enemyDamage": {

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1491,9 +1491,22 @@
         }
       },
       "requires": [
+        "canTrickyJump",
+        "canConsecutiveWalljump",
         "canPreciseWalljump",
-        "canStaggeredWalljump",
-        "canTrickyJump"
+        {"or": [
+          "canStaggeredWalljump",
+          "ScrewAttack",
+          "canPseudoScrew",
+          {"and": [
+            "canWallJumpInstantMorph",
+            {"enemyDamage": {
+              "enemy": "Cacatac",
+              "type": "contact",
+              "hits": 1
+            }}
+          ]}
+        ]}
       ]
     },
     {
@@ -1507,8 +1520,21 @@
         }
       },
       "requires": [
-        "canStaggeredWalljump",
-        "canCarefulJump"
+        "canCarefulJump",
+        "canConsecutiveWalljump",
+        {"or": [
+          "canStaggeredWalljump",
+          "ScrewAttack",
+          "canPseudoScrew",
+          {"and": [
+            "canWallJumpInstantMorph",
+            {"enemyDamage": {
+              "enemy": "Cacatac",
+              "type": "contact",
+              "hits": 1
+            }}
+          ]}
+        ]}
       ]
     },
     {
@@ -1522,8 +1548,21 @@
         }
       },
       "requires": [
-        "canStaggeredWalljump",
-        "canCarefulJump"
+        "canCarefulJump",
+        "canConsecutiveWalljump",
+        {"or": [
+          "canStaggeredWalljump",
+          "ScrewAttack",
+          "canPseudoScrew",
+          {"and": [
+            "canWallJumpInstantMorph",
+            {"enemyDamage": {
+              "enemy": "Cacatac",
+              "type": "contact",
+              "hits": 1
+            }}
+          ]}
+        ]}
       ]
     },
     {


### PR DESCRIPTION
The strats with 4+ tile runway are in Medium, which doesn't really seem fair. I think you want to do 3 walljumps here, like in this video: https://videos.maprando.com/video/983. The version with 2 walljumps is more difficult, requiring more precise timing on the initial jump and wall jumps, and risks getting knocked down by a Cac spike. With 3 walljumps there's more leniency and it leaves room to adjust the walljumps to avoid Cac spikes. By adding a canConsecutiveWalljump it will put these into Hard, except for the shorter-runway version which is already Very Hard because of canTrickyJump.