### PR TITLE
Post Crocomire Jump Room - fix missing obstaclesNotCleared id 28

### DIFF
--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -602,6 +602,7 @@
       "name": "Leave with Shinecharge - Power Bomb Blocks Intact",
       "requires": [
         {"obstaclesCleared": ["B"]},
+        {"obstaclesNotCleared": ["A"]},
         "canShinechargeMovement",
         {"canShineCharge": {
           "usedTiles": 32,


### PR DESCRIPTION
https://dev.maprando.com/seed/kzDPKrrYC/data/visualizer/index.html

Step 7 / Grav in PCJR:

Strat: Break Speed Blocks, Broken Power Bomb Blocks
https://dev.maprando.com/logic/room/127/2/2/23

Strat: Leave with Shinecharge - Power Bomb Blocks Intact
https://dev.maprando.com/logic/room/127/2/2/28

I think the second strat is missing an `"obstaclesNotCleared": ["B"]`?