### PR TITLE
Tighten PCJR diagonal spark framesRequired

### DIFF
--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -296,7 +296,7 @@
       "name": "PCJR Left Side Diagonal Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 175
+          "framesRequired": 155
         }
       },
       "requires": [


### PR DESCRIPTION
Most of Norfair still needs another pass to refine cross-room shinecharge strats. I wanted to address this one now because it's affecting a notable, putting it in the wrong difficulty tier.

Video: https://videos.maprando.com/video/1091