### PR TITLE
Add Morph reqs to reserve double damage boosts

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -3386,10 +3386,13 @@
         "canCrouchJump",
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
-        "Morph",
         {"or": [
           "h_canMaxHeightSpringBallJump",
           "HiJump"
+        ]},
+        {"or": [
+          "Morph",
+          "canOffScreenMovement"
         ]},
         {"autoReserveTrigger": {"minReserveEnergy": 85}},
         {"enemyDamage": {
@@ -3402,7 +3405,8 @@
       "note": [
         "Jump with either Springball or HiJump onto the global Sciser while it is climbing the section above the Speed locked item.",
         "Have Reserves set to manual and return them to auto after taking a deadly crab hit in order to gain two damage boosts.",
-        "If the Speed blocks are broken, the global crab will not be able to reach this part of the room."
+        "If the Speed blocks are broken, the global crab will not be able to reach this part of the room.",
+        "If Morph is unavailable, then a down-grab must be done blind: buffer the down input through the reserve refill, then press forward immediately after taking damage."
       ]
     }
   ],

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -3386,6 +3386,7 @@
         "canCrouchJump",
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
+        "Morph",
         {"or": [
           "h_canMaxHeightSpringBallJump",
           "HiJump"

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1283,10 +1283,13 @@
         "canCrouchJump",
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
-        "Morph",
         {"or": [
           "h_canMaxHeightSpringBallJump",
           "HiJump"
+        ]},
+        {"or": [
+          "Morph",
+          "canOffScreenMovement"
         ]},
         {"autoReserveTrigger": {"minReserveEnergy": 85}},
         {"enemyDamage": {
@@ -1299,7 +1302,8 @@
       "note": [
         "Jump with either Springball or HiJump onto a Sciser while it is climbing the right-most mountain.",
         "Have Reserves set to manual and return them to auto after taking a deadly crab hit in order to gain two damage boosts.",
-        "This gains barely enough height to reach the ledge above."
+        "This gains barely enough height to reach the ledge above.",
+        "If Morph is unavailable, then a down-grab must be done blind: buffer the down input through the reserve refill, then press forward immediately after taking damage."
       ]
     },
     {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1283,6 +1283,7 @@
         "canCrouchJump",
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
+        "Morph",
         {"or": [
           "h_canMaxHeightSpringBallJump",
           "HiJump"


### PR DESCRIPTION
This trick seems much more difficult without Morph. I'm not sure if "canOffScreenMovement" captures the difficulty but wanted to at least put something there; it might belong more in Insane though? At least, my reaction time is not quick enough to do the forward input after hearing the hurt sound, so it instead has to be a timing based on knowing how long the reserve refill will last. It could also be my audio latency is not great with my emulator setup, so maybe for others it might not be as bad.

I tried the Cathedral Entrance one morphless too and couldn't get it at all; I think I don't understand how it's supposed to work, a video could probably help. It already had a note about it so I assume it's ok though