### PR TITLE
Remove colosseum grapple clip notable

### DIFF
--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1891,15 +1891,6 @@
       ]
     },
     {
-      "id": 3,
-      "name": "Colosseum Green Door Grapple Clip",
-      "note": [
-        "Use a Mochtroid to clip into the space behind the grapple blocks.",
-        "Then use Grapple on the blocks to be pushed a precise amount into the wall above the door.",
-        "From there, use grapple again to be pushed diagonally down into the transition behind the Green shell."
-      ]
-    },
-    {
       "id": 4,
       "name": "Colosseum Full Halfie Shinespark",
       "note": [


### PR DESCRIPTION
I think we decided a while ago to not have the grapple clip strats on this door be notable, but the (reusable) notable itself wasn't removed. So this cleans that up. This will get rid of the warnings about the unused notable.
