### PR TITLE
Remove Room Names From Notable Names

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -496,9 +496,9 @@
     {
       "id": 23,
       "link": [1, 3],
-      "name": "Blue Brinstar E-Tank Ceiling Damage Boost",
+      "name": "Ceiling Damage Boost",
       "requires": [
-        {"notable": "Blue Brinstar E-Tank Ceiling Damage Boost"},
+        {"notable": "Ceiling Damage Boost"},
         "h_ZebesIsAwake",
         "canNeutralDamageBoost",
         {"enemyDamage": {
@@ -559,9 +559,9 @@
     {
       "id": 27,
       "link": [1, 3],
-      "name": "Taco Tank in Blue Brinstar Energy Tank Room",
+      "name": "Taco Tank",
       "requires": [
-        {"notable": "Taco Tank in Blue Brinstar Energy Tank Room"},
+        {"notable": "Taco Tank"},
         "canCWJ",
         "canInsaneWalljump",
         "canStationarySpinJump"
@@ -614,7 +614,7 @@
         }
       },
       "requires": [
-        {"notable": "Blue Brinstar Energy Tank G-Mode Flashing Lights"},
+        {"notable": "G-Mode Flashing Lights"},
         {"or": [
           "h_ZebesNotAwake",
           "h_canArtificialMorphSpringBall",
@@ -688,7 +688,7 @@
         }
       },
       "requires": [
-        {"notable": "Blue Brinstar Energy Tank G-Mode Flashing Lights"},
+        {"notable": "G-Mode Flashing Lights"},
         {"or": [
           "h_ZebesNotAwake",
           "h_canArtificialMorphSpringBall",
@@ -860,9 +860,9 @@
     {
       "id": 45,
       "link": [4, 2],
-      "name": "Blue Brin E-Tank Return Through Crumble Blocks",
+      "name": "Return Through Crumble Blocks",
       "requires": [
-        {"notable": "Blue Brin E-Tank Return Through Crumble Blocks"},
+        {"notable": "Return Through Crumble Blocks"},
         "Morph",
         {"or": [
           "canConsecutiveWalljump",
@@ -1076,9 +1076,9 @@
     {
       "id": 55,
       "link": [4, 2],
-      "name": "Blue Brinstar Energy Tank Room - Geemer Ice Stuck XRay Climb",
+      "name": "Geemer Ice Stuck XRay Climb",
       "requires": [
-        {"notable": "Blue Brinstar Energy Tank Room - Geemer Ice Stuck XRay Climb"},
+        {"notable": "Geemer Ice Stuck XRay Climb"},
         "canWallIceClip",
         "canXRayClimb",
         "Grapple",
@@ -1208,7 +1208,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Blue Brinstar Energy Tank G-Mode Flashing Lights",
+      "name": "G-Mode Flashing Lights",
       "note": [
         "The eye scanners are particularly annoying while in g-mode. They scan Samus with bright flashing lights which remain for a further distance.",
         "This is notable so a player can disable having to enter these flashing lights. If disabled, Samus will only require being in g-mode in this room if Zebes is awake."
@@ -1216,7 +1216,7 @@
     },
     {
       "id": 2,
-      "name": "Blue Brinstar E-Tank Ceiling Damage Boost",
+      "name": "Ceiling Damage Boost",
       "note": [
         "Have Samus shoot the shot block revealing the item and then quickly get hit by an enemy at the peak of her jump in order to reach the item.",
         "No directional inputs should be held while getting hit by the enemy in order to have a neutral boost and reach the item.",
@@ -1226,17 +1226,17 @@
     },
     {
       "id": 3,
-      "name": "Taco Tank in Blue Brinstar Energy Tank Room",
+      "name": "Taco Tank",
       "note": "Triple frame perfect dashing stationary spinjump into delayed CWJ and precise hitbox manipulation."
     },
     {
       "id": 4,
-      "name": "Blue Brin E-Tank Return Through Crumble Blocks",
+      "name": "Return Through Crumble Blocks",
       "note": "The Crumble Block does not respawn, so it's possible to grab the items and go back up without breaking the Power Bomb blocks."
     },
     {
       "id": 5,
-      "name": "Blue Brinstar Energy Tank Room - Geemer Ice Stuck XRay Climb",
+      "name": "Geemer Ice Stuck XRay Climb",
       "note": [
         "Keep the two Geemers on screen while moving to the right side of the room.",
         "Freeze the second Geemer as it exits the Morph Tunnel, with the Crumble block.",

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -335,9 +335,9 @@
     {
       "id": 16,
       "link": [3, 4],
-      "name": "Brinstar Reserve Hole-in-One",
+      "name": "Hole-in-One",
       "requires": [
-        {"notable": "Brinstar Reserve Hole-in-One"},
+        {"notable": "Hole-in-One"},
         "Morph",
         "ScrewAttack",
         {"or": [
@@ -369,7 +369,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Brinstar Reserve Hole-in-One",
+      "name": "Hole-in-One",
       "note": [
         "A single very precise jump into the bomb blocks can break both sets of blocks with screw attack. Obtaining the item requires morph, so this strat has no soft lock risk.",
         "Alternatively, tunnel crawl through to break both blocks with multiple, less precise jumps."

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -233,9 +233,9 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "Early Supers Leave With Spark To The Left",
+      "name": "Leave With Spark To The Left",
       "requires": [
-        {"notable": "Early Supers Leave With Spark To The Left"},
+        {"notable": "Leave With Spark To The Left"},
         {"obstaclesNotCleared": ["A"]},
         "h_canCrouchJumpDownGrab",
         {"canShineCharge": {
@@ -293,9 +293,9 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Early Supers Mockball",
+      "name": "Mockball",
       "requires": [
-        {"notable": "Early Supers Mockball"},
+        {"notable": "Mockball"},
         {"obstaclesNotCleared": ["A"]},
         "canMockball"
       ],
@@ -340,9 +340,9 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "Early Supers Crouch Gate Clip Damage Boost",
+      "name": "Crouch Gate Clip Damage Boost",
       "requires": [
-        {"notable": "Early Supers Crouch Gate Clip Damage Boost"},
+        {"notable": "Crouch Gate Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
         "canCrouchGateClip",
         "canCameraManip",
@@ -943,7 +943,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Early Supers Leave With Spark To The Left",
+      "name": "Leave With Spark To The Left",
       "note": [
         "Gain a shinecharge on the long, lower platform in the screen above, then carry it left and down.",
         "Use crumble quick drops, land on the floor at the bottom, spin jump left into the doorway, and activate the spark.",
@@ -952,12 +952,12 @@
     },
     {
       "id": 2,
-      "name": "Early Supers Mockball",
+      "name": "Mockball",
       "note": "Mockball to roll over the crumble blocks without falling down, and under the gate before it closes."
     },
     {
       "id": 3,
-      "name": "Early Supers Crouch Gate Clip Damage Boost",
+      "name": "Crouch Gate Clip Damage Boost",
       "note": [
         "Spawn a Zeb then run and do a very small spin jump to clip into the first gate before the Zeb reaches you.",
         "Do a damage boost off of the Zeb while inside the first gate to get enough speed to clip into the next gate.",

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -774,9 +774,9 @@
     {
       "id": 28,
       "link": [3, 2],
-      "name": "Etecoon E-Tank Beetom Clip",
+      "name": "Beetom Clip",
       "requires": [
-        {"notable": "Etecoon E-Tank Beetom Clip"},
+        {"notable": "Beetom Clip"},
         {"or": [
           "h_canXRayMorphIceClip",
           "h_canPreciseIceClip"
@@ -819,9 +819,9 @@
     {
       "id": 29,
       "link": [3, 2],
-      "name": "Etecoon E-Tank Beetom Clip (High Pixel, Preserve Flash Suit)",
+      "name": "Beetom Clip (High Pixel, Preserve Flash Suit)",
       "requires": [
-        {"notable": "Etecoon E-Tank Beetom Clip (High Pixel, Preserve Flash Suit)"},
+        {"notable": "Beetom Clip (High Pixel, Preserve Flash Suit)"},
         "h_canHighPixelIceClip",
         "Morph",
         {"enemyDamage": {
@@ -981,9 +981,9 @@
     {
       "id": 34,
       "link": [3, 6],
-      "name": "Etecoon Spikeway Tunnel Crawl (Left to Right)",
+      "name": "Spikeway Tunnel Crawl (Left to Right)",
       "requires": [
-        {"notable": "Etecoon Spikeway Tunnel Crawl"},
+        {"notable": "Spikeway Tunnel Crawl"},
         "canTunnelCrawl",
         "canTrickyJump",
         {"thornHits": 31}
@@ -1003,9 +1003,9 @@
     {
       "id": 35,
       "link": [3, 6],
-      "name": "Etecoon Spikeway Aim Cancel Wiggle",
+      "name": "Spikeway Aim Cancel Wiggle",
       "requires": [
-        {"notable": "Etecoon Spikeway Aim Cancel Wiggle"},
+        {"notable": "Spikeway Aim Cancel Wiggle"},
         "canTurnaroundAimCancel",
         "canBeVeryPatient",
         {"thornHits": 180}
@@ -1016,9 +1016,9 @@
     {
       "id": 36,
       "link": [3, 6],
-      "name": "Etecoon Spikeway Xray Wiggle (Left to Right)",
+      "name": "Spikeway X-Ray Wiggle (Left to Right)",
       "requires": [
-        {"notable": "Etecoon Spikeway Xray Wiggle"},
+        {"notable": "Spikeway X-Ray Wiggle"},
         "canXRayWaitForIFrames",
         "canXRayTurnaround",
         {"thornHits": 1}
@@ -1378,9 +1378,9 @@
     {
       "id": 57,
       "link": [4, 7],
-      "name": "Etecoon Beetom Tricky Dodge (Right to Left)",
+      "name": "Beetom Tricky Dodge (Right to Left)",
       "requires": [
-        {"notable": "Etecoon Beetom Tricky Dodge"},
+        {"notable": "Beetom Tricky Dodge"},
         "canTrickyJump"
       ],
       "clearsObstacles": ["A"],
@@ -1420,9 +1420,9 @@
     {
       "id": 61,
       "link": [6, 3],
-      "name": "Etecoon Spikeway Tunnel Crawl (Right to Left)",
+      "name": "Spikeway Tunnel Crawl (Right to Left)",
       "requires": [
-        {"notable": "Etecoon Spikeway Tunnel Crawl"},
+        {"notable": "Spikeway Tunnel Crawl"},
         "canTunnelCrawl",
         "canTrickyJump",
         {"thornHits": 31},
@@ -1443,9 +1443,9 @@
     {
       "id": 62,
       "link": [6, 3],
-      "name": "Etecoon Spikeway Xray Wiggle (Right to Left)",
+      "name": "Spikeway X-Ray Wiggle (Right to Left)",
       "requires": [
-        {"notable": "Etecoon Spikeway Xray Wiggle"},
+        {"notable": "Spikeway X-Ray Wiggle"},
         "canXRayWaitForIFrames",
         "canXRayTurnaround",
         {"thornHits": 1}
@@ -1596,9 +1596,9 @@
     {
       "id": 70,
       "link": [6, 7],
-      "name": "Etecoon Beetom Tricky Dodge (Left to Right)",
+      "name": "Beetom Tricky Dodge (Left to Right)",
       "requires": [
-        {"notable": "Etecoon Beetom Tricky Dodge"},
+        {"notable": "Beetom Tricky Dodge"},
         "canTrickyJump",
         {"obstaclesNotCleared": ["B"]}
       ],
@@ -1637,7 +1637,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Etecoon Beetom Tricky Dodge",
+      "name": "Beetom Tricky Dodge",
       "note": [
         "Patiently and carefully lure the Beetoms to get them stuck under the platforms. Afterwards, a farm can be used to gain energy.",
         "Then jump into the thorns to get invulnerability frames and run through, while luring the Beetoms under the platforms to use the farms."
@@ -1645,7 +1645,7 @@
     },
     {
       "id": 2,
-      "name": "Etecoon Spikeway Tunnel Crawl",
+      "name": "Spikeway Tunnel Crawl",
       "note": [
         "Perform a tunnel crawl through the Etecoon morph tunnel thorns. Perform one jump per thorn hit.",
         "Note that because of the thorn damage, getting into the tunnel is a bit more tricky."
@@ -1653,7 +1653,7 @@
     },
     {
       "id": 3,
-      "name": "Etecoon Spikeway Xray Wiggle",
+      "name": "Spikeway X-Ray Wiggle",
       "note": [
         "Slowly move through the thorns by alternating between X-Ray turnarounds and normal turnarounds.",
         "Maintain IFrames by using X-Ray whenever a thorn would deal damage."
@@ -1661,7 +1661,7 @@
     },
     {
       "id": 4,
-      "name": "Etecoon E-Tank Beetom Clip",
+      "name": "Beetom Clip",
       "note": [
         "Jump and freeze the Beetom at a precise location in order to jump through the crumble blocks.",
         "The pixel window is larger and higher with Morph and an X-Ray Stand Up.",
@@ -1670,7 +1670,7 @@
     },
     {
       "id": 5,
-      "name": "Etecoon E-Tank Beetom Clip (High Pixel, Preserve Flash Suit)",
+      "name": "Beetom Clip (High Pixel, Preserve Flash Suit)",
       "note": [
         "Jump and freeze the Beetom at a pixel perfect location in order to jump through the crumble blocks.",
         "The pixel is nearly the highest possible position with HiJump disabled, from the left ledge.",
@@ -1681,7 +1681,7 @@
     },
     {
       "id": 6,
-      "name": "Etecoon Spikeway Aim Cancel Wiggle",
+      "name": "Spikeway Aim Cancel Wiggle",
       "note": "Wiggle through the thorns. It is a long wiggle with a lot of thorn hits."
     }
   ],

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -118,9 +118,9 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "Green Brinstar Beetom Room Frozen Beetom Bridge (Left Door)",
+      "name": "Frozen Beetom Bridge (Left Door)",
       "requires": [
-        {"notable": "Green Brinstar Beetom Room Frozen Beetom Bridge"},
+        {"notable": "Frozen Beetom Bridge"},
         "canTrickyJump",
         "h_canFrozenEnemyRunway",
         {"enemyDamage": {
@@ -994,9 +994,9 @@
     {
       "id": 44,
       "link": [2, 2],
-      "name": "Green Brinstar Beetom Room Frozen Beetom Bridge (Right Door)",
+      "name": "Frozen Beetom Bridge (Right Door)",
       "requires": [
-        {"notable": "Green Brinstar Beetom Room Frozen Beetom Bridge"},
+        {"notable": "Frozen Beetom Bridge"},
         "canTrickyJump",
         "h_canFrozenEnemyRunway",
         {"enemyDamage": {
@@ -1132,7 +1132,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Green Brinstar Beetom Room Frozen Beetom Bridge",
+      "name": "Frozen Beetom Bridge",
       "note": [
         "Stand in the pit and freeze the Beetoms by shooting up. Keep them all separated and equally spaced apart to maximize the length of the runway.",
         "Freeze the Beetoms that aren't currently in use to avoid them from attaching to Samus and stacking together."

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4338,14 +4338,14 @@
     {
       "id": 162,
       "link": [7, 8],
-      "name": "Green Brinstar Main Shaft Moonfall Spark",
+      "name": "Main Shaft Moonfall Spark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 140
         }
       },
       "requires": [
-        {"notable": "Green Brinstar Main Shaft Moonfall Spark"},
+        {"notable": "Main Shaft Moonfall Spark"},
         "canMoonfall",
         "canShinechargeMovementTricky",
         {"shinespark": {"frames": 12}}
@@ -5519,9 +5519,9 @@
     {
       "id": 231,
       "link": [12, 13],
-      "name": "Green Brinstar Main Shaft TAS Dance",
+      "name": "TAS Dance",
       "requires": [
-        {"notable": "Green Brinstar Main Shaft TAS Dance"},
+        {"notable": "TAS Dance"},
         "canMoonfall"
       ],
       "note": [
@@ -5614,9 +5614,9 @@
     {
       "id": 238,
       "link": [13, 14],
-      "name": "Green Brinstar Main Shaft Bottom Ice Clip",
+      "name": "Bottom Ice Clip",
       "requires": [
-        {"notable": "Green Brinstar Main Shaft Bottom Ice Clip"},
+        {"notable": "Bottom Ice Clip"},
         "h_canBombThings",
         "h_additionalBomb",
         {"enemyDamage": {
@@ -5759,7 +5759,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Green Brinstar Main Shaft Moonfall Spark",
+      "name": "Main Shaft Moonfall Spark",
       "note": [
         "Come in with a shinecharge, and perform a moonfall off the ledge.",
         "While falling, fire a shot at the door and immediately activate the shinespark wind-up, to horizontally spark through the door."
@@ -5775,7 +5775,7 @@
     },
     {
       "id": 3,
-      "name": "Green Brinstar Main Shaft TAS Dance",
+      "name": "TAS Dance",
       "note": [
         "Moonfall on the Green Brinstar Elevator Platform to build up enough speed to fall through the Power Bomb Blocks below.",
         "Moonfall so as to stay on the platform, break spin, and turnaround between 70 and 76 times total.",
@@ -5787,7 +5787,7 @@
     },
     {
       "id": 4,
-      "name": "Green Brinstar Main Shaft Bottom Ice Clip",
+      "name": "Bottom Ice Clip",
       "note": [
         "Break the bomb block at the bottom right of the main shaft.",
         "Bring a Zeela down to the bottom of the room.",

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -357,9 +357,9 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Green Hill Zone Wall Jump to Top Right Door",
+      "name": "Wall Jump to Top Right Door",
       "requires": [
-        {"notable": "Green Hill Zone Wall Jump to Top Right Door"},
+        {"notable": "Wall Jump to Top Right Door"},
         "canPreciseWalljump"
       ],
       "flashSuitChecked": true,
@@ -1005,9 +1005,9 @@
     {
       "id": 48,
       "link": [3, 1],
-      "name": "Green Hills Grapple Gate Glitch",
+      "name": "Grapple Gate Glitch",
       "requires": [
-        {"notable": "Green Hills Grapple Gate Glitch"},
+        {"notable": "Grapple Gate Glitch"},
         "Grapple",
         "SpeedBooster",
         "canTrickyJump"
@@ -1165,14 +1165,14 @@
     {
       "id": 56,
       "link": [3, 2],
-      "name": "Green Hills Grapple Teleport Fling to Right (from Moat)",
+      "name": "Grapple Teleport Fling to Right (from Moat)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[7, 2]]
         }
       },
       "requires": [
-        {"notable": "Green Hills Grapple Teleport Fling to Right (from Moat)"},
+        {"notable": "Grapple Teleport Fling to Right (from Moat)"},
         "canInsaneJump"
       ],
       "note": [
@@ -1183,14 +1183,14 @@
     {
       "id": 57,
       "link": [3, 2],
-      "name": "Green Hills Grapple Teleport into Grapple Jump (from Red Brinstar Firefleas)",
+      "name": "Grapple Teleport into Grapple Jump (from Red Brinstar Firefleas)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
         }
       },
       "requires": [
-        {"notable": "Green Hills Grapple Teleport into Grapple Jump (from Red Brinstar Firefleas)"},
+        {"notable": "Grapple Teleport into Grapple Jump (from Red Brinstar Firefleas)"},
         "canTrickyGrappleJump",
         "canInsaneJump"
       ],
@@ -1420,9 +1420,9 @@
     {
       "id": 71,
       "link": [4, 5],
-      "name": "Green Hill Zone X-Ray Wiggle (Out)",
+      "name": "X-Ray Wiggle (Out)",
       "requires": [
-        {"notable": "Green Hill Zone X-Ray Wiggle"},
+        {"notable": "X-Ray Wiggle"},
         "canXRayTurnaround"
       ],
       "flashSuitChecked": true,
@@ -1431,9 +1431,9 @@
     {
       "id": 72,
       "link": [4, 5],
-      "name": "Green Hill Zone Tunnel Crawl (Out)",
+      "name": "Tunnel Crawl (Out)",
       "requires": [
-        {"notable": "Green Hill Zone Tunnel Crawl"},
+        {"notable": "Tunnel Crawl"},
         "canTunnelCrawl"
       ],
       "note": "It's a long Tunnel Crawl, so there's a heavy softlock risk."
@@ -1479,9 +1479,9 @@
     {
       "id": 77,
       "link": [5, 4],
-      "name": "Green Hill Zone X-Ray Wiggle (In)",
+      "name": "X-Ray Wiggle (In)",
       "requires": [
-        {"notable": "Green Hill Zone X-Ray Wiggle"},
+        {"notable": "X-Ray Wiggle"},
         "canTwoTileSqueeze",
         "canXRayTurnaround"
       ],
@@ -1494,9 +1494,9 @@
     {
       "id": 78,
       "link": [5, 4],
-      "name": "Green Hill Zone Tunnel Crawl (In)",
+      "name": "Tunnel Crawl (In)",
       "requires": [
-        {"notable": "Green Hill Zone Tunnel Crawl"},
+        {"notable": "Tunnel Crawl"},
         "canTunnelCrawl"
       ],
       "note": "It's a long Tunnel Crawl, so there's a heavy softlock risk."
@@ -1506,12 +1506,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Green Hill Zone Tunnel Crawl",
+      "name": "Tunnel Crawl",
       "note": "It's a long Tunnel Crawl, so there's a heavy softlock risk."
     },
     {
       "id": 2,
-      "name": "Green Hill Zone X-Ray Wiggle",
+      "name": "X-Ray Wiggle",
       "note": [
         "It's a long Wiggle, but you can see the item before going in too far.",
         "Spin jumping directly into the tube will disable X-Ray, so enter aiming down to standup first."
@@ -1519,19 +1519,19 @@
     },
     {
       "id": 3,
-      "name": "Green Hill Zone Wall Jump to Top Right Door",
+      "name": "Wall Jump to Top Right Door",
       "note": "Wall jump on the top half of the Geega pipe, then on the overhang."
     },
     {
       "id": 4,
-      "name": "Green Hills Grapple Gate Glitch",
+      "name": "Grapple Gate Glitch",
       "note": [
         "Build up some run speed and then extend the Grapple Beam through the Blue Gate, while jumping, to open it from the wrong side."
       ]
     },
     {
       "id": 5,
-      "name": "Green Hills Grapple Teleport Fling to Right (from Moat)",
+      "name": "Grapple Teleport Fling to Right (from Moat)",
       "note": [
         "After teleporting, extend the Grapple, and swing back and forth to fix the camera and then to gain momentum.",
         "A precisely timed release of Grapple will allow Samus to fling onto the ledge on the right."
@@ -1539,7 +1539,7 @@
     },
     {
       "id": 6,
-      "name": "Green Hills Grapple Teleport into Grapple Jump (from Red Brinstar Firefleas)",
+      "name": "Grapple Teleport into Grapple Jump (from Red Brinstar Firefleas)",
       "note": [
         "After teleporting, swing back and forth to fix the camera.",
         "Swing to the right by soft-bouncing against the door followed by fully extending the Grapple Beam.",

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -273,9 +273,9 @@
     {
       "id": 14,
       "link": [2, 2],
-      "name": "Spore Spawn Kihunter Ice Clip Door Lock Skip Without Morph and X-Ray",
+      "name": "Ice Clip Door Lock Skip Without Morph and X-Ray",
       "requires": [
-        {"notable": "Spore Spawn Kihunter Ice Clip Door Lock Skip Without Morph and X-Ray"},
+        {"notable": "Ice Clip Door Lock Skip Without Morph and X-Ray"},
         "h_canPreciseIceClip"
       ],
       "bypassesDoorShell": true,
@@ -417,7 +417,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Spore Spawn Kihunter Ice Clip Door Lock Skip Without Morph and X-Ray",
+      "name": "Ice Clip Door Lock Skip Without Morph and X-Ray",
       "note": [
         "Lure a Kihunter over to the right near the door. Damage it so that it falls to the ground.",
         "There is a 2 frame window at the beginning of its hop where Samus can use it to clip through the door"

--- a/region/brinstar/green/Spore Spawn Room.json
+++ b/region/brinstar/green/Spore Spawn Room.json
@@ -88,14 +88,14 @@
     {
       "id": 3,
       "link": [1, 2],
-      "name": "Sporespawn Moondance Clip",
+      "name": "Moondance Clip",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
         }
       },
       "requires": [
-        {"notable": "Sporespawn Moondance Clip"},
+        {"notable": "Moondance Clip"},
         "canFreeFallClip",
         {"enemyDamage": {
           "enemy": "Spore Spawn",
@@ -208,7 +208,6 @@
       "id": 13,
       "link": [2, 2],
       "name": "Supers",
-      "notable": false,
       "requires": [
         {"or": [
           "canDodgeWhileShooting",
@@ -225,7 +224,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Sporespawn Moondance Clip",
+      "name": "Moondance Clip",
       "note": [
         "Prepare an extended Moondance and wait for SporeSpawn to move to a side.",
         "In quick succession, Moonfall, turn left, and turn right while holding a spin break button to clip down into the fight arena."

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -158,9 +158,9 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "Warehouse Energy Tank Frozen Beetom Runway",
+      "name": "Frozen Beetom Runway",
       "requires": [
-        {"notable": "Warehouse Energy Tank Frozen Beetom Runway"},
+        {"notable": "Frozen Beetom Runway"},
         {"obstaclesNotCleared": ["A"]},
         "canTrickyJump",
         "h_canTrickyFrozenEnemyRunway",
@@ -444,7 +444,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Warehouse Energy Tank Frozen Beetom Runway",
+      "name": "Frozen Beetom Runway",
       "note": [
         "Freeze multiple Beetoms to extend the runway. Continually refreeze the ones that are in a good position while manipulating the rest.",
         "This assumes three extra tiles of runway, which can be accomplished with two perfectly placed Beetoms, three adjacent ones, or four which are partially overlapping."

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -743,9 +743,9 @@
     {
       "id": 42,
       "link": [4, 3],
-      "name": "Warehouse Entrance Arm Pump Jump",
+      "name": "Arm Pump Jump",
       "requires": [
-        {"notable": "Warehouse Entrance Arm Pump Jump"},
+        {"notable": "Arm Pump Jump"},
         "h_canBackIntoCorner",
         "canInsaneJump",
         "canDownGrab"
@@ -762,7 +762,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Warehouse Entrance Arm Pump Jump",
+      "name": "Arm Pump Jump",
       "note": [
         "Back up against the wall of the single-tile ledge.",
         "Run forward, perform a single arm pump, and jump on the last possible frame.",

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -730,9 +730,9 @@
     {
       "id": 37,
       "link": [5, 2],
-      "name": "Warehouse Kihunter Room Bottom Spark Out",
+      "name": "Bottom Spark Out",
       "requires": [
-        {"notable": "Warehouse Kihunter Room Bottom Spark Out"},
+        {"notable": "Bottom Spark Out"},
         "canShinechargeMovementComplex",
         {"obstaclesCleared": ["C"]},
         {"obstaclesNotCleared": ["D"]},
@@ -762,9 +762,9 @@
     {
       "id": 38,
       "link": [5, 2],
-      "name": "Warehouse Kihunter Room Bottom Leave Shinecharged",
+      "name": "Bottom Leave Shinecharged",
       "requires": [
-        {"notable": "Warehouse Kihunter Room Bottom Leave Shinecharged"},
+        {"notable": "Bottom Leave Shinecharged"},
         "canShinechargeMovementTricky",
         {"obstaclesCleared": ["C"]},
         {"obstaclesNotCleared": ["D"]},
@@ -819,9 +819,9 @@
     {
       "id": 41,
       "link": [5, 3],
-      "name": "Warehouse Kihunter Speedball",
+      "name": "Speedball",
       "requires": [
-        {"notable": "Warehouse Kihunter Speedball"},
+        {"notable": "Speedball"},
         "Morph",
         {"obstaclesCleared": ["C"]},
         {"obstaclesNotCleared": ["D"]},
@@ -850,9 +850,9 @@
     {
       "id": 42,
       "link": [5, 3],
-      "name": "Warehouse Kihunter Room Tunnel Charge (Shot Block Intact)",
+      "name": "Tunnel Charge (Shot Block Intact)",
       "requires": [
-        {"notable": "Warehouse Kihunter Room Tunnel Charge"},
+        {"notable": "Tunnel Charge"},
         {"obstaclesCleared": ["B", "C"]},
         {"obstaclesNotCleared": ["D"]},
         {"canShineCharge": {
@@ -883,9 +883,9 @@
     {
       "id": 43,
       "link": [5, 3],
-      "name": "Warehouse Kihunter Room Tunnel Charge (Shot Block Broken)",
+      "name": "Tunnel Charge (Shot Block Broken)",
       "requires": [
-        {"notable": "Warehouse Kihunter Room Tunnel Charge"},
+        {"notable": "Tunnel Charge"},
         {"obstaclesCleared": ["B", "C", "D"]},
         {"canShineCharge": {
           "usedTiles": 13,
@@ -948,22 +948,22 @@
   "notables": [
     {
       "id": 1,
-      "name": "Warehouse Kihunter Room Tunnel Charge",
+      "name": "Tunnel Charge",
       "note": "Generate a charge on the left side and carry it through the morph tunnel and out the right door."
     },
     {
       "id": 2,
-      "name": "Warehouse Kihunter Room Bottom Spark Out",
+      "name": "Bottom Spark Out",
       "note": "Charge a spark, then break the shot blocks, drop through, and spark out the bottom right door."
     },
     {
       "id": 3,
-      "name": "Warehouse Kihunter Room Bottom Leave Shinecharged",
+      "name": "Bottom Leave Shinecharged",
       "note": "Break the shot block, then gain a shinecharge while sliding off the ledge, down toward the bottom right door."
     },
     {
       "id": 4,
-      "name": "Warehouse Kihunter Speedball",
+      "name": "Speedball",
       "note": [
         "A very low horizontal speed is needed to drop down and break the block without hitting the corner to the left or the block above the bomb block.",
         "Or with Temporary Blue, Samus can bounce into the bomb block."

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -409,9 +409,9 @@
     {
       "id": 16,
       "link": [2, 2],
-      "name": "Warehouse Zeela Ice Moonfall Leave with Stored Fall Speed",
+      "name": "Ice Moonfall Leave with Stored Fall Speed",
       "requires": [
-        {"notable": "Warehouse Zeela Ice Moonfall"},
+        {"notable": "Ice Moonfall"},
         "canEnemyStuckMoonfall",
         "canTrickyUseFrozenEnemies",
         "Grapple"
@@ -511,9 +511,9 @@
     {
       "id": 22,
       "link": [2, 3],
-      "name": "Warehouse Zeela Ice Moonfall Screw Attack Clip",
+      "name": "Ice Moonfall Screw Attack Clip",
       "requires": [
-        {"notable": "Warehouse Zeela Ice Moonfall"},
+        {"notable": "Ice Moonfall"},
         "canEnemyStuckMoonfall",
         "canTrickyUseFrozenEnemies",
         "ScrewAttack",
@@ -730,7 +730,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Warehouse Zeela Ice Moonfall",
+      "name": "Ice Moonfall",
       "note": [
         "Freeze two Zeelas, one on the left wall below the top door platform, and one on the right wall between 1 and 2 tiles lower, both moving downward;",
         "Kill the third Zeela.",

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -881,14 +881,14 @@
     {
       "id": 25,
       "link": [3, 4],
-      "name": "Big Pink Extended Moondance Clip",
+      "name": "Extended Moondance Clip",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
         }
       },
       "requires": [
-        {"notable": "Big Pink Extended Moondance Clip"},
+        {"notable": "Extended Moondance Clip"},
         "canFreeFallClip"
       ],
       "note": [
@@ -1528,7 +1528,7 @@
     {
       "id": 64,
       "link": [7, 13],
-      "name": "Big Pink Super Block Speedball",
+      "name": "Super Block Speedball",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 5,
@@ -1536,7 +1536,7 @@
         }
       },
       "requires": [
-        {"notable": "Big Pink Super Block Speedball"},
+        {"notable": "Super Block Speedball"},
         "canSpeedball",
         "canTrickyJump",
         "canSlowShortCharge",
@@ -2114,9 +2114,9 @@
     {
       "id": 95,
       "link": [13, 1],
-      "name": "Big Pink Fast Mockball Leave With Spark",
+      "name": "Fast Mockball Leave With Spark",
       "requires": [
-        {"notable": "Big Pink Fast Mockball Leave With Spark"},
+        {"notable": "Fast Mockball Leave With Spark"},
         {"obstaclesCleared": ["A"]},
         {"canShineCharge": {
           "usedTiles": 17,
@@ -2231,9 +2231,9 @@
     {
       "id": 100,
       "link": [13, 4],
-      "name": "Big Pink Return Through Crumble Blocks",
+      "name": "Return Through Crumble Blocks",
       "requires": [
-        {"notable": "Big Pink Return Through Crumble Blocks"},
+        {"notable": "Return Through Crumble Blocks"},
         "canMidAirMorph",
         {"obstaclesCleared": ["C"]}
       ],
@@ -2299,9 +2299,9 @@
     {
       "id": 101,
       "link": [13, 4],
-      "name": "Big Pink Wall Ice Clip the Mission Impossible Crumble Blocks",
+      "name": "Wall Ice Clip the Mission Impossible Crumble Blocks",
       "requires": [
-        {"notable": "Big Pink Wall Ice Clip the Mission Impossible Crumble Blocks"},
+        {"notable": "Wall Ice Clip the Mission Impossible Crumble Blocks"},
         "canWallIceClip",
         "Wave",
         {"or": [
@@ -2323,9 +2323,9 @@
     {
       "id": 102,
       "link": [13, 5],
-      "name": "Big Pink Reo Ice Clip With Morph and X-Ray",
+      "name": "Reo Ice Clip With Morph and X-Ray",
       "requires": [
-        {"notable": "Big Pink Reo Ice Clip With Morph and X-Ray"},
+        {"notable": "Reo Ice Clip With Morph and X-Ray"},
         "h_canPreciseIceClip",
         "h_canXRayMorphIceClip"
       ],
@@ -2346,9 +2346,9 @@
     {
       "id": 103,
       "link": [13, 5],
-      "name": "Big Pink Reo Ice Clip Without Morph and X-Ray",
+      "name": "Reo Ice Clip Without Morph and X-Ray",
       "requires": [
-        {"notable": "Big Pink Reo Ice Clip Without Morph and X-Ray"},
+        {"notable": "Reo Ice Clip Without Morph and X-Ray"},
         "h_canPreciseIceClip"
       ],
       "flashSuitChecked": true,
@@ -2367,9 +2367,9 @@
     {
       "id": 104,
       "link": [13, 5],
-      "name": "Big Pink Zeb Ice Clip",
+      "name": "Zeb Ice Clip",
       "requires": [
-        {"notable": "Big Pink Zeb Ice Clip"},
+        {"notable": "Zeb Ice Clip"},
         "canStaggeredWalljump",
         "canCameraManip",
         {"or": [
@@ -2392,9 +2392,9 @@
     {
       "id": 105,
       "link": [13, 5],
-      "name": "Big Pink Blind Zeb Ice Clip (Preserve Flash Suit)",
+      "name": "Blind Zeb Ice Clip (Preserve Flash Suit)",
       "requires": [
-        {"notable": "Big Pink Blind Zeb Ice Clip (Preserve Flash Suit)"},
+        {"notable": "Blind Zeb Ice Clip (Preserve Flash Suit)"},
         "canStaggeredWalljump",
         "canCameraManip",
         "canOffScreenMovement",
@@ -2441,9 +2441,9 @@
     {
       "id": 108,
       "link": [13, 7],
-      "name": "Big Pink Off Screen Super Block",
+      "name": "Off Screen Super Block",
       "requires": [
-        {"notable": "Big Pink Off Screen Super Block"},
+        {"notable": "Off Screen Super Block"},
         "canOffScreenSuperShot",
         "h_canBombThings",
         "canCameraManip"
@@ -2459,9 +2459,9 @@
     {
       "id": 109,
       "link": [13, 7],
-      "name": "Big Pink Crystal Flash Standup - Super Block",
+      "name": "Crystal Flash Standup - Super Block",
       "requires": [
-        {"notable": "Big Pink Crystal Flash Standup - Super Block"},
+        {"notable": "Crystal Flash Standup - Super Block"},
         "h_canBombThings",
         "h_canCrystalFlash",
         {"ammo": {"type": "Super", "count": 1}}
@@ -2473,9 +2473,9 @@
     {
       "id": 110,
       "link": [13, 7],
-      "name": "Big Pink Speedball Jump into Raised Bomb Blocks",
+      "name": "Speedball Jump into Raised Bomb Blocks",
       "requires": [
-        {"notable": "Big Pink Speedball into Raised Bomb Blocks"},
+        {"notable": "Speedball into Raised Bomb Blocks"},
         "canSpeedball",
         "canLateralMidAirMorph",
         "canSlowShortCharge",
@@ -2489,9 +2489,9 @@
     {
       "id": 111,
       "link": [13, 7],
-      "name": "Big Pink Temporary Blue Bounce into Raised Bomb Blocks",
+      "name": "Temporary Blue Bounce into Raised Bomb Blocks",
       "requires": [
-        {"notable": "Big Pink Speedball into Raised Bomb Blocks"},
+        {"notable": "Speedball into Raised Bomb Blocks"},
         "canTrickyJump",
         "canTemporaryBlue",
         "canLateralMidAirMorph",
@@ -2956,7 +2956,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Big Pink Speedball into Raised Bomb Blocks",
+      "name": "Speedball into Raised Bomb Blocks",
       "note": [
         "Break the \"Spore Spawn Skip\" bomb blocks (from the left) using only speed.",
         "Either by jump morphing into them, or by falling and bouncing through them with Temporary Blue."
@@ -2964,7 +2964,7 @@
     },
     {
       "id": 2,
-      "name": "Big Pink Extended Moondance Clip",
+      "name": "Extended Moondance Clip",
       "note": [
         "Setup a Moondance such that Samus will fall through 2 tiles",
         "Moonfall towards the door, aim down while falling, and turn around twice."
@@ -2972,22 +2972,22 @@
     },
     {
       "id": 3,
-      "name": "Big Pink Super Block Speedball",
+      "name": "Super Block Speedball",
       "note": "Quickly jump and precisely shoot the super block and in the same motion take out the bomb blocks with a speedball."
     },
     {
       "id": 4,
-      "name": "Big Pink Fast Mockball Leave With Spark",
+      "name": "Fast Mockball Leave With Spark",
       "note": "Shinecharge towards the top right door.  Then turn around for a fast mockball after jumping the bug pipe."
     },
     {
       "id": 5,
-      "name": "Big Pink Return Through Crumble Blocks",
+      "name": "Return Through Crumble Blocks",
       "note": "The Crumble Block next to the Power Bomb Blocks does not respawn, so it's possible to enter from this door, grab the items, and return without breaking the Power Bomb blocks."
     },
     {
       "id": 6,
-      "name": "Big Pink Wall Ice Clip the Mission Impossible Crumble Blocks",
+      "name": "Wall Ice Clip the Mission Impossible Crumble Blocks",
       "note": [
         "Freeze a Zeb inside of the crumble blocks below the entrance to the Power Bomb room and use it to get stuck inside the crumble blocks, breaking them.",
         "Repeatedly freeze a left facing Zeb from the enemy spawner lower in the room.",
@@ -2997,7 +2997,7 @@
     },
     {
       "id": 7,
-      "name": "Big Pink Reo Ice Clip With Morph and X-Ray",
+      "name": "Reo Ice Clip With Morph and X-Ray",
       "note": [
         "Lure the Reo (Bee) to the left to use it as a platform for ice clipping up through the crumbles to the Power Bomb room exit door.",
         "Watch the Reo bounce against the left wall until it does a slow hover towards Samus.",
@@ -3013,7 +3013,7 @@
     },
     {
       "id": 8,
-      "name": "Big Pink Reo Ice Clip Without Morph and X-Ray",
+      "name": "Reo Ice Clip Without Morph and X-Ray",
       "note": [
         "Lure the Reo (Bee) to the left to use it as a platform for ice clipping up through the crumbles to the Power Bomb room exit door.",
         "Watch the Reo bounce against the left wall until it does a slow hover towards Samus.",
@@ -3028,7 +3028,7 @@
     },
     {
       "id": 9,
-      "name": "Big Pink Zeb Ice Clip",
+      "name": "Zeb Ice Clip",
       "note": [
         "Raise a Zeb to be just below the crumble blocks and blindly freeze it to set up an ice clip to reach the Power Bomb room exit door.",
         "Get a bug from the pipe to spawn facing left and freeze it while moving to the ledge below the Hopper room door.",
@@ -3041,7 +3041,7 @@
     },
     {
       "id": 10,
-      "name": "Big Pink Blind Zeb Ice Clip (Preserve Flash Suit)",
+      "name": "Blind Zeb Ice Clip (Preserve Flash Suit)",
       "note": [
         "Raise a Zeb to be just below the crumble blocks and blindly freeze it to set up an ice clip to reach the Power Bomb room exit door.",
         "Get a bug from the pipe to spawn facing left and freeze it while moving to the ledge below the Hopper room door.",
@@ -3053,7 +3053,7 @@
     },
     {
       "id": 11,
-      "name": "Big Pink Off Screen Super Block",
+      "name": "Off Screen Super Block",
       "note": [
         "Break the bomb blocks then shoot a super into the morph tunnel to break the super block off screen.",
         "Requires pixel precision, although there are several pixels that work. The camera must be fully scrolled to the right, which may require going far left and back."
@@ -3061,7 +3061,7 @@
     },
     {
       "id": 12,
-      "name": "Big Pink Crystal Flash Standup - Super Block",
+      "name": "Crystal Flash Standup - Super Block",
       "note": "Crystal Flash in the morph tunnel to force a standup, making it possible to shoot the super block from the left while it's on-screen."
     }
   ],

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -132,7 +132,7 @@
       "link": [1, 1],
       "name": "Blockade Leave with Extended Moondance",
       "requires": [
-        {"notable": "Dachora Room Blockade Extended Moondance"},
+        {"notable": "Blockade Extended Moondance"},
         {"obstaclesNotCleared": ["A"]},
         "h_canUseMorphBombs",
         "canExtendedMoondance"
@@ -199,7 +199,7 @@
       "link": [1, 2],
       "name": "Blockade Extended Moondance Clip",
       "requires": [
-        {"notable": "Dachora Room Blockade Extended Moondance"},
+        {"notable": "Blockade Extended Moondance"},
         {"obstaclesNotCleared": ["A"]},
         "h_canUseMorphBombs",
         "ScrewAttack",
@@ -303,7 +303,7 @@
       "link": [1, 3],
       "name": "Blockade Leave with Extended Moondance",
       "requires": [
-        {"notable": "Dachora Room Blockade Extended Moondance"},
+        {"notable": "Blockade Extended Moondance"},
         {"obstaclesNotCleared": ["A"]},
         "h_canUseMorphBombs",
         {"or": [
@@ -627,9 +627,9 @@
     {
       "id": 31,
       "link": [2, 3],
-      "name": "Dachora Room Shinespark No Etanks No HiJump",
+      "name": "Shinespark No Etanks No HiJump",
       "requires": [
-        {"notable": "Dachora Room Shinespark No Etanks No HiJump"},
+        {"notable": "Shinespark No Etanks No HiJump"},
         "canFastWalljumpClimb",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
@@ -1015,9 +1015,9 @@
     {
       "id": 52,
       "link": [3, 2],
-      "name": "Dachora Room Reo Zeela Stuck Moonfall",
+      "name": "Reo Zeela Stuck Moonfall",
       "requires": [
-        {"notable": "Dachora Room Reo Zeela Stuck Moonfall"},
+        {"notable": "Reo Zeela Stuck Moonfall"},
         "canTrickyUseFrozenEnemies",
         "canEnemyStuckMoonfall",
         "canBePatient",
@@ -1061,9 +1061,9 @@
     {
       "id": 55,
       "link": [3, 2],
-      "name": "Dachora Room G-Mode Setup - Lure the Zeela Down Below",
+      "name": "G-Mode Setup - Lure the Zeela Down Below",
       "requires": [
-        {"notable": "Dachora Room G-Mode Setup - Lure the Zeela Down Below"},
+        {"notable": "G-Mode Setup - Lure the Zeela Down Below"},
         "canBePatient",
         "h_getBlueSpeedMaxRunway"
       ],
@@ -1147,7 +1147,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Dachora Room Blockade Extended Moondance",
+      "name": "Blockade Extended Moondance",
       "note": [
         "Break exactly the lower-middle-right and top-right Bomb Blocks, leaving the upper-middle-right and bottommost Blocks intact.",
         "Clear all enemies before starting.",
@@ -1159,12 +1159,12 @@
     },
     {
       "id": 2,
-      "name": "Dachora Room Shinespark No Etanks No HiJump",
+      "name": "Shinespark No Etanks No HiJump",
       "note": "Quickly wall jump up the right wall and shinespark up to barely get above the speed blocks without any tanks."
     },
     {
       "id": 3,
-      "name": "Dachora Room Reo Zeela Stuck Moonfall",
+      "name": "Reo Zeela Stuck Moonfall",
       "note": [
         "Use a Reo (Bee) and a Zeela to perform an 'Enemy Stuck Moonfall', clipping Samus through the Speed blocks.",
         "Break the Bomb blocks to bring enemies over to the Speed blocks.",
@@ -1174,7 +1174,7 @@
     },
     {
       "id": 4,
-      "name": "Dachora Room G-Mode Setup - Lure the Zeela Down Below",
+      "name": "G-Mode Setup - Lure the Zeela Down Below",
       "note": [
         "Using Speed Booster, run through and break the bomb wall to free the global Zeela.",
         "Break the speed blocks just before the Zeela gets to them in order for it to go down to the bottom half of the room.",

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -334,9 +334,9 @@
     {
       "id": 10,
       "link": [1, 1],
-      "name": "Pink Hopper Reverse Gate Glitch (HiJump)",
+      "name": "Reverse Gate Glitch (HiJump)",
       "requires": [
-        {"notable": "Pink Hopper Reverse Gate Glitch"},
+        {"notable": "Reverse Gate Glitch"},
         {"obstaclesCleared": ["A"]},
         {"or": [
           "canTrickyJump",
@@ -359,9 +359,9 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "Pink Hopper Reverse Gate Glitch (HiJump, Hoppers Alive)",
+      "name": "Reverse Gate Glitch (HiJump, Hoppers Alive)",
       "requires": [
-        {"notable": "Pink Hopper Reverse Gate Glitch"},
+        {"notable": "Reverse Gate Glitch"},
         {"enemyDamage": {
           "enemy": "Sm. Sidehopper",
           "type": "contact",
@@ -387,9 +387,9 @@
     {
       "id": 12,
       "link": [1, 1],
-      "name": "Pink Hopper Reverse Gate Glitch (SpaceJump)",
+      "name": "Reverse Gate Glitch (SpaceJump)",
       "requires": [
-        {"notable": "Pink Hopper Reverse Gate Glitch"},
+        {"notable": "Reverse Gate Glitch"},
         {"obstaclesCleared": ["A"]},
         {"or": [
           "canTrickyJump",
@@ -409,9 +409,9 @@
     {
       "id": 13,
       "link": [1, 1],
-      "name": "Pink Hopper Reverse Gate Glitch (Speedy Jump)",
+      "name": "Reverse Gate Glitch (Speedy Jump)",
       "requires": [
-        {"notable": "Pink Hopper Reverse Gate Glitch"},
+        {"notable": "Reverse Gate Glitch"},
         {"obstaclesCleared": ["A"]},
         "canTrickyDashJump",
         "canOffScreenSuperShot"
@@ -427,9 +427,9 @@
     {
       "id": 14,
       "link": [1, 1],
-      "name": "Pink Hopper Reverse Gate Glitch (Door Frame Jump)",
+      "name": "Reverse Gate Glitch (Door Frame Jump)",
       "requires": [
-        {"notable": "Pink Hopper Reverse Gate Glitch"},
+        {"notable": "Reverse Gate Glitch"},
         {"obstaclesCleared": ["A"]},
         {"doorUnlockedAtNode": 1},
         "canTrickyJump",
@@ -919,12 +919,12 @@
     {
       "id": 38,
       "link": [1, 3],
-      "name": "Pink Brinstar Hopper X-Ray Climb",
+      "name": "Hopper X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        {"notable": "Pink Brinstar Hopper X-Ray Climb"},
+        {"notable": "Hopper X-Ray Climb"},
         "canXRayClimb",
         {"enemyDamage": {
           "enemy": "Sidehopper",
@@ -1086,9 +1086,9 @@
     {
       "id": 48,
       "link": [2, 3],
-      "name": "Pink Hoppers Shot Clip to Ride the Elevator",
+      "name": "Shot Clip to Ride the Elevator",
       "requires": [
-        {"notable": "Pink Hoppers Shot Clip to Ride the Elevator"},
+        {"notable": "Shot Clip to Ride the Elevator"},
         {"or": [
           {"ammo": {"type": "Missile", "count": 1}},
           {"ammo": {"type": "Super", "count": 1}},
@@ -1194,9 +1194,9 @@
     {
       "id": 54,
       "link": [2, 3],
-      "name": "Pink Hoppers Screw and Kago to Ride the Elevator",
+      "name": "Screw and Kago to Ride the Elevator",
       "requires": [
-        {"notable": "Pink Hoppers Screw and Kago to Ride the Elevator"},
+        {"notable": "Screw and Kago to Ride the Elevator"},
         "canKago",
         {"or": [
           "ScrewAttack",
@@ -1299,7 +1299,7 @@
     {
       "id": 59,
       "link": [2, 3],
-      "name": "Pink Hoppers Shinespark into the Wall to Ride the Elevator, Come in Shinecharging",
+      "name": "Shinespark into the Wall to Ride the Elevator, Come in Shinecharging",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 5,
@@ -1307,7 +1307,7 @@
         }
       },
       "requires": [
-        {"notable": "Pink Hoppers Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark into the Wall to Ride the Elevator"},
         "canHorizontalShinespark",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
@@ -1317,14 +1317,14 @@
     {
       "id": 60,
       "link": [2, 3],
-      "name": "Pink Hoppers Shinespark into the Wall to Ride the Elevator, Come in Shinecharged",
+      "name": "Shinespark into the Wall to Ride the Elevator, Come in Shinecharged",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 45
         }
       },
       "requires": [
-        {"notable": "Pink Hoppers Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark into the Wall to Ride the Elevator"},
         "canHorizontalShinespark",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
@@ -1335,12 +1335,12 @@
     {
       "id": 61,
       "link": [2, 3],
-      "name": "Pink Hoppers Shinespark into the Wall to Ride the Elevator, Come in Shinesparking",
+      "name": "Shinespark into the Wall to Ride the Elevator, Come in Shinesparking",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
       "requires": [
-        {"notable": "Pink Hoppers Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark into the Wall to Ride the Elevator"},
         "canHorizontalShinespark",
         {"shinespark": {"frames": 15, "excessFrames": 6}}
       ],
@@ -1350,9 +1350,9 @@
     {
       "id": 62,
       "link": [2, 3],
-      "name": "Pink Hoppers Shinespark into the Wall to Ride the Elevator, Use Flash Suit",
+      "name": "Shinespark into the Wall to Ride the Elevator, Use Flash Suit",
       "requires": [
-        {"notable": "Pink Hoppers Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark into the Wall to Ride the Elevator"},
         "canHorizontalShinespark",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 1, "excessFrames": 1}}
@@ -1589,9 +1589,9 @@
     {
       "id": 76,
       "link": [4, 4],
-      "name": "Pink Hopper Reverse Gate Glitch (Ice)",
+      "name": "Reverse Gate Glitch (Ice)",
       "requires": [
-        {"notable": "Pink Hopper Reverse Gate Glitch"},
+        {"notable": "Reverse Gate Glitch"},
         {"obstaclesNotCleared": ["A"]},
         "canTrickyUseFrozenEnemies",
         "h_canBackIntoCorner",
@@ -1616,9 +1616,9 @@
     {
       "id": 77,
       "link": [4, 4],
-      "name": "Pink Hopper Reverse Gate Glitch (HiJump, Ice)",
+      "name": "Reverse Gate Glitch (HiJump, Ice)",
       "requires": [
-        {"notable": "Pink Hopper Reverse Gate Glitch"},
+        {"notable": "Reverse Gate Glitch"},
         {"obstaclesNotCleared": ["A"]},
         {"or": [
           "h_canBackIntoCorner",
@@ -1645,12 +1645,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Pink Hoppers Shinespark into the Wall to Ride the Elevator",
+      "name": "Shinespark into the Wall to Ride the Elevator",
       "note": "Shinesparking horizontally into the wall will trigger the elevator as Samus's echos hit it."
     },
     {
       "id": 2,
-      "name": "Pink Hopper Reverse Gate Glitch",
+      "name": "Reverse Gate Glitch",
       "note": [
         "This strat involves shooting a Super diagonally from the correct height while flush against the left wall.",
         "Its acceleration will cause it to clip into the blue gate off-screen."
@@ -1658,7 +1658,7 @@
     },
     {
       "id": 3,
-      "name": "Pink Brinstar Hopper X-Ray Climb",
+      "name": "Hopper X-Ray Climb",
       "note": [
         "To minimize damage from the Hoppers, get stuck in the door relatively high and move quickly.",
         "Climb up somewhat less than 1 screen, until Samus' head appears between 1 and 3 tiles below the door.",
@@ -1667,7 +1667,7 @@
     },
     {
       "id": 4,
-      "name": "Pink Hoppers Shot Clip to Ride the Elevator",
+      "name": "Shot Clip to Ride the Elevator",
       "note": [
         "The elevator can be raised by clipping a shot into the floor, shot while falling with the right amount of vertical speed.",
         "This can be done with a Missile, Super, or charged Spazer or Plasma shot, a well positioned angle Spazer shot while crouched, or an  or Ice SBA."
@@ -1675,7 +1675,7 @@
     },
     {
       "id": 5,
-      "name": "Pink Hoppers Screw and Kago to Ride the Elevator",
+      "name": "Screw and Kago to Ride the Elevator",
       "note": [
         "Start the elevator ride by using Screw Attack or Pseudo Screw in the hole.",
         "Kago the elevator to fall back in and hit the elevator again. This is much easier while the elevator is still rising, but can still be done with Morph afterwards.",

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -641,9 +641,9 @@
     {
       "id": 28,
       "link": [2, 3],
-      "name": "Pink Brinstar Power Bombs Crystal Flash Clip",
+      "name": "Crystal Flash Clip",
       "requires": [
-        {"notable": "Pink Brinstar Power Bombs Crystal Flash Clip"},
+        {"notable": "Crystal Flash Clip"},
         "h_canCrystalFlash",
         "canCeilingClip"
       ],
@@ -867,7 +867,7 @@
     },
     {
       "id": 2,
-      "name": "Pink Brinstar Power Bombs Crystal Flash Clip",
+      "name": "Crystal Flash Clip",
       "note": [
         "Perform the crystal flash all the way to the left, against the crumble blocks to prevent the elevator on the right from blocking you in.",
         "Simply jump after performing the crystal flash to jump through the floor."

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -365,7 +365,7 @@
     {
       "id": 19,
       "link": [1, 2],
-      "name": "Waterway Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [
@@ -375,7 +375,7 @@
         }
       },
       "requires": [
-        {"notable": "Waterway Grapple Teleport Inside Wall"}
+        {"notable": "Grapple Teleport Inside Wall"}
       ],
       "note": [
         "Enter the room in a pose that allows Samus to stand.",
@@ -684,7 +684,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Waterway Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "note": [
         "Enter the room in a pose that allows Samus to stand.",
         "After teleporting, retract Grapple by pressing up.",

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -344,14 +344,14 @@
     {
       "id": 13,
       "link": [1, 3],
-      "name": "Below Spazer Grapple Teleport Clip",
+      "name": "Grapple Teleport Clip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12]]
         }
       },
       "requires": [
-        {"notable": "Below Spazer Grapple Teleport Clip"}
+        {"notable": "Grapple Teleport Clip"}
       ],
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
@@ -645,7 +645,7 @@
     {
       "id": 31,
       "link": [3, 1],
-      "name": "Below Spazer Jump Shot Speedball",
+      "name": "Jump Shot Speedball",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 3,
@@ -654,7 +654,7 @@
         }
       },
       "requires": [
-        {"notable": "Below Spazer Jump Shot Speedball"},
+        {"notable": "Jump Shot Speedball"},
         "canSpeedball",
         "canTrickyJump"
       ],
@@ -843,7 +843,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Below Spazer Grapple Teleport Clip",
+      "name": "Grapple Teleport Clip",
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, hold left while releasing Grapple to stay standing (not being forced into a crouch).",
@@ -852,7 +852,7 @@
     },
     {
       "id": 2,
-      "name": "Below Spazer Jump Shot Speedball",
+      "name": "Jump Shot Speedball",
       "note": [
         "Jump from the Spazer Room door with speed to break the bomb blocks.",
         "Time a precise shot during the jump to clear the shot block.",

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -142,9 +142,9 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "Hellway Frozen Zeb Runway",
+      "name": "Frozen Zeb Runway",
       "requires": [
-        {"notable": "Hellway Frozen Zeb Runway"},
+        {"notable": "Frozen Zeb Runway"},
         "canTrickyJump",
         "h_canTrickyFrozenEnemyRunway",
         {"thornHits": 2}
@@ -456,7 +456,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Hellway Frozen Zeb Runway",
+      "name": "Frozen Zeb Runway",
       "note": [
         "Freeze the left-most Zeb while it is rising and is 1 pixel too low from making a flat runway.",
         "When it is close to thawing, run into the thorns to the left and hold left to avoid a vertical damage boost, then refreeze the Zeb as it crosses.",

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -330,9 +330,9 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "name": "Long Ceiling Bomb Jump",
       "requires": [
-        {"notable": "Red Brinstar Firefleas Ceiling Bomb Jump"},
+        {"notable": "Long Ceiling Bomb Jump"},
         "canLongCeilingBombJump",
         "canBeVeryPatient"
       ],
@@ -344,7 +344,7 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Red Brinstar Firefleas Ceiling Bomb Jump (Artificial Morph)",
+      "name": "Long Ceiling Bomb Jump (Artificial Morph)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -352,7 +352,7 @@
         }
       },
       "requires": [
-        {"notable": "Red Brinstar Firefleas Ceiling Bomb Jump"},
+        {"notable": "Long Ceiling Bomb Jump"},
         "h_canArtificialMorphLongCeilingBombJump",
         "canBeVeryPatient",
         "canInsaneJump"
@@ -650,9 +650,9 @@
     {
       "id": 31,
       "link": [2, 1],
-      "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "name": "Long Ceiling Bomb Jump",
       "requires": [
-        {"notable": "Red Brinstar Firefleas Ceiling Bomb Jump"},
+        {"notable": "Long Ceiling Bomb Jump"},
         "canLongCeilingBombJump",
         "canBeVeryPatient"
       ],
@@ -661,7 +661,7 @@
     {
       "id": 32,
       "link": [2, 1],
-      "name": "Red Brinstar Firefleas Ceiling Bomb Jump (Artificial Morph)",
+      "name": "Long Ceiling Bomb Jump (Artificial Morph)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -669,7 +669,7 @@
         }
       },
       "requires": [
-        {"notable": "Red Brinstar Firefleas Ceiling Bomb Jump"},
+        {"notable": "Long Ceiling Bomb Jump"},
         "h_canArtificialMorphBombHorizontally",
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphLongCeilingBombJump",
@@ -1158,7 +1158,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Red Brinstar Firefleas Ceiling Bomb Jump",
+      "name": "Long Ceiling Bomb Jump",
       "note": "This is a very long ceiling bomb jump."
     },
     {

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -309,9 +309,9 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "Red Tower Door Frame Extended Moondance",
+      "name": "Door Frame Extended Moondance",
       "requires": [
-        {"notable": "Red Tower Door Frame Extended Moondance"},
+        {"notable": "Door Frame Extended Moondance"},
         {"obstaclesNotCleared": ["A"]},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
@@ -420,7 +420,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        {"notable": "Red Tower R-Mode Frozen Beetom X-Ray Climb"},
+        {"notable": "R-Mode Frozen Beetom X-Ray Climb"},
         {"enemyDamage": {
           "enemy": "Beetom",
           "type": "contact",
@@ -982,14 +982,14 @@
     {
       "id": 28,
       "link": [1, 5],
-      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharged)",
+      "name": "Hero Shot Shinespark (Come In Shinecharged)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 100
         }
       },
       "requires": [
-        {"notable": "Red Tower Hero Shot Shinespark"},
+        {"notable": "Hero Shot Shinespark"},
         "canHeroShot",
         {"shinespark": {"frames": 77, "excessFrames": 3}},
         {"ammo": {"type": "Missile", "count": 1}}
@@ -1004,7 +1004,7 @@
     {
       "id": 29,
       "link": [1, 5],
-      "name": "Red Tower Hero Shot Shinespark (Come In Shinecharging)",
+      "name": "Hero Shot Shinespark (Come In Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 10,
@@ -1012,7 +1012,7 @@
         }
       },
       "requires": [
-        {"notable": "Red Tower Hero Shot Shinespark"},
+        {"notable": "Hero Shot Shinespark"},
         "canHeroShot",
         {"shinespark": {"frames": 77, "excessFrames": 3}},
         {"ammo": {"type": "Missile", "count": 1}}
@@ -1026,9 +1026,9 @@
     {
       "id": 30,
       "link": [1, 5],
-      "name": "Red Tower Hero Shot Shinespark (Use Flash Suit)",
+      "name": "Hero Shot Shinespark (Use Flash Suit)",
       "requires": [
-        {"notable": "Red Tower Hero Shot Shinespark"},
+        {"notable": "Hero Shot Shinespark"},
         "canHeroShot",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 77, "excessFrames": 3}},
@@ -1111,9 +1111,9 @@
     {
       "id": 36,
       "link": [1, 9],
-      "name": "Red Tower Frozen Beetom Ice Climb",
+      "name": "Frozen Beetom Ice Climb",
       "requires": [
-        {"notable": "Red Tower Frozen Beetom Ice Climb"},
+        {"notable": "Frozen Beetom Ice Climb"},
         "canTrickyUseFrozenEnemies",
         "canFlatleyJump",
         {"or": [
@@ -1338,7 +1338,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        {"notable": "Red Tower R-Mode Frozen Beetom X-Ray Climb"},
+        {"notable": "R-Mode Frozen Beetom X-Ray Climb"},
         {"or": [
           "canWalljump",
           "HiJump",
@@ -1683,7 +1683,7 @@
     {
       "id": 63,
       "link": [3, 6],
-      "name": "Red Tower IBJ Between the Bottom Rippers (Artificial Morph)",
+      "name": "IBJ Between the Bottom Rippers (Artificial Morph)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -1691,7 +1691,7 @@
         }
       },
       "requires": [
-        {"notable": "Red Tower IBJ Between the Bottom Rippers"},
+        {"notable": "IBJ Between the Bottom Rippers"},
         "h_canArtificialMorphDoubleBombJump",
         "h_canArtificialMorphStaggeredIBJ",
         "h_canArtificialMorphPowerBomb"
@@ -1786,7 +1786,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        {"notable": "Red Tower R-Mode Frozen Beetom X-Ray Climb"},
+        {"notable": "R-Mode Frozen Beetom X-Ray Climb"},
         {"or": [
           "canWalljump",
           "HiJump",
@@ -2034,7 +2034,7 @@
     {
       "id": 78,
       "link": [4, 5],
-      "name": "Red Tower Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [
@@ -2044,7 +2044,7 @@
         }
       },
       "requires": [
-        {"notable": "Red Tower Grapple Teleport Inside Wall"},
+        {"notable": "Grapple Teleport Inside Wall"},
         "Morph"
       ],
       "note": [
@@ -2117,7 +2117,7 @@
     {
       "id": 82,
       "link": [4, 6],
-      "name": "Red Tower IBJ Between the Bottom Rippers (Artificial Morph)",
+      "name": "IBJ Between the Bottom Rippers (Artificial Morph)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -2125,7 +2125,7 @@
         }
       },
       "requires": [
-        {"notable": "Red Tower IBJ Between the Bottom Rippers"},
+        {"notable": "IBJ Between the Bottom Rippers"},
         "h_canArtificialMorphDoubleBombJump",
         "h_canArtificialMorphStaggeredIBJ",
         "h_canArtificialMorphPowerBomb"
@@ -2220,7 +2220,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        {"notable": "Red Tower R-Mode Frozen Beetom X-Ray Climb"},
+        {"notable": "R-Mode Frozen Beetom X-Ray Climb"},
         {"enemyDamage": {
           "enemy": "Beetom",
           "type": "contact",
@@ -2455,9 +2455,9 @@
     {
       "id": 102,
       "link": [7, 6],
-      "name": "Red Tower IBJ Between the Bottom Rippers",
+      "name": "IBJ Between the Bottom Rippers",
       "requires": [
-        {"notable": "Red Tower IBJ Between the Bottom Rippers"},
+        {"notable": "IBJ Between the Bottom Rippers"},
         "canDoubleBombJump",
         "canStaggeredIBJ"
       ],
@@ -2485,9 +2485,9 @@
     {
       "id": 104,
       "link": [7, 6],
-      "name": "Red Tower Midair HBJ",
+      "name": "Midair HBJ",
       "requires": [
-        {"notable": "Red Tower Midair HBJ"},
+        {"notable": "Midair HBJ"},
         "canWallJumpBombBoost",
         "canHBJ"
       ],
@@ -2569,9 +2569,9 @@
     {
       "id": 111,
       "link": [9, 5],
-      "name": "Red Tower Hero Shot",
+      "name": "Hero Shot",
       "requires": [
-        {"notable": "Red Tower Hero Shot"},
+        {"notable": "Hero Shot"},
         "canHeroShot",
         "canPreciseWalljump",
         "canStaggeredWalljump"
@@ -2601,9 +2601,9 @@
     {
       "id": 113,
       "link": [9, 5],
-      "name": "Red Tower Climb with Space Jump",
+      "name": "Climb with Space Jump",
       "requires": [
-        {"notable": "Red Tower Climb with Space Jump"},
+        {"notable": "Climb with Space Jump"},
         "SpaceJump",
         "canTrickyJump"
       ],
@@ -2799,7 +2799,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Red Tower R-Mode Frozen Beetom X-Ray Climb",
+      "name": "R-Mode Frozen Beetom X-Ray Climb",
       "note": [
         "Gain R-mode while entering the room.",
         "Use the respawning bugs to refill reserve energy.",
@@ -2815,7 +2815,7 @@
     },
     {
       "id": 2,
-      "name": "Red Tower Hero Shot Shinespark",
+      "name": "Hero Shot Shinespark",
       "note": [
         "Come in shinecharged (or shinecharging) from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
         "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
@@ -2824,12 +2824,12 @@
     },
     {
       "id": 3,
-      "name": "Red Tower IBJ Between the Bottom Rippers",
+      "name": "IBJ Between the Bottom Rippers",
       "note": "Requires switching between single and double IBJs. While Doubles are not techincally necessary, they make the strat more bearable."
     },
     {
       "id": 4,
-      "name": "Red Tower Door Frame Extended Moondance",
+      "name": "Door Frame Extended Moondance",
       "note": [
         "Bring the Beetom close to the door and begin Moondancing.",
         "Stop after exactly 175 moonfalls, so as not to fall through the floor.",
@@ -2838,7 +2838,7 @@
     },
     {
       "id": 5,
-      "name": "Red Tower Frozen Beetom Ice Climb",
+      "name": "Frozen Beetom Ice Climb",
       "note": [
         "Freeze the Beetom and use it as a platform to climb the room without wall jumps.",
         "This can be done with well-timed Flatley jumps on top of the frozen Beetom,",
@@ -2854,7 +2854,7 @@
     },
     {
       "id": 6,
-      "name": "Red Tower Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "note": [
         "After teleporting, Samus should be standing inside the wall.",
         "Retract Grapple by pressing up, which will pull Samus down and right.",
@@ -2865,7 +2865,7 @@
     },
     {
       "id": 7,
-      "name": "Red Tower Midair HBJ",
+      "name": "Midair HBJ",
       "note": [
         "Starting on the right ledge at the bottom of Red Tower, wall jump just below the middle plant, just above the top ripper.",
         "Place two bombs out of the wall jump landing on the first bomb and getting boosted by both.",
@@ -2874,12 +2874,12 @@
     },
     {
       "id": 8,
-      "name": "Red Tower Hero Shot",
+      "name": "Hero Shot",
       "note": "Wall jump between the Rippers. Either shoot the block, fall, and quickly climb again, or shoot from the bottom and follow Samus's shot up the tower."
     },
     {
       "id": 9,
-      "name": "Red Tower Climb with Space Jump",
+      "name": "Climb with Space Jump",
       "note": [
         "Climb the top of Red Tower with just Space Jump.",
         "This can be done by dodging the Rippers and shooting the block as Samus is going upward, so she goes through the block as it breaks.",

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -342,7 +342,7 @@
     {
       "id": 8,
       "link": [1, 3],
-      "name": "Climb Behemoth Shinespark (Top Door)",
+      "name": "Behemoth Shinespark (Top Door)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 55
@@ -350,7 +350,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "canShinechargeMovementComplex",
         {"or": [
           "canCrouchJump",
@@ -367,7 +367,7 @@
     {
       "id": 9,
       "link": [1, 3],
-      "name": "Climb Behemoth Shinespark (Top Door, Through Toilet)",
+      "name": "Behemoth Shinespark (Top Door, Through Toilet)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 65
@@ -375,7 +375,7 @@
         "comesThroughToilet": "yes"
       },
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "canShinechargeMovementComplex",
         {"or": [
           "canCrouchJump",
@@ -633,7 +633,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"shinespark": {"frames": 147}}
       ],
@@ -643,7 +643,7 @@
     {
       "id": 24,
       "link": [2, 3],
-      "name": "Climb G-Mode Morph Blind Climb to the Top",
+      "name": "G-Mode Morph Blind Climb to the Top",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -651,7 +651,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb G-Mode Morph Blind Climb to the Top"},
+        {"notable": "G-Mode Morph Blind Climb to the Top"},
         "h_canArtificialMorphMovement",
         "canOffScreenMovement",
         {"or": [
@@ -685,7 +685,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"shinespark": {
           "frames": 147,
@@ -707,7 +707,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"shinespark": {
           "frames": 147,
@@ -750,7 +750,7 @@
     {
       "id": 27,
       "link": [2, 4],
-      "name": "Climb Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, Cross-Room)",
+      "name": "Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, Cross-Room)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 14,
@@ -758,7 +758,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Temporary Blue Chain Through Bomb Blocks"},
+        {"notable": "Temporary Blue Chain Through Bomb Blocks"},
         "canChainTemporaryBlue",
         {"or": [
           "HiJump",
@@ -1160,7 +1160,7 @@
     {
       "id": 47,
       "link": [3, 6],
-      "name": "Climb Morph Tunnel SpeedBall (Top Right)",
+      "name": "Morph Tunnel SpeedBall (Top Right)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 1,
@@ -1170,7 +1170,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Morph Tunnel SpeedBall"},
+        {"notable": "Morph Tunnel SpeedBall"},
         "canInsaneJump",
         "canSpeedball",
         "canTrickyDashJump",
@@ -1341,7 +1341,7 @@
     {
       "id": 56,
       "link": [4, 3],
-      "name": "Climb G-Mode Morph Insane IBJ to Top (from Crateria Supers Bottom)",
+      "name": "G-Mode Morph Insane IBJ to Top (from Crateria Supers Bottom)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -1349,7 +1349,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb G-Mode Morph Insane IBJ to Top"},
+        {"notable": "G-Mode Morph Insane IBJ to Top"},
         "h_canArtificialMorphIBJ",
         "canBeExtremelyPatient"
       ],
@@ -1427,7 +1427,7 @@
     {
       "id": 61,
       "link": [4, 6],
-      "name": "Climb Morph Tunnel SpeedBall (Lower Right)",
+      "name": "Morph Tunnel SpeedBall (Lower Right)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 2,
@@ -1437,7 +1437,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Morph Tunnel SpeedBall"},
+        {"notable": "Morph Tunnel SpeedBall"},
         "canSpeedball",
         "canTrickyDashJump",
         "canSlowShortCharge",
@@ -1768,7 +1768,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"shinespark": {"frames": 147}}
       ],
@@ -1819,7 +1819,7 @@
     {
       "id": 79,
       "link": [5, 3],
-      "name": "Climb G-Mode Morph Insane IBJ to Top (from Pit Room)",
+      "name": "G-Mode Morph Insane IBJ to Top (from Pit Room)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -1827,7 +1827,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb G-Mode Morph Insane IBJ to Top"},
+        {"notable": "G-Mode Morph Insane IBJ to Top"},
         "h_canArtificialMorphIBJ",
         "canBeExtremelyPatient"
       ],
@@ -1869,7 +1869,7 @@
         }
       },
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"shinespark": {
           "frames": 147,
@@ -2059,7 +2059,7 @@
       "link": [6, 3],
       "name": "Behemoth Spark Top",
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"canShineCharge": {
           "usedTiles": 28,
@@ -2079,7 +2079,7 @@
       "link": [6, 3],
       "name": "Behemoth Spark Top, Use Flash Suit",
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 18, "excessFrames": 4}}
@@ -2093,9 +2093,9 @@
     {
       "id": 95,
       "link": [6, 3],
-      "name": "Climb Temporary Blue Chain Through Bomb Blocks to Top",
+      "name": "Temporary Blue Chain Through Bomb Blocks to Top",
       "requires": [
-        {"notable": "Climb Temporary Blue Chain Through Bomb Blocks"},
+        {"notable": "Temporary Blue Chain Through Bomb Blocks"},
         "canLongChainTemporaryBlue",
         "canXRayTurnaround",
         "canTrickyJump",
@@ -2134,7 +2134,7 @@
       "link": [6, 4],
       "name": "Behemoth Spark Bottom",
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"canShineCharge": {
           "usedTiles": 28,
@@ -2155,9 +2155,9 @@
     {
       "id": 98,
       "link": [6, 4],
-      "name": "Climb Moonfall Block Break",
+      "name": "Moonfall Block Break",
       "requires": [
-        {"notable": "Climb Moonfall Block Break"},
+        {"notable": "Moonfall Block Break"},
         "Morph",
         "ScrewAttack",
         "canMoonfall",
@@ -2177,7 +2177,7 @@
       "link": [6, 4],
       "name": "Behemoth Spark Bottom, Use Flash Suit",
       "requires": [
-        {"notable": "Climb Behemoth Shinespark"},
+        {"notable": "Behemoth Shinespark"},
         "Morph",
         {"useFlashSuit": {}},
         {"or": [
@@ -2211,9 +2211,9 @@
     {
       "id": 100,
       "link": [6, 4],
-      "name": "Climb Temporary Blue Chain Through Bomb Blocks (Bottom Left to Bottom)",
+      "name": "Temporary Blue Chain Through Bomb Blocks (Bottom Left to Bottom)",
       "requires": [
-        {"notable": "Climb Temporary Blue Chain Through Bomb Blocks"},
+        {"notable": "Temporary Blue Chain Through Bomb Blocks"},
         "canChainTemporaryBlue",
         "canXRayTurnaround",
         "canTrickyJump",
@@ -2234,9 +2234,9 @@
     {
       "id": 101,
       "link": [6, 4],
-      "name": "Climb Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, In-Room)",
+      "name": "Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, In-Room)",
       "requires": [
-        {"notable": "Climb Temporary Blue Chain Through Bomb Blocks"},
+        {"notable": "Temporary Blue Chain Through Bomb Blocks"},
         "canChainTemporaryBlue",
         {"or": [
           "HiJump",
@@ -2328,27 +2328,27 @@
   "notables": [
     {
       "id": 1,
-      "name": "Climb Behemoth Shinespark",
+      "name": "Behemoth Shinespark",
       "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right. For the top block, spark from a crouch."
     },
     {
       "id": 2,
-      "name": "Climb G-Mode Morph Insane IBJ to Top",
+      "name": "G-Mode Morph Insane IBJ to Top",
       "note": "Using IBJ to get from to bottom to the top of Climb without unmorphing. Precise timing and enemy manipulations are required to reach the top without taking a hit."
     },
     {
       "id": 3,
-      "name": "Climb Temporary Blue Chain Through Bomb Blocks",
+      "name": "Temporary Blue Chain Through Bomb Blocks",
       "note": "A long Temporary Blue chain with x-ray turnarounds to climb up and destroy the bomb blocks blocking the morph tunnels."
     },
     {
       "id": 4,
-      "name": "Climb Morph Tunnel SpeedBall",
+      "name": "Morph Tunnel SpeedBall",
       "note": "Enter the room with a very specific run speed to jump from the door, avoid the ceiling, and land a speedball perfectly in the tunnel to break the Bomb block."
     },
     {
       "id": 5,
-      "name": "Climb G-Mode Morph Blind Climb to the Top",
+      "name": "G-Mode Morph Blind Climb to the Top",
       "note": [
         "Overload PLMs using the scroll blocks next to the bomb wall",
         "After passing through, you need to go from the bottom to the top of Climb and into the bomb blocks while still in G-mode Morph.",
@@ -2357,7 +2357,7 @@
     },
     {
       "id": 6,
-      "name": "Climb Moonfall Block Break",
+      "name": "Moonfall Block Break",
       "note": [
         "The bomb blocks can be broken by spinjumping with Screw attack and holding right, if moonfall makes Samus clip through the platform.",
         "Use the small blue platform 2nd from the top on the right side."

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -619,9 +619,9 @@
     {
       "id": 23,
       "link": [1, 6],
-      "name": "Crateria Supers In-Room X-Mode BlueSuit",
+      "name": "In-Room X-Mode BlueSuit",
       "requires": [
-        {"notable": "Crateria Supers In-Room X-Mode BlueSuit"},
+        {"notable": "In-Room X-Mode BlueSuit"},
         "canSuperJump",
         {"spikeHits": 3},
         "h_canShineChargeMaxRunway",
@@ -713,9 +713,9 @@
     {
       "id": 27,
       "link": [1, 6],
-      "name": "Climb Supers In-Room SpeedKeep for Temporary Blue",
+      "name": "In-Room SpeedKeep for Temporary Blue",
       "requires": [
-        {"notable": "Climb Supers In-Room SpeedKeep for Temporary Blue"},
+        {"notable": "In-Room SpeedKeep for Temporary Blue"},
         "canSpeedKeep",
         "canSlowShortCharge",
         {"doorUnlockedAtNode": 1},
@@ -953,7 +953,7 @@
     {
       "id": 41,
       "link": [2, 3],
-      "name": "Crateria Supers G-Mode Up with PBs",
+      "name": "G-Mode Up with Power Bombs",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -961,7 +961,7 @@
         }
       },
       "requires": [
-        {"notable": "Crateria Supers G-Mode Up with PBs"},
+        {"notable": "G-Mode Up with Power Bombs"},
         {"itemNotCollectedAtNode": 3},
         "canConsecutiveWalljump",
         "Morph",
@@ -993,7 +993,7 @@
     {
       "id": 42,
       "link": [2, 3],
-      "name": "Crateria Supers G-Mode Morph Long Ceiling Bomb Jump",
+      "name": "G-Mode Morph Long Ceiling Bomb Jump",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -1001,7 +1001,7 @@
         }
       },
       "requires": [
-        {"notable": "Crateria Supers G-Mode Morph Long Ceiling Bomb Jump"},
+        {"notable": "G-Mode Morph Long Ceiling Bomb Jump"},
         "h_canArtificialMorphCeilingBombJump",
         "canBeVeryPatient"
       ],
@@ -1341,12 +1341,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Crateria Supers In-Room X-Mode BlueSuit",
+      "name": "In-Room X-Mode BlueSuit",
       "note": "Use X-Mode to store a spikesuit, and then convert that to a blue suit with more X-Mode."
     },
     {
       "id": 2,
-      "name": "Climb Supers In-Room SpeedKeep for Temporary Blue",
+      "name": "In-Room SpeedKeep for Temporary Blue",
       "note": [
         "Using only the short runway and spike pit, use one or more SpeedKeeps to Speedball towards the Super Missile item location.",
         "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike I-Frames expire."
@@ -1354,12 +1354,12 @@
     },
     {
       "id": 3,
-      "name": "Crateria Supers G-Mode Up with PBs",
+      "name": "G-Mode Up with Power Bombs",
       "note": "Wall jump up 9 times, placing a PB at the top. Only works in direct g-mode with the item still uncollected."
     },
     {
       "id": 4,
-      "name": "Crateria Supers G-Mode Morph Long Ceiling Bomb Jump",
+      "name": "G-Mode Morph Long Ceiling Bomb Jump",
       "note": [
         "Ascend with a long IBJ, then ceiling bomb jump against the speed blocks to overload the PLMs. Falling is very unforgiving.",
         "Note that the boyons can be killed with bombs."

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -81,7 +81,7 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "Final Missile Bombway Shinespark",
+      "name": "Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 2,
@@ -89,7 +89,7 @@
         }
       },
       "requires": [
-        {"notable": "Final Missile Bombway Shinespark"},
+        {"notable": "Shinespark"},
         "canMidAirMorph",
         "canShinechargeMovementTricky",
         {"shinespark": {"frames": 7}}
@@ -412,7 +412,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Final Missile Bombway Shinespark",
+      "name": "Shinespark",
       "note": "Tight movement is needed to enter with a shinecharge, carry it through the morph tunnel, and spark out the right door in time."
     }
   ],

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -730,9 +730,9 @@
     {
       "id": 27,
       "link": [3, 1],
-      "name": "Landing Site Big Jump with Blue Speed",
+      "name": "Big Jump with Blue Speed",
       "requires": [
-        {"notable": "Landing Site Big Jump with Blue Speed"},
+        {"notable": "Big Jump with Blue Speed"},
         "canTrickyJump",
         {"or": [
           {"obstaclesCleared": ["A"]},
@@ -752,9 +752,9 @@
     {
       "id": 28,
       "link": [3, 1],
-      "name": "Landing Site Blue Space Jump (Top)",
+      "name": "Blue Space Jump (Top)",
       "requires": [
-        {"notable": "Landing Site Blue Space Jump (Top)"},
+        {"notable": "Blue Space Jump (Top)"},
         "canBlueSpaceJump",
         "canTrickyDashJump",
         {"getBlueSpeed": {"usedTiles": 30, "openEnd": 2}}
@@ -771,9 +771,9 @@
     {
       "id": 29,
       "link": [3, 1],
-      "name": "Landing Site Big Jump with Blue Speed Bounce",
+      "name": "Big Jump with Blue Speed Bounce",
       "requires": [
-        {"notable": "Landing Site Big Jump with Blue Speed"},
+        {"notable": "Big Jump with Blue Speed"},
         "canTrickyJump",
         "Morph",
         "canLateralMidAirMorph",
@@ -790,9 +790,9 @@
     {
       "id": 30,
       "link": [3, 1],
-      "name": "Landing Site Big Jump Leave With Temporary Blue",
+      "name": "Big Jump Leave With Temporary Blue",
       "requires": [
-        {"notable": "Landing Site Big Jump Leave With Temporary Blue"},
+        {"notable": "Big Jump Leave With Temporary Blue"},
         "canTrickyJump",
         "Morph",
         "canLateralMidAirMorph",
@@ -855,7 +855,7 @@
       "link": [3, 1],
       "name": "Use Flash Suit, Speedy Blue Jump",
       "requires": [
-        {"notable": "Landing Site Big Jump with Blue Speed"},
+        {"notable": "Big Jump with Blue Speed"},
         {"getBlueSpeed": {"usedTiles": 30, "openEnd": 2}},
         "canHorizontalShinespark",
         {"useFlashSuit": {}},
@@ -1126,9 +1126,9 @@
     {
       "id": 46,
       "link": [4, 1],
-      "name": "Landing Site Blue Space Jump (Bottom)",
+      "name": "Blue Space Jump (Bottom)",
       "requires": [
-        {"notable": "Landing Site Blue Space Jump (Bottom)"},
+        {"notable": "Blue Space Jump (Bottom)"},
         "canBlueSpaceJump",
         "HiJump",
         {"getBlueSpeed": {
@@ -1365,12 +1365,12 @@
     {
       "id": 59,
       "link": [4, 3],
-      "name": "Landing Site Crystal Flash X-Ray Climb",
+      "name": "Crystal Flash X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        {"notable": "Landing Site Crystal Flash X-Ray Climb"},
+        {"notable": "Crystal Flash X-Ray Climb"},
         "canXRayClimb",
         "h_canCrystalFlash"
       ],
@@ -1774,7 +1774,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Landing Site Big Jump with Blue Speed",
+      "name": "Big Jump with Blue Speed",
       "note": [
         "Use the runway near the top right door to jump towards the top left bomb blocks and break them using the blue speed from SpeedBooster.",
         "This can be done using the full runway, with a one-tap shortcharge, where the tap is at the top of the lowest slope, and the jump is at the top of the last slope.",
@@ -1784,7 +1784,7 @@
     },
     {
       "id": 2,
-      "name": "Landing Site Blue Space Jump (Top)",
+      "name": "Blue Space Jump (Top)",
       "note": [
         "This strat is fairly precise. All jumps should be as small as possible.",
         "Using at least one-tap short charge, jump off the ledge and descend as much as possible while keeping space jump active.",
@@ -1794,7 +1794,7 @@
     },
     {
       "id": 3,
-      "name": "Landing Site Big Jump Leave With Temporary Blue",
+      "name": "Big Jump Leave With Temporary Blue",
       "note": [
         "Use the runway near the Power Bomb room door to jump to the left, morphing as Samus begins descending, to bounce through the Bomb blocks.",
         "Any time while bouncing, hold an angle button and unmorph to gain temporary blue; then chain it to reach the door with temporary blue.",
@@ -1803,7 +1803,7 @@
     },
     {
       "id": 4,
-      "name": "Landing Site Blue Space Jump (Bottom)",
+      "name": "Blue Space Jump (Bottom)",
       "note": [
         "Starting near the right runway, run through the bomb block passage, then jump right after exiting.",
         "Using HiJump and space jump, Samus is able to elevate enough to break through the bomb blocks blocking the Gauntlet entrance."
@@ -1811,7 +1811,7 @@
     },
     {
       "id": 5,
-      "name": "Landing Site Crystal Flash X-Ray Climb",
+      "name": "Crystal Flash X-Ray Climb",
       "note": [
         "Become doorstuck in the bottom right door of Landing Site, using a Crystal Flash to continue X-Ray climbing past the slope above the door.",
         "Start by climbing until the slope pushed Samus down.",

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1889,14 +1889,14 @@
     {
       "id": 85,
       "link": [6, 7],
-      "name": "Parlor Carry Shinecharge From Right to Bottom",
+      "name": "Carry Shinecharge From Right to Bottom",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 121
         }
       },
       "requires": [
-        {"notable": "Parlor Carry Shinecharge From Right to Bottom"},
+        {"notable": "Carry Shinecharge From Right to Bottom"},
         "canShinechargeMovementComplex"
       ],
       "exitCondition": {
@@ -2091,9 +2091,9 @@
     {
       "id": 95,
       "link": [7, 7],
-      "name": "Parlor Ice Moonfall Door Lock Skip Without Supers",
+      "name": "Ice Moonfall Door Lock Skip Without Supers",
       "requires": [
-        {"notable": "Parlor Ice Moonfall Door Lock Skip Without Supers"},
+        {"notable": "Ice Moonfall Door Lock Skip Without Supers"},
         "h_ZebesIsAwake",
         "canEnemyStuckMoonfall",
         "canTrickyUseFrozenEnemies",
@@ -2111,9 +2111,9 @@
     {
       "id": 96,
       "link": [7, 7],
-      "name": "G-Mode Setup - Parlor Downward G-Mode Setup with Ice",
+      "name": "Downward G-Mode Setup with Ice",
       "requires": [
-        {"notable": "G-Mode Setup - Parlor Downward G-Mode Setup with Ice"},
+        {"notable": "Downward G-Mode Setup with Ice"},
         "h_ZebesIsAwake",
         "canEnemyStuckMoonfall",
         "canFreeFallClip",
@@ -2738,7 +2738,7 @@
     },
     {
       "id": 6,
-      "name": "Parlor Carry Shinecharge From Right to Bottom",
+      "name": "Carry Shinecharge From Right to Bottom",
       "note": [
         "Walk off the ledge (rather than running off), aim down, and shoot.",
         "Depending on your momentum coming in, if Zebes is awake you may need to shoot down twice, once to kill the Geemer and once to open the door.",
@@ -2747,7 +2747,7 @@
     },
     {
       "id": 7,
-      "name": "Parlor Ice Moonfall Door Lock Skip Without Supers",
+      "name": "Ice Moonfall Door Lock Skip Without Supers",
       "note": [
         "Freeze a Geemer on the right of the overhang just below the door to Final Missile Bombway.",
         "Freeze a second Geemer on the top left of its platform and setup a moonfall between them.",
@@ -2758,7 +2758,7 @@
     },
     {
       "id": 8,
-      "name": "G-Mode Setup - Parlor Downward G-Mode Setup with Ice",
+      "name": "Downward G-Mode Setup with Ice",
       "note": [
         "Freeze a Geemer on the bottom of the overhang just below the door to Final Missile Bombway. Freeze a second Geemer on the top left of its platform and setup a moonfall between them.",
         "Fall off the Geemers and clip into the tile left of the door. Press up to get out of crouch and lose the stored vertical speed (so that X-Ray works). Then turn-around, open the door, and go into the door transition as the third Geemer hits you.",

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -127,9 +127,9 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "Bowling Alley Path Double Frozen Choot Runway (Left)",
+      "name": "Double Frozen Choot Runway (Left)",
       "requires": [
-        {"notable": "Bowling Alley Path Double Frozen Choot Runway"},
+        {"notable": "Double Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway",
         "Gravity"
       ],
@@ -150,9 +150,9 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "Bowling Alley Path Double Frozen Choot Runway, Suitless (Left)",
+      "name": "Double Frozen Choot Runway, Suitless (Left)",
       "requires": [
-        {"notable": "Bowling Alley Path Double Frozen Choot Runway"},
+        {"notable": "Double Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway"
       ],
       "exitCondition": {
@@ -173,9 +173,9 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "Bowling Alley Path Triple Frozen Choot Runway (Left)",
+      "name": "Triple Frozen Choot Runway (Left)",
       "requires": [
-        {"notable": "Bowling Alley Path Triple Frozen Choot Runway"},
+        {"notable": "Triple Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway",
         "Gravity",
         "canInsaneJump",
@@ -204,9 +204,9 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "Bowling Alley Path Triple Frozen Choot Runway, Suitless (Left)",
+      "name": "Triple Frozen Choot Runway, Suitless (Left)",
       "requires": [
-        {"notable": "Bowling Alley Path Triple Frozen Choot Runway"},
+        {"notable": "Triple Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway",
         "canInsaneJump",
         {"enemyDamage": {
@@ -943,9 +943,9 @@
     {
       "id": 35,
       "link": [2, 2],
-      "name": "Bowling Alley Path Double Frozen Choot Runway (Right)",
+      "name": "Double Frozen Choot Runway (Right)",
       "requires": [
-        {"notable": "Bowling Alley Path Double Frozen Choot Runway"},
+        {"notable": "Double Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway",
         "Gravity"
       ],
@@ -966,9 +966,9 @@
     {
       "id": 36,
       "link": [2, 2],
-      "name": "Bowling Alley Path Double Frozen Choot Runway, Suitless (Right)",
+      "name": "Double Frozen Choot Runway, Suitless (Right)",
       "requires": [
-        {"notable": "Bowling Alley Path Double Frozen Choot Runway"},
+        {"notable": "Double Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway"
       ],
       "exitCondition": {
@@ -989,9 +989,9 @@
     {
       "id": 37,
       "link": [2, 2],
-      "name": "Bowling Alley Path Triple Frozen Choot Runway (Right)",
+      "name": "Triple Frozen Choot Runway (Right)",
       "requires": [
-        {"notable": "Bowling Alley Path Triple Frozen Choot Runway"},
+        {"notable": "Triple Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway",
         "Gravity",
         "canInsaneJump",
@@ -1020,9 +1020,9 @@
     {
       "id": 38,
       "link": [2, 2],
-      "name": "Bowling Alley Path Triple Frozen Choot Runway, Suitless (Right)",
+      "name": "Triple Frozen Choot Runway, Suitless (Right)",
       "requires": [
-        {"notable": "Bowling Alley Path Triple Frozen Choot Runway"},
+        {"notable": "Triple Frozen Choot Runway"},
         "h_canTrickyFrozenEnemyRunway",
         "canInsaneJump",
         {"enemyDamage": {
@@ -1079,7 +1079,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Bowling Alley Path Double Frozen Choot Runway",
+      "name": "Double Frozen Choot Runway",
       "note": [
         "Freeze two Choots to significantly increase the length of the runway.",
         "Freeze each near the end of its descent or immediately after it jumps in order to be able to run onto and off of it without a problem.",
@@ -1088,7 +1088,7 @@
     },
     {
       "id": 2,
-      "name": "Bowling Alley Path Triple Frozen Choot Runway",
+      "name": "Triple Frozen Choot Runway",
       "note": [
         "Freeze all three Choots to significantly increase the length of the runway and run across the entire room.",
         "Freeze each immediately after it jumps in order to be able to run onto and off of it without a problem.",

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -426,9 +426,9 @@
     {
       "id": 24,
       "link": [3, 3],
-      "name": "Crateria Kihunter Room Ice Moonfall Door Lock Skip",
+      "name": "Ice Moonfall Door Lock Skip",
       "requires": [
-        {"notable": "Crateria Kihunter Room Ice Moonfall Door Lock Skip"},
+        {"notable": "Ice Moonfall Door Lock Skip"},
         "canEnemyStuckMoonfall",
         "canFreeFallClip",
         "canTrickyUseFrozenEnemies"
@@ -486,7 +486,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Crateria Kihunter Room Ice Moonfall Door Lock Skip",
+      "name": "Ice Moonfall Door Lock Skip",
       "note": [
         "Freeze the two Scisers to set up a moonfall between them, and aim down.",
         "Hold left to move to the right at the correct time, which will set up an automatic turn-around, allowing Samus to clip past the floating platform below, past the door shell, and through the transition.",

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -283,9 +283,9 @@
     {
       "id": 9,
       "link": [1, 2],
-      "name": "East Ocean Springball Bounce to the Door with SpaceJump",
+      "name": "Springball Bounce to the Door with SpaceJump",
       "requires": [
-        {"notable": "East Ocean Springball Bounce to the Door with SpaceJump"},
+        {"notable": "Springball Bounce to the Door with SpaceJump"},
         "canTrickyJump",
         "canSpaceJumpWaterBounce",
         "canSpringBallBounce",
@@ -305,9 +305,9 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "East Ocean Speedy Springball Bounce to the Door",
+      "name": "Speedy Springball Bounce to the Door",
       "requires": [
-        {"notable": "East Ocean Speedy Springball Bounce to the Door"},
+        {"notable": "Speedy Springball Bounce to the Door"},
         "canInsaneJump",
         "SpeedBooster",
         "canSpringBallBounce",
@@ -388,7 +388,7 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "East Ocean Shinespark Water Escape",
+      "name": "Shinespark Water Escape",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 6,
@@ -397,7 +397,7 @@
         }
       },
       "requires": [
-        {"notable": "East Ocean Shinespark Water Escape"},
+        {"notable": "Shinespark Water Escape"},
         {"or": [
           "ScrewAttack",
           "canPseudoScrew",
@@ -430,7 +430,7 @@
     {
       "id": 13,
       "link": [1, 2],
-      "name": "East Ocean Shinespark Water Escape With Lower Choot Alive (Morph)",
+      "name": "Shinespark Water Escape With Lower Choot Alive (Morph)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 6,
@@ -439,7 +439,7 @@
         }
       },
       "requires": [
-        {"notable": "East Ocean Shinespark Water Escape With Lower Choot Alive"},
+        {"notable": "Shinespark Water Escape With Lower Choot Alive"},
         {"or": [
           {"and": [
             {"enemyDamage": {
@@ -471,7 +471,7 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "East Ocean Shinespark Water Escape With Lower Choot Alive (Ice Wave Spazer)",
+      "name": "Shinespark Water Escape With Lower Choot Alive (Ice Wave Spazer)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 6,
@@ -480,7 +480,7 @@
         }
       },
       "requires": [
-        {"notable": "East Ocean Shinespark Water Escape With Lower Choot Alive"},
+        {"notable": "Shinespark Water Escape With Lower Choot Alive"},
         "Ice",
         "Wave",
         "Spazer",
@@ -792,9 +792,9 @@
     {
       "id": 33,
       "link": [3, 1],
-      "name": "East Ocean Suitless Damage Boost Water Escape",
+      "name": "Suitless Damage Boost Water Escape",
       "requires": [
-        {"notable": "East Ocean Suitless Damage Boost Water Escape"},
+        {"notable": "Suitless Damage Boost Water Escape"},
         "canSuitlessMaridia",
         "canHorizontalDamageBoost",
         "canCrouchJump",
@@ -829,9 +829,9 @@
     {
       "id": 36,
       "link": [3, 2],
-      "name": "East Ocean Space Jump Water Escape with Ice and XRay Standup",
+      "name": "Space Jump Water Escape with Ice and XRay Standup",
       "requires": [
-        {"notable": "East Ocean Space Jump Water Escape with Ice and XRay Standup"},
+        {"notable": "Space Jump Water Escape with Ice and XRay Standup"},
         {"enemyDamage": {
           "enemy": "Choot",
           "type": "contact",
@@ -858,9 +858,9 @@
     {
       "id": 37,
       "link": [3, 2],
-      "name": "East Ocean Space Jump Water Escape with Ice (Left to Right)",
+      "name": "Space Jump Water Escape with Ice (Left to Right)",
       "requires": [
-        {"notable": "East Ocean Space Jump Water Escape with Ice (Left to Right)"},
+        {"notable": "Space Jump Water Escape with Ice (Left to Right)"},
         "canSpaceJumpWaterBounce",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump"
@@ -873,9 +873,9 @@
     {
       "id": 38,
       "link": [3, 2],
-      "name": "East Ocean Space Jump Water Escape (Left to Right)",
+      "name": "Space Jump Water Escape (Left to Right)",
       "requires": [
-        {"notable": "East Ocean Space Jump Water Escape (Left to Right)"},
+        {"notable": "Space Jump Water Escape (Left to Right)"},
         "canSpaceJumpWaterBounce",
         "canPreciseWalljump",
         "canMidairWiggle"
@@ -1170,9 +1170,9 @@
     {
       "id": 58,
       "link": [4, 3],
-      "name": "East Ocean Suitless Damage Boost Underwater Pillar",
+      "name": "Suitless Damage Boost Underwater Pillar",
       "requires": [
-        {"notable": "East Ocean Suitless Damage Boost Underwater Pillar"},
+        {"notable": "Suitless Damage Boost Underwater Pillar"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canNeutralDamageBoost",
@@ -1212,7 +1212,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "East Ocean Shinespark Water Escape With Lower Choot Alive",
+      "name": "Shinespark Water Escape With Lower Choot Alive",
       "note": [
         "Enter the room while building a shinespark and use it on the lowest part of the ramp to diagonally spark up and out of the water.",
         "The timing and positioning for the Shinespark are very precise, and there are no extra frames on the Shinespark timer to work with.",
@@ -1222,7 +1222,7 @@
     },
     {
       "id": 2,
-      "name": "East Ocean Springball Bounce to the Door with SpaceJump",
+      "name": "Springball Bounce to the Door with SpaceJump",
       "note": [
         "Build up run speed and then use controlled springball bounces to cross the ocean to the far right ledge, and then use SpaceJump to reach the door.",
         "Mockball down the submerged ramp and begin SpringBall bouncing under water using the platforms.",
@@ -1231,7 +1231,7 @@
     },
     {
       "id": 3,
-      "name": "East Ocean Speedy Springball Bounce to the Door",
+      "name": "Speedy Springball Bounce to the Door",
       "note": [
         "Using an exact runway size of 7 tiles; use extremely precise, controlled springball bounces to cross the ocean.",
         "7 tiles of runspeed can freely be achieved by requipping SpeedBooster after reaching the max normal run speed.",
@@ -1242,7 +1242,7 @@
     },
     {
       "id": 4,
-      "name": "East Ocean Shinespark Water Escape",
+      "name": "Shinespark Water Escape",
       "note": [
         "Enter the room while building a shinespark and use it on the lowest part of the ramp to diagonally spark up and out of the water.",
         "Use very low jump height space jumps to carry momentum to the far side of the submerged ramp.",
@@ -1254,12 +1254,12 @@
     },
     {
       "id": 5,
-      "name": "East Ocean Suitless Damage Boost Water Escape",
+      "name": "Suitless Damage Boost Water Escape",
       "note": "Find the Choot that is closest to the surface of the water, crouch jump under it and damage boost onto the dry platform to the left."
     },
     {
       "id": 6,
-      "name": "East Ocean Space Jump Water Escape with Ice and XRay Standup",
+      "name": "Space Jump Water Escape with Ice and XRay Standup",
       "note": [
         "Freeze the right-most ramp Choot in a way where Samus can climb on top of it and use Space Jump to escape the water.",
         "Use a turn around to avoid knockback when making contact with the Choot to better time the use of Ice.",
@@ -1272,7 +1272,7 @@
     },
     {
       "id": 7,
-      "name": "East Ocean Space Jump Water Escape with Ice (Left to Right)",
+      "name": "Space Jump Water Escape with Ice (Left to Right)",
       "note": [
         "Get to the right of the Choot on the rightmost platform. Spin jump up to the right, break spin while aligned with the wall, then freeze the Choot and stand on it while it is midair to the right of the stalagmite.",
         "Jump from the Choot to the water line and space jump at the water line to the Kamer platform."
@@ -1280,7 +1280,7 @@
     },
     {
       "id": 8,
-      "name": "East Ocean Space Jump Water Escape (Left to Right)",
+      "name": "Space Jump Water Escape (Left to Right)",
       "note": [
         "Standing from the rightmost platform, jump to the right of the stalagmite. Perform a midair wiggle to get to the left to the stalagmite, then precisely wall jump off of it.",
         "Then perform a frame perfect space jump at the water line to bounce on the water over to the Kamer platform."
@@ -1288,7 +1288,7 @@
     },
     {
       "id": 9,
-      "name": "East Ocean Suitless Damage Boost Underwater Pillar",
+      "name": "Suitless Damage Boost Underwater Pillar",
       "note": [
         "Crouch jump down grab to get over the first two pillars.",
         "For the third pillar, crouch jump to time a damage boost on the Skultera.",

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -104,9 +104,9 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "Moat Leave With Grapple Teleport",
+      "name": "Leave With Grapple Teleport",
       "requires": [
-        {"notable": "Moat Leave With Grapple Teleport"},
+        {"notable": "Leave With Grapple Teleport"},
         "canMoonwalk",
         "canInsaneJump"
       ],
@@ -209,7 +209,7 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Moat SpringBall Bounce, Run Through the Door",
+      "name": "SpringBall Bounce, Run Through the Door",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": "any",
@@ -217,7 +217,7 @@
         }
       },
       "requires": [
-        {"notable": "Moat SpringBall Bounce"},
+        {"notable": "SpringBall Bounce"},
         "canSpringBallBounce",
         "canDisableEquipment",
         {"or": [
@@ -231,9 +231,9 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Moat SpringBall Bounce, Open Doorway",
+      "name": "SpringBall Bounce, Open Doorway",
       "requires": [
-        {"notable": "Moat SpringBall Bounce"},
+        {"notable": "SpringBall Bounce"},
         "canSpringBallBounce",
         "canDisableEquipment",
         {"doorUnlockedAtNode": 1},
@@ -1147,12 +1147,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Moat SpringBall Bounce",
+      "name": "SpringBall Bounce",
       "note": "From an open doorway or adjacent room, run, jump, lateral midair morph on the way down, then bounce off the pedestal to get to the other side."
     },
     {
       "id": 2,
-      "name": "Moat Leave With Grapple Teleport",
+      "name": "Leave With Grapple Teleport",
       "note": [
         "Hold angle-up, jump, bonk the ceiling, and use Grapple just before landing.",
         "Moonwalk into the transition on the same frame that the Grapple Beam reaches the Grapple block.",

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -794,7 +794,7 @@
         }
       },
       "requires": [
-        {"notable": "West Ocean - Get Inside the Bridge"},
+        {"notable": "Get Inside the Bridge"},
         "canFreeFallClip",
         "canSkipDoorLock"
       ],
@@ -1129,7 +1129,7 @@
     {
       "id": 42,
       "link": [4, 8],
-      "name": "West Ocean - G-Mode Deep Stuck X-Ray Climb into the Bridge",
+      "name": "G-Mode Deep Stuck X-Ray Climb into the Bridge",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -1137,7 +1137,7 @@
         }
       },
       "requires": [
-        {"notable": "West Ocean - Get Inside the Bridge"},
+        {"notable": "Get Inside the Bridge"},
         "canSkipDoorLock",
         {"or": [
           "canArtificialMorph",
@@ -1165,14 +1165,14 @@
     {
       "id": 43,
       "link": [4, 8],
-      "name": "West Ocean - Shinespark Deep Stuck X-Ray Climb into the Bridge",
+      "name": "Shinespark Deep Stuck X-Ray Climb into the Bridge",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 1
         }
       },
       "requires": [
-        {"notable": "West Ocean - Get Inside the Bridge"},
+        {"notable": "Get Inside the Bridge"},
         "canSkipDoorLock",
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canShinesparkDeepStuck",
@@ -1184,7 +1184,7 @@
     {
       "id": 44,
       "link": [4, 8],
-      "name": "West Ocean - Very Deep Stuck X-Ray Climb into the Bridge",
+      "name": "Very Deep Stuck X-Ray Climb into the Bridge",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -1192,7 +1192,7 @@
         }
       },
       "requires": [
-        {"notable": "West Ocean - Get Inside the Bridge"},
+        {"notable": "Get Inside the Bridge"},
         {"or": [
           "canArtificialMorph",
           "canWalljump",
@@ -1531,9 +1531,9 @@
     {
       "id": 63,
       "link": [5, 4],
-      "name": "West Ocean Grapple Clip Door Lock Skip",
+      "name": "Grapple Clip Door Lock Skip",
       "requires": [
-        {"notable": "West Ocean Grapple Clip Door Lock Skip"},
+        {"notable": "Grapple Clip Door Lock Skip"},
         "canUseEnemies",
         "canGrappleClip",
         "h_canCrystalFlash",
@@ -1759,9 +1759,9 @@
     {
       "id": 74,
       "link": [6, 2],
-      "name": "West Ocean - G-Mode Setup Lure Zeb from Below (to Top Right Section - Top Right Door)",
+      "name": "G-Mode Setup Lure Zeb from Below (to Top Right Section - Top Right Door)",
       "requires": [
-        {"notable": "West Ocean - G-Mode Setup Lure Zeb from Below"},
+        {"notable": "G-Mode Setup Lure Zeb from Below"},
         "canTrickyUseFrozenEnemies",
         {"or": [
           "h_canBombThings",
@@ -1793,9 +1793,9 @@
     {
       "id": 75,
       "link": [6, 3],
-      "name": "West Ocean - G-Mode Setup Lure Zeb from Below (to Top Right Section - Bottom Right Door)",
+      "name": "G-Mode Setup Lure Zeb from Below (to Top Right Section - Bottom Right Door)",
       "requires": [
-        {"notable": "West Ocean - G-Mode Setup Lure Zeb from Below"},
+        {"notable": "G-Mode Setup Lure Zeb from Below"},
         "canTrickyUseFrozenEnemies",
         {"or": [
           "h_canBombThings",
@@ -1899,9 +1899,9 @@
     {
       "id": 82,
       "link": [6, 12],
-      "name": "West Ocean Bug Boost with Ice",
+      "name": "Bug Boost with Ice",
       "requires": [
-        {"notable": "West Ocean Bug Boost with Ice"},
+        {"notable": "Bug Boost with Ice"},
         "Morph",
         "canNeutralDamageBoost",
         "canTrickyUseFrozenEnemies",
@@ -1924,9 +1924,9 @@
     {
       "id": 83,
       "link": [6, 12],
-      "name": "West Ocean Bug Boost with Wave or Spazer",
+      "name": "Bug Boost with Wave or Spazer",
       "requires": [
-        {"notable": "West Ocean Bug Boost with Wave or Spazer"},
+        {"notable": "Bug Boost with Wave or Spazer"},
         {"or": [
           "Wave",
           "Spazer"
@@ -1950,9 +1950,9 @@
     {
       "id": 84,
       "link": [6, 12],
-      "name": "West Ocean Bug Boost",
+      "name": "Bug Boost",
       "requires": [
-        {"notable": "West Ocean Bug Boost"},
+        {"notable": "Bug Boost"},
         "canNeutralDamageBoost",
         "canMockball",
         {"enemyDamage": {
@@ -1971,9 +1971,9 @@
     {
       "id": 85,
       "link": [6, 12],
-      "name": "West Ocean Bug Ice Clip",
+      "name": "Bug Ice Clip",
       "requires": [
-        {"notable": "West Ocean Bug Ice Clip"},
+        {"notable": "Bug Ice Clip"},
         {"or": [
           "h_canXRayMorphIceClip",
           "h_canPreciseIceClip"
@@ -2226,9 +2226,9 @@
     {
       "id": 102,
       "link": [12, 6],
-      "name": "West Ocean Shinespark, Morph Tunnel Rush",
+      "name": "Shinespark, Morph Tunnel Rush",
       "requires": [
-        {"notable": "West Ocean Shinespark, Morph Tunnel Rush"},
+        {"notable": "Shinespark, Morph Tunnel Rush"},
         "canShinechargeMovementComplex",
         "h_canUseSpringBall",
         "h_canShineChargeMaxRunway",
@@ -2251,9 +2251,9 @@
     {
       "id": 103,
       "link": [12, 8],
-      "name": "West Ocean - Enemy Stuck Moonfall into the Bridge",
+      "name": "Enemy Stuck Moonfall into the Bridge",
       "requires": [
-        {"notable": "West Ocean - Get Inside the Bridge"},
+        {"notable": "Get Inside the Bridge"},
         "canSkipDoorLock",
         "canEnemyStuckMoonfall",
         "canFreeFallClip",
@@ -2355,9 +2355,9 @@
     {
       "id": 111,
       "link": [12, 14],
-      "name": "West Ocean - Enemy Stuck Moonfall Super Block Clip",
+      "name": "Enemy Stuck Moonfall Super Block Clip",
       "requires": [
-        {"notable": "West Ocean - Enemy Stuck Moonfall Super Block Clip"},
+        {"notable": "Enemy Stuck Moonfall Super Block Clip"},
         "canEnemyStuckMoonfall",
         "canFreeFallClip",
         "canTrickyUseFrozenEnemies",
@@ -2409,9 +2409,9 @@
     {
       "id": 114,
       "link": [13, 4],
-      "name": "West Ocean Floor Shinecharge, Fast Wallclimb to Gravity Door",
+      "name": "Ocean Floor Shinecharge, Fast Wallclimb to Gravity Door",
       "requires": [
-        {"notable": "West Ocean Floor Shinecharge, Fast Wallclimb to Gravity Door"},
+        {"notable": "Ocean Floor Shinecharge, Fast Wallclimb to Gravity Door"},
         "canShinechargeMovementComplex",
         "canFastWalljumpClimb",
         "HiJump",
@@ -2435,9 +2435,9 @@
     {
       "id": 115,
       "link": [13, 4],
-      "name": "West Ocean Floor Shinecharge, Fast Spacejump Wallclimb to Gravity Door",
+      "name": "Ocean Floor Shinecharge, Fast Spacejump Wallclimb to Gravity Door",
       "requires": [
-        {"notable": "West Ocean Floor Shinecharge, Fast Spacejump Wallclimb to Gravity Door"},
+        {"notable": "Ocean Floor Shinecharge, Fast Spacejump Wallclimb to Gravity Door"},
         "canShinechargeMovementComplex",
         "canFastWalljumpClimb",
         "HiJump",
@@ -2775,9 +2775,9 @@
     {
       "id": 134,
       "link": [17, 10],
-      "name": "West Ocean G-mode Overload PLMs by PBing Missile Item",
+      "name": "G-mode Overload PLMs by PBing Missile Item",
       "requires": [
-        {"notable": "West Ocean G-mode Overload PLMs by PBing Missile Item"},
+        {"notable": "G-mode Overload PLMs by PBing Missile Item"},
         "canEnterGMode",
         {"itemNotCollectedAtNode": 10},
         "h_canUsePowerBombs",
@@ -2830,7 +2830,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "West Ocean - G-Mode Setup Lure Zeb from Below",
+      "name": "G-Mode Setup Lure Zeb from Below",
       "note": [
         "Start from the Middle Right Door next to the Zeb farm.",
         "While standing on the right of the Zeb farm, freeze the Zeb while it is still moving up and facing to the right.",
@@ -2841,7 +2841,7 @@
     },
     {
       "id": 2,
-      "name": "West Ocean - Get Inside the Bridge",
+      "name": "Get Inside the Bridge",
       "note": [
         "Enter the bridge using a deep-stuck X-ray climb from below or high fall speed from above.",
         "The doors do not connect to the same locations as Homing Geemer Room.",
@@ -2851,7 +2851,7 @@
     },
     {
       "id": 3,
-      "name": "West Ocean Grapple Clip Door Lock Skip",
+      "name": "Grapple Clip Door Lock Skip",
       "note": [
         "Grapple on the Ripper to get inside the wall under the door.",
         "Do a Crystal Flash to force a standup.",
@@ -2860,7 +2860,7 @@
     },
     {
       "id": 4,
-      "name": "West Ocean Bug Boost with Ice",
+      "name": "Bug Boost with Ice",
       "note": [
         "Get a Zeb to move left into the morph passage, and reach the end of the tunnel before it.",
         "Freeze the bug at the correct height, such that it will move and be able to hit Samus while in the morph tunnel.",
@@ -2871,7 +2871,7 @@
     },
     {
       "id": 5,
-      "name": "West Ocean Bug Boost with Wave or Spazer",
+      "name": "Bug Boost with Wave or Spazer",
       "note": [
         "Get a Zeb to move left into the morph passage, and reach the end of the tunnel before it.",
         "Shoot the block with Wave or while crouching with Spazer before luring the bug.",
@@ -2881,7 +2881,7 @@
     },
     {
       "id": 6,
-      "name": "West Ocean Bug Boost",
+      "name": "Bug Boost",
       "note": [
         "Get a Zeb to move left into the morph passage, and reach the end of the tunnel before it.",
         "Must be quick enough to shoot the shot block first. Requires a mockball on the 4 tile floor before the tunnel.",
@@ -2890,7 +2890,7 @@
     },
     {
       "id": 7,
-      "name": "West Ocean Bug Ice Clip",
+      "name": "Bug Ice Clip",
       "note": [
         "Freeze a bug three tiles to the right of the morph tunnel entrance, directly under the tile where ceiling is higher.",
         "Jump onto the bug, crouch, and jump up.",
@@ -2900,7 +2900,7 @@
     },
     {
       "id": 8,
-      "name": "West Ocean Shinespark, Morph Tunnel Rush",
+      "name": "Shinespark, Morph Tunnel Rush",
       "note": [
         "Preopen the door and shotblock, then go back and charge a shinespark.",
         "Springball through the short morphball tunnel to just have enough time to shinespark out the door."
@@ -2908,7 +2908,7 @@
     },
     {
       "id": 9,
-      "name": "West Ocean - Enemy Stuck Moonfall Super Block Clip",
+      "name": "Enemy Stuck Moonfall Super Block Clip",
       "note": [
         "Watch the lowest Tripper move until it reaches the left side wall and then move it off camera.",
         "Move to the Zeb Spawner and freeze the bug as it is rising and facing left.",
@@ -2920,17 +2920,17 @@
     },
     {
       "id": 10,
-      "name": "West Ocean Floor Shinecharge, Fast Wallclimb to Gravity Door",
+      "name": "Ocean Floor Shinecharge, Fast Wallclimb to Gravity Door",
       "note": "Use walljumps to climb from the ocean floor up to the gravity suit room door."
     },
     {
       "id": 11,
-      "name": "West Ocean Floor Shinecharge, Fast Spacejump Wallclimb to Gravity Door",
+      "name": "Ocean Floor Shinecharge, Fast Spacejump Wallclimb to Gravity Door",
       "note": "Spacejump out of the water then use walljumps up to the gravity suit room door."
     },
     {
       "id": 12,
-      "name": "West Ocean G-mode Overload PLMs by PBing Missile Item",
+      "name": "G-mode Overload PLMs by PBing Missile Item",
       "note": [
         "To overload the PLMs, place a PB precisely to the right of the bottom of the second overhang above the door to the Moat.",
         "This is at the max jump height without HiJump. Placing the PB higher or lower will not overload the PLMs without many PBs."

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -349,12 +349,12 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "Gauntlet E-Tank R-Mode Blue Suit",
+      "name": "R-Mode Blue Suit",
       "entranceCondition": {
         "comeInWithRMode": {}
       },
       "requires": [
-        {"notable": "Gauntlet E-Tank R-Mode Blue Suit"},
+        {"notable": "R-Mode Blue Suit"},
         "canBePatient",
         {"or": [
           {"canShineCharge": {
@@ -746,7 +746,7 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Gauntlet Energy Tank Room Spark Master",
+      "name": "Spark Master",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 8,
@@ -754,7 +754,7 @@
         }
       },
       "requires": [
-        {"notable": "Gauntlet Energy Tank Room Spark Master"},
+        {"notable": "Spark Master"},
         "canSlowShortCharge",
         "canShinechargeMovementTricky",
         "h_canUsePowerBombs",
@@ -1148,7 +1148,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Gauntlet E-Tank R-Mode Blue Suit",
+      "name": "R-Mode Blue Suit",
       "note": [
         "Use R-Mode to get a blue suit to cross the room and get the item, or to leave the right shinecharged.",
         "In R-Mode, fill your Reserves at the farm. Damage down again so that Samus is within 1 Zebbo hit from triggering Reserves.",
@@ -1159,7 +1159,7 @@
     },
     {
       "id": 2,
-      "name": "Gauntlet Energy Tank Room Spark Master",
+      "name": "Spark Master",
       "note": [
         "Use SpeedBooster to break the runway Bomb block and then to shinespark across the room, saving Power Bombs.",
         "One Power Bomb is still needed to break the tunnel block.",

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -375,7 +375,7 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Gauntlet Entrance Blue SpaceJump (Left to Right, Come in Getting Blue Speed)",
+      "name": "Blue SpaceJump (Left to Right, Come in Getting Blue Speed)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -385,7 +385,7 @@
         }
       },
       "requires": [
-        {"notable": "Gauntlet Entrance Blue SpaceJump"},
+        {"notable": "Blue SpaceJump"},
         "canBlueSpaceJump",
         "canTrickyJump"
       ],
@@ -399,14 +399,14 @@
     {
       "id": 16,
       "link": [1, 2],
-      "name": "Gauntlet Entrance Blue SpaceJump (Left to Right, Come in Blue Spinning)",
+      "name": "Blue SpaceJump (Left to Right, Come in Blue Spinning)",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "unusableTiles": 0
         }
       },
       "requires": [
-        {"notable": "Gauntlet Entrance Blue SpaceJump"},
+        {"notable": "Blue SpaceJump"},
         "canBlueSpaceJump",
         "canTrickyJump"
       ],
@@ -465,7 +465,7 @@
     {
       "id": 46,
       "link": [1, 2],
-      "name": "Gauntlet Temporary Blue Chains",
+      "name": "Temporary Blue Chains",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -475,7 +475,7 @@
         }
       },
       "requires": [
-        {"notable": "Gauntlet Temporary Blue Chains"},
+        {"notable": "Temporary Blue Chains"},
         "canChainTemporaryBlue",
         {"acidFrames": 10},
         {"or": [
@@ -649,7 +649,7 @@
     {
       "id": 27,
       "link": [2, 1],
-      "name": "Gauntlet Entrance Blue SpaceJump (Right to Left, Come in Getting Blue Speed)",
+      "name": "Blue SpaceJump (Right to Left, Come in Getting Blue Speed)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -659,7 +659,7 @@
         }
       },
       "requires": [
-        {"notable": "Gauntlet Entrance Blue SpaceJump"},
+        {"notable": "Blue SpaceJump"},
         "canBlueSpaceJump",
         "canTrickyJump"
       ],
@@ -674,14 +674,14 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Gauntlet Entrance Blue SpaceJump (Right to Left, Come in Blue Spinning)",
+      "name": "Blue SpaceJump (Right to Left, Come in Blue Spinning)",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "unusableTiles": 0
         }
       },
       "requires": [
-        {"notable": "Gauntlet Entrance Blue SpaceJump"},
+        {"notable": "Blue SpaceJump"},
         "canBlueSpaceJump",
         "canTrickyJump"
       ],
@@ -739,7 +739,7 @@
     {
       "id": 47,
       "link": [2, 1],
-      "name": "Gauntlet Temporary Blue Chains",
+      "name": "Temporary Blue Chains",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -749,7 +749,7 @@
         }
       },
       "requires": [
-        {"notable": "Gauntlet Temporary Blue Chains"},
+        {"notable": "Temporary Blue Chains"},
         "canChainTemporaryBlue"
       ],
       "note": [
@@ -942,9 +942,9 @@
     {
       "id": 41,
       "link": [2, 2],
-      "name": "Gauntlet Entrance Shinecharge Under Yapping Maw",
+      "name": "Shinecharge Under Yapping Maw",
       "requires": [
-        {"notable": "Gauntlet Entrance Shinecharge Under Yapping Maw"},
+        {"notable": "Shinecharge Under Yapping Maw"},
         {"obstaclesCleared": ["A"]},
         "canMidairShinespark",
         "canCameraManip",
@@ -1041,12 +1041,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Gauntlet Entrance Blue SpaceJump",
+      "name": "Blue SpaceJump",
       "note": "This is a series of precise space jumps that clears a path through the room while avoiding the solid walls."
     },
     {
       "id": 2,
-      "name": "Gauntlet Temporary Blue Chains",
+      "name": "Temporary Blue Chains",
       "note": [
         "Use a temporary blue chain to reach the center of the room, breaking the bomb blocks along the way.",
         "Then use the newly cleared runway to set up a second temporary blue chain to cross the rest of the room."
@@ -1054,7 +1054,7 @@
     },
     {
       "id": 3,
-      "name": "Gauntlet Entrance Shinecharge Under Yapping Maw",
+      "name": "Shinecharge Under Yapping Maw",
       "note": [
         "Jump towards the yapping maw before it is on screen so it moves up.",
         "Quickly move it off camera so it will be `frozen` in place.",

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -1295,9 +1295,9 @@
     {
       "id": 58,
       "link": [9, 1],
-      "name": "Green Pirate Shaft Beetom Xray Climb",
+      "name": "Beetom X-Ray Climb",
       "requires": [
-        {"notable": "Green Pirate Shaft Beetom Xray Climb"},
+        {"notable": "Beetom X-Ray Climb"},
         "canXRayClimb",
         "Morph",
         "canWallIceClip",
@@ -1426,9 +1426,9 @@
     {
       "id": 62,
       "link": [9, 2],
-      "name": "Green Pirate Shaft Beetom Moondance",
+      "name": "Beetom Moondance",
       "requires": [
-        {"notable": "Green Pirate Shaft Beetom Moondance"},
+        {"notable": "Beetom Moondance"},
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {
@@ -1448,9 +1448,9 @@
     {
       "id": 63,
       "link": [9, 2],
-      "name": "Green Pirate Shaft Beetom Stuck Moonfall",
+      "name": "Beetom Stuck Moonfall",
       "requires": [
-        {"notable": "Green Pirate Shaft Beetom Stuck Moonfall"},
+        {"notable": "Beetom Stuck Moonfall"},
         "canEnemyStuckMoonfall",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {
@@ -1878,7 +1878,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Green Pirate Shaft Beetom Xray Climb",
+      "name": "Beetom X-Ray Climb",
       "note": [
         "Shoot out only the lower 2 shot blocks on the side Samus will be climbing.",
         "Grab a Beetom and use Morph to pixel align the Beetom with the edge of the wall.  While facing right.",
@@ -1892,7 +1892,7 @@
     },
     {
       "id": 2,
-      "name": "Green Pirate Shaft Beetom Moondance",
+      "name": "Beetom Moondance",
       "note": [
         "Pick up a Beetom and bring it up to the centered platform below the crumble blocks.",
         "Freeze it at about head height where Samus can move around inside its sprite, and use it to Moondance.",
@@ -1903,7 +1903,7 @@
     },
     {
       "id": 3,
-      "name": "Green Pirate Shaft Beetom Stuck Moonfall",
+      "name": "Beetom Stuck Moonfall",
       "note": [
         "Position both Beetoms above the shot block for an 'Enemy Stuck Moonfall' to clip through the floor below, bypassing the morph tunnel.",
         "1) Attach a Beetom and freeze it off of Samus while standing on the shot block.",

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -73,7 +73,6 @@
       "id": 25,
       "link": [1, 1],
       "name": "Statues Cutscene",
-      "notable": false,
       "requires": [
         "f_DefeatedKraid",
         "f_DefeatedPhantoon",
@@ -190,9 +189,9 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Golden Four Underwater Walljumps",
+      "name": "Underwater Walljump",
       "requires": [
-        {"notable": "Golden Four Underwater Walljumps"},
+        {"notable": "Underwater Walljump"},
         "f_TourianOpen",
         "canUnderwaterWalljump"
       ],
@@ -471,7 +470,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Golden Four Underwater Walljumps",
+      "name": "Underwater Walljump",
       "note": "Walljump up the elevator room walls without Gravity suit.  Space Jump helps once the waterline is reached."
     }
   ],

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -453,9 +453,9 @@
     {
       "id": 15,
       "link": [2, 3],
-      "name": "Reverse Amphitheatre, Vertical Dive",
+      "name": "Reverse, Vertical Dive",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         {"or": [
@@ -498,9 +498,9 @@
     {
       "id": 16,
       "link": [2, 4],
-      "name": "Reverse Amphitheatre Partial Dive",
+      "name": "Reverse Partial Dive",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         {"heatFrames": 180},
@@ -511,9 +511,9 @@
     {
       "id": 17,
       "link": [2, 5],
-      "name": "Reverse Amphitheatre Thread the Needle (Charge Plasma)",
+      "name": "Reverse Thread the Needle (Charge Plasma)",
       "requires": [
-        {"notable": "Reverse Amphitheatre Thread the Needle"},
+        {"notable": "Reverse Thread the Needle"},
         {"obstaclesNotCleared": ["A"]},
         "canInsaneJump",
         "canSuitlessLavaDive",
@@ -537,7 +537,7 @@
     {
       "id": 18,
       "link": [2, 5],
-      "name": "Reverse Amphitheatre Thread the Needle (Blue Speed)",
+      "name": "Reverse Thread the Needle (Blue Speed)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 9,
@@ -546,7 +546,7 @@
         }
       },
       "requires": [
-        {"notable": "Reverse Amphitheatre Thread the Needle"},
+        {"notable": "Reverse Thread the Needle"},
         {"obstaclesNotCleared": ["A"]},
         "canInsaneJump",
         "canSuitlessLavaDive",
@@ -564,9 +564,9 @@
     {
       "id": 19,
       "link": [3, 1],
-      "name": "Amphitheatre Space Jump Acid Climb",
+      "name": "Space Jump Acid Climb",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         "Gravity",
@@ -603,9 +603,9 @@
     {
       "id": 20,
       "link": [3, 1],
-      "name": "Amphitheatre Acid Stutter Shinespark",
+      "name": "Acid Stutter Shinespark",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "h_heatProof",
         "Gravity",
@@ -635,9 +635,9 @@
     {
       "id": 21,
       "link": [3, 1],
-      "name": "Amphitheatre Speedy Gravity Jump",
+      "name": "Speedy Gravity Jump",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "HiJump",
         "canTrickyDashJump",
@@ -723,9 +723,9 @@
     {
       "id": 25,
       "link": [3, 5],
-      "name": "Amphitheatre Acid Hop",
+      "name": "Acid Hop",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "canSuitlessLavaDive",
         {"or": [
@@ -745,9 +745,9 @@
     {
       "id": 26,
       "link": [4, 1],
-      "name": "Reverse Amphitheatre SpaceJump",
+      "name": "Reverse SpaceJump",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "Gravity",
         "SpaceJump",
@@ -873,9 +873,9 @@
     {
       "id": 30,
       "link": [4, 3],
-      "name": "Reverse Amphitheatre Continued Dive",
+      "name": "Reverse Continued Dive",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         {"or": [
           {"and": [
@@ -894,9 +894,9 @@
     {
       "id": 31,
       "link": [5, 1],
-      "name": "Amphitheatre Acid Wall Climb with Gravity",
+      "name": "Acid Wall Climb with Gravity",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "Gravity",
         {"or": [
@@ -930,9 +930,9 @@
     {
       "id": 32,
       "link": [5, 1],
-      "name": "Amphitheatre Acid Wall Climb without Gravity",
+      "name": "Acid Wall Climb without Gravity",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "canConsecutiveWalljump",
         {"or": [
@@ -1004,9 +1004,9 @@
     {
       "id": 34,
       "link": [5, 1],
-      "name": "Amphitheatre Triple SpringBall Jump",
+      "name": "Triple SpringBall Jump",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "h_heatProof",
         "canSuitlessLavaDive",
@@ -1040,9 +1040,9 @@
     {
       "id": 35,
       "link": [5, 1],
-      "name": "Amphitheatre Gravity Jump SpringBall Jump",
+      "name": "Gravity Jump SpringBall Jump",
       "requires": [
-        {"notable": "Amphitheatre Reverse Acid Dive"},
+        {"notable": "Reverse Acid Dive"},
         {"obstaclesNotCleared": ["A"]},
         "HiJump",
         "canTrickyJump",
@@ -1146,12 +1146,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Amphitheatre Reverse Acid Dive",
+      "name": "Reverse Acid Dive",
       "note": "Dive into the acid and get to the doorway high on the left wall. Note that you can wall jump climb in acid without gravity."
     },
     {
       "id": 2,
-      "name": "Reverse Amphitheatre Thread the Needle",
+      "name": "Reverse Thread the Needle",
       "note": [
         "Jump directly from the top door's ramp, through the pirates, to the far bottom left of the acid filled room.",
         "Begin running from the top of the second slope and jump at the bottom of the third slope, bonking the large stalagtite in the ceiling.",

--- a/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
+++ b/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
@@ -87,9 +87,9 @@
     {
       "id": 3,
       "link": [1, 2],
-      "name": "Lower Norfair Jail Crystal Flash Clip",
+      "name": "Crystal Flash Clip",
       "requires": [
-        {"notable": "Lower Norfair Jail Crystal Flash Clip"},
+        {"notable": "Crystal Flash Clip"},
         "h_heatProof",
         "h_canJumpIntoCrystalFlashClip",
         "canTrickyJump"
@@ -104,7 +104,7 @@
     {
       "id": 4,
       "link": [1, 3],
-      "name": "Lower Norfair Jail Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [
@@ -114,7 +114,7 @@
         }
       },
       "requires": [
-        {"notable": "Lower Norfair Jail Grapple Teleport Inside Wall"},
+        {"notable": "Grapple Teleport Inside Wall"},
         "Morph",
         {"heatFrames": 180}
       ],
@@ -339,7 +339,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Lower Norfair Jail Crystal Flash Clip",
+      "name": "Crystal Flash Clip",
       "note": [
         "Stand next to the Crumble Blocks and jump into a Crystal Flash Clip to briefly clip into the ceiling above those blocks.",
         "Hold down exiting the Crystal Flash to shrink Samus' hitbox and on the next frame press forward to move above the Crumble blocks.",
@@ -348,7 +348,7 @@
     },
     {
       "id": 2,
-      "name": "Lower Norfair Jail Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "note": [
         "In the previous room, avoid triggering the transition too deeply (position 238), otherwise Samus ends up stuck too far right in the wall.",
         "After teleporting, Samus should be standing inside the wall.",

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -203,7 +203,7 @@
     {
       "id": 2,
       "link": [1, 2],
-      "name": "LN Firefleas G-Mode Morph Blind Top to Bottom - Power Bomb the Bottom Fune (Top Left Door)",
+      "name": "G-Mode Morph Blind Top to Bottom - Power Bomb the Bottom Fune (Top Left Door)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -211,7 +211,7 @@
         }
       },
       "requires": [
-        {"notable": "LN Firefleas G-Mode Morph Blind Top to Bottom"},
+        {"notable": "G-Mode Morph Blind Top to Bottom"},
         "canOffScreenMovement",
         "canTrickyJump",
         {"or": [
@@ -245,7 +245,7 @@
     {
       "id": 4,
       "link": [1, 6],
-      "name": "LN Firefleas G-Mode Morph Blind Top to Bottom - Jump over the Bottom Fune (Top Left Door)",
+      "name": "G-Mode Morph Blind Top to Bottom - Jump over the Bottom Fune (Top Left Door)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -253,7 +253,7 @@
         }
       },
       "requires": [
-        {"notable": "LN Firefleas G-Mode Morph Blind Top to Bottom"},
+        {"notable": "G-Mode Morph Blind Top to Bottom"},
         "canOffScreenMovement",
         "canTrickyJump",
         "h_canArtificialMorphSpringBall"
@@ -466,9 +466,9 @@
     {
       "id": 18,
       "link": [2, 6],
-      "name": "LN Fireflea Room Morph Over the Fune",
+      "name": "Morph Over the Fune",
       "requires": [
-        {"notable": "LN Fireflea Room Morph Over the Fune"},
+        {"notable": "Morph Over the Fune"},
         {"noFlashSuit": {}},
         "h_canFourTileJumpMorph",
         "canTrickyJump",
@@ -738,7 +738,7 @@
     {
       "id": 32,
       "link": [3, 2],
-      "name": "LN Firefleas G-Mode Morph Blind Top to Bottom - Power Bomb the Bottom Fune (Top Right Door)",
+      "name": "G-Mode Morph Blind Top to Bottom - Power Bomb the Bottom Fune (Top Right Door)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -746,7 +746,7 @@
         }
       },
       "requires": [
-        {"notable": "LN Firefleas G-Mode Morph Blind Top to Bottom"},
+        {"notable": "G-Mode Morph Blind Top to Bottom"},
         "canOffScreenMovement",
         "canTrickyJump",
         {"or": [
@@ -795,7 +795,7 @@
     {
       "id": 35,
       "link": [3, 6],
-      "name": "LN Firefleas G-Mode Morph Blind Top to Bottom - Jump over the Bottom Fune (Top Left Door)",
+      "name": "G-Mode Morph Blind Top to Bottom - Jump over the Bottom Fune (Top Left Door)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -803,7 +803,7 @@
         }
       },
       "requires": [
-        {"notable": "LN Firefleas G-Mode Morph Blind Top to Bottom"},
+        {"notable": "G-Mode Morph Blind Top to Bottom"},
         "canOffScreenMovement",
         "canTrickyJump",
         "h_canArtificialMorphSpringBall"
@@ -830,9 +830,9 @@
     {
       "id": 37,
       "link": [4, 5],
-      "name": "LN Fireflea Ice Bridge (Right to Left)",
+      "name": "Ice Bridge (Right to Left)",
       "requires": [
-        {"notable": "LN Firefleas Ice Bridge"},
+        {"notable": "Ice Bridge"},
         "canTrickyUseFrozenEnemies",
         "canCarefulJump"
       ],
@@ -874,9 +874,9 @@
     {
       "id": 41,
       "link": [5, 4],
-      "name": "LN Fireflea Ice Bridge (Left to Right)",
+      "name": "Ice Bridge (Left to Right)",
       "requires": [
-        {"notable": "LN Firefleas Ice Bridge"},
+        {"notable": "Ice Bridge"},
         "canTrickyUseFrozenEnemies",
         "canCarefulJump"
       ],
@@ -1128,7 +1128,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "LN Firefleas Ice Bridge",
+      "name": "Ice Bridge",
       "note": [
         "Avoid killing the Firefleas and instead freeze them as a way accross the spikes.",
         "It helps to freeze them low, closer to the spikes."
@@ -1136,7 +1136,7 @@
     },
     {
       "id": 2,
-      "name": "LN Firefleas G-Mode Morph Blind Top to Bottom",
+      "name": "G-Mode Morph Blind Top to Bottom",
       "note": [
         "Traversing the room without getting hit requires fairly tricky off-screen movement.",
         "Note that Samus moves freely through the off-screen Funes, but will take damage from the Boulders.",
@@ -1149,7 +1149,7 @@
     },
     {
       "id": 3,
-      "name": "LN Fireflea Room Morph Over the Fune",
+      "name": "Morph Over the Fune",
       "note": [
         "A paricularly precise mid-air morph can get up and over the Fune without damage.",
         "Stand a half tile away from the Fune when jump morphing for a higher ceiling.",

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -275,9 +275,9 @@
     {
       "id": 10,
       "link": [2, 5],
-      "name": "Reverse Spring Ball Maze Crystal Flash Clip",
+      "name": "Reverse Crystal Flash Clip",
       "requires": [
-        {"notable": "Reverse Spring Ball Maze Crystal Flash Clip"},
+        {"notable": "Reverse Crystal Flash Clip"},
         {"heatFrames": 300},
         "h_canCrystalFlash",
         "canCeilingClip",
@@ -1008,9 +1008,9 @@
     {
       "id": 48,
       "link": [6, 5],
-      "name": "LN Spring Ball Maze Air Speedball",
+      "name": "Air Speedball",
       "requires": [
-        {"notable": "LN Spring Ball Maze Air Speedball"},
+        {"notable": "Air Speedball"},
         "h_canNavigateHeatRooms",
         "h_canUseSpringBall",
         "canSpeedball",
@@ -1439,12 +1439,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Reverse Spring Ball Maze Crystal Flash Clip",
+      "name": "Reverse Crystal Flash Clip",
       "note": "Perform the crystal flash all the way against the left wall of the accessible tunnel, then jump through the ceiling."
     },
     {
       "id": 2,
-      "name": "LN Spring Ball Maze Air Speedball",
+      "name": "Air Speedball",
       "note": "Jump and Morph with a speedball to enter the morph tunnel and then use SpringBall to break the bomb blocks."
     }
   ],

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -200,9 +200,9 @@
     {
       "id": 8,
       "link": [1, 3],
-      "name": "Metal Pirates Speed Echoes Kill (Left to Right)",
+      "name": "Speed Echoes Kill (Left to Right)",
       "requires": [
-        {"notable": "Metal Pirates Speed Echoes Kill"},
+        {"notable": "Speed Echoes Kill"},
         {"obstaclesNotCleared": ["A"]},
         "canUseSpeedEchoes",
         "canHitbox",
@@ -414,9 +414,9 @@
     {
       "id": 19,
       "link": [2, 3],
-      "name": "Metal Pirates Speed Echoes Kill (Right to Left)",
+      "name": "Speed Echoes Kill (Right to Left)",
       "requires": [
-        {"notable": "Metal Pirates Speed Echoes Kill"},
+        {"notable": "Speed Echoes Kill"},
         {"obstaclesNotCleared": ["A"]},
         "canUseSpeedEchoes",
         "canHitbox",
@@ -868,9 +868,9 @@
     {
       "id": 32,
       "link": [3, 3],
-      "name": "Metal Pirates Shinespark Farm",
+      "name": "Shinespark Farm",
       "requires": [
-        {"notable": "Metal Pirates Speed Echoes Kill"},
+        {"notable": "Speed Echoes Kill"},
         "h_heatProof",
         "canDodgeWhileShooting",
         "canUseSpeedEchoes",
@@ -887,7 +887,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Metal Pirates Speed Echoes Kill",
+      "name": "Speed Echoes Kill",
       "note": [
         "Use the Echoes created by shinesparking to defeat the Metal Pirates.",
         "This involves Shineparking into a precise point while also turning the Pirates vulnerable as the echoes reach them."

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -706,12 +706,12 @@
     {
       "id": 27,
       "link": [2, 4],
-      "name": "Mickey Mouse Temporary Blue Crumble Jump without SpringBall",
+      "name": "Temporary Blue Crumble Jump without SpringBall",
       "entranceCondition": {
         "comeInWithTemporaryBlue": {}
       },
       "requires": [
-        {"notable": "Mickey Mouse Temporary Blue Crumble Jump without SpringBall"},
+        {"notable": "Temporary Blue Crumble Jump without SpringBall"},
         {"obstaclesNotCleared": ["A"]},
         "canPrepareForNextRoom",
         "canChainTemporaryBlue",
@@ -874,9 +874,9 @@
     {
       "id": 36,
       "link": [4, 2],
-      "name": "Mickey Mouse Crumble Speedjump",
+      "name": "Crumble Speedjump",
       "requires": [
-        {"notable": "Mickey Mouse Crumble Speedjump"},
+        {"notable": "Crumble Speedjump"},
         {"obstaclesCleared": ["A"]},
         "canCrumbleJump",
         "canTrickyDashJump",
@@ -892,9 +892,9 @@
     {
       "id": 37,
       "link": [4, 2],
-      "name": "Mickey Mouse Crumble Jump IBJ",
+      "name": "Crumble Jump IBJ",
       "requires": [
-        {"notable": "Mickey Mouse Crumble Jump IBJ"},
+        {"notable": "Crumble Jump IBJ"},
         {"obstaclesCleared": ["A"]},
         "canCrumbleJump",
         "canJumpIntoIBJ",
@@ -1259,9 +1259,9 @@
     {
       "id": 61,
       "link": [6, 9],
-      "name": "Mickey Mouse Ice Clip Setup",
+      "name": "Ice Clip Setup",
       "requires": [
-        {"notable": "Mickey Mouse Viola Ice Clip"},
+        {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -1690,9 +1690,9 @@
     {
       "id": 79,
       "link": [9, 2],
-      "name": "Mickey Mouse Multiviola Clip (Bomb Block Clip)",
+      "name": "Multiviola Clip (Bomb Block Clip)",
       "requires": [
-        {"notable": "Mickey Mouse Viola Ice Clip"},
+        {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
         "h_canPreciseIceClip",
         "canPartialFloorClip",
@@ -1723,9 +1723,9 @@
     {
       "id": 80,
       "link": [9, 2],
-      "name": "Mickey Mouse Viola Clip (XRay Standup Bomb Block Clip)",
+      "name": "Multiviola Clip (X-Ray Standup Bomb Block Clip)",
       "requires": [
-        {"notable": "Mickey Mouse Viola Ice Clip"},
+        {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
         "h_canXRayMorphIceClip",
         {"or": [
@@ -1746,9 +1746,9 @@
     {
       "id": 81,
       "link": [9, 4],
-      "name": "Mickey Mouse Multiviola Clip (Power Bomb)",
+      "name": "Multiviola Clip (Power Bomb)",
       "requires": [
-        {"notable": "Mickey Mouse Viola Ice Clip"},
+        {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
         "h_canPreciseIceClip",
         {"enemyDamage": {
@@ -1772,9 +1772,9 @@
     {
       "id": 82,
       "link": [9, 4],
-      "name": "Mickey Mouse Viola Clip (XRay Standup and Morph)",
+      "name": "Multiviola Clip (X-Ray Standup and Morph)",
       "requires": [
-        {"notable": "Mickey Mouse Viola Ice Clip"},
+        {"notable": "Multiviola Ice Clip"},
         "h_canXRayMorphIceClip"
       ],
       "flashSuitChecked": true,
@@ -1786,9 +1786,9 @@
     {
       "id": 83,
       "link": [9, 4],
-      "name": "Mickey Mouse Multiviola Clip (Screw Attack)",
+      "name": "Multiviola Clip (Screw Attack)",
       "requires": [
-        {"notable": "Mickey Mouse Viola Ice Clip"},
+        {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
         "h_canPreciseIceClip",
         {"enemyDamage": {
@@ -1811,9 +1811,9 @@
     {
       "id": 84,
       "link": [9, 4],
-      "name": "Mickey Mouse Multiviola Clip (Bombs)",
+      "name": "Multiviola Clip (Bombs)",
       "requires": [
-        {"notable": "Mickey Mouse Viola Ice Clip"},
+        {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
         "h_canPreciseIceClip",
         {"enemyDamage": {
@@ -1843,7 +1843,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Mickey Mouse Viola Ice Clip",
+      "name": "Multiviola Ice Clip",
       "note": [
         "Guide the bottom right Multiviola from the bottom of Mickey Mouse room all the way to the crumble blocks and use it to ice clip through.",
         "The Multiviola will bounce around the bottom area 4 times before it is able to pass through the shot block.",
@@ -1855,7 +1855,7 @@
     },
     {
       "id": 2,
-      "name": "Mickey Mouse Temporary Blue Crumble Jump without SpringBall",
+      "name": "Temporary Blue Crumble Jump without SpringBall",
       "note": [
         "Carry Temporary Blue through the top door of Mickey Mouse to break the left side of the bomb blocks.",
         "There is a small frame window where Samus can soft unmorph on the crumble blocks and jump again while retaining temporary blue."
@@ -1863,7 +1863,7 @@
     },
     {
       "id": 3,
-      "name": "Mickey Mouse Crumble Speedjump",
+      "name": "Crumble Speedjump",
       "note": [
         "Spinjump off a crumble block with just a tiny amount of run speed.",
         "That gives just enough height to be able to walljump out."
@@ -1871,7 +1871,7 @@
     },
     {
       "id": 4,
-      "name": "Mickey Mouse Crumble Jump IBJ",
+      "name": "Crumble Jump IBJ",
       "note": [
         "Jump and mid-air morph off a crumble block to begin the IBJ.",
         "Use double bomb jumps to make it up quickly before the shot block respawns."

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -306,9 +306,9 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Pillar Room with Two Power Bombs (Left to Right)",
+      "name": "Two Power Bombs (Left to Right)",
       "requires": [
-        {"notable": "Lower Norfair Pillar Room with Two Power Bombs"},
+        {"notable": "Two Power Bombs"},
         "canMidAirMorph",
         "canCarefulJump",
         {"ammo": {"type": "PowerBomb", "count": 2}},
@@ -448,7 +448,7 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Lower Norfair Pillar Room with Bombs (Left to Right)",
+      "name": "Bombs (Left to Right)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 1,
@@ -456,7 +456,7 @@
         }
       },
       "requires": [
-        {"notable": "Lower Norfair Pillar Room with Bombs"},
+        {"notable": "Bombs"},
         "h_canUseMorphBombs",
         "canWallJumpInstantMorph",
         "canInsaneJump",
@@ -487,7 +487,7 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Lower Norfair Pillar Room with Bombs, no WallJump (Left to Right)",
+      "name": "Bombs, no WallJump (Left to Right)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 1,
@@ -495,7 +495,7 @@
         }
       },
       "requires": [
-        {"notable": "Lower Norfair Pillar Room with Bombs"},
+        {"notable": "Bombs"},
         "h_canUseMorphBombs",
         "Gravity",
         "canResetFallSpeed",
@@ -755,9 +755,9 @@
     {
       "id": 18,
       "link": [2, 1],
-      "name": "Pillar Room with Two Power Bombs (Right to Left)",
+      "name": "Two Power Bombs (Right to Left)",
       "requires": [
-        {"notable": "Lower Norfair Pillar Room with Two Power Bombs"},
+        {"notable": "Two Power Bombs"},
         "canMidAirMorph",
         {"ammo": {"type": "PowerBomb", "count": 2}},
         "canCarefulJump",
@@ -895,7 +895,7 @@
     {
       "id": 20,
       "link": [2, 1],
-      "name": "Lower Norfair Pillar Room with Bombs (Right to Left)",
+      "name": "Bombs (Right to Left)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 3,
@@ -903,7 +903,7 @@
         }
       },
       "requires": [
-        {"notable": "Lower Norfair Pillar Room with Bombs"},
+        {"notable": "Bombs"},
         "canWallJumpInstantMorph",
         "canInsaneJump",
         "canResetFallSpeed",
@@ -934,7 +934,7 @@
     {
       "id": 21,
       "link": [2, 1],
-      "name": "Lower Norfair Pillar Room with Bombs, no WallJump (Right to Left)",
+      "name": "Bombs, no WallJump (Right to Left)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 3,
@@ -942,7 +942,7 @@
         }
       },
       "requires": [
-        {"notable": "Lower Norfair Pillar Room with Bombs"},
+        {"notable": "Bombs"},
         "h_canUseMorphBombs",
         "Gravity",
         "canResetFallSpeed",
@@ -1132,7 +1132,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Lower Norfair Pillar Room with Two Power Bombs",
+      "name": "Two Power Bombs",
       "note": [
         "Place the Power Bombs as forward as possible in order to only need to use two.",
         "This makes it more likely to fall in the acid."
@@ -1140,7 +1140,7 @@
     },
     {
       "id": 2,
-      "name": "Lower Norfair Pillar Room with Bombs",
+      "name": "Bombs",
       "note": [
         "Cross the Pillar Room with Bombs and minimal damage.",
         "Some acid damage is expected, but any mistakes greatly increases the time spent in acid."

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -571,7 +571,7 @@
     {
       "id": 27,
       "link": [3, 5],
-      "name": "Kihunter Shaft Grapple Teleport Semi-Blind Movement",
+      "name": "Grapple Teleport Semi-Blind Movement",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [
@@ -582,7 +582,7 @@
         }
       },
       "requires": [
-        {"notable": "Kihunter Shaft Grapple Teleport Semi-Blind Movement"},
+        {"notable": "Grapple Teleport Semi-Blind Movement"},
         "canOffScreenMovement",
         {"heatFrames": 330}
       ],
@@ -675,9 +675,9 @@
     {
       "id": 35,
       "link": [3, 7],
-      "name": "KiHunter Shaft KiHunter Dodge (Bottom)",
+      "name": "KiHunter Dodge (Bottom)",
       "requires": [
-        {"notable": "KiHunter Shaft KiHunter Dodge"},
+        {"notable": "KiHunter Dodge"},
         "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 100}
@@ -687,9 +687,9 @@
     {
       "id": 36,
       "link": [3, 7],
-      "name": "Kihunter Shaft Manipulation from Save Room (Bottom)",
+      "name": "Kihunter Manipulation from Middle Door (Bottom)",
       "requires": [
-        {"notable": "Kihunter Shaft Manipulation from Save Room"},
+        {"notable": "Kihunter Manipulation from Middle Door"},
         "h_canNavigateHeatRooms",
         "canStopOnADime",
         "canCarefulJump",
@@ -1297,9 +1297,9 @@
     {
       "id": 71,
       "link": [7, 5],
-      "name": "KiHunter Shaft KiHunter Dodge (Top)",
+      "name": "KiHunter Dodge (Top)",
       "requires": [
-        {"notable": "KiHunter Shaft KiHunter Dodge"},
+        {"notable": "KiHunter Dodge"},
         "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 710}
@@ -1313,9 +1313,9 @@
     {
       "id": 72,
       "link": [7, 5],
-      "name": "Kihunter Shaft Manipulation from Save Room (Top)",
+      "name": "Kihunter Manipulation from Middle Door (Top)",
       "requires": [
-        {"notable": "Kihunter Shaft Manipulation from Save Room"},
+        {"notable": "Kihunter Manipulation from Middle Door"},
         "h_canNavigateHeatRooms",
         "canStopOnADime",
         "canCarefulJump",
@@ -1340,7 +1340,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "KiHunter Shaft KiHunter Dodge",
+      "name": "KiHunter Dodge",
       "note": [
         "When coming from the Save room door, the first KiHunter can be baited by jumping into the door then walking left.",
         "The second KiHunter can be jumped past by waiting for the right timing, if it is in the way.",
@@ -1350,7 +1350,7 @@
     },
     {
       "id": 2,
-      "name": "Kihunter Shaft Manipulation from Save Room",
+      "name": "Kihunter Manipulation from Middle Door",
       "note": [
         "Manipulate the Three KiHunters to avoid all of them when entering the room from the Save room door.",
         "Stop on a dime on entry for positioning, because it is precise.",
@@ -1362,7 +1362,7 @@
     },
     {
       "id": 3,
-      "name": "Kihunter Shaft Grapple Teleport Semi-Blind Movement",
+      "name": "Grapple Teleport Semi-Blind Movement",
       "note": [
         "The grapple teleport skips past the Kihunters.",
         "With good semi-blind movement, this makes it possible to reach the top with minimal heat damage."

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -371,9 +371,9 @@
     {
       "id": 12,
       "link": [2, 4],
-      "name": "Writg New Route with HiJump, Speed, and PowerBombs",
+      "name": "New Route with HiJump, Speed, and PowerBombs",
       "requires": [
-        {"notable": "Writg New Route with HiJump, Speed, and PowerBombs"},
+        {"notable": "New Route with HiJump, Speed, and PowerBombs"},
         "HiJump",
         "SpeedBooster",
         "canPreciseWalljump",
@@ -423,9 +423,9 @@
     {
       "id": 14,
       "link": [2, 4],
-      "name": "WRITG with PowerBombs and a Jump Assist",
+      "name": "PowerBombs and a Jump Assist",
       "requires": [
-        {"notable": "WRITG with PowerBombs and a Jump Assist"},
+        {"notable": "PowerBombs and a Jump Assist"},
         "canPreciseWalljump",
         "canHitbox",
         "h_canUsePowerBombs",
@@ -453,9 +453,9 @@
     {
       "id": 15,
       "link": [2, 4],
-      "name": "Writg Frozen Pirate Platforms",
+      "name": "Frozen Pirate Platforms",
       "requires": [
-        {"notable": "Writg Frozen Pirate Platforms"},
+        {"notable": "Frozen Pirate Platforms"},
         "canTrickyUseFrozenEnemies",
         "canDodgeWhileShooting",
         "Charge",
@@ -482,9 +482,9 @@
     {
       "id": 16,
       "link": [2, 4],
-      "name": "Writg Low Ice Pirate Freeze",
+      "name": "Low Ice Pirate Freeze",
       "requires": [
-        {"notable": "Writg Low Ice Pirate Freeze"},
+        {"notable": "Low Ice Pirate Freeze"},
         "canTrickyUseFrozenEnemies",
         "Charge",
         "canPreciseWalljump",
@@ -517,9 +517,9 @@
     {
       "id": 17,
       "link": [2, 4],
-      "name": "Writg New Low Ice Pirate Freeze",
+      "name": "New Low Ice Pirate Freeze",
       "requires": [
-        {"notable": "Writg New Low Ice Pirate Freeze"},
+        {"notable": "New Low Ice Pirate Freeze"},
         "canTrickyUseFrozenEnemies",
         "Charge",
         "canPreciseWalljump",
@@ -553,9 +553,9 @@
     {
       "id": 18,
       "link": [2, 4],
-      "name": "Writg Power Bomb Diagonal Bomb Jump",
+      "name": "Power Bomb Diagonal Bomb Jump",
       "requires": [
-        {"notable": "Writg Power Bomb Diagonal Bomb Jump"},
+        {"notable": "Power Bomb Diagonal Bomb Jump"},
         "canFastWalljumpClimb",
         "canWallJumpBombBoost",
         "canDiagonalBombJump",
@@ -584,12 +584,12 @@
     {
       "id": 19,
       "link": [2, 4],
-      "name": "Writg X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        {"notable": "Writg X-Ray Climb"},
+        {"notable": "X-Ray Climb"},
         "canXRayClimb",
         {"enemyDamage": {
           "enemy": "Namihe",
@@ -1459,9 +1459,9 @@
     {
       "id": 62,
       "link": [6, 4],
-      "name": "Writg HiJump and Only Screw",
+      "name": "HiJump and Only Screw",
       "requires": [
-        {"notable": "Writg HiJump and Only Screw"},
+        {"notable": "HiJump and Only Screw"},
         "h_heatProof",
         "HiJump",
         "ScrewAttack",
@@ -1490,7 +1490,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Writg New Route with HiJump, Speed, and PowerBombs",
+      "name": "New Route with HiJump, Speed, and PowerBombs",
       "note": [
         "Jump with some run speed to place the power bomb high enough to break the bomb blocks.",
         "During the explosion, jump through the left wall pirate and precisely walljump to reach the upper area."
@@ -1498,7 +1498,7 @@
     },
     {
       "id": 2,
-      "name": "WRITG with PowerBombs and a Jump Assist",
+      "name": "PowerBombs and a Jump Assist",
       "note": [
         "Avoid the bottom pirates and jump high enough to break the bomb blocks with a power bomb.",
         "During the explosion, climb the right wall passing through any pirates and use a movement item to reach the top."
@@ -1506,14 +1506,14 @@
     },
     {
       "id": 3,
-      "name": "Writg Frozen Pirate Platforms",
+      "name": "Frozen Pirate Platforms",
       "note": [
         "Freeze the pirates to use as platforms to get up through the bomb blocks. Note that the pirates' hitboxes are larger than they seem."
       ]
     },
     {
       "id": 4,
-      "name": "Writg Low Ice Pirate Freeze",
+      "name": "Low Ice Pirate Freeze",
       "note": [
         "Deal an exact amount of damage to a wall pirate to freeze it while breaking the bomb blocks with a power bomb without taking damage.",
         "Quickly move to the right side and walljump up to the right height to power bomb out the bomb blocks, double hitting the top wall pirate.",
@@ -1525,7 +1525,7 @@
     },
     {
       "id": 5,
-      "name": "Writg New Low Ice Pirate Freeze",
+      "name": "New Low Ice Pirate Freeze",
       "note": [
         "Deal an exact amount of damage to a wall pirate to freeze it while breaking the bomb blocks with a power bomb without taking damage.",
         "Wait briefly on the left side of the center platform, then jump and shoot 4 missiles at the top pirate.",
@@ -1537,7 +1537,7 @@
     },
     {
       "id": 6,
-      "name": "Writg Power Bomb Diagonal Bomb Jump",
+      "name": "Power Bomb Diagonal Bomb Jump",
       "note": [
         "Ignore the Yellow Pirates by walljumping up the left side to start a diagonal bomb jump from the wall, including a power bomb to clear the bomb blocks.",
         "Two quick walljumps upon entering the room can position Samus to get the left pirate to jump to the right and jump over the right pirate's lazer attack.",
@@ -1546,7 +1546,7 @@
     },
     {
       "id": 7,
-      "name": "Writg X-Ray Climb",
+      "name": "X-Ray Climb",
       "note": [
         "Climb Writg while avoiding wall pirates and Namihe flames.",
         "Immediately climb above the Namihe flames and wait for the wall pirate to jump across into Samus.",
@@ -1556,7 +1556,7 @@
     },
     {
       "id": 8,
-      "name": "Writg HiJump and Only Screw",
+      "name": "HiJump and Only Screw",
       "note": [
         "Break the bomb blocks in The Worst Room In The Game with extremely precise walljumps.",
         "Either with a fully delayed max height jump from the wall, or with an instant turnaround after jumping from the lower layer of bomb blocks."

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -190,9 +190,9 @@
     {
       "id": 8,
       "link": [1, 4],
-      "name": "Dodge the Three Musketeers Going Down",
+      "name": "Dodge Going Down",
       "requires": [
-        {"notable": "Dodge the Three Musketeers Going Down"},
+        {"notable": "Dodge Going Down"},
         "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 500}
@@ -515,9 +515,9 @@
     {
       "id": 26,
       "link": [4, 1],
-      "name": "Dodge the 3 Musketeers Going Up",
+      "name": "Dodge Going Up",
       "requires": [
-        {"notable": "Dodge the 3 Musketeers Going Up"},
+        {"notable": "Dodge Going Up"},
         "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"or": [
@@ -988,7 +988,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Dodge the Three Musketeers Going Down",
+      "name": "Dodge Going Down",
       "note": [
         "Wait for the top one to pass by.",
         "Jump down when the lower two are by the left wall and jump over them when they swoop."
@@ -996,7 +996,7 @@
     },
     {
       "id": 2,
-      "name": "Dodge the 3 Musketeers Going Up",
+      "name": "Dodge Going Up",
       "note": [
         "Read the movements of the Kihunters and jump over or roll under them as appropriate.",
         "Changing platforms is the hardest part: ",

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -1029,9 +1029,9 @@
     {
       "id": 54,
       "link": [5, 7],
-      "name": "Wasteland Statue Clip Damage Boost (HiJump)",
+      "name": "Statue Clip Damage Boost (HiJump)",
       "requires": [
-        {"notable": "Wasteland Statue Clip Damage Boost"},
+        {"notable": "Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
         "h_canUsePowerBombs",
         "HiJump",
@@ -1058,9 +1058,9 @@
     {
       "id": 55,
       "link": [5, 7],
-      "name": "Wasteland HiJumpless Statue Clip Damage Boost",
+      "name": "HiJumpless Statue Clip Damage Boost",
       "requires": [
-        {"notable": "Wasteland HiJumpless Statue Clip Damage Boost"},
+        {"notable": "HiJumpless Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
         "h_canUsePowerBombs",
         "canTrickyJump",
@@ -1088,9 +1088,9 @@
     {
       "id": 56,
       "link": [5, 8],
-      "name": "Wasteland Statue Clip Damage Boost (HiJump, SpeedBall)",
+      "name": "Statue Clip Damage Boost (HiJump, SpeedBall)",
       "requires": [
-        {"notable": "Wasteland Statue Clip Damage Boost"},
+        {"notable": "Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
         "h_canUsePowerBombs",
         "HiJump",
@@ -1125,9 +1125,9 @@
     {
       "id": 57,
       "link": [5, 8],
-      "name": "Wasteland HiJumpless Statue Clip Damage Boost (SpeedBall)",
+      "name": "HiJumpless Statue Clip Damage Boost (SpeedBall)",
       "requires": [
-        {"notable": "Wasteland HiJumpless Statue Clip Damage Boost"},
+        {"notable": "HiJumpless Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
         "h_canUsePowerBombs",
         "canPartialFloorClip",
@@ -1407,9 +1407,9 @@
     {
       "id": 76,
       "link": [7, 4],
-      "name": "Wasteland Avoid Dessgeegas by Rolling",
+      "name": "Avoid Dessgeegas by Rolling",
       "requires": [
-        {"notable": "Wasteland Avoid Dessgeegas by Rolling"},
+        {"notable": "Avoid Dessgeegas by Rolling"},
         "Morph",
         "canCameraManip",
         {"heatFrames": 210}
@@ -1766,7 +1766,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Wasteland Statue Clip Damage Boost",
+      "name": "Statue Clip Damage Boost",
       "note": [
         "Break the Power Bomb statue leaving 1 row of blocks.",
         "Partially clip between the Power Bomb blocks and the solid tiles beneath.",
@@ -1777,7 +1777,7 @@
     },
     {
       "id": 2,
-      "name": "Wasteland HiJumpless Statue Clip Damage Boost",
+      "name": "HiJumpless Statue Clip Damage Boost",
       "note": [
         "Break the Power Bomb statue leaving 1 row of blocks.",
         "Partially clip between the Power Bomb blocks and the solid tiles beneath.",
@@ -1789,7 +1789,7 @@
     },
     {
       "id": 3,
-      "name": "Wasteland Avoid Dessgeegas by Rolling",
+      "name": "Avoid Dessgeegas by Rolling",
       "note": [
         "Roll under the Dessgeegas until all three move off camera and stop chasing Samus.",
         "Roll directly from the Morph tunnel, past the first Dessgeega.",

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -210,9 +210,9 @@
     {
       "id": 3,
       "link": [1, 3],
-      "name": "GT Crumble Jump to Left Item",
+      "name": "Crumble Jump to Left Item",
       "requires": [
-        {"notable": "Golden Torizo Crumble Jump"},
+        {"notable": "Crumble Jump"},
         "h_canNavigateHeatRooms",
         "canCrumbleJump",
         {"heatFrames": 80}
@@ -222,9 +222,9 @@
     {
       "id": 4,
       "link": [1, 3],
-      "name": "GT Bomb Boost to Left Item",
+      "name": "Bomb Boost to Left Item",
       "requires": [
-        {"notable": "Golden Torizo Horizontal Bomb Jump"},
+        {"notable": "Horizontal Bomb Jump"},
         "h_canNavigateHeatRooms",
         "canBombHorizontally",
         {"heatFrames": 160}
@@ -486,9 +486,9 @@
     {
       "id": 21,
       "link": [3, 1],
-      "name": "GT Crumble Jump from Left Item",
+      "name": "Crumble Jump from Left Item",
       "requires": [
-        {"notable": "Golden Torizo Crumble Jump"},
+        {"notable": "Crumble Jump"},
         "h_canNavigateHeatRooms",
         "canCrumbleJump",
         {"heatFrames": 100}
@@ -498,9 +498,9 @@
     {
       "id": 22,
       "link": [3, 1],
-      "name": "GT Bomb Boost from Left Item",
+      "name": "Bomb Boost from Left Item",
       "requires": [
-        {"notable": "Golden Torizo Horizontal Bomb Jump"},
+        {"notable": "Horizontal Bomb Jump"},
         "h_canNavigateHeatRooms",
         "canBombHorizontally",
         {"heatFrames": 190}
@@ -649,9 +649,9 @@
     {
       "id": 35,
       "link": [5, 4],
-      "name": "GT Supers Walljump Into Double Shinespark",
+      "name": "Right Item Walljump Into Double Shinespark",
       "requires": [
-        {"notable": "Golden Torizo Supers Double Shinespark"},
+        {"notable": "Right Item Double Shinespark"},
         "h_canNavigateHeatRooms",
         "f_DefeatedGoldenTorizo",
         "canShinechargeMovementComplex",
@@ -673,9 +673,9 @@
     {
       "id": 36,
       "link": [5, 4],
-      "name": "GT Supers Double Shinespark With HiJump",
+      "name": "Right Item Double Shinespark With HiJump",
       "requires": [
-        {"notable": "Golden Torizo Supers Double Shinespark"},
+        {"notable": "Right Item Double Shinespark"},
         "h_canNavigateHeatRooms",
         "f_DefeatedGoldenTorizo",
         "canShinechargeMovementComplex",
@@ -742,7 +742,7 @@
       "link": [5, 5],
       "name": "Safe Spot Heatproof Supers",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_heatProof",
         "Super"
       ],
@@ -755,7 +755,7 @@
       "link": [5, 5],
       "name": "Safe Spot Heatproof Charge",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_heatProof",
         "Charge",
         "canBeVeryPatient"
@@ -768,7 +768,7 @@
       "link": [5, 5],
       "name": "Safe Spot Supers",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         {"heatFrames": 1200},
         {"ammo": {"type": "Super", "count": 30}}
@@ -790,7 +790,7 @@
       "link": [5, 5],
       "name": "Safe Spot Supers (Farming)",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         "canTrickyJump",
         {"ammo": {"type": "Super", "count": 15}},
@@ -823,7 +823,7 @@
       "link": [5, 5],
       "name": "Safe Spot Supers (Farming, Few Supers)",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         "canTrickyJump",
         "canBePatient",
@@ -855,9 +855,9 @@
     {
       "id": 51,
       "link": [5, 5],
-      "name": "Golden Torizo Crystal Flash",
+      "name": "Crystal Flash During Fight",
       "requires": [
-        {"notable": "Golden Torizo Crystal Flash"},
+        {"notable": "Crystal Flash During Fight"},
         "h_canNavigateHeatRooms",
         {"or": [
           {"ammo": {"type": "Super", "count": 30}},
@@ -888,7 +888,7 @@
       "link": [5, 5],
       "name": "Safe Spot Full Combo",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         "Charge",
         "Ice",
@@ -904,7 +904,7 @@
       "link": [5, 5],
       "name": "Safe Spot Almost Full Combo",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         "Charge",
         "Wave",
@@ -919,7 +919,7 @@
       "link": [5, 5],
       "name": "Safe Spot Charge Plasma",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         "Charge",
         "Plasma",
@@ -933,7 +933,7 @@
       "link": [5, 5],
       "name": "Safe Spot Full Spazer",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         "Charge",
         "Ice",
@@ -949,7 +949,7 @@
       "link": [5, 5],
       "name": "Safe Spot Two Beam Charge",
       "requires": [
-        {"notable": "Golden Torizo Safe Spot"},
+        {"notable": "Safe Spot Kill"},
         "h_canNavigateHeatRooms",
         "Charge",
         {"heatFrames": 6500},
@@ -1008,9 +1008,9 @@
     {
       "id": 58,
       "link": [5, 5],
-      "name": "Golden Torizo Missiles Only",
+      "name": "Missiles Only Kill",
       "requires": [
-        {"notable": "Golden Torizo Missiles Only"},
+        {"notable": "Missiles Only Kill"},
         "h_heatProof",
         "Morph",
         {"resourceCapacity": [{"type": "Missile", "count": 15}]},
@@ -1278,7 +1278,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Golden Torizo Supers Double Shinespark",
+      "name": "Right Item Double Shinespark",
       "note": [
         "One vertical spark is needed to open up the breakable blocks on the right ceiling.",
         "Then, a second horizontal spark is performed where those blocks were cleared to reveal the item."
@@ -1286,7 +1286,7 @@
     },
     {
       "id": 2,
-      "name": "Golden Torizo Safe Spot",
+      "name": "Safe Spot Kill",
       "note": [
         "The ability to get into the safe spot in the Golden Torizo fight, where Samus can attack while being safe from GT's standard attacks.",
         "To get into the safe spot near the door: Stand on the left side of the floor pillar for GT to jump back. Then stand to the right of the nearby background pillar.",
@@ -1295,18 +1295,18 @@
     },
     {
       "id": 3,
-      "name": "Golden Torizo Crumble Jump",
+      "name": "Crumble Jump",
       "note": "Jump on the crumble blocks to reach the Missile item location at the risk of falling through.",
       "devNote": "It is possible to directly jump over the crumble blocks but the input timings and strat expectations resemble a crumble jump while just being harder."
     },
     {
       "id": 4,
-      "name": "Golden Torizo Horizontal Bomb Jump",
+      "name": "Horizontal Bomb Jump",
       "note": "Use a bomb explosion to jump horizontally over the GT crumble blocks."
     },
     {
       "id": 5,
-      "name": "Golden Torizo Crystal Flash",
+      "name": "Crystal Flash During Fight",
       "note": [
         "Midway through the fight, use a Crystal Flash to refill Samus' energy.",
         "Crystal Flashing while standing in the safe spot at GT's feet is safe."
@@ -1314,7 +1314,7 @@
     },
     {
       "id": 6,
-      "name": "Golden Torizo Missiles Only",
+      "name": "Missiles Only Kill",
       "note": [
         "Killing Golden Torizo only with missiles using enemy state manipulation to get missiles to connect.",
         "This can be done by rolling under GT, triggering the sit attack, and then shooting missiles during the stand up animation.",

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -567,9 +567,9 @@
     {
       "id": 20,
       "link": [2, 3],
-      "name": "Screw Attack Room Doorway CWJ",
+      "name": "Doorway CWJ",
       "requires": [
-        {"notable": "Screw Attack Room Doorway CWJ"},
+        {"notable": "Doorway CWJ"},
         {"obstaclesCleared": ["A"]},
         "h_heatProof",
         "HiJump",
@@ -605,7 +605,7 @@
     {
       "id": 21,
       "link": [2, 3],
-      "name": "Screw Attack Room Transition Screwjump",
+      "name": "Transition Screwjump",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 6,
@@ -613,7 +613,7 @@
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Transition Screwjump"},
+        {"notable": "Transition Screwjump"},
         "h_canNavigateHeatRooms",
         "ScrewAttack",
         "HiJump",
@@ -625,7 +625,7 @@
     {
       "id": 22,
       "link": [2, 3],
-      "name": "Screw Attack Room Transition Screwjump (Tricky Dash Jump)",
+      "name": "Transition Screwjump (Tricky Dash Jump)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 2,
@@ -633,7 +633,7 @@
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Transition Screwjump"},
+        {"notable": "Transition Screwjump"},
         "h_canNavigateHeatRooms",
         "ScrewAttack",
         "HiJump",
@@ -747,14 +747,14 @@
     {
       "id": 28,
       "link": [2, 3],
-      "name": "Screw Attack Room Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12]]
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Grapple Teleport Inside Wall"},
+        {"notable": "Grapple Teleport Inside Wall"},
         "canOffScreenMovement",
         "Morph",
         {"heatFrames": 200}
@@ -798,7 +798,7 @@
     {
       "id": 31,
       "link": [2, 4],
-      "name": "Screw Attack Room Temporary Blue Descent and Shinespark Escape Middle Door Part 1",
+      "name": "Temporary Blue Descent and Shinespark Escape Middle Door Part 1",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 0,
@@ -806,7 +806,7 @@
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Descent and Shinespark Escape"},
+        {"notable": "Descent and Shinespark Escape"},
         "canTemporaryBlue",
         "canPrepareForNextRoom",
         {"heatFrames": 75}
@@ -818,14 +818,14 @@
     {
       "id": 32,
       "link": [2, 4],
-      "name": "Screw Attack Room Screw Descent and Shinespark Escape Middle Door Part 1",
+      "name": "Screw Descent and Shinespark Escape Middle Door Part 1",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 125
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Descent and Shinespark Escape"},
+        {"notable": "Descent and Shinespark Escape"},
         "ScrewAttack",
         "canShinechargeMovement",
         {"heatFrames": 120}
@@ -845,7 +845,7 @@
     {
       "id": 34,
       "link": [2, 5],
-      "name": "Screw Attack Room Transition Speedjump with Bombs",
+      "name": "Transition Speedjump with Bombs",
       "entranceCondition": {
         "comeInJumping": {
           "minTiles": 6,
@@ -853,7 +853,7 @@
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Transition Speedjump with Bombs"},
+        {"notable": "Transition Speedjump with Bombs"},
         "HiJump",
         "canMidAirMorph",
         "h_canUseMorphBombs",
@@ -865,7 +865,7 @@
     {
       "id": 35,
       "link": [2, 5],
-      "name": "Screw Attack Room Transition Speedjump with Bombs (Tricky Dash Jump)",
+      "name": "Transition Speedjump with Bombs (Tricky Dash Jump)",
       "entranceCondition": {
         "comeInJumping": {
           "minTiles": 2,
@@ -873,7 +873,7 @@
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Transition Speedjump with Bombs"},
+        {"notable": "Transition Speedjump with Bombs"},
         "HiJump",
         "canTrickyDashJump",
         "canMidAirMorph",
@@ -1036,7 +1036,7 @@
     {
       "id": 45,
       "link": [3, 4],
-      "name": "Screw Attack Room Temporary Blue Descent and Shinespark Escape Top Door Part 1",
+      "name": "Temporary Blue Descent and Shinespark Escape Top Door Part 1",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -1044,7 +1044,7 @@
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Descent and Shinespark Escape"},
+        {"notable": "Descent and Shinespark Escape"},
         "canTemporaryBlue",
         "canShinechargeMovementTricky",
         {"heatFrames": 130}
@@ -1057,7 +1057,7 @@
     {
       "id": 46,
       "link": [3, 4],
-      "name": "Screw Attack Room Screw Descent and Shinespark Escape Top Door Part 1",
+      "name": "Screw Descent and Shinespark Escape Top Door Part 1",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -1065,7 +1065,7 @@
         }
       },
       "requires": [
-        {"notable": "Screw Attack Room Descent and Shinespark Escape"},
+        {"notable": "Descent and Shinespark Escape"},
         "ScrewAttack",
         "canShinechargeMovement",
         {"heatFrames": 170}
@@ -1191,9 +1191,9 @@
     {
       "id": 55,
       "link": [4, 2],
-      "name": "Screw Attack Room Shinespark Escape Mid Door Part 2",
+      "name": "Shinespark Escape Mid Door Part 2",
       "requires": [
-        {"notable": "Screw Attack Room Descent and Shinespark Escape"},
+        {"notable": "Descent and Shinespark Escape"},
         "canShinechargeMovement",
         {"obstaclesCleared": ["C"]},
         {"heatFrames": 240},
@@ -1221,9 +1221,9 @@
     {
       "id": 56,
       "link": [4, 3],
-      "name": "Screw Attack Room Shinespark Escape Top Door Part 2",
+      "name": "Shinespark Escape Top Door Part 2",
       "requires": [
-        {"notable": "Screw Attack Room Descent and Shinespark Escape"},
+        {"notable": "Descent and Shinespark Escape"},
         "canShinechargeMovement",
         {"obstaclesCleared": ["C"]},
         {"heatFrames": 270},
@@ -1313,7 +1313,7 @@
     {
       "id": 63,
       "link": [5, 3],
-      "name": "Screw Attack Room IBJ",
+      "name": "IBJ",
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canIBJ",
@@ -1327,7 +1327,7 @@
     {
       "id": 64,
       "link": [5, 3],
-      "name": "Screw Attack Room IBJ to Break the Top Blocks",
+      "name": "IBJ to Break the Top Blocks",
       "requires": [
         "h_canNavigateHeatRooms",
         "canPowerBombMidIBJ",
@@ -1470,7 +1470,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Screw Attack Room Descent and Shinespark Escape",
+      "name": "Descent and Shinespark Escape",
       "note": [
         "Store a shinespark and break the Screw Attack Room bomb blocks from above in order to collect the item and shinespark out.",
         "Screw Attack is easier to excute but has fewer shinespark frames to work with.",
@@ -1479,22 +1479,22 @@
     },
     {
       "id": 2,
-      "name": "Screw Attack Room Transition Screwjump",
+      "name": "Transition Screwjump",
       "note": "Run through the doorway with enough momentum to break the bomb blocks with Screw."
     },
     {
       "id": 3,
-      "name": "Screw Attack Room Transition Speedjump with Bombs",
+      "name": "Transition Speedjump with Bombs",
       "note": "Run in the adjacent room and jump through the door, to place a Bomb to break the obstacle."
     },
     {
       "id": 4,
-      "name": "Screw Attack Room Doorway CWJ",
+      "name": "Doorway CWJ",
       "note": "Position Samus in the doorway a few pixels from the edge. Dashing stationary spinjump into a delayed CWJ and hopefully catch the upper ledge with a walljump."
     },
     {
       "id": 5,
-      "name": "Screw Attack Room Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "note": [
         "After teleporting, Samus should be standing inside the wall.",
         "Retract Grapple by pressing up, which will pull Samus down and right.",

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -383,9 +383,9 @@
     {
       "id": 21,
       "link": [3, 2],
-      "name": "East Pants Room Puyo Clip with Morph and X-Ray",
+      "name": "Puyo Clip with Morph and X-Ray",
       "requires": [
-        {"notable": "East Pants Room Puyo Clip"},
+        {"notable": "Puyo Clip"},
         "Gravity",
         "h_canXRayMorphIceClip",
         {"or": [
@@ -406,9 +406,9 @@
     {
       "id": 22,
       "link": [3, 2],
-      "name": "East Pants Room Puyo Clip Precise Freeze",
+      "name": "Puyo Clip Precise Freeze",
       "requires": [
-        {"notable": "East Pants Room Puyo Clip Precise Freeze"},
+        {"notable": "Puyo Clip Precise Freeze"},
         "Gravity",
         "h_canPreciseIceClip",
         {"or": [
@@ -426,9 +426,9 @@
     {
       "id": 23,
       "link": [3, 2],
-      "name": "East Pants Room Suitless Puyo Clip",
+      "name": "Suitless Puyo Clip",
       "requires": [
-        {"notable": "East Pants Room Suitless Puyo Clip"},
+        {"notable": "Suitless Puyo Clip"},
         "canSuitlessMaridia",
         "h_canHighPixelIceClip",
         {"enemyDamage": {
@@ -491,7 +491,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "East Pants Room Puyo Clip",
+      "name": "Puyo Clip",
       "note": [
         "Freeze a Puyo at the correct height for clipping through the tile high ceiling, with Gravity Suit equipped.",
         "With Morph and X-Ray, freeze the Puyo at standing-shot height and then jump on top of it with a spinjump before morphing, unmorphing, and using X-Ray to standup and clip.",
@@ -500,12 +500,12 @@
     },
     {
       "id": 2,
-      "name": "East Pants Room Puyo Clip Precise Freeze",
+      "name": "Puyo Clip Precise Freeze",
       "note": "Freeze the Puyo at the start of its jump animation, on the right frame."
     },
     {
       "id": 3,
-      "name": "East Pants Room Suitless Puyo Clip",
+      "name": "Suitless Puyo Clip",
       "note": [
         "Positioning the Puyo requires it to perform a big jump then start falling with a frame perfect freeze.",
         "One possible setup stands on the left tile of the right side and lets the puyo jump up taking a contact hit.",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -208,7 +208,7 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "East Sand Hall Cross-Room Speed Jump (Left to Right)",
+      "name": "Cross-Room Speed Jump (Left to Right)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 19.3625,
@@ -217,7 +217,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Speed Jump"},
+        {"notable": "Cross-Room Speed Jump"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canTrickyDashJump"
@@ -231,7 +231,7 @@
     {
       "id": 9,
       "link": [1, 2],
-      "name": "East Sand Hall Cross-Room SpringBall Jump (Left to Right)",
+      "name": "Cross-Room SpringBall Jump (Left to Right)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 10,
@@ -239,7 +239,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room SpringBall Jump"},
+        {"notable": "Cross-Room SpringBall Jump"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canLateralMidAirMorph",
@@ -254,7 +254,7 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "East Sand Hall Cross-Room Spring Ball Bounce (Left to Right)",
+      "name": "Cross-Room Spring Ball Bounce (Left to Right)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
           "speedBooster": true,
@@ -263,7 +263,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Spring Ball Bounce (Left to Right)"},
+        {"notable": "Cross-Room Spring Ball Bounce (Left to Right)"},
         "canTrickyJump"
       ],
       "note": [
@@ -275,7 +275,7 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)",
+      "name": "Cross-Room Blue Spring Ball Bounce (Left to Right)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.1",
@@ -284,7 +284,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)"},
+        {"notable": "Cross-Room Blue Spring Ball Bounce (Left to Right)"},
         "canTrickyDashJump",
         "canTrickySpringBallBounce",
         "canInsaneJump"
@@ -335,7 +335,7 @@
     {
       "id": 13,
       "link": [1, 2],
-      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
+      "name": "Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.1",
@@ -344,7 +344,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)"},
+        {"notable": "Cross-Room Blue Spring Ball Bounce (Left to Right)"},
         "canTrickyDashJump",
         "canTrickySpringBallBounce",
         "canInsaneJump",
@@ -555,7 +555,7 @@
     {
       "id": 23,
       "link": [1, 4],
-      "name": "East Sand Hall Cross Room Jump with Ice or Damage Boost",
+      "name": "Cross Room Jump with Ice or Damage Boost",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": false,
@@ -563,7 +563,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross Room Jump with Ice or Damage Boost"},
+        {"notable": "Cross Room Jump with Ice or Damage Boost"},
         "canCrossRoomJumpIntoWater",
         "canPlayInSand",
         "canInsaneJump",
@@ -652,7 +652,7 @@
     {
       "id": 26,
       "link": [2, 1],
-      "name": "East Sand Hall Cross-Room Speed Jump (Right to Left)",
+      "name": "Cross-Room Speed Jump (Right to Left)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 19.3625,
@@ -661,7 +661,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Speed Jump"},
+        {"notable": "Cross-Room Speed Jump"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canTrickyDashJump"
@@ -720,7 +720,7 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
+      "name": "Cross-Room Blue Spring Ball Bounce (Right to Left)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.0",
@@ -728,7 +728,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)"},
+        {"notable": "Cross-Room Blue Spring Ball Bounce (Right to Left)"},
         {"or": [
           "canTrickyJump",
           "canSlowShortCharge"
@@ -743,7 +743,7 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
+      "name": "Cross-Room Blue Spring Ball Bounce, Leave With Temporary Blue",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "minExtraRunSpeed": "$2.1",
@@ -752,7 +752,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)"},
+        {"notable": "Cross-Room Blue Spring Ball Bounce (Right to Left)"},
         "canTrickyDashJump",
         "canTrickySpringBallBounce",
         "canPauseRemorphTemporaryBlue",
@@ -780,7 +780,7 @@
     {
       "id": 30,
       "link": [2, 1],
-      "name": "East Sand Hall Cross-Room Spring Ball Bounce (Right to Left)",
+      "name": "Cross-Room Spring Ball Bounce (Right to Left)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
           "speedBooster": true,
@@ -789,7 +789,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room Spring Ball Bounce (Right to Left)"},
+        {"notable": "Cross-Room Spring Ball Bounce (Right to Left)"},
         "canTrickyJump"
       ],
       "note": [
@@ -805,7 +805,7 @@
     {
       "id": 31,
       "link": [2, 1],
-      "name": "East Sand Hall Cross-Room SpringBall Jump (Right to Left)",
+      "name": "Cross-Room SpringBall Jump (Right to Left)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 10,
@@ -813,7 +813,7 @@
         }
       },
       "requires": [
-        {"notable": "East Sand Hall Cross-Room SpringBall Jump"},
+        {"notable": "Cross-Room SpringBall Jump"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canLateralMidAirMorph",
@@ -977,9 +977,9 @@
     {
       "id": 40,
       "link": [2, 2],
-      "name": "East Sand Hall Right Door G-Mode Setup Suitless HiJump",
+      "name": "Right Door G-Mode Setup Suitless HiJump",
       "requires": [
-        {"notable": "East Sand Hall Right Door G-Mode Setup Suitless HiJump"},
+        {"notable": "Right Door G-Mode Setup Suitless HiJump"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "canMidairWiggle",
@@ -1275,9 +1275,9 @@
     {
       "id": 54,
       "link": [4, 1],
-      "name": "East Sand Hall Suitless Bootless Evir Freeze (Center to Left)",
+      "name": "Suitless Bootless Evir Freeze (Center to Left)",
       "requires": [
-        {"notable": "East Sand Hall Suitless Bootless Evir Freeze (Center to Left)"},
+        {"notable": "Suitless Bootless Evir Freeze (Center to Left)"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canTrickyUseFrozenEnemies",
@@ -1409,9 +1409,9 @@
     {
       "id": 59,
       "link": [4, 2],
-      "name": "East Sand Hall Spring Ball HiJump",
+      "name": "Spring Ball HiJump",
       "requires": [
-        {"notable": "East Sand Hall Spring Ball HiJump"},
+        {"notable": "Spring Ball HiJump"},
         "canSuitlessMaridia",
         "HiJump",
         "canTrickySpringBallJump",
@@ -1439,9 +1439,9 @@
     {
       "id": 60,
       "link": [4, 2],
-      "name": "East Sand Hall Suitless Bootless Evir Freeze (Center to Right)",
+      "name": "Suitless Bootless Evir Freeze (Center to Right)",
       "requires": [
-        {"notable": "East Sand Hall Suitless Bootless Evir Freeze (Center to Right)"},
+        {"notable": "Suitless Bootless Evir Freeze (Center to Right)"},
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
@@ -1477,7 +1477,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "East Sand Hall Cross-Room Speed Jump",
+      "name": "Cross-Room Speed Jump",
       "note": [
         "Stand at an effective distance of approximately 20 tiles from the door.",
         "Run through the door, and jump any time after the transition, holding jump through the entire room to make it to the other side.",
@@ -1486,7 +1486,7 @@
     },
     {
       "id": 2,
-      "name": "East Sand Hall Cross-Room SpringBall Jump",
+      "name": "Cross-Room SpringBall Jump",
       "note": [
         "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
         "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
@@ -1494,7 +1494,7 @@
     },
     {
       "id": 3,
-      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Left to Right)",
+      "name": "Cross-Room Blue Spring Ball Bounce (Left to Right)",
       "note": [
         "Use a 3-tap or 4-tap to gain a speedball with a specific amount of speed in the other room (between $2.1 and $2.3 extra run speed), and either roll in or do a controlled bounce to enter while descending close to the ground.",
         "Bounce on the platform in front of the door, then bounce on the second-to-last pillar."
@@ -1502,7 +1502,7 @@
     },
     {
       "id": 4,
-      "name": "East Sand Hall Cross-Room Blue Spring Ball Bounce (Right to Left)",
+      "name": "Cross-Room Blue Spring Ball Bounce (Right to Left)",
       "note": [
         "Gain a speedball in the other room, and either roll in or do a controlled bounce to enter while descending close to the ground.",
         "Bounce anywhere on the platform in front of the door, clearing the whole room at once.",
@@ -1511,7 +1511,7 @@
     },
     {
       "id": 5,
-      "name": "East Sand Hall Cross-Room Spring Ball Bounce (Left to Right)",
+      "name": "Cross-Room Spring Ball Bounce (Left to Right)",
       "note": [
         "Gain run speed using between 19 and 33 tiles in the other room, and either roll in or do a controlled bounce to enter while descending close to the ground.",
         "Bounce near the end of the platform in front of the door, clearing the whole room at once.",
@@ -1520,7 +1520,7 @@
     },
     {
       "id": 6,
-      "name": "East Sand Hall Cross Room Jump with Ice or Damage Boost",
+      "name": "Cross Room Jump with Ice or Damage Boost",
       "note": [
         "Requires a runway of 7 tiles (with no open end) in the adjacent room. Requires two precise inputs of jumping through the doorway and aiming down before hitting the ceiling.",
         "Damage boost off of the right Evir in order to land on the first pillar. With Ice, instead freeze the Evir to land on it and avoid the damage.",
@@ -1529,7 +1529,7 @@
     },
     {
       "id": 7,
-      "name": "East Sand Hall Cross-Room Spring Ball Bounce (Right to Left)",
+      "name": "Cross-Room Spring Ball Bounce (Right to Left)",
       "note": [
         "Gain run speed using between 19 and 33 tiles in the other room, and either roll in or do a controlled bounce to enter while descending close to the ground.",
         "Bounce near the end of the platform in front of the door, clearing the whole room at once.",
@@ -1538,7 +1538,7 @@
     },
     {
       "id": 8,
-      "name": "East Sand Hall Right Door G-Mode Setup Suitless HiJump",
+      "name": "Right Door G-Mode Setup Suitless HiJump",
       "note": [
         "The Evir won't shoot unless Samus enters the sand falls. Getting to the transition tiles while standing before the projectile while suitless is very precise.",
         "From the sand, turnaround spinjump towards the right. Turn towards the sandfall about when you're level with the platform. Turn right and shoot as soon as you enter the sandfall. And try to land right next to the transition."
@@ -1546,7 +1546,7 @@
     },
     {
       "id": 9,
-      "name": "East Sand Hall Suitless Bootless Evir Freeze (Center to Left)",
+      "name": "Suitless Bootless Evir Freeze (Center to Left)",
       "note": [
         "If entering from the sandfall above, come in at the far left of the transition, with either a spin-jump or i-frames, to avoid the Evir shot;",
         "land on the right side of the pillar to the left, being careful to not bring left Evir on camera.",
@@ -1561,7 +1561,7 @@
     },
     {
       "id": 10,
-      "name": "East Sand Hall Spring Ball HiJump",
+      "name": "Spring Ball HiJump",
       "note": [
         "On the left side of the raised platform, jump for max height.",
         "Lateral Midair Morph for horizontal momentum, and perform the springball jump the moment before touching the sandfall.",
@@ -1570,7 +1570,7 @@
     },
     {
       "id": 11,
-      "name": "East Sand Hall Suitless Bootless Evir Freeze (Center to Right)",
+      "name": "Suitless Bootless Evir Freeze (Center to Right)",
       "note": [
         "From the sand fall, quickly get onto the left platform to prevent the right side Evir from lowering too far.",
         "Jump on the sand to the right while freezing the Evir as high as possible. Refreeze the Evir so it is a slightly higher platform than the right pillar.",

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -200,7 +200,7 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "Oasis Cross Room Jump with Screw Attack (From the Left)",
+      "name": "Cross Room Jump with Screw Attack (From the Left)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -208,7 +208,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack"},
+        {"notable": "Cross Room Jump with Screw Attack"},
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack"
@@ -223,7 +223,7 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "Oasis Cross Room Jump with Screw Attack and Speed (From the Left)",
+      "name": "Cross Room Jump with Screw Attack and Speed (From the Left)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -231,7 +231,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack"},
+        {"notable": "Cross Room Jump with Screw Attack"},
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack"
@@ -488,7 +488,7 @@
     {
       "id": 16,
       "link": [1, 3],
-      "name": "Oasis Cross Room Jump with Screw Attack and Speed through the Top Door (From the Left)",
+      "name": "Cross Room Jump with Screw Attack and Speed through the Top Door (From the Left)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -496,7 +496,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack and Speed through the Top Door"},
+        {"notable": "Cross Room Jump with Screw Attack and Speed through the Top Door"},
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack",
@@ -566,7 +566,7 @@
     {
       "id": 19,
       "link": [1, 4],
-      "name": "Oasis Cross Room Jump with Screw Attack and Speed to the Top (From the Left)",
+      "name": "Cross Room Jump with Screw Attack and Speed to the Top (From the Left)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -574,7 +574,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack"},
+        {"notable": "Cross Room Jump with Screw Attack"},
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack",
@@ -920,7 +920,7 @@
     {
       "id": 33,
       "link": [2, 2],
-      "name": "Oasis Cross Room Jump with Screw Attack (From the Right)",
+      "name": "Cross Room Jump with Screw Attack (From the Right)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -928,7 +928,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack"},
+        {"notable": "Cross Room Jump with Screw Attack"},
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack"
@@ -943,7 +943,7 @@
     {
       "id": 34,
       "link": [2, 2],
-      "name": "Oasis Cross Room Jump with Screw Attack and Speed (From the Right)",
+      "name": "Cross Room Jump with Screw Attack and Speed (From the Right)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -951,7 +951,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack"},
+        {"notable": "Cross Room Jump with Screw Attack"},
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack"
@@ -1029,7 +1029,7 @@
     {
       "id": 39,
       "link": [2, 3],
-      "name": "Oasis Cross Room Jump with Screw Attack and Speed through the Top Door (From the Right)",
+      "name": "Cross Room Jump with Screw Attack and Speed through the Top Door (From the Right)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -1037,7 +1037,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack and Speed through the Top Door"},
+        {"notable": "Cross Room Jump with Screw Attack and Speed through the Top Door"},
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack",
@@ -1107,7 +1107,7 @@
     {
       "id": 42,
       "link": [2, 4],
-      "name": "Oasis Cross Room Jump with Screw Attack and Speed to the Top (From the Right)",
+      "name": "Cross Room Jump with Screw Attack and Speed to the Top (From the Right)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -1115,7 +1115,7 @@
         }
       },
       "requires": [
-        {"notable": "Oasis Cross Room Jump with Screw Attack"},
+        {"notable": "Cross Room Jump with Screw Attack"},
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack",
@@ -1488,7 +1488,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Oasis Cross Room Jump with Screw Attack",
+      "name": "Cross Room Jump with Screw Attack",
       "note": [
         "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump.",
         "It helps to enter as low as possible and with as much horizontal speed as possible and with HiJump turned off.",
@@ -1497,7 +1497,7 @@
     },
     {
       "id": 2,
-      "name": "Oasis Cross Room Jump with Screw Attack and Speed through the Top Door",
+      "name": "Cross Room Jump with Screw Attack and Speed through the Top Door",
       "note": [
         "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump, and make it all the way through the top door.",
         "This uses exactly 14 tiles (with no open end) - more rises too fast to do the trick, less does not have the height needed to reach the door.",

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -189,14 +189,14 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "Pants Room Shinespark (From the Left)",
+      "name": "Shinespark (From the Left)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 150
         }
       },
       "requires": [
-        {"notable": "Pants Room Shinespark"},
+        {"notable": "Shinespark"},
         "h_canNavigateUnderwater",
         "canShinechargeMovementComplex",
         "Grapple",
@@ -216,14 +216,14 @@
     {
       "id": 5,
       "link": [1, 2],
-      "name": "Pants Room Diagonal Shinespark (From the Left)",
+      "name": "Diagonal Shinespark (From the Left)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 110
         }
       },
       "requires": [
-        {"notable": "Pants Room Shinespark"},
+        {"notable": "Shinespark"},
         "h_canNavigateUnderwater",
         "canShinechargeMovementTricky",
         "canPlayInSand",
@@ -349,14 +349,14 @@
     {
       "id": 15,
       "link": [3, 2],
-      "name": "Pants Room Shinespark (From the Right)",
+      "name": "Shinespark (From the Right)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 150
         }
       },
       "requires": [
-        {"notable": "Pants Room Shinespark"},
+        {"notable": "Shinespark"},
         "h_canNavigateUnderwater",
         "canShinechargeMovementComplex",
         "Grapple",
@@ -418,9 +418,9 @@
     {
       "id": 19,
       "link": [4, 2],
-      "name": "Pants Room Grapple Jump (To The Top)",
+      "name": "Grapple Jump (To The Top)",
       "requires": [
-        {"notable": "Pants Room Grapple Jump"},
+        {"notable": "Grapple Jump"},
         "canSuitlessMaridia",
         "canTrickyGrappleJump",
         "canMidairWiggle",
@@ -557,9 +557,9 @@
     {
       "id": 26,
       "link": [4, 5],
-      "name": "Pants Room Gravity Jump",
+      "name": "Gravity Jump",
       "requires": [
-        {"notable": "Pants Room Gravity Jump"},
+        {"notable": "Gravity Jump"},
         "Grapple",
         "canGravityJump",
         "canPlayInSand",
@@ -597,9 +597,9 @@
     {
       "id": 28,
       "link": [4, 5],
-      "name": "Pants Room Suitless Flatley Turnaround Climb",
+      "name": "Suitless Flatley Turnaround Climb",
       "requires": [
-        {"notable": "Pants Room Suitless Flatley Turnaround Climb"},
+        {"notable": "Suitless Flatley Turnaround Climb"},
         "Grapple",
         "canSuitlessMaridia",
         "HiJump",
@@ -614,9 +614,9 @@
     {
       "id": 29,
       "link": [4, 5],
-      "name": "Pants Room Grapple Jump (Above Grapple Block)",
+      "name": "Grapple Jump (Above Grapple Block)",
       "requires": [
-        {"notable": "Pants Room Grapple Jump"},
+        {"notable": "Grapple Jump"},
         "canSuitlessMaridia",
         "canTrickyGrappleJump",
         "canMidairWiggle"
@@ -724,9 +724,9 @@
     {
       "id": 34,
       "link": [5, 2],
-      "name": "Pants Room Bomb Jump Water Escape",
+      "name": "Bomb Jump Water Escape",
       "requires": [
-        {"notable": "Pants Room Bomb Jump Water Escape"},
+        {"notable": "Bomb Jump Water Escape"},
         "HiJump",
         "h_canMaxHeightSpringBallJump",
         "canSpringFling",
@@ -794,7 +794,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Pants Room Grapple Jump",
+      "name": "Grapple Jump",
       "note": [
         "Use the grapple block to initiate a Grapple Jump to climb up to the higher level and above the water line.",
         "Aiming the Grapple Jump to line up with the one tile hole is difficult and Samus is moving at high speeds.",
@@ -804,7 +804,7 @@
     },
     {
       "id": 2,
-      "name": "Pants Room Shinespark",
+      "name": "Shinespark",
       "note": [
         "Preselect Grapple and be ready to use it when entering the room. Release up or angle up before release grapple so the shinespark does not activate instantly.",
         "Use the windup frames for a shinespark to extend the duration timer."
@@ -812,7 +812,7 @@
     },
     {
       "id": 3,
-      "name": "Pants Room Gravity Jump",
+      "name": "Gravity Jump",
       "note": [
         "Gets above the grapple block by doing a well-positioned and well-timed Gravity jump following a good jump off the sand.",
         "It is also possible to do this off of a wall jump on the side immediately followed by a gravity jump.",
@@ -822,7 +822,7 @@
     },
     {
       "id": 4,
-      "name": "Pants Room Suitless Flatley Turnaround Climb",
+      "name": "Suitless Flatley Turnaround Climb",
       "note": [
         "Use a flatley turnaround jump to get Samus inside the gap during a spinjump.",
         "Samus must jump from the left side platform."
@@ -830,7 +830,7 @@
     },
     {
       "id": 5,
-      "name": "Pants Room Bomb Jump Water Escape",
+      "name": "Bomb Jump Water Escape",
       "note": [
         "Wait the water tide to reach its peak, then crouch jump into a spring ball jump into an IBJ.",
         "Perform the spring ball jump near max height.",

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -224,9 +224,9 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Shaktool Room Reverse",
+      "name": "Reverse",
       "requires": [
-        {"notable": "Shaktool Room Reverse"},
+        {"notable": "Reverse"},
         "h_canUsePowerBombs"
       ],
       "clearsObstacles": ["A", "B"],
@@ -236,7 +236,7 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "G-Mode Morph Reverse Shaktool",
+      "name": "Reverse G-Mode Morph",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -244,7 +244,7 @@
         }
       },
       "requires": [
-        {"notable": "G-Mode Morph Reverse Shaktool"},
+        {"notable": "Reverse G-Mode Morph"},
         {"or": [
           {"and": [
             "Gravity",
@@ -452,9 +452,9 @@
     {
       "id": 22,
       "link": [2, 2],
-      "name": "Shaktool Room Bounce the Snails Around the Room",
+      "name": "Bounce the Snails Around the Room",
       "requires": [
-        {"notable": "Shaktool Room Bounce the Snails Around the Room"},
+        {"notable": "Bounce the Snails Around the Room"},
         "h_ShaktoolCameraFix",
         "canDodgeWhileShooting",
         "canTrickyJump",
@@ -475,9 +475,9 @@
     {
       "id": 23,
       "link": [2, 2],
-      "name": "Shaktool Room Suitless Bounce the Snails Around the Room",
+      "name": "Suitless Bounce the Snails Around the Room",
       "requires": [
-        {"notable": "Shaktool Room Suitless Bounce the Snails Around the Room"},
+        {"notable": "Suitless Bounce the Snails Around the Room"},
         "canDodgeWhileShooting",
         "canTrickyJump",
         {"or": [
@@ -647,12 +647,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Shaktool Room Reverse",
+      "name": "Reverse",
       "note": "Let the Snails (Yards) dig through the sand and follow them. They will not dig while off screen or while Samus is facing them, even while morphed."
     },
     {
       "id": 2,
-      "name": "G-Mode Morph Reverse Shaktool",
+      "name": "Reverse G-Mode Morph",
       "note": [
         "The Snails will dig through the sand without showing any visual difference. Each block they pass through gets closer to overloading PLMs.",
         "In order to PB the left wall before PLMs are overloaded, it is necessary to only allow one snail to dig, either by bombing one or by facing one to prevent movement until it is off screen.",
@@ -664,7 +664,7 @@
     },
     {
       "id": 3,
-      "name": "Shaktool Room Bounce the Snails Around the Room",
+      "name": "Bounce the Snails Around the Room",
       "note": [
         "Bounce the snails around the room in order to destroy the sand blocks, opening up the runway.",
         "A snail can be made to bounce in 3 ways: shooting it off a wall or ceiling, kicking it on the ground, or touching it while it is already bouncing.",
@@ -678,7 +678,7 @@
     },
     {
       "id": 4,
-      "name": "Shaktool Room Suitless Bounce the Snails Around the Room",
+      "name": "Suitless Bounce the Snails Around the Room",
       "note": [
         "Bounce the snails around the room in order to destroy the sand blocks, opening up the runway.",
         "Without Gravity, this requires greater caution as the water will slow Samus down and increase the risk of taking damage from a snail.",

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -203,9 +203,9 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Spring Ball Room Escape - Suitless, Bootless, Space Jump",
+      "name": "Escape - Suitless, Bootless, Space Jump",
       "requires": [
-        {"notable": "Spring Ball Room Escape - Suitless, Bootless, Space Jump"},
+        {"notable": "Escape - Suitless, Bootless, Space Jump"},
         "canSuitlessMaridia",
         "canSpringBallJumpMidAir",
         "canSunkenTileWideWallClimb",
@@ -224,7 +224,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Spring Ball Room Escape - Suitless, Bootless, Space Jump",
+      "name": "Escape - Suitless, Bootless, Space Jump",
       "note": [
         "Perform a canSunkenTileWideWallClimb to get to the water surface, then use space jump at the water surface.",
         "Then either use space jump when the water is low then a spring ball jump to escape, or space jump when the water is high into a tight midair morph."

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -195,7 +195,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "West Sand Hall Tricky Speedy Jump (Left to Right)",
+      "name": "Tricky Speedy Jump (Left to Right)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 19.4375,
@@ -204,7 +204,7 @@
         }
       },
       "requires": [
-        {"notable": "West Sand Hall Tricky Speedy Jump (Left to Right)"},
+        {"notable": "Tricky Speedy Jump (Left to Right)"},
         "canSuitlessMaridia",
         "canTrickyDashJump",
         "canInsaneJump"
@@ -224,7 +224,7 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "West Sand Hall Tricky Speedy Airball (Left to Right)",
+      "name": "Tricky Speedy Airball (Left to Right)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 19.9375,
@@ -233,7 +233,7 @@
         }
       },
       "requires": [
-        {"notable": "West Sand Hall Tricky Speedy Airball (Left to Right)"},
+        {"notable": "Tricky Speedy Airball (Left to Right)"},
         "canSuitlessMaridia",
         "canTrickyDashJump",
         "canLateralMidAirMorph"
@@ -316,9 +316,9 @@
     {
       "id": 12,
       "link": [1, 5],
-      "name": "West Sand Hall Insane Bomb Jump",
+      "name": "Insane Bomb Jump",
       "requires": [
-        {"notable": "West Sand Hall Insane Bomb Jump"},
+        {"notable": "Insane Bomb Jump"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canSandfallBounce",
@@ -408,7 +408,7 @@
     {
       "id": 16,
       "link": [1, 5],
-      "name": "West Sand Hall Spring Fling with Momentum",
+      "name": "Spring Fling with Momentum",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -416,7 +416,7 @@
         }
       },
       "requires": [
-        {"notable": "West Sand Hall Spring Fling with Momentum"},
+        {"notable": "Spring Fling with Momentum"},
         "canCrossRoomJumpIntoWater",
         "canPlayInSand",
         "canLateralMidAirMorph",
@@ -718,7 +718,7 @@
     {
       "id": 35,
       "link": [2, 5],
-      "name": "West Sand Hall Tricky Speedy Jump (Right to Left)",
+      "name": "Tricky Speedy Jump (Right to Left)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 10.4375,
@@ -726,7 +726,7 @@
         }
       },
       "requires": [
-        {"notable": "West Sand Hall Tricky Speedy Jump (Right to Left)"},
+        {"notable": "Tricky Speedy Jump (Right to Left)"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "canTrickyDashJump"
@@ -747,7 +747,7 @@
     {
       "id": 36,
       "link": [2, 5],
-      "name": "West Sand Hall Tricky Speedy Airball (Right to Left)",
+      "name": "Tricky Speedy Airball (Right to Left)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 7.5,
@@ -756,7 +756,7 @@
         }
       },
       "requires": [
-        {"notable": "West Sand Hall Tricky Speedy Airball (Right to Left)"},
+        {"notable": "Tricky Speedy Airball (Right to Left)"},
         "canSuitlessMaridia",
         "canTrickyDashJump",
         "canInsaneJump",
@@ -774,7 +774,7 @@
     {
       "id": 37,
       "link": [2, 5],
-      "name": "West Sand Hall Cross Room Space Jump (Right to Left)",
+      "name": "Cross Room Space Jump (Right to Left)",
       "entranceCondition": {
         "comeInSpaceJumping": {
           "minTiles": 36,
@@ -782,7 +782,7 @@
         }
       },
       "requires": [
-        {"notable": "West Sand Hall Cross Room Space Jump (Right to Left)"},
+        {"notable": "Cross Room Space Jump (Right to Left)"},
         "canPreciseSpaceJump",
         "canInsaneJump",
         "canDownGrab"
@@ -922,9 +922,9 @@
     {
       "id": 45,
       "link": [4, 2],
-      "name": "West Sand Hall Suitless Bootless Spring Ball (Center to Right)",
+      "name": "Suitless Bootless Spring Ball (Center to Right)",
       "requires": [
-        {"notable": "West Sand Hall Suitless Bootless Spring Ball"},
+        {"notable": "Suitless Bootless Spring Ball"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "h_canMaxHeightSpringBallJump",
@@ -957,9 +957,9 @@
     {
       "id": 46,
       "link": [4, 2],
-      "name": "West Sand Hall Ice Only (Center to Right)",
+      "name": "Ice Only (Center to Right)",
       "requires": [
-        {"notable": "West Sand Hall Ice Only (Center to Right)"},
+        {"notable": "Ice Only (Center to Right)"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "canTrickyJump",
@@ -1047,9 +1047,9 @@
     {
       "id": 50,
       "link": [4, 5],
-      "name": "West Sand Hall Suitless Bootless Spring Ball (Center to Left)",
+      "name": "Suitless Bootless Spring Ball (Center to Left)",
       "requires": [
-        {"notable": "West Sand Hall Suitless Bootless Spring Ball"},
+        {"notable": "Suitless Bootless Spring Ball"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "h_canMaxHeightSpringBallJump",
@@ -1085,9 +1085,9 @@
     {
       "id": 51,
       "link": [4, 5],
-      "name": "West Sand Hall Ice Beam Only (Center to Left)",
+      "name": "Ice Beam Only (Center to Left)",
       "requires": [
-        {"notable": "West Sand Hall Ice Beam Only (Center to Left)"},
+        {"notable": "Ice Beam Only (Center to Left)"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "canTrickyJump",
@@ -1113,9 +1113,9 @@
     {
       "id": 52,
       "link": [4, 5],
-      "name": "West Sand Hall Suitless Damage Boost (Center to Left)",
+      "name": "Suitless Damage Boost (Center to Left)",
       "requires": [
-        {"notable": "West Sand Hall Suitless Damage Boost (Center to Left)"},
+        {"notable": "Suitless Damage Boost (Center to Left)"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "canInsaneJump",
@@ -1240,9 +1240,9 @@
     {
       "id": 58,
       "link": [5, 4],
-      "name": "West Sand Hall Suitless Bootless Spring Ball (Left to Center)",
+      "name": "Suitless Bootless Spring Ball (Left to Center)",
       "requires": [
-        {"notable": "West Sand Hall Suitless Bootless Spring Ball"},
+        {"notable": "Suitless Bootless Spring Ball"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "h_canMaxHeightSpringBallJump",
@@ -1271,7 +1271,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "West Sand Hall Suitless Bootless Spring Ball",
+      "name": "Suitless Bootless Spring Ball",
       "note": [
         "Perform multiple stationary lateral mid-air morphs, while avoiding the Evir projectiles, to cross the room.",
         "It is necessary to start the jumps from the far side of the platforms in order to gain more horizontal momentum before entering the sand falls.",
@@ -1281,7 +1281,7 @@
     },
     {
       "id": 2,
-      "name": "West Sand Hall Tricky Speedy Jump (Left to Right)",
+      "name": "Tricky Speedy Jump (Left to Right)",
       "note": [
         "Run into the room using exactly 20 tiles of runway (with closed ends) in the other room, or up to 6 pixels more (getting extra run speed exactly $4.4).",
         "Jump on the last possible frame, and aim down as Samus approaches the overhang, to avoid bonking it.",
@@ -1290,7 +1290,7 @@
     },
     {
       "id": 3,
-      "name": "West Sand Hall Tricky Speedy Airball (Left to Right)",
+      "name": "Tricky Speedy Airball (Left to Right)",
       "note": [
         "Run into the room using exactly 20 tiles of runway (with an open end) in the other room, or up to 11 pixels more or 1 pixel less (getting extra run speed $4.5 or $4.6).",
         "Jump toward the end of the runway, quickly aim down, and then morph when close to the ceiling.",
@@ -1299,7 +1299,7 @@
     },
     {
       "id": 4,
-      "name": "West Sand Hall Insane Bomb Jump",
+      "name": "Insane Bomb Jump",
       "note": [
         "Time a bomb to hit Samus when she is morphed, 1 pixel into the sand, inside a sandfall, and moving horizontally.",
         "There is a setup using a Sand IBJ to rise up the sandfall from the floor and Sandfall Bounce with the correct timing.",
@@ -1308,7 +1308,7 @@
     },
     {
       "id": 5,
-      "name": "West Sand Hall Spring Fling with Momentum",
+      "name": "Spring Fling with Momentum",
       "note": [
         "Enter with at least 1 tile of run speed from an air room, with Speedbooster unequipped.",
         "Jump from near the end of the runway (though a jump from 1-2 tiles away from the end can still work).",
@@ -1319,7 +1319,7 @@
     },
     {
       "id": 6,
-      "name": "West Sand Hall Tricky Speedy Jump (Right to Left)",
+      "name": "Tricky Speedy Jump (Right to Left)",
       "note": [
         "Run into the room using between 11 and 12 tiles of runway in the other room (extra run speed between $2.D and $3.1).",
         "Jump somewhat soon after entering the room, and land on the pillar just past the last Evir.",
@@ -1328,7 +1328,7 @@
     },
     {
       "id": 7,
-      "name": "West Sand Hall Tricky Speedy Airball (Right to Left)",
+      "name": "Tricky Speedy Airball (Right to Left)",
       "note": [
         "Run into the room with an exact amount of speed, by using 7.5 tiles of runway or up to 4 pixels more (getting extra run speed exactly $2.3).",
         "After entering the room, jump from the last tile or two of runway, perform a lateral mid-air morph, and land on the pillar just past the last Evir."
@@ -1336,7 +1336,7 @@
     },
     {
       "id": 8,
-      "name": "West Sand Hall Cross Room Space Jump (Right to Left)",
+      "name": "Cross Room Space Jump (Right to Left)",
       "note": [
         "In the other room, gain run speed using at least 36 tiles (extra run speed at least $6.4), and Space Jump low through the door.",
         "Land on the block just past the last Evir."
@@ -1344,7 +1344,7 @@
     },
     {
       "id": 9,
-      "name": "West Sand Hall Ice Only (Center to Right)",
+      "name": "Ice Only (Center to Right)",
       "note": [
         "From the sand fall, quickly get onto the left platform to prevent the right side Evir from lowering too far.",
         "Freeze the right Evir, then jump on the sand to the right while shooting ice over the first Evir to also freeze the second.",
@@ -1354,7 +1354,7 @@
     },
     {
       "id": 10,
-      "name": "West Sand Hall Ice Beam Only (Center to Left)",
+      "name": "Ice Beam Only (Center to Left)",
       "note": [
         "Freeze the Evir quickly before it descends and use it to get to the platforms.",
         "Getting a good jump while on the right side of the floating block can get Samus to the leftmost block.",
@@ -1363,7 +1363,7 @@
     },
     {
       "id": 11,
-      "name": "West Sand Hall Suitless Damage Boost (Center to Left)",
+      "name": "Suitless Damage Boost (Center to Left)",
       "note": [
         "Use the projectile from a fully submerged Evir to boost Samus into the sandfall, providing just enough height to make the first and hardest jump.",
         "Time the projectile to hit Samus when at the maximum height from a jump.",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -334,7 +334,7 @@
         "comeInWithTemporaryBlue": {}
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Temporary Blue To Items"},
+        {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
         "canLongChainTemporaryBlue",
         {"ammo": {"type": "PowerBomb", "count": 1}},
@@ -359,12 +359,12 @@
     {
       "id": 8,
       "link": [1, 9],
-      "name": "Aqueduct Left-Side X-Ray Climb (Upper)",
+      "name": "Left-Side X-Ray Climb (Upper)",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        {"notable": "Aqueduct Left-Side X-Ray Climb (Upper)"},
+        {"notable": "Left-Side X-Ray Climb (Upper)"},
         "canXRayClimb"
       ],
       "flashSuitChecked": true,
@@ -499,7 +499,7 @@
       "link": [2, 1],
       "name": "Snail Clip with Morph to the Left Middle Door",
       "requires": [
-        {"notable": "Aqueduct Snail Clip With Gravity and Morph"},
+        {"notable": "Snail Clip With Gravity and Morph"},
         "Gravity",
         "canUseEnemies",
         "Morph",
@@ -598,9 +598,9 @@
     {
       "id": 19,
       "link": [2, 1],
-      "name": "Aqueduct Bootless Suitless Snail Climb (Crab Shaft Door)",
+      "name": "Bootless Suitless Snail Climb (Crab Shaft Door)",
       "requires": [
-        {"notable": "Aqueduct Bootless Suitless Snail Climb"},
+        {"notable": "Bootless Suitless Snail Climb"},
         "h_canNavigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -997,9 +997,9 @@
     {
       "id": 38,
       "link": [2, 5],
-      "name": "Aqueduct Bootless Suitless Snail Climb (Right Door)",
+      "name": "Bootless Suitless Snail Climb (Right Door)",
       "requires": [
-        {"notable": "Aqueduct Bootless Suitless Snail Climb"},
+        {"notable": "Bootless Suitless Snail Climb"},
         "h_canNavigateUnderwater",
         "canSnailClimb"
       ],
@@ -1088,7 +1088,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Temporary Blue To Items"},
+        {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
         "h_canDoubleSpringBallJumpWithHiJump",
         "canChainTemporaryBlue",
@@ -1116,7 +1116,7 @@
         "comeInWithTemporaryBlue": {}
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Temporary Blue To Items"},
+        {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
         "h_canDoubleSpringBallJumpWithHiJump",
         "canChainTemporaryBlue",
@@ -1139,7 +1139,7 @@
     {
       "id": 45,
       "link": [2, 7],
-      "name": "G-Mode Overload PLMs - PB the Items (To the Items)",
+      "name": "G-Mode Overload PLMs - Power Bomb the Items (To the Items)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -1147,7 +1147,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct G-Mode Overload PLMs - PB the Items"},
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
         {"or": [
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
@@ -1179,7 +1179,7 @@
     {
       "id": 46,
       "link": [2, 7],
-      "name": "G-Mode Morph Overload PLMs - PB the Items (To the Items)",
+      "name": "G-Mode Morph Overload PLMs - Power Bomb the Items (To the Items)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -1187,7 +1187,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct G-Mode Overload PLMs - PB the Items"},
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
         {"or": [
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
@@ -1258,9 +1258,9 @@
     {
       "id": 50,
       "link": [2, 9],
-      "name": "Aqueduct Bootless Suitless Snail Climb (Top Door)",
+      "name": "Bootless Suitless Snail Climb (Top Door)",
       "requires": [
-        {"notable": "Aqueduct Bootless Suitless Snail Climb"},
+        {"notable": "Bootless Suitless Snail Climb"},
         "h_canNavigateUnderwater",
         "canSnailClimb"
       ],
@@ -1450,9 +1450,9 @@
     {
       "id": 63,
       "link": [5, 1],
-      "name": "Aqueduct Blue Space Jump",
+      "name": "Blue Space Jump",
       "requires": [
-        {"notable": "Aqueduct Blue Space Jump"},
+        {"notable": "Blue Space Jump"},
         "Gravity",
         "canPreciseSpaceJump",
         {"or": [
@@ -1805,7 +1805,7 @@
       "link": [5, 7],
       "name": "Snail Clip with Morph to the Items",
       "requires": [
-        {"notable": "Aqueduct Snail Clip With Gravity and Morph"},
+        {"notable": "Snail Clip With Gravity and Morph"},
         "Gravity",
         "canUseEnemies",
         "Morph",
@@ -1856,7 +1856,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Blue Bomber"},
+        {"notable": "Suitless Blue Bomber"},
         "canSuitlessMaridia",
         "HiJump",
         "canSpeedball",
@@ -1887,7 +1887,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Blue Bomber"},
+        {"notable": "Suitless Blue Bomber"},
         "canSuitlessMaridia",
         "HiJump",
         "canTrickySpringBallBounce",
@@ -1918,7 +1918,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Blue Bomber"},
+        {"notable": "Suitless Blue Bomber"},
         "canSuitlessMaridia",
         "canTrickyDashJump",
         "canSpeedball",
@@ -1947,7 +1947,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Blue Bomber"},
+        {"notable": "Suitless Blue Bomber"},
         "canSuitlessMaridia",
         "canTrickyDashJump",
         "canInsaneJump",
@@ -1972,7 +1972,7 @@
         "comeInWithTemporaryBlue": {}
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Temporary Blue To Items"},
+        {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
         "HiJump",
         "canChainTemporaryBlue",
@@ -2027,7 +2027,7 @@
     {
       "id": 89,
       "link": [5, 7],
-      "name": "G-Mode Overload PLMs - PB the Items (To the Items)",
+      "name": "G-Mode Overload PLMs - Power Bomb the Items (To the Items)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -2035,7 +2035,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct G-Mode Overload PLMs - PB the Items"},
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
         {"or": [
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
@@ -2067,7 +2067,7 @@
     {
       "id": 90,
       "link": [5, 7],
-      "name": "G-Mode Morph Overload PLMs - PB the Items (To the Items)",
+      "name": "G-Mode Morph Overload PLMs - Power Bomb the Items (To the Items)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -2075,7 +2075,7 @@
         }
       },
       "requires": [
-        {"notable": "Aqueduct G-Mode Overload PLMs - PB the Items"},
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
         {"or": [
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
@@ -2428,7 +2428,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Temporary Blue To Items"},
+        {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
         "canChainTemporaryBlue",
         {"ammo": {"type": "PowerBomb", "count": 1}},
@@ -2460,7 +2460,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Aqueduct Suitless Temporary Blue To Items"},
+        {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
         "canChainTemporaryBlue",
         "canXRayTurnaround",
@@ -2478,7 +2478,7 @@
     {
       "id": 109,
       "link": [6, 7],
-      "name": "G-Mode Overload PLMs - PB the Items (To the Items)",
+      "name": "G-Mode Overload PLMs - Power Bomb the Items (To the Items)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -2487,7 +2487,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Aqueduct G-Mode Overload PLMs - PB the Items"},
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
         {"or": [
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
@@ -2519,7 +2519,7 @@
     {
       "id": 110,
       "link": [6, 7],
-      "name": "G-Mode Morph Overload PLMs - PB the Items (To the Items)",
+      "name": "G-Mode Morph Overload PLMs - Power Bomb the Items (To the Items)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -2528,7 +2528,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Aqueduct G-Mode Overload PLMs - PB the Items"},
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
         {"or": [
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
@@ -2634,9 +2634,9 @@
     {
       "id": 119,
       "link": [9, 1],
-      "name": "Aqueduct Snail Stuck Moonfall",
+      "name": "Snail Stuck Moonfall",
       "requires": [
-        {"notable": "Aqueduct Snail Stuck Moonfall"},
+        {"notable": "Snail Stuck Moonfall"},
         "h_canNavigateUnderwater",
         "canEnemyStuckMoonfall",
         "canBePatient",
@@ -2922,12 +2922,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Aqueduct Bootless Suitless Snail Climb",
+      "name": "Bootless Suitless Snail Climb",
       "note": "Snail Climb without movement items by better coordinating the movements of both the snail and Samus."
     },
     {
       "id": 2,
-      "name": "Aqueduct Snail Clip With Gravity and Morph",
+      "name": "Snail Clip With Gravity and Morph",
       "note": [
         "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
         "The Snail's positioning is very precise. Morph can be used to help get onto the Snail and get off without taking a hit if it is in the wrong location.",
@@ -2936,7 +2936,7 @@
     },
     {
       "id": 3,
-      "name": "Aqueduct G-Mode Overload PLMs - PB the Items",
+      "name": "G-Mode Overload PLMs - Power Bomb the Items",
       "note": [
         "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
         "There is a row of tiles that works, just above and to the left of the right door.",
@@ -2945,7 +2945,7 @@
     },
     {
       "id": 4,
-      "name": "Aqueduct Suitless Blue Bomber",
+      "name": "Suitless Blue Bomber",
       "note": [
         "Perform a speedball or an uncontrolled bounce onto the platform below the Speed blocks.",
         "Unmorph and continue holding up in order to break the Speed blocks while passing up through them.",
@@ -2957,7 +2957,7 @@
     },
     {
       "id": 5,
-      "name": "Aqueduct Suitless Temporary Blue To Items",
+      "name": "Suitless Temporary Blue To Items",
       "note": [
         "Reach the Speed blocks below the items while chaining temporary blue.",
         "Perform a spring ball jump and immediately unmorph and continue holding up, to break some of the Speed blocks while passing up through them.",
@@ -2968,7 +2968,7 @@
     },
     {
       "id": 6,
-      "name": "Aqueduct Left-Side X-Ray Climb (Upper)",
+      "name": "Left-Side X-Ray Climb (Upper)",
       "note": [
         "Climb up 1 screen.",
         "Aim to end this XRay climb when Samus is visually near but not above the top of the left side door.",
@@ -2988,7 +2988,7 @@
     },
     {
       "id": 8,
-      "name": "Aqueduct Blue Space Jump",
+      "name": "Blue Space Jump",
       "note": [
         "Gain blue speed by running right-to-left on the 20-tile runway below the items.",
         "Then use Space Jump to carry it across the top of the room to break the bomb blocks.",
@@ -2998,7 +2998,7 @@
     },
     {
       "id": 9,
-      "name": "Aqueduct Snail Stuck Moonfall",
+      "name": "Snail Stuck Moonfall",
       "note": [
         "Use two snails to perform an 'Enemy Stuck Moonfall' to bypass the bomb blocks above the middle left door of Aqueduct.",
         "Position one snail on the above door shell, and the second above the corner of pipe below",

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1070,9 +1070,9 @@
     {
       "id": 42,
       "link": [1, 5],
-      "name": "Botwoon Energy Tank Room Puyo Bomb-Grapple-Jump",
+      "name": "Puyo Bomb-Grapple-Jump",
       "requires": [
-        {"notable": "Botwoon Energy Tank Room Puyo Bomb-Grapple-Jump"},
+        {"notable": "Puyo Bomb-Grapple-Jump"},
         "canSuitlessMaridia",
         "canBombGrappleJump",
         "canCrouchJump"
@@ -1085,9 +1085,9 @@
     {
       "id": 43,
       "link": [1, 5],
-      "name": "Botwoon Energy Tank Room Sand Grapple Boost",
+      "name": "Sand Grapple Boost",
       "requires": [
-        {"notable": "Botwoon Energy Tank Room Sand Grapple Boost"},
+        {"notable": "Sand Grapple Boost"},
         "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
         "canSandGrappleBoost",
@@ -2080,7 +2080,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Botwoon Energy Tank Room Puyo Bomb-Grapple-Jump",
+      "name": "Puyo Bomb-Grapple-Jump",
       "note": [
         "Lure a Puyo close to the sand and use it to Bomb-Grapple-Jump up to the Morph Ball maze.",
         "It helps to predict the jump pattern of the enemy."
@@ -2088,7 +2088,7 @@
     },
     {
       "id": 2,
-      "name": "Botwoon Energy Tank Room Sand Grapple Boost",
+      "name": "Sand Grapple Boost",
       "note": [
         "Lure a Puyo close to the sand to use for a Sand Grapple Boost.",
         "As it is close to entering the sand, land on the sand and crouch.",

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -186,9 +186,9 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Botwoon Hallway Mochtroid Clip (Left to Right)",
+      "name": "Mochtroid Ice Clip (Left to Right)",
       "requires": [
-        {"notable": "Botwoon Hallway Mochtroid Ice Clip"},
+        {"notable": "Mochtroid Ice Clip"},
         "h_canNavigateUnderwater",
         "canCeilingClip",
         "canUseFrozenEnemies",
@@ -366,14 +366,14 @@
     {
       "id": 14,
       "link": [2, 1],
-      "name": "Botwoon Hallway Reverse Shinespark, Come in Shinecharged",
+      "name": "Reverse Shinespark, Come in Shinecharged",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 120
         }
       },
       "requires": [
-        {"notable": "Botwoon Hallway Reverse Shinespark"},
+        {"notable": "Reverse Shinespark"},
         "canSuitlessMaridia",
         "canCarefulJump",
         "Wave",
@@ -391,7 +391,7 @@
     {
       "id": 15,
       "link": [2, 1],
-      "name": "Botwoon Hallway Reverse Shinespark, Come in Shinecharging",
+      "name": "Reverse Shinespark, Come in Shinecharging",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 2,
@@ -399,7 +399,7 @@
         }
       },
       "requires": [
-        {"notable": "Botwoon Hallway Reverse Shinespark"},
+        {"notable": "Reverse Shinespark"},
         "canWaterShineCharge",
         "Wave",
         "canShinechargeMovementComplex",
@@ -416,9 +416,9 @@
     {
       "id": 16,
       "link": [2, 1],
-      "name": "Botwoon Hallway Mochtroid Clip (Right to Left)",
+      "name": "Mochtroid Ice Clip (Right to Left)",
       "requires": [
-        {"notable": "Botwoon Hallway Mochtroid Ice Clip"},
+        {"notable": "Mochtroid Ice Clip"},
         "h_canNavigateUnderwater",
         "canCeilingClip",
         "canUseFrozenEnemies",
@@ -445,9 +445,9 @@
     {
       "id": 34,
       "link": [2, 1],
-      "name": "Botwoon Hallway Mochtroid Clip, Precise Crouch Jump (Right to Left)",
+      "name": "Mochtroid Ice Clip, Precise Crouch Jump (Right to Left)",
       "requires": [
-        {"notable": "Botwoon Hallway Mochtroid Ice Clip"},
+        {"notable": "Mochtroid Ice Clip"},
         "canCeilingClip",
         "canUseFrozenEnemies",
         "h_canUnderwaterCrouchJumpDownGrab",
@@ -804,7 +804,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Botwoon Hallway Mochtroid Ice Clip",
+      "name": "Mochtroid Ice Clip",
       "note": [
         "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
         "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling."
@@ -812,7 +812,7 @@
     },
     {
       "id": 2,
-      "name": "Botwoon Hallway Reverse Shinespark",
+      "name": "Reverse Shinespark",
       "note": [
         "Quickly move next to the first set of speed blocks at the left end of the hole.",
         "Shoot a Wave shot, then just before it goes off screen, horizontally spark to the left to get through all the shot and speed blocks.",

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -241,9 +241,9 @@
     {
       "id": 25,
       "link": [1, 1],
-      "name": "Suitless Botwoon Kill",
+      "name": "Suitless Kill",
       "requires": [
-        {"notable": "Suitless Botwoon Kill"},
+        {"notable": "Suitless Kill"},
         "canSuitlessMaridia",
         {"enemyKill": {
           "enemies": [["Botwoon 1"]]
@@ -469,9 +469,9 @@
     {
       "id": 30,
       "link": [2, 2],
-      "name": "Back-Side Botwoon Fight - Gravity, Charge, Wave",
+      "name": "Back-Side Fight - Gravity, Charge, Wave",
       "requires": [
-        {"notable": "Back-Side Botwoon Fight with Charge and Wave"},
+        {"notable": "Back-Side Fight with Charge and Wave"},
         "Gravity",
         "Charge",
         "Wave",
@@ -494,9 +494,9 @@
     {
       "id": 31,
       "link": [2, 2],
-      "name": "Back-Side Botwoon Fight - Suitless, Charge, Wave",
+      "name": "Back-Side Fight - Suitless, Charge, Wave",
       "requires": [
-        {"notable": "Back-Side Botwoon Fight with Charge and Wave"},
+        {"notable": "Back-Side Fight with Charge and Wave"},
         "canSuitlessMaridia",
         "Charge",
         "Wave",
@@ -519,9 +519,9 @@
     {
       "id": 32,
       "link": [2, 2],
-      "name": "Back-Side Botwoon Microwave",
+      "name": "Back-Side Waveless Microwave",
       "requires": [
-        {"notable": "Back-Side Botwoon Magic Pixel Beam Fight"},
+        {"notable": "Back-Side Magic Pixel Beam Fight"},
         "h_canNavigateUnderwater",
         "Charge",
         "Plasma",
@@ -539,9 +539,9 @@
     {
       "id": 33,
       "link": [2, 2],
-      "name": "Back-Side Botwoon Magic Pixel",
+      "name": "Back-Side Magic Pixel Fight",
       "requires": [
-        {"notable": "Back-Side Botwoon Magic Pixel Beam Fight"},
+        {"notable": "Back-Side Magic Pixel Beam Fight"},
         "h_canNavigateUnderwater",
         {"enemyKill": {
           "enemies": [
@@ -561,9 +561,9 @@
     {
       "id": 34,
       "link": [2, 2],
-      "name": "Back-Side Botwoon Plasma Shield Microwave",
+      "name": "Back-Side Plasma Shield Microwave",
       "requires": [
-        {"notable": "Back-Side Botwoon Plasma Shield Microwave"},
+        {"notable": "Back-Side Plasma Shield Microwave"},
         "h_canNavigateUnderwater",
         "canSpecialBeamAttack",
         "Plasma",
@@ -581,9 +581,9 @@
     {
       "id": 35,
       "link": [2, 2],
-      "name": "Back-Side Botwoon Plasma Shield Fight",
+      "name": "Back-Side Plasma Shield Fight",
       "requires": [
-        {"notable": "Back-Side Botwoon Plasma Shield Fight"},
+        {"notable": "Back-Side Plasma Shield Fight"},
         "h_canNavigateUnderwater",
         {"enemyKill": {
           "enemies": [
@@ -599,9 +599,9 @@
     {
       "id": 36,
       "link": [2, 2],
-      "name": "Back-Side Botwoon Super Only Fight",
+      "name": "Back-Side Super Only Fight",
       "requires": [
-        {"notable": "Back-Side Botwoon Super Only Fight"},
+        {"notable": "Back-Side Super Only Fight"},
         "h_canNavigateUnderwater",
         "canBeExtremelyPatient",
         {"enemyKill": {
@@ -623,12 +623,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Back-Side Botwoon Fight with Charge and Wave",
+      "name": "Back-Side Fight with Charge and Wave",
       "note": "Use Charge and Wave to kill Botwoon from the right, through the wall."
     },
     {
       "id": 2,
-      "name": "Back-Side Botwoon Magic Pixel Beam Fight",
+      "name": "Back-Side Magic Pixel Beam Fight",
       "note": [
         "Stand on a particular two pixels to the right of the dividing wall and fight Botwoon using charge beam shots.",
         "Using angle down the spot is where Samus' front toe touches the wall.",
@@ -637,7 +637,7 @@
     },
     {
       "id": 3,
-      "name": "Suitless Botwoon Kill",
+      "name": "Suitless Kill",
       "note": [
         "Fight Botwoon without Gravity suit.",
         "The left corner can be used to avoid most attacks and may be worth using even in the opening of the fight for safety."
@@ -645,14 +645,14 @@
     },
     {
       "id": 4,
-      "name": "Back-Side Botwoon Plasma Shield Fight",
+      "name": "Back-Side Plasma Shield Fight",
       "note": [
         "Stand near the dividing wall and unleash the Plasma Special Beam Attack!"
       ]
     },
     {
       "id": 5,
-      "name": "Back-Side Botwoon Super Only Fight",
+      "name": "Back-Side Super Only Fight",
       "note": [
         "Wait for the one pattern (bottom->right) where Botwoon's head passes through the dividing barrier briefly and fire a Super Missile.",
         "This takes a long time, averaging one Super per minute."
@@ -660,7 +660,7 @@
     },
     {
       "id": 6,
-      "name": "Back-Side Botwoon Plasma Shield Microwave",
+      "name": "Back-Side Plasma Shield Microwave",
       "note": [
         "Stand on the appropriate pixel for shooting diagonally through the wall and use the microwave trick to defeat Botwoon.",
         "Using angle up, it is where Samus' front foot is on the seam in the floor.",

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -376,14 +376,14 @@
     {
       "id": 14,
       "link": [1, 3],
-      "name": "Colosseum Full Halfie Shinespark (Forward)",
+      "name": "Full Halfie Shinespark (Forward)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 60
         }
       },
       "requires": [
-        {"notable": "Colosseum Full Halfie Shinespark"},
+        {"notable": "Full Halfie Shinespark"},
         "canShinechargeMovementComplex",
         "canMidairShinespark",
         "canTrickyJump",
@@ -446,9 +446,9 @@
     {
       "id": 18,
       "link": [1, 3],
-      "name": "Colosseum Spike Platforming with Move Assist (Left to Right)",
+      "name": "Spike Platforming with Move Assist (Left to Right)",
       "requires": [
-        {"notable": "Colosseum Spike Platforming with Move Assist (Left to Right)"},
+        {"notable": "Spike Platforming with Move Assist (Left to Right)"},
         "canWalljump",
         "Morph",
         "canCarefulJump",
@@ -479,7 +479,7 @@
     {
       "id": 19,
       "link": [1, 3],
-      "name": "Colosseum Spike Platforming with SpringBall (Left to Right)",
+      "name": "Spike Platforming with SpringBall (Left to Right)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 2,
@@ -487,7 +487,7 @@
         }
       },
       "requires": [
-        {"notable": "Colosseum Spike Platforming with SpringBall (Left to Right)"},
+        {"notable": "Spike Platforming with SpringBall (Left to Right)"},
         "canWalljump",
         "Morph",
         "canCarefulJump",
@@ -509,9 +509,9 @@
     {
       "id": 20,
       "link": [1, 3],
-      "name": "Colosseum with no Equipment (Left to Right)",
+      "name": "Spike Platforming with No Equipment (Left to Right)",
       "requires": [
-        {"notable": "Colosseum with no Equipment"},
+        {"notable": "Spike Platforming with No Equipment"},
         "canWalljump",
         "canInsaneJump",
         "canHorizontalDamageBoost",
@@ -560,9 +560,9 @@
     {
       "id": 22,
       "link": [1, 3],
-      "name": "Colosseum Mochtroid Suitless, HiJumpless Ice Climb (Left to Right)",
+      "name": "Mochtroid Suitless, HiJumpless Ice Climb (Left to Right)",
       "requires": [
-        {"notable": "Colosseum Mochtroid Suitless, HiJumpless Ice Climb"},
+        {"notable": "Mochtroid Suitless, HiJumpless Ice Climb"},
         "canSuitlessMaridia",
         "canMochtroidIceClimb",
         "canPlayInSand",
@@ -782,9 +782,9 @@
     {
       "id": 33,
       "link": [2, 2],
-      "name": "Colosseum Frozen Mochtroid Grapple Clip Door Lock Skip",
+      "name": "Frozen Mochtroid Grapple Clip Door Lock Skip",
       "requires": [
-        {"notable": "Colosseum Frozen Mochtroid Grapple Clip Door Lock Skip"},
+        {"notable": "Frozen Mochtroid Grapple Clip Door Lock Skip"},
         {"or": [
           {"and": [
             "Gravity",
@@ -811,9 +811,9 @@
     {
       "id": 34,
       "link": [2, 2],
-      "name": "Colosseum Grapple Bomb Hang Door Lock Skip",
+      "name": "Grapple Bomb Hang Door Lock Skip",
       "requires": [
-        {"notable": "Colosseum Grapple Bomb Hang Door Lock Skip"},
+        {"notable": "Grapple Bomb Hang Door Lock Skip"},
         "Gravity",
         "h_canBombThings",
         "canGrappleBombHang",
@@ -836,9 +836,9 @@
     {
       "id": 35,
       "link": [2, 2],
-      "name": "Colosseum Unmorph Grapple Hang Door Lock Skip",
+      "name": "Unmorph Grapple Hang Door Lock Skip",
       "requires": [
-        {"notable": "Colosseum Unmorph Grapple Hang Door Lock Skip"},
+        {"notable": "Unmorph Grapple Hang Door Lock Skip"},
         "Gravity",
         "canUnmorphGrappleHang",
         "canGrappleClip"
@@ -985,9 +985,9 @@
     {
       "id": 45,
       "link": [2, 3],
-      "name": "Colosseum Bomb Jump Water Escape",
+      "name": "Bomb Jump Water Escape",
       "requires": [
-        {"notable": "Colosseum Bomb Jump Water Escape"},
+        {"notable": "Bomb Jump Water Escape"},
         "HiJump",
         "h_canMaxHeightSpringBallJump",
         "canSpringFling",
@@ -1334,14 +1334,14 @@
     {
       "id": 60,
       "link": [3, 1],
-      "name": "Colosseum Full Halfie Shinespark (Reverse)",
+      "name": "Full Halfie Shinespark (Reverse)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 60
         }
       },
       "requires": [
-        {"notable": "Colosseum Full Halfie Shinespark"},
+        {"notable": "Full Halfie Shinespark"},
         "canShinechargeMovementComplex",
         "canMidairShinespark",
         "canTrickyJump",
@@ -1394,9 +1394,9 @@
     {
       "id": 64,
       "link": [3, 1],
-      "name": "Colosseum Bomb Jump Water Escape",
+      "name": "Bomb Jump Water Escape",
       "requires": [
-        {"notable": "Colosseum Bomb Jump Water Escape"},
+        {"notable": "Bomb Jump Water Escape"},
         "HiJump",
         "canPreciseWalljump",
         "canIframeSpikeJump",
@@ -1438,9 +1438,9 @@
     {
       "id": 65,
       "link": [3, 1],
-      "name": "Colosseum with no Equipment (Right to Left)",
+      "name": "Spike Platforming with No Equipment (Right to Left)",
       "requires": [
-        {"notable": "Colosseum with no Equipment"},
+        {"notable": "Spike Platforming with No Equipment"},
         "canPreciseWalljump",
         "canInsaneJump",
         "canIframeSpikeJump",
@@ -1491,9 +1491,9 @@
     {
       "id": 67,
       "link": [3, 1],
-      "name": "Colosseum Mochtroid Suitless, HiJumpless Ice Climb (Right to Left)",
+      "name": "Mochtroid Suitless, HiJumpless Ice Climb (Right to Left)",
       "requires": [
-        {"notable": "Colosseum Mochtroid Suitless, HiJumpless Ice Climb"},
+        {"notable": "Mochtroid Suitless, HiJumpless Ice Climb"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canPlayInSand",
@@ -1674,14 +1674,14 @@
     {
       "id": 76,
       "link": [3, 2],
-      "name": "Colosseum Stored Moonfall Grapple Door Lock Skip",
+      "name": "Stored Moonfall Grapple Door Lock Skip",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
         }
       },
       "requires": [
-        {"notable": "Colosseum Stored Moonfall Grapple Door Lock Skip"},
+        {"notable": "Stored Moonfall Grapple Door Lock Skip"},
         "canGrappleClip"
       ],
       "bypassesDoorShell": true,
@@ -1875,7 +1875,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Colosseum with no Equipment",
+      "name": "Spike Platforming with No Equipment",
       "note": [
         "Cross the Colosseum by using the spikes as platforms to stay out of the water.",
         "Requires some very difficult jumps and excellent control over spike damage knockback."
@@ -1883,7 +1883,7 @@
     },
     {
       "id": 2,
-      "name": "Colosseum Mochtroid Suitless, HiJumpless Ice Climb",
+      "name": "Mochtroid Suitless, HiJumpless Ice Climb",
       "note": [
         "Cross the Colosseum by using the Mochtroids as frozen platforms.",
         "Some Mochtroids need to be led into the water either from the previous section of room or from jumping high in the current section.",
@@ -1892,7 +1892,7 @@
     },
     {
       "id": 3,
-      "name": "Colosseum Green Door Grapple Clip",
+      "name": "Green Door Grapple Clip",
       "note": [
         "Use a Mochtroid to clip into the space behind the grapple blocks.",
         "Then use Grapple on the blocks to be pushed a precise amount into the wall above the door.",
@@ -1901,7 +1901,7 @@
     },
     {
       "id": 4,
-      "name": "Colosseum Full Halfie Shinespark",
+      "name": "Full Halfie Shinespark",
       "note": [
         "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
         "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
@@ -1909,7 +1909,7 @@
     },
     {
       "id": 5,
-      "name": "Colosseum Bomb Jump Water Escape",
+      "name": "Bomb Jump Water Escape",
       "note": [
         "With HiJump, perform a mid-air spring ball jump into an IBJ to escape the water.",
         "This can be done at the left, the center, and right side of the room.",
@@ -1918,7 +1918,7 @@
     },
     {
       "id": 6,
-      "name": "Colosseum Spike Platforming with Move Assist (Left to Right)",
+      "name": "Spike Platforming with Move Assist (Left to Right)",
       "note": [
         "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the Colosseum.",
         "Requires knowing the position of every spike in the room, and hitting the spikes while morphed can help.",
@@ -1927,7 +1927,7 @@
     },
     {
       "id": 7,
-      "name": "Colosseum Spike Platforming with SpringBall (Left to Right)",
+      "name": "Spike Platforming with SpringBall (Left to Right)",
       "note": [
         "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the Colosseum.",
         "Requires knowing the position of every spike in the room, and hitting the spikes while morphed can help.",
@@ -1936,7 +1936,7 @@
     },
     {
       "id": 8,
-      "name": "Colosseum Frozen Mochtroid Grapple Clip Door Lock Skip",
+      "name": "Frozen Mochtroid Grapple Clip Door Lock Skip",
       "note": [
         "Crouch and freeze a Mochtroid to clip into the space behind the grapple blocks.",
         "Jump and tap grapple while aiming diagonally to be pushed into the wall just the right amount.",
@@ -1947,7 +1947,7 @@
     },
     {
       "id": 9,
-      "name": "Colosseum Grapple Bomb Hang Door Lock Skip",
+      "name": "Grapple Bomb Hang Door Lock Skip",
       "note": [
         "Get a boost from a Bomb or Power Bomb while grappled to the second Grapple block below the top right door.",
         "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
@@ -1963,7 +1963,7 @@
     },
     {
       "id": 10,
-      "name": "Colosseum Unmorph Grapple Hang Door Lock Skip",
+      "name": "Unmorph Grapple Hang Door Lock Skip",
       "note": [
         "Grapple to the second Grapple block from the bottom (the one partially underwater), jump off from it, morph, and press against the wall to the right.",
         "Unmorph slightly before the peak of the jump (a 3-frame window), then immediately use grapple (a 2-frame window) to get stuck standing a pixel inside the second Grapple block.",
@@ -1981,7 +1981,7 @@
     },
     {
       "id": 11,
-      "name": "Colosseum Stored Moonfall Grapple Door Lock Skip",
+      "name": "Stored Moonfall Grapple Door Lock Skip",
       "note": [
         "Perform a moonfall with stored fall speed to clip into the air space between the grapple blocks and the wall.",
         "Jump and tap grapple while aiming diagonally to be pushed into the wall just the right amount.",

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -321,9 +321,9 @@
     {
       "id": 12,
       "link": [1, 3],
-      "name": "Crab Shaft Suitless Walljump Climb with HiJump",
+      "name": "Suitless Walljump Climb with HiJump",
       "requires": [
-        {"notable": "Crab Shaft Suitless Walljump Climb with HiJump"},
+        {"notable": "Suitless Walljump Climb with HiJump"},
         "canSuitlessMaridia",
         "HiJump",
         "canConsecutiveWalljump"
@@ -409,9 +409,9 @@
     {
       "id": 16,
       "link": [1, 3],
-      "name": "Crab Shaft Crab Climb",
+      "name": "Crab Climb",
       "requires": [
-        {"notable": "Crab Shaft Ice Only Crab Climb"},
+        {"notable": "Ice Only Crab Climb"},
         "h_canNavigateUnderwater",
         "canTrickyUseFrozenEnemies",
         "canCarefulJump",
@@ -653,9 +653,9 @@
     {
       "id": 28,
       "link": [1, 3],
-      "name": "Crab Shaft Sciser Ice Clip Door Lock Skip",
+      "name": "Crab Ice Clip Door Lock Skip",
       "requires": [
-        {"notable": "Crab Shaft Sciser Ice Clip Door Lock Skip"},
+        {"notable": "Crab Ice Clip Door Lock Skip"},
         {"ammo": {"type": "Super", "count": 1}},
         {"or": [
           "h_canXRayMorphIceClip",
@@ -677,9 +677,9 @@
     {
       "id": 29,
       "link": [1, 3],
-      "name": "Crab Shaft Sciser High Pixel Ice Clip Door Lock Skip",
+      "name": "Crab High Pixel Ice Clip Door Lock Skip",
       "requires": [
-        {"notable": "Crab Shaft Sciser High Pixel Ice Clip Door Lock Skip"},
+        {"notable": "Crab High Pixel Ice Clip Door Lock Skip"},
         {"ammo": {"type": "Super", "count": 1}},
         "h_canHighPixelIceClip"
       ],
@@ -760,9 +760,9 @@
     {
       "id": 34,
       "link": [2, 1],
-      "name": "Crab Shaft Bottom Frozen Falling Crab",
+      "name": "Bottom Frozen Falling Crab",
       "requires": [
-        {"notable": "Crab Shaft Ice Only Crab Climb"},
+        {"notable": "Ice Only Crab Climb"},
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         "canDodgeWhileShooting",
@@ -777,9 +777,9 @@
     {
       "id": 35,
       "link": [2, 1],
-      "name": "Crab Shaft Bottom Frozen Crab Steps",
+      "name": "Bottom Frozen Crab Steps",
       "requires": [
-        {"notable": "Crab Shaft Ice Only Crab Climb"},
+        {"notable": "Ice Only Crab Climb"},
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         "canCrouchJump",
@@ -794,15 +794,15 @@
     {
       "id": 36,
       "link": [2, 1],
-      "name": "Crab Shaft Bottom Repetitive Walljumps",
+      "name": "Bottom Repetitive Walljumps",
       "requires": [
-        {"notable": "Crab Shaft Ice Only Crab Climb"},
+        {"notable": "Ice Only Crab Climb"},
         "canSunkenTileWideWallClimb",
         "canUseFrozenEnemies",
         "canStationarySpinJump"
       ],
       "note": [
-        "Similar to naked watering hole escape.",
+        "Similar to naked Watering Hole escape.",
         "Freeze a crab under the gap above, do a stationary spinjump facing right, then walljump until you're up.",
         "Another frozen crab can help complete the way up."
       ]
@@ -1336,17 +1336,17 @@
   "notables": [
     {
       "id": 1,
-      "name": "Crab Shaft Ice Only Crab Climb",
+      "name": "Ice Only Crab Climb",
       "note": "Climb the frozen crabs Suitless without the help of SpringBall jumps or HiJump."
     },
     {
       "id": 2,
-      "name": "Crab Shaft Suitless Walljump Climb with HiJump",
+      "name": "Suitless Walljump Climb with HiJump",
       "note": "Wall jump back and forth up the shaft. It's a really long climb."
     },
     {
       "id": 3,
-      "name": "Crab Shaft Sciser Ice Clip Door Lock Skip",
+      "name": "Crab Ice Clip Door Lock Skip",
       "note": [
         "Shoot the shot block in the middle of the room, to allow a global Sciser (crab) to pass to the top part of the room.",
         "Use Ice to climb the Scisers to the top of the room.",
@@ -1356,7 +1356,7 @@
     },
     {
       "id": 4,
-      "name": "Crab Shaft Sciser High Pixel Ice Clip Door Lock Skip",
+      "name": "Crab High Pixel Ice Clip Door Lock Skip",
       "note": [
         "Shoot the shot block in the middle of the room, to allow a global Sciser (crab) to pass to the top part of the room.",
         "Use Ice to climb the Scisers to the top of the room.",

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -194,9 +194,9 @@
     {
       "id": 45,
       "link": [1, 1],
-      "name": "Draygon Grapple Kill",
+      "name": "Grapple Kill",
       "requires": [
-        {"notable": "Draygon Grapple Kill"},
+        {"notable": "Grapple Kill"},
         "h_canNavigateUnderwater",
         "canUseGrapple",
         {"draygonElectricityFrames": 240},
@@ -215,9 +215,9 @@
     {
       "id": 46,
       "link": [1, 1],
-      "name": "Draygon Grapple Quick Kill",
+      "name": "Grapple Quick Kill",
       "requires": [
-        {"notable": "Draygon Grapple Quick Kill"},
+        {"notable": "Grapple Quick Kill"},
         "h_canNavigateUnderwater",
         "canPreciseGrapple",
         "h_canBreakOneDraygonTurret",
@@ -232,9 +232,9 @@
     {
       "id": 47,
       "link": [1, 1],
-      "name": "Draygon Shinespark Kill",
+      "name": "Shinespark Kill",
       "requires": [
-        {"notable": "Draygon Shinespark Kill"},
+        {"notable": "Shinespark Kill"},
         "Gravity",
         "canMidairShinespark",
         "canShinechargeMovementComplex",
@@ -285,9 +285,9 @@
     {
       "id": 49,
       "link": [1, 1],
-      "name": "Suitless Draygon",
+      "name": "Suitless Fight",
       "requires": [
-        {"notable": "Suitless Draygon"},
+        {"notable": "Suitless Fight"},
         "canSuitlessMaridia",
         "Morph",
         "h_canBreakThreeDraygonTurrets",
@@ -575,9 +575,9 @@
     {
       "id": 42,
       "link": [1, 2],
-      "name": "Draygon Turret Grapple Jump",
+      "name": "Turret Grapple Jump",
       "requires": [
-        {"notable": "Draygon Turret Grapple Jump"},
+        {"notable": "Turret Grapple Jump"},
         "canSuitlessMaridia",
         "canGrappleJump",
         {"draygonElectricityFrames": 60},
@@ -588,9 +588,9 @@
     {
       "id": 43,
       "link": [1, 2],
-      "name": "Draygon Shinespark out the Right with a Gravity Jump",
+      "name": "Shinespark out the Right with a Gravity Jump",
       "requires": [
-        {"notable": "Draygon Shinespark out the Right with a Gravity Jump"},
+        {"notable": "Shinespark out the Right with a Gravity Jump"},
         "canGravityJump",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
@@ -936,22 +936,22 @@
   "notables": [
     {
       "id": 1,
-      "name": "Draygon Turret Grapple Jump",
+      "name": "Turret Grapple Jump",
       "note": "Performing a grapple jump off of a Draygon turret. Usually done by bouncing off the wall for momentum."
     },
     {
       "id": 2,
-      "name": "Draygon Shinespark out the Right with a Gravity Jump",
+      "name": "Shinespark out the Right with a Gravity Jump",
       "note": "Charge a shinespark in the bottom of Draygon's room, then Gravity jump up in order to shinespark out of the right door."
     },
     {
       "id": 3,
-      "name": "Suitless Draygon",
+      "name": "Suitless Fight",
       "note": "Fight Draygon without gravity, but with Morph."
     },
     {
       "id": 4,
-      "name": "Draygon Shinespark Kill",
+      "name": "Shinespark Kill",
       "note": [
         "Shinecharge in-room, then horizontally spark through Draygon multiple times.",
         "It takes 3 Shinesparks if that is the only source of damage onto Draygon.",
@@ -960,7 +960,7 @@
     },
     {
       "id": 5,
-      "name": "Draygon Grapple Kill",
+      "name": "Grapple Kill",
       "note": [
         "Kill Draygon by grappling to the top left turret.",
         "Number of Draygon hits varies; 5 hits are assumed, which is close to a worst-case scenario."
@@ -968,7 +968,7 @@
     },
     {
       "id": 6,
-      "name": "Draygon Grapple Quick Kill",
+      "name": "Grapple Quick Kill",
       "note": [
         "Kill Draygon by grappling to a bottom turret as you get grabbed.",
         "Avoids taking all the hits from Draygon."

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -288,7 +288,7 @@
     {
       "id": 8,
       "link": [2, 1],
-      "name": "East Cac Alley G-Mode Morph, IBJ, HBJ",
+      "name": "G-Mode Morph, IBJ, HBJ",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -296,7 +296,7 @@
         }
       },
       "requires": [
-        {"notable": "East Cac Alley G-Mode Morph, IBJ, HBJ"},
+        {"notable": "G-Mode Morph, IBJ, HBJ"},
         "Gravity",
         "h_canArtificialMorphIBJ",
         "h_canArtificialMorphHBJ"
@@ -649,7 +649,7 @@
     {
       "id": 27,
       "link": [2, 4],
-      "name": "East Cac Alley Cross Room Jump with IBJ",
+      "name": "Cross Room Jump with IBJ",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": false,
@@ -657,7 +657,7 @@
         }
       },
       "requires": [
-        {"notable": "East Cac Alley Cross Room Jump with IBJ"},
+        {"notable": "Cross Room Jump with IBJ"},
         "canJumpIntoIBJ",
         "canBombHorizontally",
         "canResetFallSpeed",
@@ -711,12 +711,12 @@
     {
       "id": 30,
       "link": [2, 4],
-      "name": "East Cac Alley Cross Room Jump with Spring Ball, Bomb Boost",
+      "name": "Cross Room Jump with Spring Ball, Bomb Boost",
       "entranceCondition": {
         "comeInWithBombBoost": {}
       },
       "requires": [
-        {"notable": "East Cac Alley Cross Room Jump with Spring Ball, Bomb Boost"},
+        {"notable": "Cross Room Jump with Spring Ball, Bomb Boost"},
         "canSpringBallBombJump",
         "canCrossRoomJumpIntoWater",
         {"or": [
@@ -995,9 +995,9 @@
     {
       "id": 48,
       "link": [5, 4],
-      "name": "Cacatac Alley Springball Spike Boost",
+      "name": "Springball Spike Boost",
       "requires": [
-        {"notable": "Cacatac Alley Springball Spike Boost"},
+        {"notable": "Springball Spike Boost"},
         "HiJump",
         "canSuitlessMaridia",
         "canCarefulJump",
@@ -1024,9 +1024,9 @@
     {
       "id": 50,
       "link": [5, 4],
-      "name": "Cacatac Alley HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump",
+      "name": "HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump",
       "requires": [
-        {"notable": "Cacatac Alley HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump"},
+        {"notable": "HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump"},
         "canBombGrappleJump",
         "canDoubleSpringBallJumpMidAir",
         "h_canMaxHeightSpringBallJump"
@@ -1040,9 +1040,9 @@
     {
       "id": 51,
       "link": [5, 4],
-      "name": "Cacatac Alley Bomb Jump Water Escape",
+      "name": "Bomb Jump Water Escape",
       "requires": [
-        {"notable": "Cacatac Alley Bomb Jump Water Escape"},
+        {"notable": "Bomb Jump Water Escape"},
         "HiJump",
         "h_canMaxHeightSpringBallJump",
         "canSpringFling",
@@ -1270,12 +1270,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "East Cac Alley G-Mode Morph, IBJ, HBJ",
+      "name": "G-Mode Morph, IBJ, HBJ",
       "note": "This requires multiple HBJ to get over spike pits. The first one, by the right door, must be started at the top of an IBJ."
     },
     {
       "id": 2,
-      "name": "East Cac Alley Cross Room Jump with IBJ",
+      "name": "Cross Room Jump with IBJ",
       "note": [
         "Requires a runway of at least 1 tiles in the adjacent room, although it is easier with more.",
         "Start the IBJ as far left as possible. The furthest right is just right of the waterfall.",
@@ -1285,17 +1285,17 @@
     },
     {
       "id": 3,
-      "name": "East Cac Alley Cross Room Jump with Spring Ball, Bomb Boost",
+      "name": "Cross Room Jump with Spring Ball, Bomb Boost",
       "note": "Use the bomb boost as Samus is going through the doorway, then spring ball after breaking the water, then ibj or use an unmorph bomb boost."
     },
     {
       "id": 4,
-      "name": "Cacatac Alley Springball Spike Boost",
+      "name": "Springball Spike Boost",
       "note": "When the Cacatac on the ground fires a spike, perform a  springball Jump to break the waterline and then hit the spike for extra height."
     },
     {
       "id": 5,
-      "name": "Cacatac Alley HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump",
+      "name": "HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump",
       "note": [
         "1) Crouch jump and then SpringBall jump.",
         "2) Bomb-Grapple-Jump using the distant Cacatac who is above the water.",
@@ -1304,7 +1304,7 @@
     },
     {
       "id": 6,
-      "name": "Cacatac Alley Bomb Jump Water Escape",
+      "name": "Bomb Jump Water Escape",
       "note": [
         "Perform the spring ball jump near max height.",
         "Place the first bomb after the spring ball jump; just above the water line.",

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -228,9 +228,9 @@
     {
       "id": 14,
       "link": [1, 4],
-      "name": "East Sand Hole Underwater Walljumps",
+      "name": "Underwater Walljump",
       "requires": [
-        {"notable": "East Sand Hole Underwater Walljumps"},
+        {"notable": "Underwater Walljump"},
         "Morph",
         "canPlayInSand",
         "canUnderwaterWalljump"
@@ -240,9 +240,9 @@
     {
       "id": 15,
       "link": [1, 4],
-      "name": "East Sand Hole Insane Walljump Morph",
+      "name": "Insane Walljump Morph",
       "requires": [
-        {"notable": "East Sand Hole Insane Walljump Morph"},
+        {"notable": "Insane Walljump Morph"},
         "canSuitlessMaridia",
         "canConsecutiveWalljump",
         "canPlayInSand",
@@ -255,9 +255,9 @@
     {
       "id": 16,
       "link": [1, 4],
-      "name": "East Sand Hole Sandfall Bounce to Power Bombs",
+      "name": "Sandfall Bounce",
       "requires": [
-        {"notable": "East Sand Hole Sandfall Bounce to Power Bombs"},
+        {"notable": "Sandfall Bounce"},
         "canSuitlessMaridia",
         "canSandfallBounce",
         "canTrickySpringBallJump",
@@ -611,9 +611,9 @@
     {
       "id": 7,
       "link": [5, 3],
-      "name": "East Sand Hole Suitless HiJump Perfect Bomb Boost",
+      "name": "Suitless HiJump Perfect Bomb Boost",
       "requires": [
-        {"notable": "East Sand Hole Suitless HiJump Perfect Bomb Boost"},
+        {"notable": "Suitless HiJump Perfect Bomb Boost"},
         "canSuitlessMaridia",
         "HiJump",
         "canCrouchJump",
@@ -639,7 +639,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "East Sand Hole Suitless HiJump Perfect Bomb Boost",
+      "name": "Suitless HiJump Perfect Bomb Boost",
       "note": [
         "Reach the left side item using a single bomb explosion barely reach it.",
         "Use HiJump to reach the water line and then use a Bomb Jump Water Escape motion to Bomb jump out of the water.",
@@ -649,17 +649,17 @@
     },
     {
       "id": 2,
-      "name": "East Sand Hole Underwater Walljumps",
+      "name": "Underwater Walljump",
       "note": "Jump off the sand and use Underwater Walljumps to enter the maze leading to the Power Bomb location."
     },
     {
       "id": 3,
-      "name": "East Sand Hole Insane Walljump Morph",
+      "name": "Insane Walljump Morph",
       "note": "Walljump up and instant morph with exact timing and positioning so as to enter the Power Bomb location through the maze's exit."
     },
     {
       "id": 4,
-      "name": "East Sand Hole Sandfall Bounce to Power Bombs",
+      "name": "Sandfall Bounce",
       "note": [
         "By using the sandfall physics, it is possible to springballjump to the Maridia Power Bomb location without Gravity or HiJump.",
         "This requires a very precise spinjump into the sandfall which also exits the sandfall, after being pushed down, with more height than a regular jump.",

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -352,9 +352,9 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "Halfie Climb Top Left Suitless Bombless Leave With Grapple Teleport",
+      "name": "Top Left Suitless Bombless Leave With Grapple Teleport",
       "requires": [
-        {"notable": "Halfie Climb Top Left Suitless Bombless Leave With Grapple Teleport"},
+        {"notable": "Top Left Suitless Bombless Leave With Grapple Teleport"},
         "canUnmorphGrappleHang"
       ],
       "exitCondition": {
@@ -411,14 +411,14 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "Halfie Climb Stored Moonfall Grapple Door Lock Skip",
+      "name": "Stored Moonfall Grapple Door Lock Skip",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
         }
       },
       "requires": [
-        {"notable": "Halfie Climb Stored Moonfall Grapple Door Lock Skip"},
+        {"notable": "Stored Moonfall Grapple Door Lock Skip"},
         {"doorUnlockedAtNode": 1},
         "canGrappleClip"
       ],
@@ -1071,9 +1071,9 @@
     {
       "id": 48,
       "link": [2, 1],
-      "name": "Halfie Climb Very Long Underwater Walljump Climb",
+      "name": "Very Long Underwater Walljump Climb",
       "requires": [
-        {"notable": "Halfie Climb Very Long Underwater Walljump Climb"},
+        {"notable": "Very Long Underwater Walljump Climb"},
         "canUnderwaterWalljump"
       ],
       "note": "This underwater walljump is very long."
@@ -1081,7 +1081,7 @@
     {
       "id": 49,
       "link": [2, 1],
-      "name": "Halfie Climb Very Deep Stuck X-Ray Climb",
+      "name": "Very Deep Stuck X-Ray Climb",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -1089,7 +1089,7 @@
         }
       },
       "requires": [
-        {"notable": "Halfie Climb Very Deep Stuck X-Ray Climb"},
+        {"notable": "Very Deep Stuck X-Ray Climb"},
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
@@ -2019,14 +2019,14 @@
     {
       "id": 96,
       "link": [3, 2],
-      "name": "Halfie Climb Enter with Shinespark from the Bottom Right",
+      "name": "Enter with Shinespark from the Bottom Right",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 100
         }
       },
       "requires": [
-        {"notable": "Halfie Climb Enter with Shinespark from the Bottom Right"},
+        {"notable": "Enter with Shinespark from the Bottom Right"},
         "Morph",
         "canSuitlessMaridia",
         "canUseEnemies",
@@ -2043,14 +2043,14 @@
     {
       "id": 97,
       "link": [3, 2],
-      "name": "Halfie Climb Enter with Shinespark from the Bottom Right (Conserve Health)",
+      "name": "Enter with Shinespark from the Bottom Right (Conserve Health)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 125
         }
       },
       "requires": [
-        {"notable": "Halfie Climb Enter with Shinespark from the Bottom Right"},
+        {"notable": "Enter with Shinespark from the Bottom Right"},
         "Morph",
         "canSuitlessMaridia",
         "canUseEnemies",
@@ -2069,7 +2069,7 @@
     {
       "id": 98,
       "link": [3, 2],
-      "name": "Halfie Climb Enter with Shinespark from the Bottom Right (Come In Blue Spinning)",
+      "name": "Enter with Shinespark from the Bottom Right (Come In Blue Spinning)",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "unusableTiles": 0,
@@ -2077,7 +2077,7 @@
         }
       },
       "requires": [
-        {"notable": "Halfie Climb Enter with Shinespark from the Bottom Right"},
+        {"notable": "Enter with Shinespark from the Bottom Right"},
         "canLongChainTemporaryBlue",
         "canStationaryLateralMidAirMorph",
         "can4HighMidAirMorph",
@@ -2098,12 +2098,12 @@
     {
       "id": 99,
       "link": [3, 2],
-      "name": "Halfie Climb Enter with Shinespark from the Bottom Right (Temporary Blue)",
+      "name": "Enter with Shinespark from the Bottom Right (Temporary Blue)",
       "entranceCondition": {
         "comeInWithTemporaryBlue": {}
       },
       "requires": [
-        {"notable": "Halfie Climb Enter with Shinespark from the Bottom Right"},
+        {"notable": "Enter with Shinespark from the Bottom Right"},
         "canLongChainTemporaryBlue",
         "canStationaryLateralMidAirMorph",
         "can4HighMidAirMorph",
@@ -2740,7 +2740,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Halfie Climb Enter with Shinespark from the Bottom Right",
+      "name": "Enter with Shinespark from the Bottom Right",
       "note": [
         "Quickly shoot out the 3 shot blocks then horizontal spark breaking the speed blocks.",
         "Wait for the Oums to roll on their own to a place where they can be climbed.",
@@ -2749,7 +2749,7 @@
     },
     {
       "id": 2,
-      "name": "Halfie Climb Top Left Suitless Bombless Leave With Grapple Teleport",
+      "name": "Top Left Suitless Bombless Leave With Grapple Teleport",
       "note": [
         "Grapple to the top Grapple in the top-left corner of the room.",
         "Hold left while waiting for the grapple wall jump check to expire, then quickly morph.",
@@ -2767,7 +2767,7 @@
     },
     {
       "id": 3,
-      "name": "Halfie Climb Stored Moonfall Grapple Door Lock Skip",
+      "name": "Stored Moonfall Grapple Door Lock Skip",
       "note": [
         "Perform a moonfall with stored fall speed to clip into the air space below the door at node 1.",
         "Land, then grapple the nearest block and release.",
@@ -2776,12 +2776,12 @@
     },
     {
       "id": 4,
-      "name": "Halfie Climb Very Long Underwater Walljump Climb",
+      "name": "Very Long Underwater Walljump Climb",
       "note": "This underwater walljump is very long."
     },
     {
       "id": 5,
-      "name": "Halfie Climb Very Deep Stuck X-Ray Climb",
+      "name": "Very Deep Stuck X-Ray Climb",
       "note": [
         "Enter with G-mode direct, back up to exactly 8 pixels away from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up a little less than 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door.",

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -211,9 +211,9 @@
     {
       "id": 7,
       "link": [1, 7],
-      "name": "West Sand Hole Suitless Wall Jump Break Free",
+      "name": "Suitless Wall Jump Break Free",
       "requires": [
-        {"notable": "West Sand Hole Suitless Wall Jump Break Free"},
+        {"notable": "Suitless Wall Jump Break Free"},
         "canSuitlessMaridia",
         "canPlayInSand",
         "HiJump",
@@ -616,9 +616,9 @@
     {
       "id": 35,
       "link": [7, 5],
-      "name": "West Sand Hole Bootless Suitless IBJ",
+      "name": "Suitless Bootless IBJ",
       "requires": [
-        {"notable": "West Sand Hole Bootless Suitless IBJ"},
+        {"notable": "Suitless Bootless IBJ"},
         "canSuitlessMaridia",
         "canJumpIntoIBJ",
         "canBombJumpWaterEscape",
@@ -631,7 +631,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "West Sand Hole Suitless Wall Jump Break Free",
+      "name": "Suitless Wall Jump Break Free",
       "note": [
         "HiJump with a good jump from the sand can reach the Solid Rock Maze region.  Use the sandfall if Samus gets stuck in the sand.",
         "Perform several wall jumps to climb up to the water level, then precise wall jumps to break free."
@@ -639,7 +639,7 @@
     },
     {
       "id": 2,
-      "name": "West Sand Hole Bootless Suitless IBJ",
+      "name": "Suitless Bootless IBJ",
       "note": "Jump off of the crumble blocks consecutively while placing a bomb on the water line and convert that into an IBJ to climb the West Sand Hole maze."
     }
   ],

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -324,9 +324,9 @@
     {
       "id": 13,
       "link": [1, 3],
-      "name": "Naked Bug Sand Hole Damage Boost (L to R)",
+      "name": "Naked Damage Boost (L to R)",
       "requires": [
-        {"notable": "Bug Sand Hole Damage Boost"},
+        {"notable": "Damage Boost"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canHorizontalDamageBoost",
@@ -341,7 +341,7 @@
     {
       "id": 14,
       "link": [1, 3],
-      "name": "Bug Sand Hole Speedy Jump Morph (L to R)",
+      "name": "Speedy Jump Morph (L to R)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -349,7 +349,7 @@
         }
       },
       "requires": [
-        {"notable": "Bug Sand Hole Speedy Jump Morph"},
+        {"notable": "Speedy Jump Morph"},
         "Morph",
         "canTrickyJump",
         "canLateralMidAirMorph"
@@ -362,7 +362,7 @@
     {
       "id": 15,
       "link": [1, 3],
-      "name": "Bug Sand Hole Speedy Jump Morph with Speed Booster (L to R)",
+      "name": "Speedy Jump Morph with Speed Booster (L to R)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -370,7 +370,7 @@
         }
       },
       "requires": [
-        {"notable": "Bug Sand Hole Speedy Jump Morph"},
+        {"notable": "Speedy Jump Morph"},
         "Morph",
         "canTrickyJump",
         "canLateralMidAirMorph"
@@ -552,9 +552,9 @@
     {
       "id": 24,
       "link": [3, 1],
-      "name": "Naked Bug Sand Hole Damage Boost (R to L)",
+      "name": "Naked Damage Boost (R to L)",
       "requires": [
-        {"notable": "Bug Sand Hole Damage Boost"},
+        {"notable": "Damage Boost"},
         "canTrickyJump",
         "canHorizontalDamageBoost",
         {"enemyDamage": {
@@ -568,7 +568,7 @@
     {
       "id": 25,
       "link": [3, 1],
-      "name": "Bug Sand Hole Speedy Jump Morph (R to L)",
+      "name": "Speedy Jump Morph (R to L)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -576,7 +576,7 @@
         }
       },
       "requires": [
-        {"notable": "Bug Sand Hole Speedy Jump Morph"},
+        {"notable": "Speedy Jump Morph"},
         "Morph",
         "canTrickyJump",
         "canLateralMidAirMorph"
@@ -589,7 +589,7 @@
     {
       "id": 26,
       "link": [3, 1],
-      "name": "Bug Sand Hole Speedy Jump Morph with Speed Booster (R to L)",
+      "name": "Speedy Jump Morph with Speed Booster (R to L)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -597,7 +597,7 @@
         }
       },
       "requires": [
-        {"notable": "Bug Sand Hole Speedy Jump Morph"},
+        {"notable": "Speedy Jump Morph"},
         "Morph",
         "canTrickyJump",
         "canLateralMidAirMorph"
@@ -1072,9 +1072,9 @@
     {
       "id": 50,
       "link": [4, 5],
-      "name": "Naked Bug Sand Hole Sand Jumps (L to R)",
+      "name": "Naked Sand Jumps (L to R)",
       "requires": [
-        {"notable": "Bug Sand Hole Sand Jumps"},
+        {"notable": "Sand Jumps"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canPlayInSand"
@@ -1256,9 +1256,9 @@
     {
       "id": 60,
       "link": [5, 4],
-      "name": "Naked Bug Sand Hole Sand Jumps (R to L)",
+      "name": "Naked Sand Jumps (R to L)",
       "requires": [
-        {"notable": "Bug Sand Hole Sand Jumps"},
+        {"notable": "Sand Jumps"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canPlayInSand"
@@ -1274,7 +1274,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Bug Sand Hole Sand Jumps",
+      "name": "Sand Jumps",
       "note": [
         "Cross the Bug Sand Hole with nothing while avoiding the enemies.",
         "Juke the Yapping Maw after entering and kill the Zoa to clear a path over the sand."
@@ -1282,12 +1282,12 @@
     },
     {
       "id": 2,
-      "name": "Bug Sand Hole Damage Boost",
+      "name": "Damage Boost",
       "note": "Wait inside the door frame of the Bug Sand Hole room while a Zoa rises out of the sand. Then use it to cross the room."
     },
     {
       "id": 3,
-      "name": "Bug Sand Hole Speedy Jump Morph",
+      "name": "Speedy Jump Morph",
       "note": [
         "With a fast enough jump into the Bug Sand Hole it is possible to cross over the water and land in the opposite door by morphing before reaching the ceiling."
       ]

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -237,9 +237,9 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Butterfly Room Careful Jump (Left to Right)",
+      "name": "Careful Jump (Left to Right)",
       "requires": [
-        {"notable": "Butterfly Room Careful Jump"},
+        {"notable": "Careful Jump"},
         "canSuitlessMaridia",
         "canCarefulJump",
         {"or": [
@@ -385,9 +385,9 @@
     {
       "id": 21,
       "link": [2, 1],
-      "name": "Butterfly Room Careful Jump (Right to Left)",
+      "name": "Careful Jump (Right to Left)",
       "requires": [
-        {"notable": "Butterfly Room Careful Jump"},
+        {"notable": "Careful Jump"},
         "canSuitlessMaridia",
         "canCarefulJump",
         {"or": [
@@ -541,9 +541,9 @@
     {
       "id": 31,
       "link": [2, 2],
-      "name": "Butterfly Room Door Lock Wall Ice Clip",
+      "name": "Door Lock Wall Ice Clip",
       "requires": [
-        {"notable": "Butterfly Room Door Lock Wall Ice Clip"},
+        {"notable": "Door Lock Wall Ice Clip"},
         "h_canNavigateUnderwater",
         "canWallIceClip",
         "Wave",
@@ -602,7 +602,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Butterfly Room Careful Jump",
+      "name": "Careful Jump",
       "note": [
         "Kill all the Zoas and don't pick up their drops. If the door is unlocked, stand in the doorframe and jump across the room.",
         "Otherwise, jump across the sand, starting 1.5 tiles away from the sandfall. Hold jump and forward the whole time. Samus will dip into the sand, but still make it to the other side."
@@ -610,7 +610,7 @@
     },
     {
       "id": 2,
-      "name": "Butterfly Room Door Lock Wall Ice Clip",
+      "name": "Door Lock Wall Ice Clip",
       "note": "Repeatedly freeze the Zoas to slowly push Samus into the wall and through the locked doorway."
     }
   ],

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -445,7 +445,7 @@
     {
       "id": 19,
       "link": [2, 3],
-      "name": "Maridia Bug Room MidAir Morph with Gravity",
+      "name": "MidAir Morph with Gravity",
       "requires": [
         "canMidAirMorph",
         "Gravity",
@@ -460,7 +460,7 @@
     {
       "id": 20,
       "link": [2, 3],
-      "name": "Maridia Bug Room Suitless MidAir Morph",
+      "name": "Suitless MidAir Morph",
       "requires": [
         "h_canThreeTileJumpMorph",
         {"obstaclesCleared": ["A"]}
@@ -469,9 +469,9 @@
     {
       "id": 21,
       "link": [2, 3],
-      "name": "Maridia Bug Room Frozen Menu Bridge",
+      "name": "Frozen Menu Bridge",
       "requires": [
-        {"notable": "Maridia Bug Room Frozen Menu Bridge"},
+        {"notable": "Frozen Menu Bridge"},
         "Morph",
         "h_canNavigateUnderwater",
         "canTrickyUseFrozenEnemies",
@@ -655,9 +655,9 @@
     {
       "id": 28,
       "link": [3, 1],
-      "name": "Maridia Bug Room Spark Out Left HiJumpless",
+      "name": "Spark Out Left HiJumpless",
       "requires": [
-        {"notable": "Maridia Bug Room Spark Out Left HiJumpless"},
+        {"notable": "Spark Out Left HiJumpless"},
         "canShinechargeMovementComplex",
         "canTrickyDashJump",
         {"canShineCharge": {
@@ -807,7 +807,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Maridia Bug Room Frozen Menu Bridge",
+      "name": "Frozen Menu Bridge",
       "note": [
         "Freeze one of the Menus (bugs) in a position where you can use it to get into the morph passage.",
         "One of the easier methods is with a damage boost. Stand in the water, take a hit for positioning, and freeze the bug near but left of Samus.",
@@ -816,7 +816,7 @@
     },
     {
       "id": 2,
-      "name": "Maridia Bug Room Spark Out Left HiJumpless",
+      "name": "Spark Out Left HiJumpless",
       "note": "Charge a spark below towards the right then run back and jump up and spark out of the left door."
     }
   ],

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -546,9 +546,9 @@
     {
       "id": 19,
       "link": [2, 3],
-      "name": "Plasma Spark Fish Climb",
+      "name": "Frozen Fish Climb",
       "requires": [
-        {"notable": "Plasma Spark Fish Climb"},
+        {"notable": "Frozen Fish Climb"},
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -1352,12 +1352,12 @@
     {
       "id": 54,
       "link": [3, 6],
-      "name": "Plasma Spark X-Ray Climb Into Fake Kassiuz Room",
+      "name": "X-Ray Climb Into Fake Kassiuz Room",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        {"notable": "Plasma Spark X-Ray Climb Into Fake Kassiuz Room"},
+        {"notable": "X-Ray Climb Into Fake Kassiuz Room"},
         "canXRayClimb"
       ],
       "flashSuitChecked": true,
@@ -1520,9 +1520,9 @@
     {
       "id": 66,
       "link": [5, 4],
-      "name": "Plasma Spark Room SpringFling into Top Right Door",
+      "name": "SpringFling into Top Right Door",
       "requires": [
-        {"notable": "Plasma Spark Room SpringFling into Top Right Door"},
+        {"notable": "SpringFling into Top Right Door"},
         "canInsaneJump",
         "canSpringFling",
         "canResetFallSpeed",
@@ -1575,7 +1575,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Plasma Spark Fish Climb",
+      "name": "Frozen Fish Climb",
       "note": [
         "Use the Skultera to get onto the top right platform. There are two distinct ways to get up using the top Skultera.",
         "1. Freeze it at the bottom of its path to the left. Crouch jump and down grab to get onto it. The positioning is very precise.",
@@ -1585,7 +1585,7 @@
     },
     {
       "id": 2,
-      "name": "Plasma Spark X-Ray Climb Into Fake Kassiuz Room",
+      "name": "X-Ray Climb Into Fake Kassiuz Room",
       "note": [
         "Climb up 2 screens plus 2 tiles, to enter a normally inaccessible area behind the top right door, containing a copy of the bottom half of Kassiuz Room.",
         "There is a blue door on the other side of the top right door; you will not be able to see it as you will be off-camera, but shoot it open and touch the transition behind it.",
@@ -1594,7 +1594,7 @@
     },
     {
       "id": 3,
-      "name": "Plasma Spark Room SpringFling into Top Right Door",
+      "name": "SpringFling into Top Right Door",
       "note": [
         "Roll off the above ledge and use both the vertical speed resets from first (un)equipping SpringBall and then by unmorphing in order to reach the door.",
         "Pause shortly after rolling off the ledge, after falling for 1 tile.  The timing is very precise.",

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -554,7 +554,7 @@
     {
       "id": 25,
       "link": [1, 2],
-      "name": "Thread the Needle Leave With Temporary Blue (Left-to-Right)",
+      "name": "Leave With Temporary Blue (Left-to-Right)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 4,
@@ -564,7 +564,7 @@
         }
       },
       "requires": [
-        {"notable": "Thread the Needle Leave With Temporary Blue"},
+        {"notable": "Leave With Temporary Blue"},
         "canChainTemporaryBlue",
         {"or": [
           "canTrickySpringBallBounce",
@@ -702,7 +702,7 @@
     {
       "id": 32,
       "link": [2, 1],
-      "name": "Thread the Needle Leave With Temporary Blue (Right to Left)",
+      "name": "Leave With Temporary Blue (Right to Left)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 4,
@@ -712,7 +712,7 @@
         }
       },
       "requires": [
-        {"notable": "Thread the Needle Leave With Temporary Blue"},
+        {"notable": "Leave With Temporary Blue"},
         "canChainTemporaryBlue",
         {"or": [
           "canTrickySpringBallBounce",
@@ -1094,7 +1094,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Thread the Needle Leave With Temporary Blue",
+      "name": "Leave With Temporary Blue",
       "note": [
         "Use Space jumps or Spring Ball bounces to carry blue speed across the room.",
         "Then chain temporary blue into the next room.",

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -125,9 +125,9 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "Watering Hole Double Frozen Zeb Runway",
+      "name": "Double Frozen Zeb Runway",
       "requires": [
-        {"notable": "Watering Hole Double Frozen Zeb Runway"},
+        {"notable": "Double Frozen Zeb Runway"},
         "h_canTrickyFrozenEnemyRunway"
       ],
       "exitCondition": {
@@ -344,7 +344,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Watering Hole Double Frozen Zeb Runway",
+      "name": "Double Frozen Zeb Runway",
       "note": [
         "Freeze both Zebs in order to significantly extend the length of the runway.",
         "Requires a pixel-perfect freeze in order to run onto and off of the frozen Zebs."

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -691,9 +691,9 @@
     {
       "id": 27,
       "link": [2, 1],
-      "name": "Crab Hole Suitless Crab Climb No Jump Assist",
+      "name": "Suitless Crab Climb No Jump Assist",
       "requires": [
-        {"notable": "Crab Hole Suitless Crab Climb No Jump Assist"},
+        {"notable": "Suitless Crab Climb No Jump Assist"},
         "canMidAirMorph",
         "canSuitlessMaridia",
         {"ammo": {"type": "Super", "count": 1}},
@@ -707,9 +707,9 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Crab Hole Suitless Crab Climb Superless with Springball",
+      "name": "Suitless Crab Climb Superless with Springball",
       "requires": [
-        {"notable": "Crab Hole Suitless Crab Climb Superless with Springball"},
+        {"notable": "Suitless Crab Climb Superless with Springball"},
         "canSuitlessMaridia",
         "canTrickyJump",
         "canTrickySpringBallJump",
@@ -726,7 +726,7 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "Crab Hole Cross Room Jump with Kago (Speedbooster)",
+      "name": "Cross Room Jump with Kago (Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -734,7 +734,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canMidAirMorph",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround",
@@ -759,7 +759,7 @@
     {
       "id": 30,
       "link": [2, 1],
-      "name": "Crab Hole Cross Room Jump with Kago (No Speedbooster)",
+      "name": "Cross Room Jump with Kago (No Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": false,
@@ -767,7 +767,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canMidAirMorph",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround",
@@ -789,7 +789,7 @@
     {
       "id": 31,
       "link": [2, 1],
-      "name": "Crab Hole Cross Room Jump Damageless Turnaround (Speedbooster)",
+      "name": "Cross Room Jump Damageless Turnaround (Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -797,7 +797,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canMidAirMorph",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround"
@@ -811,7 +811,7 @@
     {
       "id": 32,
       "link": [2, 1],
-      "name": "Crab Hole Cross Room Jump Damageless Turnaround (No Speedbooster)",
+      "name": "Cross Room Jump Damageless Turnaround (No Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -819,7 +819,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canMidAirMorph",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround",
@@ -838,7 +838,7 @@
     {
       "id": 33,
       "link": [2, 1],
-      "name": "Crab Hole Cross Room Jump with Air Ball (Speedbooster)",
+      "name": "Cross Room Jump with Air Ball (Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -846,7 +846,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -858,7 +858,7 @@
     {
       "id": 34,
       "link": [2, 1],
-      "name": "Crab Hole Cross Room Jump with Air Ball (No Speedbooster)",
+      "name": "Cross Room Jump with Air Ball (No Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": false,
@@ -866,7 +866,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -888,9 +888,9 @@
     {
       "id": 36,
       "link": [2, 1],
-      "name": "Crab Hole Ice Clip",
+      "name": "Ice Clip",
       "requires": [
-        {"notable": "Crab Hole Ice Clip"},
+        {"notable": "Ice Clip"},
         "h_canNavigateUnderwater",
         "canOffScreenMovement",
         {"or": [
@@ -925,7 +925,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -952,7 +952,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -960,7 +960,7 @@
         "Unmorph just before hitting the ceiling, to conserve upward momentum.",
         "Continue moving right to avoid a crab hit, then morph again to make it through."
       ],
-      "devNote": ["Bounce with extra run speed at least $1.5."]
+      "devNote": "Bounce with extra run speed at least $1.5."
     },
     {
       "id": 39,
@@ -974,7 +974,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -982,7 +982,7 @@
         "Unmorph just before hitting the ceiling, to conserve upward momentum.",
         "Continue moving right to avoid a crab hit, then morph again to make it through."
       ],
-      "devNote": ["Bounce with extra run speed at least $1.8."]
+      "devNote": "Bounce with extra run speed at least $1.8."
     },
     {
       "id": 40,
@@ -995,7 +995,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canPreciseSpaceJump",
         "canMomentumConservingTurnaround",
@@ -1024,7 +1024,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canPreciseSpaceJump",
         "canMomentumConservingTurnaround",
@@ -1053,7 +1053,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canPreciseSpaceJump",
         "canMomentumConservingTurnaround",
@@ -1076,7 +1076,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canPreciseSpaceJump",
         "canMomentumConservingTurnaround",
@@ -1913,7 +1913,7 @@
     {
       "id": 84,
       "link": [3, 4],
-      "name": "Crab Hole Cross Room Jump Turnaround (Speedbooster)",
+      "name": "Cross Room Jump Turnaround (Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -1921,7 +1921,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canMidAirMorph",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround"
@@ -1939,7 +1939,7 @@
     {
       "id": 85,
       "link": [3, 4],
-      "name": "Crab Hole Cross Room Jump Turnaround (No Speedbooster)",
+      "name": "Cross Room Jump Turnaround (No Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": false,
@@ -1947,7 +1947,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canMidAirMorph",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround"
@@ -1971,7 +1971,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -1995,7 +1995,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -2017,7 +2017,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingMorph"
       ],
@@ -2025,7 +2025,7 @@
         "Unmorph just before hitting the ceiling, to conserve upward momentum.",
         "Then turn around, morph, and move through the tunnel to the right, avoiding crab damage."
       ],
-      "devNote": ["Bounce with extra run speed at least $1.8."]
+      "devNote": "Bounce with extra run speed at least $1.8."
     },
     {
       "id": 89,
@@ -2038,7 +2038,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canPreciseSpaceJump",
         "canMomentumConservingTurnaround",
@@ -2061,7 +2061,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Hole Cross Room Jump Morph"},
+        {"notable": "Cross Room Jump Morph"},
         "canCrossRoomJumpIntoWater",
         "canPreciseSpaceJump",
         "canMomentumConservingTurnaround",
@@ -2699,7 +2699,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Crab Hole Cross Room Jump Morph",
+      "name": "Cross Room Jump Morph",
       "note": [
         "Use a Cross Room Jump into Water followed by a delayed Momentum Conserving Turnaround to reach the Morph tunnel above.",
         "Climbing the Left side of the center hole will run into an unavoidable Sciser.",
@@ -2709,7 +2709,7 @@
     },
     {
       "id": 2,
-      "name": "Crab Hole Suitless Crab Climb No Jump Assist",
+      "name": "Suitless Crab Climb No Jump Assist",
       "note": [
         "Use a super to knock off a crab and freeze it mid-air. Then get on that crab, possibly using a door ledge",
         "Freeze a second crab on the edge of the hole above."
@@ -2717,7 +2717,7 @@
     },
     {
       "id": 3,
-      "name": "Crab Hole Suitless Crab Climb Superless with Springball",
+      "name": "Suitless Crab Climb Superless with Springball",
       "note": [
         "Freeze one crab on the lip of the overhead opening and another on the edge of a doors platform then springballjump up.",
         "Use a Stationary Lateral Mid-Air Morph to gain enough jump height without bonking the ceiling.",
@@ -2726,7 +2726,7 @@
     },
     {
       "id": 4,
-      "name": "Crab Hole Ice Clip",
+      "name": "Ice Clip",
       "note": [
         "Freeze a crab at a very precise position in order to clip through the center Morph tunnel without a way to see.",
         "Use a frozen crab on the opposite wall in order to better time the crab being used for clipping and as a way to climb on top of it.",

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -240,7 +240,7 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Crab Tunnel Stutter Shinecharge Through The Gate",
+      "name": "Stutter Shinecharge Through The Gate",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -248,7 +248,7 @@
         }
       },
       "requires": [
-        {"notable": "Crab Tunnel Stutter Shinecharge Through The Gate"},
+        {"notable": "Stutter Shinecharge Through The Gate"},
         "canSuitlessMaridia",
         "canShinechargeMovementComplex",
         "canStutterWaterShineCharge",
@@ -313,9 +313,9 @@
     {
       "id": 14,
       "link": [2, 1],
-      "name": "Crab Tunnel Suitless Green Gate Glitch",
+      "name": "Suitless Green Gate Glitch",
       "requires": [
-        {"notable": "Crab Tunnel Suitless Green Gate Glitch"},
+        {"notable": "Suitless Green Gate Glitch"},
         {"or": [
           "h_canGreenGateGlitch",
           {"obstaclesCleared": ["A"]}
@@ -677,7 +677,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Crab Tunnel Stutter Shinecharge Through The Gate",
+      "name": "Stutter Shinecharge Through The Gate",
       "note": [
         "Requires a very precise stutter where Samus is moving slow enough while near the gate, so she can shoot it and it is fully open before she collides with it.",
         "A runway in the adjacent room of 2 tiles works best - with a longer runway, Samus will be moving too fast."
@@ -685,7 +685,7 @@
     },
     {
       "id": 2,
-      "name": "Crab Tunnel Suitless Green Gate Glitch",
+      "name": "Suitless Green Gate Glitch",
       "note": [
         "Perform the Gate Glitch by moving towards the gate and firing the super on the correct frame for it to pass through and reach the button on the other side.",
         "Due to the water physics, many traditional setups for the glitch will not work."

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -675,9 +675,9 @@
     {
       "id": 26,
       "link": [1, 5],
-      "name": "Fish Tank Very Long Underwater Walljump Climb (In Room)",
+      "name": "Very Long Underwater Walljump Climb (In Room)",
       "requires": [
-        {"notable": "Fish Tank Very Long Underwater Walljump Climb"},
+        {"notable": "Very Long Underwater Walljump Climb"},
         "canUnderwaterWalljump",
         {"or": [
           "canUseFrozenEnemies",
@@ -700,7 +700,7 @@
     {
       "id": 27,
       "link": [1, 5],
-      "name": "Fish Tank Very Long Underwater Walljump Climb (Cross Room)",
+      "name": "Very Long Underwater Walljump Climb (Cross Room)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -708,7 +708,7 @@
         }
       },
       "requires": [
-        {"notable": "Fish Tank Very Long Underwater Walljump Climb"},
+        {"notable": "Very Long Underwater Walljump Climb"},
         "canUnderwaterWalljump",
         "canTrickyJump",
         "canDisableEquipment",
@@ -855,14 +855,14 @@
     {
       "id": 35,
       "link": [2, 4],
-      "name": "Fish Tank Grapple Teleport into Grapple Jump",
+      "name": "Grapple Teleport into Grapple Jump",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
         }
       },
       "requires": [
-        {"notable": "Fish Tank Grapple Teleport into Grapple Jump"},
+        {"notable": "Grapple Teleport into Grapple Jump"},
         {"doorUnlockedAtNode": 4},
         "canMidairWiggle",
         "canTrickyGrappleJump",
@@ -1366,13 +1366,13 @@
     {
       "id": 53,
       "link": [4, 5],
-      "name": "Fish Tank Entry Fall onto Frozen Fish",
+      "name": "Room Entry Fall onto Frozen Fish",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Fish Tank Entry Fall onto Frozen Fish"},
+        {"notable": "Room Entry Fall onto Frozen Fish"},
         "h_canNavigateUnderwater",
         "canPrepareForNextRoom",
         "canTrickyUseFrozenEnemies",
@@ -1417,13 +1417,13 @@
     {
       "id": 55,
       "link": [4, 5],
-      "name": "Fish Tank Entry Reset Fall Speed",
+      "name": "Room Entry Reset Fall Speed",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Fish Tank Entry Reset Fall Speed"},
+        {"notable": "Room Entry Reset Fall Speed"},
         "canSuitlessMaridia",
         "canResetFallSpeed",
         "canPrepareForNextRoom"
@@ -1437,13 +1437,13 @@
     {
       "id": 56,
       "link": [4, 5],
-      "name": "Fish Tank Wall Jump Entry",
+      "name": "Wall Jump Entry",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Fish Tank Wall Jump Entry"},
+        {"notable": "Wall Jump Entry"},
         "canSuitlessMaridia",
         "canPreciseWalljump",
         "canPrepareForNextRoom",
@@ -1595,9 +1595,9 @@
     {
       "id": 65,
       "link": [5, 4],
-      "name": "Fish Tank Top Left Direct Jump with Gravity",
+      "name": "Top Left Direct Jump with Gravity",
       "requires": [
-        {"notable": "Fish Tank Top Left Direct Jump"},
+        {"notable": "Top Left Direct Jump"},
         "Gravity",
         "canTrickyJump"
       ],
@@ -1606,9 +1606,9 @@
     {
       "id": 66,
       "link": [5, 4],
-      "name": "Fish Tank Top Left Direct Suitless HiJump",
+      "name": "Top Left Direct Suitless HiJump",
       "requires": [
-        {"notable": "Fish Tank Top Left Direct Jump"},
+        {"notable": "Top Left Direct Jump"},
         "canSuitlessMaridia",
         "HiJump",
         "canTrickyJump",
@@ -1626,9 +1626,9 @@
     {
       "id": 67,
       "link": [5, 4],
-      "name": "Fish Tank Top Left Direct Suitless Springball Jump",
+      "name": "Top Left Direct Suitless Springball Jump",
       "requires": [
-        {"notable": "Fish Tank Top Left Direct Jump"},
+        {"notable": "Top Left Direct Jump"},
         "canSuitlessMaridia",
         "canTrickySpringBallJump",
         {"or": [
@@ -1797,9 +1797,9 @@
     {
       "id": 78,
       "link": [6, 7],
-      "name": "Fish Tank Insane Naked Jump Over Pirate (Left to Right)",
+      "name": "Insane Naked Jump Over Pirate (Left to Right)",
       "requires": [
-        {"notable": "Fish Tank Insane Naked Jump Over Pirate (Left to Right)"},
+        {"notable": "Insane Naked Jump Over Pirate (Left to Right)"},
         "canSuitlessMaridia",
         "canInsaneJump"
       ],
@@ -1882,7 +1882,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Fish Tank Top Left Direct Jump",
+      "name": "Top Left Direct Jump",
       "note": [
         "Jump into the Top-Left door of the Fish Tank room from the nearby ledge using one of Gravity, HiJump, or SpringBall.",
         "This requires a very precise jump from the very edge of the ledge and risks falling into the Bottom-Left pit which may be difficult to climb back from."
@@ -1890,26 +1890,26 @@
     },
     {
       "id": 2,
-      "name": "Fish Tank Very Long Underwater Walljump Climb",
+      "name": "Very Long Underwater Walljump Climb",
       "note": [
         "This underwater walljump is very long. Some jump assistance, cross room jump, or a flatley jump from the door frame is needed to get to the first overhang."
       ]
     },
     {
       "id": 3,
-      "name": "Fish Tank Grapple Teleport into Grapple Jump",
+      "name": "Grapple Teleport into Grapple Jump",
       "note": [
         "Swing to the right, shoot open the door above, and grapple jump through it."
       ]
     },
     {
       "id": 4,
-      "name": "Fish Tank Entry Fall onto Frozen Fish",
+      "name": "Room Entry Fall onto Frozen Fish",
       "note": "Enter on the left side of the door while aiming down and freeze the fish immediately."
     },
     {
       "id": 5,
-      "name": "Fish Tank Entry Reset Fall Speed",
+      "name": "Room Entry Reset Fall Speed",
       "note": [
         "Morph and unmorph before reaching the transition, and then drift to the ledge.",
         "Enter the room as far right as possible."
@@ -1917,7 +1917,7 @@
     },
     {
       "id": 6,
-      "name": "Fish Tank Wall Jump Entry",
+      "name": "Wall Jump Entry",
       "note": [
         "Wall jump in the room above, on the right wall of the doorway, immdiately before the door transition. Failure will likely result in a soft lock.",
         "To get to the ledge: If the room above has normal physics, hold right in this room. If the room above has water physics, shoot to break spin while holding right in this room."
@@ -1925,7 +1925,7 @@
     },
     {
       "id": 7,
-      "name": "Fish Tank Insane Naked Jump Over Pirate (Left to Right)",
+      "name": "Insane Naked Jump Over Pirate (Left to Right)",
       "note": "This is particularly precise, and requires subpixel precision."
     }
   ],

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -795,7 +795,7 @@
     {
       "id": 31,
       "link": [2, 4],
-      "name": "Glass Tunnel Cross Room Platform Stuck Wiggle to Top Door",
+      "name": "Cross Room Platform Stuck Wiggle to Top Door",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -803,7 +803,7 @@
         }
       },
       "requires": [
-        {"notable": "Glass Tunnel Cross Room Platform Stuck Wiggle to Top Door"},
+        {"notable": "Cross Room Platform Stuck Wiggle to Top Door"},
         "f_MaridiaTubeBroken",
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround",
@@ -865,14 +865,14 @@
     {
       "id": 33,
       "link": [2, 4],
-      "name": "Glass Tunnel Grapple Teleport into Grapple Jump or Tube Intact (Lower Entrance)",
+      "name": "Grapple Teleport into Grapple Jump or Tube Intact (Lower Entrance)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
         }
       },
       "requires": [
-        {"notable": "Glass Tunnel Grapple Teleport into Grapple Jump (or Tube Intact)"},
+        {"notable": "Grapple Teleport into Grapple Jump (or Tube Intact)"},
         {"doorUnlockedAtNode": 4},
         {"or": [
           {"and": [
@@ -1370,14 +1370,14 @@
     {
       "id": 56,
       "link": [3, 4],
-      "name": "Glass Tunnel Grapple Teleport into Grapple Jump or Tube Intact (Right Entrance)",
+      "name": "Grapple Teleport into Grapple Jump or Tube Intact (Right Entrance)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[5, 3]]
         }
       },
       "requires": [
-        {"notable": "Glass Tunnel Grapple Teleport into Grapple Jump (or Tube Intact)"},
+        {"notable": "Grapple Teleport into Grapple Jump (or Tube Intact)"},
         {"doorUnlockedAtNode": 4},
         {"or": [
           {"and": [
@@ -1635,7 +1635,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Breaking the Maridia Tube Gravity Jump"},
+        {"notable": "Breaking the Tube Gravity Jump"},
         {"not": "f_MaridiaTubeBroken"},
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphPowerBomb",
@@ -1715,9 +1715,9 @@
     {
       "id": 72,
       "link": [5, 4],
-      "name": "Breaking the Maridia Tube Gravity Jump",
+      "name": "Breaking the Tube Gravity Jump",
       "requires": [
-        {"notable": "Breaking the Maridia Tube Gravity Jump"},
+        {"notable": "Breaking the Tube Gravity Jump"},
         {"not": "f_MaridiaTubeBroken"},
         "canRiskPermanentLossOfAccess",
         "h_canUsePowerBombs",
@@ -1842,9 +1842,9 @@
     },
     {
       "link": [6, 4],
-      "name": "Breaking the Maridia Tube Gravity Jump (From Above)",
+      "name": "Breaking the Tube Gravity Jump (From Above)",
       "requires": [
-        {"notable": "Breaking the Maridia Tube Gravity Jump"},
+        {"notable": "Breaking the Tube Gravity Jump"},
         {"not": "f_MaridiaTubeBroken"},
         "canRiskPermanentLossOfAccess",
         "h_canUsePowerBombs",
@@ -1884,9 +1884,9 @@
     {
       "id": 83,
       "link": [6, 5],
-      "name": "Maridia Tube Unmorph Clip",
+      "name": "Unmorph Tube Clip",
       "requires": [
-        {"notable": "Glass Tunnel Maridia Tube Clip"},
+        {"notable": "Tube Clip"},
         "Morph"
       ],
       "note": "Unmorph once fully underneath the rightside slope to clip."
@@ -1894,9 +1894,9 @@
     {
       "id": 84,
       "link": [6, 5],
-      "name": "Maridia Tube Standing Clip",
+      "name": "Morphless Tube Clip",
       "requires": [
-        {"notable": "Glass Tunnel Maridia Tube Clip"},
+        {"notable": "Tube Clip"},
         "canTunnelCrawl"
       ],
       "note": [
@@ -1922,7 +1922,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Glass Tunnel Maridia Tube Clip",
+      "name": "Tube Clip",
       "note": [
         "Clip into the Maridia Tube from above without needing to break the tube.",
         "This can be done with morph by unmorphing under the sloped tiles on the right, or with canTunnelCrawl by wedging Samus under them with a precise low jump and then performing a tunnel crawl."
@@ -1930,7 +1930,7 @@
     },
     {
       "id": 2,
-      "name": "Glass Tunnel Grapple Teleport into Grapple Jump (or Tube Intact)",
+      "name": "Grapple Teleport into Grapple Jump (or Tube Intact)",
       "note": [
         "Swing to the right, shoot open the door above, and grapple jump through it.",
         "The grapple beam will need to be retracted while swinging to the right, to avoid bonking on the small platform."
@@ -1938,7 +1938,7 @@
     },
     {
       "id": 3,
-      "name": "Glass Tunnel Cross Room Platform Stuck Wiggle to Top Door",
+      "name": "Cross Room Platform Stuck Wiggle to Top Door",
       "note": [
         "Requires a runway of at least 18 tiles in the adjacent room.",
         "Ride up the right wall just above the doorway, then turnaround before and after hitting the platform following the doorway slope.",
@@ -1947,7 +1947,7 @@
     },
     {
       "id": 4,
-      "name": "Breaking the Maridia Tube Gravity Jump",
+      "name": "Breaking the Tube Gravity Jump",
       "note": [
         "Jump as the first action after breaking the tube to gravity jump to the top of the room.",
         "Open the door and go through it during the ascent. This can only be attempted once."

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -706,7 +706,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canArtificialMorphIBJ",
         "Gravity",
         "canTrickyUseFrozenEnemies",
@@ -751,7 +751,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "canTrickyUseFrozenEnemies",
         "Wave",
         "h_canUseMorphBombs",
@@ -790,7 +790,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canArtificialMorphIBJ",
         "Gravity",
         "canTrickyUseFrozenEnemies",
@@ -825,7 +825,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "canTrickyUseFrozenEnemies",
         "Wave",
         {"or": [
@@ -1434,7 +1434,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canArtificialMorphIBJ",
         "Gravity",
         "canTrickyUseFrozenEnemies",
@@ -1478,7 +1478,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "canTrickyUseFrozenEnemies",
         "Wave",
         "h_canUseMorphBombs",
@@ -1516,7 +1516,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canArtificialMorphIBJ",
         "Gravity",
         "canTrickyUseFrozenEnemies",
@@ -1551,7 +1551,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "canTrickyUseFrozenEnemies",
         "Wave",
         {"or": [
@@ -2129,7 +2129,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canArtificialMorphIBJ",
         "Gravity",
         "canTrickyUseFrozenEnemies",
@@ -2173,7 +2173,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "canTrickyUseFrozenEnemies",
         "Wave",
         "h_canUseMorphBombs",
@@ -2211,7 +2211,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canArtificialMorphIBJ",
         "Gravity",
         "canTrickyUseFrozenEnemies",
@@ -2246,7 +2246,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "canTrickyUseFrozenEnemies",
         "Wave",
         {"or": [
@@ -2312,9 +2312,9 @@
     {
       "id": 90,
       "link": [3, 9],
-      "name": "Main Street Climb with Ice and Spring Ball",
+      "name": "Climb with Ice and Spring Ball",
       "requires": [
-        {"notable": "Main Street Climb with Ice and Spring Ball"},
+        {"notable": "Climb with Ice and Spring Ball"},
         "canSuitlessMaridia",
         "canTrickySpringBallJump",
         "canTrickyUseFrozenEnemies",
@@ -2334,9 +2334,9 @@
     {
       "id": 91,
       "link": [3, 9],
-      "name": "Main Street Underwater Walljumps (Middle)",
+      "name": "Underwater Walljump (Middle)",
       "requires": [
-        {"notable": "Main Street Underwater Walljumps"},
+        {"notable": "Underwater Walljumps"},
         "canUnderwaterWalljump"
       ],
       "note": "This underwater walljump is relatively long."
@@ -2344,9 +2344,9 @@
     {
       "id": 92,
       "link": [3, 9],
-      "name": "Main Street Mid Crab Climb with Only Ice and Supers",
+      "name": "Mid Crab Climb with Only Ice and Supers",
       "requires": [
-        {"notable": "Main Street Crab Climb with Only Ice and Supers"},
+        {"notable": "Crab Climb with Only Ice and Supers"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canBeVeryPatient",
@@ -2363,9 +2363,9 @@
     {
       "id": 93,
       "link": [3, 9],
-      "name": "Main Street Ice Only Mid Crab Climb",
+      "name": "Ice Only Mid Crab Climb",
       "requires": [
-        {"notable": "Main Street Crab Climb with Only Ice"},
+        {"notable": "Crab Climb with Only Ice"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canBeVeryPatient",
@@ -2690,7 +2690,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         {"or": [
           "Gravity",
           {"and": [
@@ -2736,7 +2736,7 @@
         }
       },
       "requires": [
-        {"notable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab"},
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         {"or": [
           "Gravity",
           {"and": [
@@ -3066,9 +3066,9 @@
     {
       "id": 131,
       "link": [8, 3],
-      "name": "Main Street Underwater Walljumps (Bottom)",
+      "name": "Underwater Walljump (Bottom)",
       "requires": [
-        {"notable": "Main Street Underwater Walljumps"},
+        {"notable": "Underwater Walljumps"},
         "canUnderwaterWalljump"
       ],
       "note": "Jump from the bottom left slope for a bit of extra height to start."
@@ -3076,9 +3076,9 @@
     {
       "id": 132,
       "link": [8, 3],
-      "name": "Main Street Ice Only Bottom Crab Climb",
+      "name": "Ice Only Bottom Crab Climb",
       "requires": [
-        {"notable": "Main Street Crab Climb with Only Ice"},
+        {"notable": "Crab Climb with Only Ice"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canSunkenTileWideWallClimb",
@@ -3251,9 +3251,9 @@
     {
       "id": 140,
       "link": [9, 4],
-      "name": "Main Street Underwater Walljumps (Top)",
+      "name": "Underwater Walljump (Top)",
       "requires": [
-        {"notable": "Main Street Underwater Walljumps"},
+        {"notable": "Underwater Walljumps"},
         "canUnderwaterWalljump"
       ],
       "note": "Jump from the slope for a bit of extra height to start."
@@ -3339,9 +3339,9 @@
     {
       "id": 144,
       "link": [9, 4],
-      "name": "Main Street Top Crab Climb with Supers",
+      "name": "Top Crab Climb with Supers",
       "requires": [
-        {"notable": "Main Street Crab Climb with Only Ice and Supers"},
+        {"notable": "Crab Climb with Only Ice and Supers"},
         "canBeVeryPatient",
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
@@ -3360,9 +3360,9 @@
     {
       "id": 145,
       "link": [9, 4],
-      "name": "Main Street Ice Only Top Crab Climb",
+      "name": "Ice Only Top Crab Climb",
       "requires": [
-        {"notable": "Main Street Crab Climb with Only Ice"},
+        {"notable": "Crab Climb with Only Ice"},
         "canBeExtremelyPatient",
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
@@ -3414,12 +3414,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Main Street Underwater Walljumps",
+      "name": "Underwater Walljumps",
       "note": "Climbing all of Main Street with only HiJump and Underwater Walljumps."
     },
     {
       "id": 2,
-      "name": "Main Street Crab Climb with Only Ice and Supers",
+      "name": "Crab Climb with Only Ice and Supers",
       "note": [
         "Climbing Main Street from the door to the Fish Tank Room to the top with only three supers and ice.",
         "Requires very precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
@@ -3428,7 +3428,7 @@
     },
     {
       "id": 3,
-      "name": "Main Street Crab Climb with Only Ice",
+      "name": "Crab Climb with Only Ice",
       "note": [
         "Climbing Main Street from the very bottom to the top with only ice.",
         "Requires very precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
@@ -3437,7 +3437,7 @@
     },
     {
       "id": 4,
-      "name": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
+      "name": "G-Mode Overload Speed Blocks then use Frozen Crab",
       "note": [
         "Overload the speed blocks. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
         "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down.",
@@ -3447,7 +3447,7 @@
     },
     {
       "id": 5,
-      "name": "Main Street Climb with Ice and Spring Ball",
+      "name": "Climb with Ice and Spring Ball",
       "note": [
         "The tricky part is getting to the ledge below the missiles. There are two ways to do this:",
         "1. Stand on a frozen crab with a frozen fish at the lowest height of its cycle to the right. Further to the right is better as long as it can be stood upon without the ledge above.",

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -855,9 +855,9 @@
     {
       "id": 42,
       "link": [5, 2],
-      "name": "Mama Turtle Insane Walljump",
+      "name": "Insane Walljump",
       "requires": [
-        {"notable": "Mama Turtle Insane Walljump"},
+        {"notable": "Insane Walljump"},
         "HiJump",
         "canInsaneJump",
         "canStationarySpinJump",
@@ -892,7 +892,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Mama Turtle Insane Walljump",
+      "name": "Insane Walljump",
       "note": [
         "Perform a running stationary spinjump from a precise spot, then a CWJ with slightly more speed off the wall one tile further out.",
         "This makes it possible to just barely walljump off the grapple block."

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -727,7 +727,7 @@
     {
       "id": 17,
       "link": [1, 4],
-      "name": "Mt. Everest Spring Ball Bounce Left to Right",
+      "name": "Spring Ball Bounce Left to Right",
       "entranceCondition": {
         "comeInSpinning": {
           "speedBooster": false,
@@ -737,7 +737,7 @@
         }
       },
       "requires": [
-        {"notable": "Mt. Everest Spring Ball Bounce Left to Right"},
+        {"notable": "Spring Ball Bounce Left to Right"},
         "SpeedBooster",
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
@@ -820,14 +820,14 @@
     {
       "id": 20,
       "link": [1, 9],
-      "name": "Mt. Everest Shinespark Down-Grab to the Grapple Blocks (Left to Top)",
+      "name": "Shinespark Down-Grab to the Grapple Blocks (Left to Top)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 110
         }
       },
       "requires": [
-        {"notable": "Mt. Everest Shinespark Down-Grab to the Grapple Blocks (Left to Top)"},
+        {"notable": "Shinespark Down-Grab to the Grapple Blocks (Left to Top)"},
         "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
         "canHorizontalShinespark",
@@ -1105,7 +1105,7 @@
     {
       "id": 34,
       "link": [2, 5],
-      "name": "Mt. Everest Cross Room Jump through Top Door",
+      "name": "Cross Room Jump through Top Door",
       "entranceCondition": {
         "comeInWithPlatformBelow": {
           "minHeight": 9,
@@ -1116,7 +1116,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Mt. Everest Cross Room Jump through Top Door"},
+        {"notable": "Cross Room Jump through Top Door"},
         "canCrossRoomJumpIntoWater",
         "SpeedBooster",
         "HiJump",
@@ -1247,9 +1247,9 @@
     {
       "id": 42,
       "link": [2, 7],
-      "name": "Everest Crab HiJump Bomb-Grapple-Jump",
+      "name": "Crab HiJump Bomb-Grapple-Jump",
       "requires": [
-        {"notable": "Everest Crab HiJump Bomb-Grapple-Jump"},
+        {"notable": "Crab HiJump Bomb-Grapple-Jump"},
         "h_canNavigateUnderwater",
         "HiJump",
         "canBombGrappleJump"
@@ -1261,9 +1261,9 @@
     {
       "id": 43,
       "link": [2, 7],
-      "name": "Everest Double Crab Bomb-Grapple-Jump",
+      "name": "Double Crab Bomb-Grapple-Jump",
       "requires": [
-        {"notable": "Everest Double Crab Bomb-Grapple-Jump"},
+        {"notable": "Double Crab Bomb-Grapple-Jump"},
         "h_canNavigateUnderwater",
         "canBombGrappleJump",
         "h_canCrouchJumpDownGrab"
@@ -2617,7 +2617,7 @@
     {
       "id": 107,
       "link": [4, 9],
-      "name": "Mt. Everest Spring Ball Bounce (Right to Top, Come In With Spring Ball Bounce)",
+      "name": "Spring Ball Bounce (Right to Top, Come In With Spring Ball Bounce)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
           "speedBooster": false,
@@ -2626,7 +2626,7 @@
         }
       },
       "requires": [
-        {"notable": "Mt. Everest Spring Ball Bounce Right to Left"},
+        {"notable": "Spring Ball Bounce Right to Left"},
         "SpeedBooster",
         "canCrossRoomJumpIntoWater",
         "canTrickySpringBallBounce"
@@ -2642,7 +2642,7 @@
     {
       "id": 108,
       "link": [4, 9],
-      "name": "Mt. Everest Spring Ball Bounce (Right to Top, Come In Running)",
+      "name": "Spring Ball Bounce (Right to Top, Come In Running)",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": false,
@@ -2650,7 +2650,7 @@
         }
       },
       "requires": [
-        {"notable": "Mt. Everest Spring Ball Bounce Right to Left"},
+        {"notable": "Spring Ball Bounce Right to Left"},
         "SpeedBooster",
         "canCrossRoomJumpIntoWater",
         "canTrickySpringBallBounce"
@@ -2707,7 +2707,7 @@
     {
       "id": 112,
       "link": [4, 11],
-      "name": "Mt. Everest Spring Ball Bounce (Come in With Spring Ball Bounce, Single Spring Fling)",
+      "name": "Spring Ball Bounce (Come in With Spring Ball Bounce, Single Spring Fling)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
           "speedBooster": "any",
@@ -2717,7 +2717,7 @@
         }
       },
       "requires": [
-        {"notable": "Mt. Everest Spring Ball Bounce Right to Left"},
+        {"notable": "Spring Ball Bounce Right to Left"},
         "canCrossRoomJumpIntoWater",
         "canTrickySpringBallBounce",
         "canSpringFling"
@@ -2737,7 +2737,7 @@
     {
       "id": 113,
       "link": [4, 11],
-      "name": "Mt. Everest Spring Ball Bounce (Come in With Spring Ball Bounce, Multiple Spring Fling)",
+      "name": "Spring Ball Bounce (Come in With Spring Ball Bounce, Multiple Spring Fling)",
       "entranceCondition": {
         "comeInWithSpringBallBounce": {
           "speedBooster": "any",
@@ -2747,7 +2747,7 @@
         }
       },
       "requires": [
-        {"notable": "Mt. Everest Spring Ball Bounce Right to Left"},
+        {"notable": "Spring Ball Bounce Right to Left"},
         "canCrossRoomJumpIntoWater",
         "canTrickySpringBallBounce",
         "canSpringFling",
@@ -2764,7 +2764,7 @@
     {
       "id": 114,
       "link": [4, 11],
-      "name": "Mt. Everest Spring Ball Bounce (Come in Running, Multiple Spring Fling)",
+      "name": "Spring Ball Bounce (Come in Running, Multiple Spring Fling)",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 1.4375,
@@ -2772,7 +2772,7 @@
         }
       },
       "requires": [
-        {"notable": "Mt. Everest Spring Ball Bounce Right to Left"},
+        {"notable": "Spring Ball Bounce Right to Left"},
         "canCrossRoomJumpIntoWater",
         "canTrickySpringBallBounce",
         "canSpringFling",
@@ -3727,7 +3727,7 @@
     {
       "id": 164,
       "link": [7, 10],
-      "name": "Mt. Everest Right Bottom Half Crab Climb with Supers and HiJump",
+      "name": "Right Bottom Half Crab Climb with Supers and HiJump",
       "requires": [
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
@@ -3745,7 +3745,7 @@
     {
       "id": 165,
       "link": [7, 10],
-      "name": "Mt. Everest Right Bottom Half Crab Climb with Supers and Spring Ball",
+      "name": "Right Bottom Half Crab Climb with Supers and Spring Ball",
       "requires": [
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
@@ -3763,9 +3763,9 @@
     {
       "id": 166,
       "link": [7, 10],
-      "name": "Mt. Everest Right Bottom Half Crab Climb with 1 Super",
+      "name": "Right Bottom Half Crab Climb with 1 Super",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only 1 Super"},
+        {"notable": "Right Crab Climb with Only 1 Super"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canTrickyJump",
@@ -3788,9 +3788,9 @@
     {
       "id": 167,
       "link": [7, 10],
-      "name": "Mt. Everest Right Bottom Half Crab Climb with Supers",
+      "name": "Right Bottom Half Crab Climb with Supers",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only 2 Supers"},
+        {"notable": "Right Crab Climb with Only 2 Supers"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canTrickyJump",
@@ -3809,9 +3809,9 @@
     {
       "id": 168,
       "link": [7, 10],
-      "name": "Mt. Everest Right Bottom Half Crab Climb with HiJump",
+      "name": "Right Bottom Half Crab Climb with HiJump",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only HiJump or Springball"},
+        {"notable": "Right Crab Climb with Only HiJump or Springball"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "HiJump",
@@ -3839,9 +3839,9 @@
     {
       "id": 169,
       "link": [7, 10],
-      "name": "Mt. Everest Right Bottom Half Crab Climb with Spring Ball",
+      "name": "Right Bottom Half Crab Climb with Spring Ball",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only HiJump or Springball"},
+        {"notable": "Right Crab Climb with Only HiJump or Springball"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canTrickySpringBallJump",
@@ -4396,7 +4396,7 @@
     {
       "id": 202,
       "link": [10, 4],
-      "name": "Mt. Everest Right Top Half Crab Climb with Supers and HiJump",
+      "name": "Right Top Half Crab Climb with Supers and HiJump",
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
@@ -4415,7 +4415,7 @@
     {
       "id": 203,
       "link": [10, 4],
-      "name": "Mt. Everest Right Top Half Crab Climb with Supers and Spring Ball",
+      "name": "Right Top Half Crab Climb with Supers and Spring Ball",
       "requires": [
         "canSuitlessMaridia",
         "canTrickySpringBallJump",
@@ -4432,9 +4432,9 @@
     {
       "id": 204,
       "link": [10, 4],
-      "name": "Mt. Everest Right Top Half Crab Climb with Supers",
+      "name": "Right Top Half Crab Climb with Supers",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only 2 Supers"},
+        {"notable": "Right Crab Climb with Only 2 Supers"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canTrickyJump",
@@ -4453,9 +4453,9 @@
     {
       "id": 205,
       "link": [10, 4],
-      "name": "Mt. Everest Right Top Half Crab Climb with only Ice",
+      "name": "Right Top Half Crab Climb with only Ice",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only 1 Super"},
+        {"notable": "Right Crab Climb with Only 1 Super"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canTrickyJump",
@@ -4472,9 +4472,9 @@
     {
       "id": 206,
       "link": [10, 4],
-      "name": "Mt. Everest Right Top Half Crab Climb with HiJump",
+      "name": "Right Top Half Crab Climb with HiJump",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only HiJump or Springball"},
+        {"notable": "Right Crab Climb with Only HiJump or Springball"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "HiJump",
@@ -4493,9 +4493,9 @@
     {
       "id": 207,
       "link": [10, 4],
-      "name": "Mt. Everest Right Top Half Crab Climb with Spring Ball",
+      "name": "Right Top Half Crab Climb with Spring Ball",
       "requires": [
-        {"notable": "Mt. Everest Right Crab Climb with Only HiJump or Springball"},
+        {"notable": "Right Crab Climb with Only HiJump or Springball"},
         "canSuitlessMaridia",
         "canCrazyCrabClimb",
         "canTrickySpringBallJump",
@@ -4656,9 +4656,9 @@
     {
       "id": 213,
       "link": [11, 1],
-      "name": "Mt. Everest Top Left Shinecharge (to Top Left)",
+      "name": "Top Left Shinecharge (to Top Left)",
       "requires": [
-        {"notable": "Mt. Everest Top Left Shinecharge"},
+        {"notable": "Top Left Shinecharge"},
         "Gravity",
         {"canShineCharge": {
           "usedTiles": 11,
@@ -4687,9 +4687,9 @@
     {
       "id": 214,
       "link": [11, 5],
-      "name": "Mt. Everest Top Left Shinecharge (to Top Center)",
+      "name": "Top Left Shinecharge (to Top Center)",
       "requires": [
-        {"notable": "Mt. Everest Top Left Shinecharge"},
+        {"notable": "Top Left Shinecharge"},
         "Gravity",
         "SpaceJump",
         "canTrickyDashJump",
@@ -4720,9 +4720,9 @@
     {
       "id": 215,
       "link": [11, 5],
-      "name": "Mt. Everest Top Left Shinecharge (to Top Center, with HiJump)",
+      "name": "Top Left Shinecharge (to Top Center, with HiJump)",
       "requires": [
-        {"notable": "Mt. Everest Top Left Shinecharge"},
+        {"notable": "Top Left Shinecharge"},
         "Gravity",
         "HiJump",
         "SpaceJump",
@@ -4829,7 +4829,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Mt. Everest Right Crab Climb with Only HiJump or Springball",
+      "name": "Right Crab Climb with Only HiJump or Springball",
       "note": [
         "Using HiJump or SpringBallJumpMidAir and ice to freeze a crab and climb the right side of Mt. Everest.",
         "Requires precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs."
@@ -4837,7 +4837,7 @@
     },
     {
       "id": 2,
-      "name": "Mt. Everest Right Crab Climb with Only 2 Supers",
+      "name": "Right Crab Climb with Only 2 Supers",
       "note": [
         "Climbing the right side of Mt. Everest with only two supers and ice. (As used in 14% Icebooster)",
         "Requires very precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
@@ -4847,7 +4847,7 @@
     },
     {
       "id": 3,
-      "name": "Mt. Everest Right Crab Climb with Only 1 Super",
+      "name": "Right Crab Climb with Only 1 Super",
       "note": [
         "A harder version of 'Mt. Everest Right Crab Climb with Only 2 Supers'",
         "Requires extremely precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
@@ -4857,7 +4857,7 @@
     },
     {
       "id": 4,
-      "name": "Mt. Everest Top Left Shinecharge",
+      "name": "Top Left Shinecharge",
       "note": [
         "Gain a shinecharge on the ledge near the top-left door.",
         "This is a very short runway, making it an exceptionally difficult short-charge."
@@ -4865,7 +4865,7 @@
     },
     {
       "id": 5,
-      "name": "Mt. Everest Spring Ball Bounce Right to Left",
+      "name": "Spring Ball Bounce Right to Left",
       "note": [
         "Cross the room from right to left by using Spring Ball to bounce on the first Grapple block platform.",
         "This is easier if Speed Booster is unequipped.",
@@ -4874,7 +4874,7 @@
     },
     {
       "id": 6,
-      "name": "Mt. Everest Spring Ball Bounce Left to Right",
+      "name": "Spring Ball Bounce Left to Right",
       "note": [
         "In the other room, use 6 runway tiles to gain an extra run speed of exactly $1.D, with Speed Booster unequipped.",
         "Jump into a lateral mid-air morph and touch the door transition while descending close to the ground.",
@@ -4891,12 +4891,12 @@
     },
     {
       "id": 7,
-      "name": "Mt. Everest Shinespark Down-Grab to the Grapple Blocks (Left to Top)",
+      "name": "Shinespark Down-Grab to the Grapple Blocks (Left to Top)",
       "note": "Crouch on the lowest stair, then shinespark horizontally to bonk at the top corner of the grapple block. Down grab to get onto it."
     },
     {
       "id": 8,
-      "name": "Mt. Everest Cross Room Jump through Top Door",
+      "name": "Cross Room Jump through Top Door",
       "note": [
         "Run and jump up through the door using SpeedBooster in the room below.",
         "Bonk the door frame as you pass through the transition, to cancel your horizontal momentum.",
@@ -4918,14 +4918,14 @@
     },
     {
       "id": 9,
-      "name": "Everest Crab HiJump Bomb-Grapple-Jump",
+      "name": "Crab HiJump Bomb-Grapple-Jump",
       "note": [
         "Jump into a mid-air morph, lay a Bomb, unmorph, use grapple to kill a Sciser, to be able to get a second jump mid-air."
       ]
     },
     {
       "id": 10,
-      "name": "Everest Double Crab Bomb-Grapple-Jump",
+      "name": "Double Crab Bomb-Grapple-Jump",
       "note": [
         "Position 2 Scisers so that they can each be used for a Bomb-Grapple-Jump, back to back.",
         "This gives a total of 3 jumps to climb from the bottom of Everest up to one of the lower peaks.",

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -385,9 +385,9 @@
     {
       "id": 19,
       "link": [2, 3],
-      "name": "Red Fish Space Jump Spring Ball Jump",
+      "name": "Space Jump Spring Ball Jump",
       "requires": [
-        {"notable": "Red Fish Space Jump Spring Ball Jump"},
+        {"notable": "Space Jump Spring Ball Jump"},
         "canSpaceJumpWaterBounce",
         "canTrickySpringBallJump",
         "can4HighMidAirMorph"
@@ -399,9 +399,9 @@
     {
       "id": 20,
       "link": [2, 3],
-      "name": "Red Fish Space Jump Escape",
+      "name": "Space Jump Escape",
       "requires": [
-        {"notable": "Red Fish Space Jump Escape"},
+        {"notable": "Space Jump Escape"},
         "canSpaceJumpWaterEscape",
         "canInsaneJump"
       ],
@@ -708,14 +708,14 @@
   "notables": [
     {
       "id": 1,
-      "name": "Red Fish Space Jump Spring Ball Jump",
+      "name": "Space Jump Spring Ball Jump",
       "note": [
         "Use a Space Jump water bounce followed by a tight mid-air morph, to get a mid-air Spring Ball jump out of the water."
       ]
     },
     {
       "id": 2,
-      "name": "Red Fish Space Jump Escape",
+      "name": "Space Jump Escape",
       "note": [
         "Escape the water using a well-timed Space Jump water bounce followed by a frame-perfect Space jump just above the water, at a specific time when the tide is descending."
       ]

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -333,9 +333,9 @@
     {
       "id": 11,
       "link": [1, 3],
-      "name": "Grapple Tutorial 3 Frozen Gamet Bridge",
+      "name": "Frozen Gamet Bridge",
       "requires": [
-        {"notable": "Grapple Tutorial 3 Frozen Gamet Bridge"},
+        {"notable": "Frozen Gamet Bridge"},
         "canTrickyUseFrozenEnemies"
       ],
       "note": [
@@ -347,9 +347,9 @@
     {
       "id": 12,
       "link": [1, 3],
-      "name": "Grapple Tutorial 3 Double Gamet Boost",
+      "name": "Double Gamet Boost",
       "requires": [
-        {"notable": "Grapple Tutorial 3 Double Gamet Boost"},
+        {"notable": "Double Gamet Boost"},
         "h_canNavigateUnderwater",
         "canTrickyJump",
         "canHorizontalDamageBoost",
@@ -945,7 +945,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Grapple Tutorial 3 Frozen Gamet Bridge",
+      "name": "Frozen Gamet Bridge",
       "note": [
         "Lead a Gamet up through the water and freeze it to cross the first moat.",
         "Freeze the Gamet before it starts moving left.",
@@ -954,7 +954,7 @@
     },
     {
       "id": 2,
-      "name": "Grapple Tutorial 3 Double Gamet Boost",
+      "name": "Double Gamet Boost",
       "note": [
         "1- Stand near the farm point, on the edge of where you make Gamets spawn.",
         "2- Wait for the water position to be high.",

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -1216,9 +1216,9 @@
     {
       "id": 56,
       "link": [5, 1],
-      "name": "Post Crocomire Farming Room Speed Jump",
+      "name": "Speedy Jump",
       "requires": [
-        {"notable": "Post Crocomire Farming Room Speed Jump"},
+        {"notable": "Speedy Jump"},
         "canTrickyDashJump",
         "canWalljump"
       ],
@@ -1275,9 +1275,9 @@
     {
       "id": 59,
       "link": [5, 1],
-      "name": "Post Crocomire Farming Room Damage Boost",
+      "name": "Damage Boost",
       "requires": [
-        {"notable": "Post Crocomire Farming Room Damage Boost"},
+        {"notable": "Damage Boost"},
         "canTrickyJump",
         {"or": [
           "h_canCrouchJumpDownGrab",
@@ -1632,7 +1632,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Post Crocomire Farming Room Speed Jump",
+      "name": "Speedy Jump",
       "note": [
         "Doesn't require opening the bottom right door. Just using the available space and jumping late enough.",
         "It does require killing the Gamets and leaving the drops there so they don't kill your momentum."
@@ -1640,7 +1640,7 @@
     },
     {
       "id": 2,
-      "name": "Post Crocomire Farming Room Damage Boost",
+      "name": "Damage Boost",
       "note": "Use the moving platform (Kamer) to elevate the Gamets."
     }
   ],

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -163,7 +163,7 @@
     {
       "id": 3,
       "link": [1, 2],
-      "name": "PCJR Full Room Space Jump Through Speed Blocks",
+      "name": "Full Room Space Jump Through Speed Blocks",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 9,
@@ -171,7 +171,7 @@
         }
       },
       "requires": [
-        {"notable": "PCJR Full Room Space Jump Through Speed Blocks"},
+        {"notable": "Full Room Space Jump Through Speed Blocks"},
         "canBlueSpaceJump",
         "canPreciseSpaceJump"
       ],
@@ -293,14 +293,14 @@
     {
       "id": 10,
       "link": [1, 3],
-      "name": "PCJR Left Side Diagonal Shinespark",
+      "name": "Left Side Diagonal Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 175
         }
       },
       "requires": [
-        {"notable": "PCJR Left Side Diagonal Shinespark"},
+        {"notable": "Left Side Diagonal Shinespark"},
         "canTrickyJump",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
@@ -317,7 +317,7 @@
       "link": [1, 3],
       "name": "Indiana Jones Grapple",
       "requires": [
-        {"notable": "PCJR Indiana Jones Grapple"},
+        {"notable": "Indiana Jones Grapple"},
         "canUseEnemies",
         "canPreciseGrapple"
       ],
@@ -363,7 +363,7 @@
     {
       "id": 15,
       "link": [1, 6],
-      "name": "PCJR G-Mode Morph Long Diagonal Bomb Jump (Indirect)",
+      "name": "G-Mode Morph Long Diagonal Bomb Jump (Indirect)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "indirect",
@@ -371,7 +371,7 @@
         }
       },
       "requires": [
-        {"notable": "PCJR G-Mode Morph Long Diagonal Bomb Jump"},
+        {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
         "h_canArtificialMorphDiagonalBombJump"
       ],
       "flashSuitChecked": true,
@@ -380,7 +380,7 @@
     {
       "id": 16,
       "link": [1, 6],
-      "name": "PCJR G-Mode Morph Long Diagonal Bomb Jump (Direct)",
+      "name": "G-Mode Morph Long Diagonal Bomb Jump (Direct)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -388,7 +388,7 @@
         }
       },
       "requires": [
-        {"notable": "PCJR G-Mode Morph Long Diagonal Bomb Jump"},
+        {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
         "h_canArtificialMorphDiagonalBombJump"
       ],
       "clearsObstacles": ["D"],
@@ -456,9 +456,9 @@
     {
       "id": 19,
       "link": [2, 1],
-      "name": "PCJR Big Jump Shinespark",
+      "name": "Big Jump Shinespark",
       "requires": [
-        {"notable": "PCJR Big Jump Shinespark"},
+        {"notable": "Big Jump Shinespark"},
         "canShinechargeMovementComplex",
         "canMidairShinespark",
         {"obstaclesCleared": ["B"]},
@@ -961,7 +961,7 @@
       "link": [3, 1],
       "name": "Indiana Jones Grapple in Reverse",
       "requires": [
-        {"notable": "PCJR Indiana Jones Grapple"},
+        {"notable": "Indiana Jones Grapple"},
         "canUseEnemies",
         "canPreciseGrapple"
       ],
@@ -1122,9 +1122,9 @@
     {
       "id": 58,
       "link": [5, 2],
-      "name": "PCJR Acid Shinespark",
+      "name": "Acid Shinespark",
       "requires": [
-        {"notable": "PCJR Acid Shinespark"},
+        {"notable": "Acid Shinespark"},
         "Gravity",
         "canSuitlessLavaDive",
         "canShinechargeMovement",
@@ -1170,9 +1170,9 @@
     {
       "id": 61,
       "link": [5, 3],
-      "name": "PCJR Springwall",
+      "name": "Springwall",
       "requires": [
-        {"notable": "PCJR Springwall"},
+        {"notable": "Springwall"},
         "HiJump",
         "h_canTrickySpringwall",
         "canPreciseWalljump",
@@ -1230,9 +1230,9 @@
     {
       "id": 64,
       "link": [5, 3],
-      "name": "Indy Jones Mella Ice Clip",
+      "name": "Mella Ice Clip",
       "requires": [
-        {"notable": "Indy Jones Mella Ice Clip"},
+        {"notable": "Mella Ice Clip"},
         "Morph",
         {"or": [
           "h_canXRayMorphIceClip",
@@ -1348,22 +1348,22 @@
   "notables": [
     {
       "id": 1,
-      "name": "PCJR Indiana Jones Grapple",
+      "name": "Indiana Jones Grapple",
       "note": "Involves grappling off several Rippers, where falling may lead to a soft lock."
     },
     {
       "id": 2,
-      "name": "PCJR G-Mode Morph Long Diagonal Bomb Jump",
+      "name": "G-Mode Morph Long Diagonal Bomb Jump",
       "note": "Perform a long diagonal bomb jump from the left door to the solid platforms above the acid."
     },
     {
       "id": 3,
-      "name": "PCJR Full Room Space Jump Through Speed Blocks",
+      "name": "Full Room Space Jump Through Speed Blocks",
       "note": "The blocks can be broken if you can generate a blue suit using the previous room's runway, and carry it to the blocks by slowing floating down with Space Jump."
     },
     {
       "id": 4,
-      "name": "PCJR Left Side Diagonal Shinespark",
+      "name": "Left Side Diagonal Shinespark",
       "note": [
         "Store a shinespark near the Grapple Room door and use the remaining runway to jump as far as possible to the right.",
         "Once near the acid platforms, Shinespark diagonally to reach the Missile Location."
@@ -1371,17 +1371,17 @@
     },
     {
       "id": 5,
-      "name": "PCJR Big Jump Shinespark",
+      "name": "Big Jump Shinespark",
       "note": "Charge a spark to the right, then come back, run and jump, and do a horizontal spark at the apex."
     },
     {
       "id": 6,
-      "name": "PCJR Acid Shinespark",
+      "name": "Acid Shinespark",
       "note": "Gravity makes it possible to charge a spark in the acid in order to break the speed blocks."
     },
     {
       "id": 7,
-      "name": "PCJR Springwall",
+      "name": "Springwall",
       "note": [
         "A particularly precise springwall.",
         "Aim the walljump at the bottom of the second sloped wall fixture, where it looks like you cant jump off of.",
@@ -1390,7 +1390,7 @@
     },
     {
       "id": 8,
-      "name": "Indy Jones Mella Ice Clip",
+      "name": "Mella Ice Clip",
       "note": [
         "Freeze the Mella at a precise location in order to jump through the crumble block, then wall jump up the long channel and mid air morph to get out.",
         "The Mella pixel positioning window is larger and higher with Morph and an X-Ray Stand Up."

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -682,9 +682,9 @@
     {
       "id": 13,
       "link": [1, 7],
-      "name": "Bubble Mountain Damage Boost (Left to Right)",
+      "name": "Damage Boost (Left to Right)",
       "requires": [
-        {"notable": "Bubble Mountain Damage Boost"},
+        {"notable": "Damage Boost"},
         "canHorizontalDamageBoost",
         {"enemyDamage": {
           "enemy": "Waver",
@@ -3357,9 +3357,9 @@
     {
       "id": 117,
       "link": [7, 1],
-      "name": "Bubble Mountain Damage Boost (Right to Left)",
+      "name": "Damage Boost (Right to Left)",
       "requires": [
-        {"notable": "Bubble Mountain Damage Boost"},
+        {"notable": "Damage Boost"},
         "canHorizontalDamageBoost",
         {"enemyDamage": {
           "enemy": "Waver",
@@ -4061,9 +4061,9 @@
     {
       "id": 148,
       "link": [9, 1],
-      "name": "Bubble Mountain Tricky Spring Ball Jump with Grapple",
+      "name": "Tricky Spring Ball Jump with Grapple",
       "requires": [
-        {"notable": "Bubble Mountain Tricky Spring Ball Jump with Grapple"},
+        {"notable": "Tricky Spring Ball Jump with Grapple"},
         "canTrickySpringBallJump",
         "canPreciseGrapple"
       ],
@@ -4149,9 +4149,9 @@
     {
       "id": 157,
       "link": [9, 7],
-      "name": "Bubble Mountain Right Side Delayed Walljumps",
+      "name": "Right Side Delayed Walljumps",
       "requires": [
-        {"notable": "Bubble Mountain Right Side Delayed Walljumps"},
+        {"notable": "Right Side Delayed Walljumps"},
         "canDelayedWalljump",
         "canConsecutiveWalljump"
       ],
@@ -4245,12 +4245,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Bubble Mountain Damage Boost",
+      "name": "Damage Boost",
       "note": "Crossing between the topmost doors of Bubble Mountain by damage boosting using a Waver."
     },
     {
       "id": 2,
-      "name": "Bubble Mountain Tricky Spring Ball Jump with Grapple",
+      "name": "Tricky Spring Ball Jump with Grapple",
       "note": [
         "Perform a very tight Spring Ball jump from the Save room door runway, starting from either a crouch or spin jump,",
         "then use Grapple to barely reach the ceiling blocks."
@@ -4258,7 +4258,7 @@
     },
     {
       "id": 3,
-      "name": "Bubble Mountain Right Side Delayed Walljumps",
+      "name": "Right Side Delayed Walljumps",
       "note": "A tricky, delayed walljump makes it possible to climb to top right in-room, with nothing."
     }
   ],

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -184,7 +184,7 @@
     {
       "id": 6,
       "link": [1, 5],
-      "name": "Cathedral Entrance 10 Power Bomb Crystal Flash",
+      "name": "10 Power Bomb Crystal Flash",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 0.0,
@@ -193,7 +193,7 @@
         }
       },
       "requires": [
-        {"notable": "Cathedral Entrance 10 Power Bomb Crystal Flash"},
+        {"notable": "10 Power Bomb Crystal Flash"},
         "canPrepareForNextRoom",
         {"heatFrames": 570},
         "h_canHeated10PowerBombCrystalFlash"
@@ -298,7 +298,7 @@
     {
       "id": 13,
       "link": [2, 5],
-      "name": "Cathedral Entrance 10 Power Bomb Crystal Flash",
+      "name": "10 Power Bomb Crystal Flash",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 0.0,
@@ -307,7 +307,7 @@
         }
       },
       "requires": [
-        {"notable": "Cathedral Entrance 10 Power Bomb Crystal Flash"},
+        {"notable": "10 Power Bomb Crystal Flash"},
         "canPrepareForNextRoom",
         {"heatFrames": 420},
         "h_canHeated10PowerBombCrystalFlash"
@@ -401,9 +401,9 @@
     {
       "id": 18,
       "link": [3, 1],
-      "name": "Cathedral Entrance Left Door Frozen Sova Step",
+      "name": "Left Door Frozen Sova Step",
       "requires": [
-        {"notable": "Cathedral Entrance Left Door Frozen Sova Step"},
+        {"notable": "Left Door Frozen Sova Step"},
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
         "canCameraManip",
@@ -430,9 +430,9 @@
     {
       "id": 20,
       "link": [3, 2],
-      "name": "Cathedral Entrance Sova Morph Only Boost",
+      "name": "Sova Morph Only Boost",
       "requires": [
-        {"notable": "Cathedral Entrance Sova Morph Only Boost"},
+        {"notable": "Sova Morph Only Boost"},
         "canInsaneWalljump",
         "canMidAirMorph",
         "canNeutralDamageBoost",
@@ -625,9 +625,9 @@
     {
       "id": 33,
       "link": [4, 1],
-      "name": "Cathedral Entrance Speedjump (Right to Left)",
+      "name": "Speedjump (Right to Left)",
       "requires": [
-        {"notable": "Cathedral Entrance Speedjump (Right to Left)"},
+        {"notable": "Speedjump (Right to Left)"},
         "canTrickyDashJump",
         {"heatFrames": 150}
       ],
@@ -748,9 +748,9 @@
     {
       "id": 37,
       "link": [4, 2],
-      "name": "Cathedral Entrance Speedjump (Left to Right)",
+      "name": "Speedjump (Left to Right)",
       "requires": [
-        {"notable": "Cathedral Entrance Speedjump (Left to Right)"},
+        {"notable": "Speedjump (Left to Right)"},
         "canTrickyDashJump",
         "canWalljump",
         {"heatFrames": 150}
@@ -945,9 +945,9 @@
     {
       "id": 48,
       "link": [5, 2],
-      "name": "Cathedral Entrance Sova Boost (Walljump)",
+      "name": "Sova Boost (Walljump)",
       "requires": [
-        {"notable": "Cathedral Entrance Sova Boost"},
+        {"notable": "Sova Boost"},
         "canInsaneWalljump",
         "canWallJumpInstantMorph",
         "canNeutralDamageBoost",
@@ -972,9 +972,9 @@
     {
       "id": 49,
       "link": [5, 2],
-      "name": "Cathedral Entrance Sova Boost (Reserve Double Damage Boost)",
+      "name": "Sova Boost (Reserve Double Damage Boost)",
       "requires": [
-        {"notable": "Cathedral Entrance Sova Boost"},
+        {"notable": "Sova Boost"},
         "canCrouchJump",
         "canInsaneJump",
         {"or": [
@@ -1004,9 +1004,9 @@
     {
       "id": 50,
       "link": [5, 2],
-      "name": "Cathedral Entrance Sova Boost (Reserve Delay Bomb Boost and Sova Boost)",
+      "name": "Sova Boost (Reserve Delay Bomb Boost and Sova Boost)",
       "requires": [
-        {"notable": "Cathedral Entrance Sova Boost"},
+        {"notable": "Sova Boost"},
         "h_canBombThings",
         "canMidAirMorph",
         "canTrickyJump",
@@ -1108,7 +1108,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Cathedral Entrance 10 Power Bomb Crystal Flash",
+      "name": "10 Power Bomb Crystal Flash",
       "note": [
         "Use a Sm. Dessgeega to collect a Power Bomb, to be able to perform a Crystal Flash with a capacity of only 10 Power Bombs.",
         "Normalized whole-room movement can be used to manipulate the Sm. Dessgeegas, to be able to do this strat reliably without heat protection.",
@@ -1117,7 +1117,7 @@
     },
     {
       "id": 2,
-      "name": "Cathedral Entrance Sova Boost",
+      "name": "Sova Boost",
       "note": [
         "Wait for the global Sova to begin climbing the wall below the right side door.",
         "Jump into it just before it reaches the ledge that the door is on to gain height through a neutral damage boost.",
@@ -1127,7 +1127,7 @@
     },
     {
       "id": 3,
-      "name": "Cathedral Entrance Left Door Frozen Sova Step",
+      "name": "Left Door Frozen Sova Step",
       "note": [
         "Guide the morph tunnel Sova on top of the shot blocks by keeping it on camera.",
         "Move the camera away once it is on top of the shot blocks.  It will not move while off camera.",
@@ -1139,7 +1139,7 @@
     },
     {
       "id": 4,
-      "name": "Cathedral Entrance Sova Morph Only Boost",
+      "name": "Sova Morph Only Boost",
       "note": [
         "Use a very well timed and precise walljump into morph to hit the global Sova so that the damage bonks Samus up to the door ledge.",
         "Aim for the lowest part of slope looking wall tile, where it does not look possible to make contact with a walljump, and fully delay the jump.",
@@ -1148,7 +1148,7 @@
     },
     {
       "id": 5,
-      "name": "Cathedral Entrance Speedjump (Right to Left)",
+      "name": "Speedjump (Right to Left)",
       "note": [
         "This is a precise strat which requires maximum run speed.",
         "Perform a spin jump right next to the left wall.",
@@ -1158,7 +1158,7 @@
     },
     {
       "id": 6,
-      "name": "Cathedral Entrance Speedjump (Left to Right)",
+      "name": "Speedjump (Left to Right)",
       "note": [
         "This is a precise strat which requires maximum run speed.",
         "Jump when passing under the floating platform and barely avoid hitting the rightmost wall.",

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -234,9 +234,9 @@
     {
       "id": 6,
       "link": [2, 1],
-      "name": "Double Chamber Walljump Climb Using the Kamer",
+      "name": "Walljump Climb Using the Kamer",
       "requires": [
-        {"notable": "Double Chamber Walljump Climb Using the Kamer"},
+        {"notable": "Walljump Climb Using the Kamer"},
         "canPreciseWalljump",
         "canConsecutiveWalljump",
         "canUseEnemies",
@@ -272,9 +272,9 @@
     {
       "id": 7,
       "link": [2, 1],
-      "name": "Double Chamber Walljump Climb Using the Kamer with HiJump",
+      "name": "Walljump Climb Using the Kamer with HiJump",
       "requires": [
-        {"notable": "Double Chamber Walljump Climb Using the Kamer"},
+        {"notable": "Walljump Climb Using the Kamer"},
         "HiJump",
         "canUseEnemies",
         "canWalljump",
@@ -1001,9 +1001,9 @@
     {
       "id": 44,
       "link": [3, 3],
-      "name": "Double Chamber Shinespark through Wave Beam Door (Top Path)",
+      "name": "Shinespark through Wave Beam Door (Top Path)",
       "requires": [
-        {"notable": "Double Chamber Shinespark through Wave Beam Door"},
+        {"notable": "Shinespark through Wave Beam Door"},
         "HiJump",
         {"or": [
           "SpaceJump",
@@ -1049,9 +1049,9 @@
     {
       "id": 45,
       "link": [3, 3],
-      "name": "Double Chamber Shinespark through Wave Beam Door (Through Crumbles)",
+      "name": "Shinespark through Wave Beam Door (Through Crumbles)",
       "requires": [
-        {"notable": "Double Chamber Shinespark through Wave Beam Door"},
+        {"notable": "Shinespark through Wave Beam Door"},
         "HiJump",
         "Morph",
         {"or": [
@@ -1236,9 +1236,9 @@
     {
       "id": 57,
       "link": [3, 4],
-      "name": "Hijumpless Double Chamber Spike Speedjump",
+      "name": "Hijumpless Spike Speedjump",
       "requires": [
-        {"notable": "Hijumpless Double Chamber Spike Speedjump"},
+        {"notable": "Hijumpless Spike Speedjump"},
         "canIframeSpikeJump",
         {"spikeHits": 1},
         "SpeedBooster",
@@ -1278,9 +1278,9 @@
     {
       "id": 59,
       "link": [3, 4],
-      "name": "Double Chamber HiJumpless Wall Jump",
+      "name": "HiJumpless Wall Jump",
       "requires": [
-        {"notable": "Double Chamber HiJumpless Wall Jump"},
+        {"notable": "HiJumpless Wall Jump"},
         "h_heatProof",
         "canInsaneWalljump",
         {"or": [
@@ -1581,7 +1581,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Double Chamber Walljump Climb Using the Kamer",
+      "name": "Walljump Climb Using the Kamer",
       "note": [
         "Wall jump up the left wall and then on the moving platform (Kamer) while avoiding the Fune's fireball.",
         "The Kamers will temporarily move down if Samus is below them, so it is best to walk under the first Kamer before climbing the wall.",
@@ -1590,7 +1590,7 @@
     },
     {
       "id": 2,
-      "name": "Double Chamber Shinespark through Wave Beam Door",
+      "name": "Shinespark through Wave Beam Door",
       "note": [
         "Charge a spark along the bottom of Double Chamber and use it to spark through the right side door.",
         "Requires opening the door and shutter first."
@@ -1598,7 +1598,7 @@
     },
     {
       "id": 3,
-      "name": "Hijumpless Double Chamber Spike Speedjump",
+      "name": "Hijumpless Spike Speedjump",
       "note": [
         "Position Samus into the bottom right corner, using invulnerability frames run then jump while on the crumble blocks.",
         "It is possible to use a damage boost on the Ripper to save energy and position Samus into the corner."
@@ -1606,7 +1606,7 @@
     },
     {
       "id": 4,
-      "name": "Double Chamber HiJumpless Wall Jump",
+      "name": "HiJumpless Wall Jump",
       "note": [
         "Jump into the spike pit, hitting the Ripper to avoid spike damage.",
         "Climb the left wall while avoiding falling onto the spikes or through the crumble blocks. The ledge is the same size of that in writg."

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -208,9 +208,9 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "Frog Speedway Speed Block Moondance (Leave with Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
-        {"notable": "Frog Speedway Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
@@ -235,9 +235,9 @@
     {
       "id": 9,
       "link": [1, 1],
-      "name": "Frog Speedway Speed Block Moondance (Leave with More Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
-        {"notable": "Frog Speedway Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
@@ -365,9 +365,9 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "Frog Speedway Speed Block Moondance (Leave with Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
-        {"notable": "Frog Speedway Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
@@ -398,9 +398,9 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Frog Speedway Speed Block Moondance (Leave with More Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
-        {"notable": "Frog Speedway Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
@@ -515,9 +515,9 @@
     {
       "id": 20,
       "link": [2, 1],
-      "name": "Frog Speedway Shot Block Overload (Speedless Speedway)",
+      "name": "Shot Block Overload (Speedless Speedway)",
       "requires": [
-        {"notable": "Frog Speedway Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           "Spazer",
@@ -584,7 +584,7 @@
         }
       },
       "requires": [
-        {"notable": "Frog Speedway Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           {"and": [
@@ -743,7 +743,7 @@
         }
       },
       "requires": [
-        {"notable": "Frog Speedway Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           "Spazer",
@@ -799,7 +799,7 @@
         }
       },
       "requires": [
-        {"notable": "Frog Speedway Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           "Spazer",
@@ -871,7 +871,7 @@
       "link": [2, 2],
       "name": "Shot Block Overload for Frozen Beetom Moondance",
       "requires": [
-        {"notable": "Frog Speedway Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {
@@ -901,7 +901,7 @@
       "link": [2, 2],
       "name": "Shot Block Overload for Frozen Beetom Extended Moondance",
       "requires": [
-        {"notable": "Frog Speedway Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {
@@ -953,7 +953,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Frog Speedway Shot Block Overload (Speedless Speedway)",
+      "name": "Shot Block Overload (Speedless Speedway)",
       "note": [
         "This strat is only usable right to left.",
         "This room has many offscreen shot blocks. Shooting enough of them with wave + spazer or wave + plasma allows you to pass through the speed blocks.",
@@ -962,7 +962,7 @@
     },
     {
       "id": 2,
-      "name": "Frog Speedway Speed Block Moondance",
+      "name": "Speed Block Moondance",
       "note": [
         "Use SpeedBooster to construct a structure for Moondancing that has 1 chest height block and 1 head height block to the right of it and no other Speed blocks.",
         "Crystal Flash below the lower block, exactly pixel aligned with its right side, to standup and then begin Moondancing.",

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -203,9 +203,9 @@
     {
       "id": 43,
       "link": [1, 5],
-      "name": "Lava Dive Thread the Needle Entry",
+      "name": "Thread the Needle Entry",
       "requires": [
-        {"notable": "Lava Dive Thread the Needle Entry"},
+        {"notable": "Thread the Needle Entry"},
         {"or": [
           "canSuitlessLavaDive",
           "Gravity"
@@ -387,7 +387,7 @@
     {
       "id": 14,
       "link": [2, 3],
-      "name": "Lava Dive Shinespark",
+      "name": "Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -395,7 +395,7 @@
         }
       },
       "requires": [
-        {"notable": "Lava Dive Shinespark"},
+        {"notable": "Shinespark"},
         "Gravity",
         {"or": [
           "h_lavaProof",
@@ -421,9 +421,9 @@
     {
       "id": 15,
       "link": [2, 3],
-      "name": "Lava Dive GT Max Suitless Right Side Climb",
+      "name": "GT Max Suitless Right Side Climb",
       "requires": [
-        {"notable": "Lava Dive GT Max Suitless Right Side Climb"},
+        {"notable": "GT Max Suitless Right Side Climb"},
         "canSuitlessLavaDive",
         "canUseEnemies",
         "HiJump",
@@ -659,9 +659,9 @@
     {
       "id": 27,
       "link": [4, 3],
-      "name": "Lava Dive with HiJump (Criss Cross Walljumps)",
+      "name": "HiJump (Criss Cross Walljumps)",
       "requires": [
-        {"notable": "Lava Dive with HiJump"},
+        {"notable": "HiJump"},
         "HiJump",
         "canSuitlessLavaDive",
         "canUseEnemies",
@@ -678,9 +678,9 @@
     {
       "id": 28,
       "link": [4, 3],
-      "name": "Lava Dive with HiJump and Springwall",
+      "name": "HiJump and Springwall",
       "requires": [
-        {"notable": "Lava Dive with HiJump"},
+        {"notable": "HiJump"},
         {"or": [
           "h_lavaProof",
           "canSuitlessLavaDive"
@@ -704,9 +704,9 @@
     {
       "id": 29,
       "link": [4, 3],
-      "name": "Lava Dive HiJumpless Suitless Double Springball Jump",
+      "name": "HiJumpless Suitless Double Springball Jump",
       "requires": [
-        {"notable": "Lava Dive HiJumpless Suitless Double Springball Jump"},
+        {"notable": "HiJumpless Suitless Double Springball Jump"},
         "canSuitlessLavaDive",
         "canUseEnemies",
         "canDoubleSpringBallJumpMidAir",
@@ -720,9 +720,9 @@
     {
       "id": 30,
       "link": [4, 3],
-      "name": "Lava Dive HiJumpless Nahime Morph Kago",
+      "name": "HiJumpless Nahime Morph Kago",
       "requires": [
-        {"notable": "Lava Dive HiJumpless Nahime Morph Kago"},
+        {"notable": "HiJumpless Nahime Morph Kago"},
         "canSuitlessLavaDive",
         "canInsaneWalljump",
         "canInsaneJump",
@@ -747,9 +747,9 @@
     {
       "id": 31,
       "link": [4, 3],
-      "name": "Lava Dive Diagonal Bomb Jump",
+      "name": "Diagonal Bomb Jump",
       "requires": [
-        {"notable": "Lava Dive Diagonal Bomb Jump"},
+        {"notable": "Diagonal Bomb Jump"},
         "h_heatProof",
         "Gravity",
         {"or": [
@@ -958,9 +958,9 @@
     {
       "id": 38,
       "link": [5, 3],
-      "name": "HiJumpless Lava Dive",
+      "name": "HiJumpless Dive",
       "requires": [
-        {"notable": "HiJumpless Lava Dive"},
+        {"notable": "HiJumpless Dive"},
         "canSuitlessLavaDive",
         "canIframeSpikeJump",
         "canStaggeredWalljump",
@@ -1057,7 +1057,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Lava Dive with HiJump",
+      "name": "HiJump",
       "note": [
         "Climb through the Lava by walljumping off of the Namihes with HiJump.",
         "This can be done by jumping from the left side Namihes to the hanging ceiling in the center of the room and climbing further from there.",
@@ -1066,7 +1066,7 @@
     },
     {
       "id": 2,
-      "name": "Lava Dive Thread the Needle Entry",
+      "name": "Thread the Needle Entry",
       "note": [
         "Gain a specifc amount of speed by running from a standstill, starting slightly more than 3 tiles from the edge of the Ridley statue jaw.",
         "Jump on the last possible frame (second-to-last frame may also work, depending on subpixels).",
@@ -1075,7 +1075,7 @@
     },
     {
       "id": 3,
-      "name": "Lava Dive Shinespark",
+      "name": "Shinespark",
       "note": [
         "Store the shinespark on the last possible pixels of runway.",
         "Quickly drop to the nearby namihe and damage boost using its flame.",
@@ -1084,7 +1084,7 @@
     },
     {
       "id": 4,
-      "name": "Lava Dive GT Max Suitless Right Side Climb",
+      "name": "GT Max Suitless Right Side Climb",
       "note": [
         "BounceBall into the Lava, Unmorphing with good timing to sink faster and drift effeciently towards the bottom right Namihe.",
         "Walljump at about eye height (4 pixel window) to gain enough height to reach the center portion of ceiling.",
@@ -1096,12 +1096,12 @@
     },
     {
       "id": 5,
-      "name": "Lava Dive HiJumpless Suitless Double Springball Jump",
+      "name": "HiJumpless Suitless Double Springball Jump",
       "note": "Double springball jump out of a walljump starting from the top of the left wall Namihe."
     },
     {
       "id": 6,
-      "name": "Lava Dive HiJumpless Nahime Morph Kago",
+      "name": "HiJumpless Nahime Morph Kago",
       "note": [
         "Enter the Bottom-Left Namihe by Kagoing inside of it.",
         "Wait for a second hit to gain I-Frames and then very quickly walljump up the spikes and across to the right side wall."
@@ -1109,7 +1109,7 @@
     },
     {
       "id": 7,
-      "name": "Lava Dive Diagonal Bomb Jump",
+      "name": "Diagonal Bomb Jump",
       "note": [
         "Begin on top of the lower left Namihe",
         "Jump into a double IBJ with such timing that Samus passes above the fired flame and such a way that there is no horizontal speed.",
@@ -1119,7 +1119,7 @@
     },
     {
       "id": 8,
-      "name": "HiJumpless Lava Dive",
+      "name": "HiJumpless Dive",
       "note": [
         "Use the bottommost right side namihe to generate a flame and walk with it to the bottommost left namihe head",
         "Use a turnaround animation as Samus is hit by the flame to cancel out knockback frames.",

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -123,9 +123,9 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Spiky Acid Snakes Suitless Damage Boosts (Left to Right)",
+      "name": "Suitless Damage Boosts (Left to Right)",
       "requires": [
-        {"notable": "Spiky Acid Snakes Suitless Damage Boosts"},
+        {"notable": "Suitless Damage Boosts"},
         {"heatFrames": 520},
         {"lavaFrames": 80},
         {"spikeHits": 3},
@@ -312,9 +312,9 @@
     {
       "id": 16,
       "link": [1, 2],
-      "name": "Spiky Acid Snakes Frozen Platforms (Left to Right)",
+      "name": "Frozen Maw Platforms (Left to Right)",
       "requires": [
-        {"notable": "Spiky Acid Snakes Frozen Platforms"},
+        {"notable": "Frozen Maw Platforms"},
         "canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
@@ -385,9 +385,9 @@
     {
       "id": 21,
       "link": [2, 1],
-      "name": "Spiky Acid Snakes Suitless Damage Boosts (Right to Left)",
+      "name": "Suitless Damage Boosts (Right to Left)",
       "requires": [
-        {"notable": "Spiky Acid Snakes Suitless Damage Boosts"},
+        {"notable": "Suitless Damage Boosts"},
         {"heatFrames": 520},
         {"lavaFrames": 80},
         {"spikeHits": 3},
@@ -573,9 +573,9 @@
     {
       "id": 30,
       "link": [2, 1],
-      "name": "Spiky Acid Snakes Frozen Platforms (Right to Left)",
+      "name": "Frozen Maw Platforms (Right to Left)",
       "requires": [
-        {"notable": "Spiky Acid Snakes Frozen Platforms"},
+        {"notable": "Frozen Maw Platforms"},
         "canResetFallSpeed",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
@@ -691,7 +691,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Spiky Acid Snakes Frozen Platforms",
+      "name": "Frozen Maw Platforms",
       "note": [
         "While crossing the Spiky Lava, land on frozen Yapping Maws to reduce the number of spike hits needed.",
         "Delay the damage boost from the spikes slightly in order to rise above the lava before moving."
@@ -699,7 +699,7 @@
     },
     {
       "id": 2,
-      "name": "Spiky Acid Snakes Suitless Damage Boosts",
+      "name": "Suitless Damage Boosts",
       "note": "Delay the damage boost from the spikes slightly in order to rise above the lava before moving."
     }
   ],

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -985,9 +985,9 @@
     {
       "id": 44,
       "link": [5, 5],
-      "name": "Upper Norfair Farming Room Gate Glitch With Farming",
+      "name": "Gate Glitch With Farming",
       "requires": [
-        {"notable": "Upper Norfair Farming Room Gate Glitch With Farming"},
+        {"notable": "Gate Glitch With Farming"},
         {"heatFrames": 300},
         "canGateGlitch",
         {"or": [
@@ -1020,7 +1020,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Upper Norfair Farming Room Gate Glitch With Farming",
+      "name": "Gate Glitch With Farming",
       "note": "Farm before, during, and after the gate glitch in order to open the gate without wasting ammo or Energy."
     }
   ],

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -138,7 +138,7 @@
     {
       "id": 5,
       "link": [1, 3],
-      "name": "Crocomire Escape High Speed Gate Glitch",
+      "name": "High Speed Gate Glitch",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -146,7 +146,7 @@
         }
       },
       "requires": [
-        {"notable": "Crocomire Escape High Speed Gate Glitch"},
+        {"notable": "High Speed Gate Glitch"},
         "h_canHeatedGreenGateGlitch",
         {"ammo": {"type": "Super", "count": 1}},
         "canInsaneJump"
@@ -287,12 +287,12 @@
     {
       "id": 13,
       "link": [2, 2],
-      "name": "Croc Escape Frozen Geruta Shinecharge (Shinespark Out Right)",
+      "name": "Frozen Geruta Shinecharge (Shinespark Out Right)",
       "entranceCondition": {
         "comeInNormally": {}
       },
       "requires": [
-        {"notable": "Croc Escape Frozen Geruta Shinecharge"},
+        {"notable": "Frozen Geruta Shinecharge"},
         "h_canTrickyFrozenEnemyRunway",
         "canCarefulJump",
         {"canShineCharge": {
@@ -392,9 +392,9 @@
     {
       "id": 21,
       "link": [2, 3],
-      "name": "Croc Escape SpringBall Bomb Boost",
+      "name": "SpringBall Bomb Boost",
       "requires": [
-        {"notable": "Croc Escape SpringBall Bomb Boost"},
+        {"notable": "SpringBall Bomb Boost"},
         "canSpringBallJumpMidAir",
         "canUnmorphBombBoost",
         "h_canCrouchJumpDownGrab",
@@ -408,9 +408,9 @@
     {
       "id": 22,
       "link": [2, 3],
-      "name": "Croc Escape SpringBall Freeze",
+      "name": "SpringBall Freeze",
       "requires": [
-        {"notable": "Croc Escape SpringBall Freeze"},
+        {"notable": "SpringBall Freeze"},
         "canTrickyUseFrozenEnemies",
         "canSpringBallJumpMidAir",
         {"heatFrames": 1600},
@@ -436,9 +436,9 @@
     {
       "id": 24,
       "link": [2, 3],
-      "name": "Croc Escape Ice Only Geruta Platforming",
+      "name": "Ice Only Geruta Platforming",
       "requires": [
-        {"notable": "Croc Escape Ice Only Geruta Platforming"},
+        {"notable": "Ice Only Geruta Platforming"},
         "canTrickyUseFrozenEnemies",
         "canCarefulJump",
         {"or": [
@@ -514,12 +514,12 @@
     {
       "id": 28,
       "link": [2, 3],
-      "name": "Croc Escape Frozen Geruta Shinecharge (Shinespark Left)",
+      "name": "Frozen Geruta Shinecharge (Shinespark Left)",
       "entranceCondition": {
         "comeInNormally": {}
       },
       "requires": [
-        {"notable": "Croc Escape Frozen Geruta Shinecharge"},
+        {"notable": "Frozen Geruta Shinecharge"},
         "h_canTrickyFrozenEnemyRunway",
         "canCarefulJump",
         "canHorizontalShinespark",
@@ -758,7 +758,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Croc Escape Frozen Geruta Shinecharge",
+      "name": "Frozen Geruta Shinecharge",
       "note": [
         "Enter from the right door and spin jump onto the first ledge while barely landing on the ledge in order to prevent getting the Geruta on camera.",
         "Walk against the left wall and jump to trigger the Geruta. It should now be moving leftwards.",
@@ -769,7 +769,7 @@
     },
     {
       "id": 2,
-      "name": "Crocomire Escape High Speed Gate Glitch",
+      "name": "High Speed Gate Glitch",
       "note": [
         "Build up 34 tiles worth of run speed and jump into the door on the last frame.",
         "Hold angle up through the transition but also aim down to duck below the ceiling until Samus is past it.",
@@ -778,7 +778,7 @@
     },
     {
       "id": 3,
-      "name": "Croc Escape SpringBall Bomb Boost",
+      "name": "SpringBall Bomb Boost",
       "note": [
         "Uses a bomb boost at the end of a mid-air SpringBall jump.",
         "Also requires a crouchjump and downgrab to complete the maneuver."
@@ -786,12 +786,12 @@
     },
     {
       "id": 4,
-      "name": "Croc Escape SpringBall Freeze",
+      "name": "SpringBall Freeze",
       "note": "Do a series of mid-air SpringBall jumps to bring the Geruta over, then freeze it and step on it."
     },
     {
       "id": 5,
-      "name": "Croc Escape Ice Only Geruta Platforming",
+      "name": "Ice Only Geruta Platforming",
       "note": [
         "Ride the Geruta left to reach the missile location by freezing it repeatedly.",
         "Stay on its left side when it touches the ceiling for the enemy to continue moving forward.",

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -248,9 +248,9 @@
     {
       "id": 7,
       "link": [2, 2],
-      "name": "Croc Speedway Speed Block Moondance (Leave with Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
-        {"notable": "Croc Speedway Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_heatProof",
         "h_getBlueSpeedMaxRunway",
         "h_canCrystalFlash",
@@ -278,9 +278,9 @@
     {
       "id": 8,
       "link": [2, 2],
-      "name": "Croc Speedway Speed Block Moondance (Leave with More Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
-        {"notable": "Croc Speedway Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_heatProof",
         "h_getBlueSpeedMaxRunway",
         "h_canCrystalFlash",
@@ -318,7 +318,7 @@
     {
       "id": 10,
       "link": [3, 2],
-      "name": "Croc Speedway Reverse Spark (From Croc Door)",
+      "name": "Reverse Spark (From Croc Door)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 35
@@ -326,7 +326,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Croc Speedway Reverse Spark"},
+        {"notable": "Reverse Spark"},
         "canShinechargeMovement",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 86, "excessFrames": 10}},
@@ -397,7 +397,7 @@
     {
       "id": 16,
       "link": [4, 2],
-      "name": "Croc Speedway Reverse Speedball",
+      "name": "Reverse Speedball",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 1,
@@ -405,7 +405,7 @@
         }
       },
       "requires": [
-        {"notable": "Croc Speedway Reverse Speedball"},
+        {"notable": "Reverse Speedball"},
         "canSpeedball",
         {"heatFrames": 570}
       ],
@@ -416,7 +416,7 @@
     {
       "id": 17,
       "link": [4, 2],
-      "name": "Croc Speedway Reverse Spark Near SpeedBlocks",
+      "name": "Reverse Spark Near SpeedBlocks",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 1,
@@ -424,7 +424,7 @@
         }
       },
       "requires": [
-        {"notable": "Croc Speedway Reverse Spark"},
+        {"notable": "Reverse Spark"},
         "canShinechargeMovement",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 84, "excessFrames": 10}},
@@ -440,14 +440,14 @@
     {
       "id": 18,
       "link": [4, 2],
-      "name": "Croc Speedway Reverse Spark Through Door",
+      "name": "Reverse Spark Through Door",
       "entranceCondition": {
         "comeInWithSpark": {
           "position": "bottom"
         }
       },
       "requires": [
-        {"notable": "Croc Speedway Reverse Spark"},
+        {"notable": "Reverse Spark"},
         {"shinespark": {"frames": 94, "excessFrames": 10}},
         {"heatFrames": 700}
       ],
@@ -724,7 +724,7 @@
     {
       "id": 32,
       "link": [5, 2],
-      "name": "Croc Speedway Reverse Spark (From Save Room)",
+      "name": "Reverse Spark (From Save Room)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 5,
@@ -732,7 +732,7 @@
         }
       },
       "requires": [
-        {"notable": "Croc Speedway Reverse Spark"},
+        {"notable": "Reverse Spark"},
         "canShinechargeMovementTricky",
         "canTrickyJump",
         "canMidairShinespark",
@@ -1056,12 +1056,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Croc Speedway Reverse Spark",
+      "name": "Reverse Spark",
       "note": "Spark left through the speed blocks through Croc Speedway. Then run to the right and back to get speed to go through the rest."
     },
     {
       "id": 2,
-      "name": "Croc Speedway Speed Block Moondance",
+      "name": "Speed Block Moondance",
       "note": [
         "Use SpeedBooster to construct a structure for Moondancing that has 2 top blocks intact, 2 middle blocks removed, and the bottom left block intact but the bottom right block removed.",
         "Clear the other unused Speed blocks and enemies.",
@@ -1071,7 +1071,7 @@
     },
     {
       "id": 3,
-      "name": "Croc Speedway Reverse Speedball",
+      "name": "Reverse Speedball",
       "note": "Break the Speedway Speed blocks by jumping over the gap with speed and continuing through the room in mockball."
     }
   ],

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -181,9 +181,9 @@
     {
       "id": 9,
       "link": [1, 3],
-      "name": "Crumble Shaft Top Item Frozen Sova",
+      "name": "Top Item Frozen Sova",
       "requires": [
-        {"notable": "Crumble Shaft Top Item Frozen Sova"},
+        {"notable": "Top Item Frozen Sova"},
         "canTrickyUseFrozenEnemies",
         "canCarefulJump",
         "canCameraManip",
@@ -624,7 +624,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Crumble Shaft Top Item Frozen Sova",
+      "name": "Top Item Frozen Sova",
       "note": [
         "Jump and aim down to lower the camera so the middle platform Sova starts moving.",
         "Then freeze it by aiming down, shoot the shot block, and use the Sova as a stable platform."

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -270,9 +270,9 @@
     {
       "id": 8,
       "link": [1, 4],
-      "name": "HiJump E-Tank Sova Boost",
+      "name": "Sova Boost",
       "requires": [
-        {"notable": "HiJump E-Tank Sova Boost"},
+        {"notable": "Sova Boost"},
         "Morph",
         "canCrouchJump",
         "canTrickyJump",
@@ -696,9 +696,9 @@
     {
       "id": 35,
       "link": [5, 3],
-      "name": "HiJump E-Tank Return Through Crumble Blocks",
+      "name": "Return Through Crumble Blocks",
       "requires": [
-        {"notable": "HiJump E-Tank Return Through Crumble Blocks"},
+        {"notable": "Return Through Crumble Blocks"},
         {"obstaclesCleared": ["A"]}
       ],
       "note": "The crumble blocks do not respawn, so it is possible to enter from the right, obtain the left item and return, without needing to break the bomb blocks."
@@ -720,7 +720,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "HiJump E-Tank Sova Boost",
+      "name": "Sova Boost",
       "note": [
         "Crouch jump and let the Sova move into Samus from the right, to get a upward boost, then hold left to boost horizontally to the ledge.",
         "Then crouch jump from the slope on the left, and morph into a neutral damage boost."
@@ -728,7 +728,7 @@
     },
     {
       "id": 2,
-      "name": "HiJump E-Tank Return Through Crumble Blocks",
+      "name": "Return Through Crumble Blocks",
       "note": "The crumble blocks do not respawn, so it is possible to enter from the right, obtain the left item and return, without needing to break the bomb blocks."
     }
   ],

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -1151,9 +1151,9 @@
     {
       "id": 57,
       "link": [7, 2],
-      "name": "Ice Beam Gate Room Frozen Sova Platform",
+      "name": "Frozen Sova Platform",
       "requires": [
-        {"notable": "Ice Beam Gate Room Frozen Sova Platform"},
+        {"notable": "Frozen Sova Platform"},
         "h_canUsePowerBombs",
         "canTrickyUseFrozenEnemies"
       ],
@@ -1167,9 +1167,9 @@
     {
       "id": 58,
       "link": [7, 2],
-      "name": "Ice Beam Gate Room Sova Boost",
+      "name": "Sova Boost",
       "requires": [
-        {"notable": "Ice Beam Gate Room Sova Boost"},
+        {"notable": "Sova Boost"},
         "h_canUsePowerBombs",
         "canCrouchJump",
         "canCarefulJump",
@@ -1316,7 +1316,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Ice Beam Gate Room Frozen Sova Platform",
+      "name": "Frozen Sova Platform",
       "note": [
         "Place a Power Bomb to break the Power Bomb blocks and the bomb blocks, without killing the global Sova.",
         "Wait 30-50 seconds for the Sova to get into position to be used as a platform."
@@ -1324,7 +1324,7 @@
     },
     {
       "id": 2,
-      "name": "Ice Beam Gate Room Sova Boost",
+      "name": "Sova Boost",
       "note": [
         "Place a Power Bomb to break the Power Bomb blocks and the bomb blocks, without killing the global Sova.",
         "Wait 30-50 seconds for the Sova to get into position.",

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -243,9 +243,9 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "Ice Beam Tutorial Room Impressive Damage Boost",
+      "name": "Impressive Damage Boost",
       "requires": [
-        {"notable": "Ice Beam Tutorial Room Impressive Damage Boost"},
+        {"notable": "Impressive Damage Boost"},
         "canHorizontalDamageBoost",
         "canTrivialMidAirMorph",
         "canTrickyJump",
@@ -346,7 +346,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Ice Beam Tutorial Room Impressive Damage Boost",
+      "name": "Impressive Damage Boost",
       "note": "Unmorph with the right timing to damage boost using the Boyon who is closest to the Morph tunnel in order to avoid taking any lava damage."
     }
   ],

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -187,13 +187,13 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Blue Hopper Dodge (Normal Entry)",
+      "name": "Hopper Dodge (Normal Entry)",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "no"
       },
       "requires": [
-        {"notable": "Blue Hopper Dodge"},
+        {"notable": "Hopper Dodge"},
         "canTrickyJump",
         {"or": [
           "canPrepareForNextRoom",
@@ -231,13 +231,13 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Blue Hopper Dodge (Toilet Entry)",
+      "name": "Hopper Dodge (Toilet Entry)",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "any"
       },
       "requires": [
-        {"notable": "Blue Hopper Dodge"},
+        {"notable": "Hopper Dodge"},
         "canCameraManip",
         "canMoonwalk",
         "canInsaneJump"
@@ -499,12 +499,12 @@
     {
       "id": 20,
       "link": [2, 1],
-      "name": "Blue Hopper Room Screw Attack Jumps",
+      "name": "Screw Attack Jumps",
       "entranceCondition": {
         "comeInNormally": {}
       },
       "requires": [
-        {"notable": "Blue Hopper Room Screw Attack Jumps"},
+        {"notable": "Screw Attack Jumps"},
         "canPrepareForNextRoom",
         "ScrewAttack",
         "canTrickyJump"
@@ -529,12 +529,12 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Blue Hopper Room Roll Under Hoppers",
+      "name": "Roll Under Hoppers",
       "entranceCondition": {
         "comeInNormally": {}
       },
       "requires": [
-        {"notable": "Blue Hopper Room Roll Under Hoppers"},
+        {"notable": "Roll Under Hoppers"},
         "Morph",
         "canPrepareForNextRoom",
         "canTrickyJump"
@@ -548,7 +548,7 @@
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Blue Hopper Room Squeeze Under Hoppers",
+      "name": "Squeeze Under Hoppers",
       "entranceCondition": {
         "comeInRunning": {
           "minTiles": 4,
@@ -556,7 +556,7 @@
         }
       },
       "requires": [
-        {"notable": "Blue Hopper Room Squeeze Under Hoppers"},
+        {"notable": "Squeeze Under Hoppers"},
         "canPrepareForNextRoom",
         "canTwoTileSqueeze"
       ],
@@ -680,12 +680,12 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "Tourian Blue Hopper Crystal Flash",
+      "name": "Crystal Flash",
       "entranceCondition": {
         "comeInNormally": {}
       },
       "requires": [
-        {"notable": "Tourian Blue Hopper Crystal Flash"},
+        {"notable": "Crystal Flash"},
         "canTrickyJump",
         "h_canCrystalFlash"
       ],
@@ -1021,7 +1021,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Blue Hopper Dodge",
+      "name": "Hopper Dodge",
       "note": [
         "Enter through the far left side of the door.",
         "Wait for the top hopper to move right to start running.",
@@ -1032,7 +1032,7 @@
     },
     {
       "id": 2,
-      "name": "Blue Hopper Room Screw Attack Jumps",
+      "name": "Screw Attack Jumps",
       "note": [
         "Spin jump into the room with Screw Attack, holding left through the transition to land near the door.",
         "Do a turn-around spin jump to the right, bonking the ceiling and overhang and then falling straight down.",
@@ -1041,7 +1041,7 @@
     },
     {
       "id": 3,
-      "name": "Blue Hopper Room Roll Under Hoppers",
+      "name": "Roll Under Hoppers",
       "note": [
         "Time Samus' movement carefully to roll underneath a Blue Hopper and also race it to the far door.",
         "Enter the room morphed and let the hoppers jump against the wall a couple of times.",
@@ -1050,7 +1050,7 @@
     },
     {
       "id": 4,
-      "name": "Blue Hopper Room Squeeze Under Hoppers",
+      "name": "Squeeze Under Hoppers",
       "note": [
         "Use at least 4 tiles of runway to gain speed, running through the transition.",
         "Hold down during and after the transition in order to aim down and squeeze under the Hopper.",
@@ -1059,7 +1059,7 @@
     },
     {
       "id": 5,
-      "name": "Tourian Blue Hopper Crystal Flash",
+      "name": "Crystal Flash",
       "note": [
         "Enter the room from the left door, morph, and wait at the left wall.",
         "After 6 hops, the bottom Hopper will do three big hops in a row.",

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -463,9 +463,9 @@
     {
       "id": 16,
       "link": [1, 2],
-      "name": "Metroid Room 1 Acid Skip CWJ",
+      "name": "Acid Skip CWJ",
       "requires": [
-        {"notable": "Metroid Room 1 Acid Skip CWJ"},
+        {"notable": "Acid Skip CWJ"},
         "canCWJ",
         "canInsaneWalljump",
         {"or": [
@@ -1026,9 +1026,9 @@
     {
       "id": 45,
       "link": [2, 2],
-      "name": "Metroid Room 1 PB Dodge Kill (Right to Left)",
+      "name": "Power Bomb Dodge Kill (Right to Left)",
       "requires": [
-        {"notable": "Metroid Room 1 PB Dodge Kill (Right to Left)"},
+        {"notable": "Power Bomb Dodge Kill (Right to Left)"},
         {"enemyKill": {
           "enemies": [["Metroid", "Metroid", "Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBomb"]
@@ -1259,9 +1259,9 @@
     {
       "id": 58,
       "link": [3, 2],
-      "name": "Metroid Room 1 Rinka Boost (Left to Right)",
+      "name": "Rinka Damage Boost (Left to Right)",
       "requires": [
-        {"notable": "Metroid Room 1 Rinka Boost"},
+        {"notable": "Rinka Damage Boost"},
         {"enemyDamage": {
           "enemy": "Rinka",
           "type": "contact",
@@ -1482,9 +1482,9 @@
     {
       "id": 67,
       "link": [4, 1],
-      "name": "Metroid Room 1 Rinka Boost (Right to Left)",
+      "name": "Rinka Damage Boost (Right to Left)",
       "requires": [
-        {"notable": "Metroid Room 1 Rinka Boost"},
+        {"notable": "Rinka Damage Boost"},
         {"enemyDamage": {
           "enemy": "Rinka",
           "type": "contact",
@@ -1721,14 +1721,14 @@
   "notables": [
     {
       "id": 1,
-      "name": "Metroid Room 1 Rinka Boost",
+      "name": "Rinka Damage Boost",
       "note": [
         "Aim a Rinka to travel horizontally across the top of the room and use it to damage boost between the two floating platforms."
       ]
     },
     {
       "id": 2,
-      "name": "Metroid Room 1 Acid Skip CWJ",
+      "name": "Acid Skip CWJ",
       "note": [
         "Align with the wall below the door while facing left.",
         "Hold dash, turn around, start running and arm pump once.",
@@ -1739,7 +1739,7 @@
     },
     {
       "id": 3,
-      "name": "Metroid Room 1 PB Dodge Kill (Right to Left)",
+      "name": "Power Bomb Dodge Kill (Right to Left)",
       "note": [
         "Group all of the Metroids by hitting the first Rinka with a Power Bomb.",
         "Once grouped, use two more Power Bombs to finish them off."

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -534,9 +534,9 @@
     {
       "id": 25,
       "link": [2, 1],
-      "name": "Metroid Room 2 PB Dodge Kill (Bottom to Top)",
+      "name": "Power Bomb Dodge Kill (Bottom to Top)",
       "requires": [
-        {"notable": "Metroid Room 2 PB Dodge Kill (Bottom to Top)"},
+        {"notable": "Power Bomb Dodge Kill (Bottom to Top)"},
         {"enemyKill": {
           "enemies": [["Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBomb"]
@@ -576,9 +576,9 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Metroid Room 2 Bottom Door Metroid Avoid",
+      "name": "Bottom Door Metroid Avoid",
       "requires": [
-        {"notable": "Metroid Room 2 Bottom Door Metroid Avoid"},
+        {"notable": "Bottom Door Metroid Avoid"},
         "canMetroidAvoid"
       ],
       "note": [
@@ -1343,12 +1343,12 @@
   "notables": [
     {
       "id": 1,
-      "name": "Metroid Room 2 PB Dodge Kill (Bottom to Top)",
+      "name": "Power Bomb Dodge Kill (Bottom to Top)",
       "note": "Kill the two Metroids with Power Bombs while avoiding damage."
     },
     {
       "id": 2,
-      "name": "Metroid Room 2 Bottom Door Metroid Avoid",
+      "name": "Bottom Door Metroid Avoid",
       "note": [
         "Buffer a spinjump towards the door to jump over the top metroid and land on the middle platform.",
         "Metroids can be knocked with Beam shots to clear a path."

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -247,9 +247,9 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Metroid Room 4 Three PB Kill (Top to Bottom)",
+      "name": "Three Power Bomb Kill (Top to Bottom)",
       "requires": [
-        {"notable": "Metroid Room 4 Three PB Kill (Top to Bottom)"},
+        {"notable": "Three Power Bomb Kill (Top to Bottom)"},
         {"enemyKill": {
           "enemies": [["Metroid", "Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBomb"]
@@ -305,9 +305,9 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "Metroid Room 4 Top Metroid Avoid",
+      "name": "Top Metroid Avoid",
       "requires": [
-        {"notable": "Metroid Room 4 Top Metroid Avoid"},
+        {"notable": "Top Metroid Avoid"},
         "canMetroidAvoid",
         "canCarefulJump"
       ],
@@ -472,9 +472,9 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Metroid Room 4 Bottom Metroid Avoid (Six PB Dodge Kill)",
+      "name": "Bottom Metroid Avoid (Six Power Bomb Dodge Kill)",
       "requires": [
-        {"notable": "Metroid Room 4 Bottom Metroid Avoid (Six PB Dodge Kill)"},
+        {"notable": "Bottom Metroid Avoid (Six Power Bomb Dodge Kill)"},
         {"enemyKill": {
           "enemies": [
             ["Metroid", "Metroid"],
@@ -493,9 +493,9 @@
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Metroid Room 4 Bottom Metroid Avoid (Three PB Dodge Kill)",
+      "name": "Bottom Metroid Avoid (Three Power Bomb Dodge Kill)",
       "requires": [
-        {"notable": "Metroid Room 4 Bottom Metroid Avoid"},
+        {"notable": "Bottom Metroid Avoid"},
         {"enemyKill": {
           "enemies": [["Metroid", "Metroid", "Metroid"]],
           "explicitWeapons": ["PowerBomb"]
@@ -516,9 +516,9 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Metroid Room 4 Bottom Metroid Avoid (Traverse Room)",
+      "name": "Bottom Metroid Avoid (Traverse Room)",
       "requires": [
-        {"notable": "Metroid Room 4 Bottom Metroid Avoid"},
+        {"notable": "Bottom Metroid Avoid"},
         "canMetroidAvoid",
         "canDodgeWhileShooting",
         "canCarefulJump"
@@ -595,7 +595,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Metroid Room 4 Bottom Metroid Avoid",
+      "name": "Bottom Metroid Avoid",
       "note": [
         "Avoid all of the Rinkas and Metroids with minimal equipment and taking no damage.",
         "Depending on room entry, it may be necessary to shoot to delay the bottom metroid.",
@@ -604,7 +604,7 @@
     },
     {
       "id": 2,
-      "name": "Metroid Room 4 Three PB Kill (Top to Bottom)",
+      "name": "Three Power Bomb Kill (Top to Bottom)",
       "note": [
         "Group the Metroids by descending the room.",
         "Then Kill all three Metroids with Power Bombs while avoiding damage."
@@ -612,7 +612,7 @@
     },
     {
       "id": 3,
-      "name": "Metroid Room 4 Top Metroid Avoid",
+      "name": "Top Metroid Avoid",
       "note": [
         "Avoid all of the Rinkas and Metroids with no equipment and taking no damage.",
         "One way to do this is to bait the top Rinkas to fire upwards, and then carefully spinjump around each corner as the Metroid below passes by."
@@ -620,7 +620,7 @@
     },
     {
       "id": 4,
-      "name": "Metroid Room 4 Bottom Metroid Avoid (Six PB Dodge Kill)",
+      "name": "Bottom Metroid Avoid (Six Power Bomb Dodge Kill)",
       "note": [
         "Take out the lower two Metroids with Power Bombs while avoiding damage.",
         "Then Kill the remaining one with three more Power Bombs."

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -391,9 +391,9 @@
     {
       "id": 30,
       "link": [2, 3],
-      "name": "Mother Brain Ice Zebetite Skip",
+      "name": "Ice Zebetite Skip",
       "requires": [
-        {"notable": "Mother Brain Ice Zebetite Skip"},
+        {"notable": "Ice Zebetite Skip"},
         "canTrickyUseFrozenEnemies",
         "Morph",
         {"or": [
@@ -429,7 +429,7 @@
     {
       "id": 11,
       "link": [2, 3],
-      "name": "Mother Brain Speed Zebetite Skip (Come in Shinecharging)",
+      "name": "Speed Zebetite Skip (Come in Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -437,7 +437,7 @@
         }
       },
       "requires": [
-        {"notable": "Mother Brain Speed Zebetite Skip"},
+        {"notable": "Speed Zebetite Skip"},
         {"shinespark": {"frames": 4}},
         {"enemyDamage": {
           "enemy": "Rinka",
@@ -455,14 +455,14 @@
     {
       "id": 12,
       "link": [2, 3],
-      "name": "Mother Brain Speed Zebetite Skip (Come in Shinecharged)",
+      "name": "Speed Zebetite Skip (Come in Shinecharged)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 100
         }
       },
       "requires": [
-        {"notable": "Mother Brain Speed Zebetite Skip"},
+        {"notable": "Speed Zebetite Skip"},
         {"shinespark": {"frames": 4}},
         {"enemyDamage": {
           "enemy": "Rinka",
@@ -481,9 +481,9 @@
     {
       "id": 32,
       "link": [2, 3],
-      "name": "Mother Brain Speed Zebetite Skip (Use Flash Suit)",
+      "name": "Speed Zebetite Skip (Use Flash Suit)",
       "requires": [
-        {"notable": "Mother Brain Speed Zebetite Skip"},
+        {"notable": "Speed Zebetite Skip"},
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 4}},
         {"enemyDamage": {
@@ -769,7 +769,6 @@
       "id": 34,
       "link": [4, 4],
       "name": "Mother Brain 2 and 3 Fight",
-      "notable": false,
       "requires": [
         {"enemyKill": {
           "enemies": [["Mother Brain 2"]]
@@ -789,9 +788,9 @@
     {
       "id": 21,
       "link": [4, 4],
-      "name": "Mother Brain R-Mode Reduced Tanks",
+      "name": "R-Mode Reduced Tanks",
       "requires": [
-        {"notable": "Mother Brain R-Mode Reduced Tanks"},
+        {"notable": "R-Mode Reduced Tanks"},
         {"obstaclesCleared": ["A"]},
         "h_canCrystalFlash",
         {"enemyKill": {
@@ -822,9 +821,9 @@
     {
       "id": 22,
       "link": [4, 4],
-      "name": "Mother Brain R-Mode Light Pillar",
+      "name": "R-Mode Light Pillar",
       "requires": [
-        {"notable": "Mother Brain R-Mode Light Pillar"},
+        {"notable": "R-Mode Light Pillar"},
         {"obstaclesCleared": ["A"]},
         "h_canCrystalFlash",
         {"enemyKill": {
@@ -862,7 +861,6 @@
       "id": 35,
       "link": [5, 5],
       "name": "Destroy Second Zebetite",
-      "notable": false,
       "requires": [
         "h_canOpenZebetites",
         {"or": [
@@ -957,7 +955,6 @@
       "id": 36,
       "link": [6, 6],
       "name": "Destroy Third Zebetite",
-      "notable": false,
       "requires": [
         "h_canOpenZebetites",
         {"or": [
@@ -1042,7 +1039,6 @@
       "id": 37,
       "link": [7, 7],
       "name": "Destroy Fourth Zebetite",
-      "notable": false,
       "requires": [
         "h_canOpenZebetites",
         {"enemyDamage": {
@@ -1058,7 +1054,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Mother Brain Speed Zebetite Skip",
+      "name": "Speed Zebetite Skip",
       "note": [
         "Shinespark diagonally into the lower Rinka Spawner while holding down, spamming jump, then pressing forward,",
         "in order to glitch through the first Mother Brain Zebetites during Samus' i-frames.",
@@ -1067,7 +1063,7 @@
     },
     {
       "id": 2,
-      "name": "Mother Brain R-Mode Reduced Tanks",
+      "name": "R-Mode Reduced Tanks",
       "note": [
         "After entering with R-mode, perform a Crystal Flash to fully refill at some point before the rainbow beam attack.",
         "An R-Mode forced stand-up will happen during the rainbow beam attack, slightly reducing the damage taken which allows surviving with one fewer tank than normal."
@@ -1075,7 +1071,7 @@
     },
     {
       "id": 3,
-      "name": "Mother Brain R-Mode Light Pillar",
+      "name": "R-Mode Light Pillar",
       "note": [
         "After entering with R-mode, perform a Crystal Flash to fully refill at some point before the rainbow beam attack.",
         "When Mother Brain is about to do the rainbow beam attack, set up a 'light pillar':",
@@ -1085,7 +1081,7 @@
     },
     {
       "id": 4,
-      "name": "Mother Brain Ice Zebetite Skip",
+      "name": "Ice Zebetite Skip",
       "note": [
         "Glitch through the Mother Brain Zebetites by using a frozen Rinka and i-frames.",
         "Freeze the Rinka at its spawn location, then spinjump or Down-Back onto it after acquiring i-frames to clip inside of the Zebetite, then jump through.",

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -256,7 +256,7 @@
         }
       },
       "requires": [
-        {"notable": "Seaweed Room Temporary Blue Chain"},
+        {"notable": "Temporary Blue Chain"},
         "canLongChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -281,7 +281,7 @@
         }
       },
       "requires": [
-        {"notable": "Seaweed Room Temporary Blue Chain"},
+        {"notable": "Temporary Blue Chain"},
         "canLongChainTemporaryBlue",
         "canXRayTurnaround"
       ],
@@ -466,7 +466,7 @@
         }
       },
       "requires": [
-        {"notable": "Seaweed Room Temporary Blue Chain"},
+        {"notable": "Temporary Blue Chain"},
         "canLongChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -1000,7 +1000,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Seaweed Room Temporary Blue Chain",
+      "name": "Temporary Blue Chain",
       "note": [
         "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
       ]

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -532,9 +532,9 @@
     {
       "id": 19,
       "link": [3, 1],
-      "name": "Reverse Tourian Escape Room 4 Dodge While Climbing",
+      "name": "Reverse Dodge While Climbing",
       "requires": [
-        {"notable": "Reverse Tourian Escape Room 4 Dodge While Climbing"},
+        {"notable": "Reverse Dodge While Climbing"},
         {"or": [
           "canCarefulJump",
           "ScrewAttack",
@@ -592,9 +592,9 @@
     {
       "id": 21,
       "link": [3, 1],
-      "name": "Tourian Escape Room 4 Suitless Acid Bath Shinespark",
+      "name": "Suitless Acid Bath Shinespark",
       "requires": [
-        {"notable": "Tourian Escape Room 4 Suitless Acid Bath Shinespark"},
+        {"notable": "Suitless Acid Bath Shinespark"},
         "canStutterWaterShineCharge",
         "canInsaneJump",
         {"acidFrames": 215},
@@ -610,9 +610,9 @@
     {
       "id": 22,
       "link": [3, 1],
-      "name": "Tourian Escape Room 4 IBJ and Acid Bath",
+      "name": "IBJ and Acid Bath",
       "requires": [
-        {"notable": "Tourian Escape Room 4 IBJ and Acid Bath"},
+        {"notable": "IBJ and Acid Bath"},
         "canSuitlessLavaDive",
         "canJumpIntoIBJ",
         "canDoubleBombJump",
@@ -740,7 +740,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Reverse Tourian Escape Room 4 Dodge While Climbing",
+      "name": "Reverse Dodge While Climbing",
       "note": [
         "Navigate Leodox Room in reverse by killing or distracting the right side pirates and manipulating or dodging the left side pirates during the shaft climb.",
         "The acid starts rising when Samus is at the bottom of the long climb.",
@@ -750,7 +750,7 @@
     },
     {
       "id": 2,
-      "name": "Tourian Escape Room 4 Suitless Acid Bath Shinespark",
+      "name": "Suitless Acid Bath Shinespark",
       "note": [
         "Gain a shinecharge by running right-to-left at the bottom of the room, performing a stutter just before the acid reaches Samus' feet.",
         "Use spin jumps to minimize damage from the acid, and spark diagonally (to the left) mid-air to make it up the shaft."
@@ -758,7 +758,7 @@
     },
     {
       "id": 3,
-      "name": "Tourian Escape Room 4 IBJ and Acid Bath",
+      "name": "IBJ and Acid Bath",
       "note": "Clear the right side Space Pirates and then race the rising acid by bomb jumping."
     }
   ],

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -295,7 +295,7 @@
     {
       "id": 15,
       "link": [1, 3],
-      "name": "Basement G-mode Morph Workrobot Ride",
+      "name": "G-mode Morph Workrobot Ride",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -303,7 +303,7 @@
         }
       },
       "requires": [
-        {"notable": "Basement G-mode Morph Workrobot Ride"},
+        {"notable": "G-mode Morph Workrobot Ride"},
         "f_DefeatedPhantoon",
         "canBePatient",
         "h_canArtificialMorphPowerBomb",
@@ -939,7 +939,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Basement G-mode Morph Workrobot Ride",
+      "name": "G-mode Morph Workrobot Ride",
       "note": [
         "On room entry, place a Power Bomb to kill the Atomic and land on the Workrobot.",
         "Wait for the Workrobot to move across the room until it meets with a second robot.",

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -291,9 +291,9 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "Bowling Alley Speed Block Moondance (Leave with Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
-        {"notable": "Bowling Alley Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
@@ -323,9 +323,9 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "Bowling Alley Speed Block Moondance (Leave with More Stored Fall Speed)",
+      "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
-        {"notable": "Bowling Alley Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
@@ -356,9 +356,9 @@
     {
       "id": 9,
       "link": [1, 5],
-      "name": "Bowling Alley Speed Block Moondance (Moonfall Clip)",
+      "name": "Speed Block Moondance (Moonfall Clip)",
       "requires": [
-        {"notable": "Bowling Alley Speed Block Moondance"},
+        {"notable": "Speed Block Moondance"},
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
@@ -754,9 +754,9 @@
     {
       "id": 34,
       "link": [2, 6],
-      "name": "Bowling Alley Ceiling Bomb Jump",
+      "name": "Ceiling Bomb Jump",
       "requires": [
-        {"notable": "Bowling Alley Ceiling Bomb Jump"},
+        {"notable": "Ceiling Bomb Jump"},
         "canLongCeilingBombJump",
         "canBeVeryPatient"
       ],
@@ -765,12 +765,12 @@
     {
       "id": 35,
       "link": [3, 2],
-      "name": "Bowling Alley X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        {"notable": "Bowling Alley X-Ray Climb"},
+        {"notable": "X-Ray Climb"},
         "canXRayClimb",
         {"or": [
           {"and": [
@@ -938,9 +938,9 @@
     {
       "id": 44,
       "link": [3, 4],
-      "name": "Bowling Alley Missile Chozo Camera Unlock",
+      "name": "Missile Chozo Camera Unlock",
       "requires": [
-        {"notable": "Bowling Alley Missile Chozo Camera Unlock"},
+        {"notable": "Missile Chozo Camera Unlock"},
         "ScrewAttack",
         "Morph",
         "canCameraManip",
@@ -1274,7 +1274,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Bowling Alley Speed Block Moondance",
+      "name": "Speed Block Moondance",
       "note": [
         "Use SpeedBooster to construct a structure for Moondancing that has 2 top blocks intact, 2 middle blocks removed, and the bottom left block intact but the bottom right block removed.",
         "Crystal Flash inside the middle hole to standup and then begin Moondancing.",
@@ -1283,12 +1283,12 @@
     },
     {
       "id": 2,
-      "name": "Bowling Alley Ceiling Bomb Jump",
+      "name": "Ceiling Bomb Jump",
       "note": "This is a very long ceiling bomb jump."
     },
     {
       "id": 3,
-      "name": "Bowling Alley X-Ray Climb",
+      "name": "X-Ray Climb",
       "note": [
         "Climb up about half a screen.",
         "If Phantoon is dead, the last part of the climb should be done carefully to avoid triggering collision with the spikes:",
@@ -1305,7 +1305,7 @@
     },
     {
       "id": 4,
-      "name": "Bowling Alley Missile Chozo Camera Unlock",
+      "name": "Missile Chozo Camera Unlock",
       "note": [
         "Break the shot blocks with Power Beam by first rolling into the morph tunnel to unlock camera scroll for this room.",
         "The blocks can now be cleared from the left side by shooting and quickly scrolling the camera to the right a small amount.",

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -241,9 +241,9 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "Sponge Bath Bull Boost",
+      "name": "Bull Boost",
       "requires": [
-        {"notable": "Sponge Bath Bull Boost"},
+        {"notable": "Bull Boost"},
         "canSuitlessMaridia",
         "HiJump",
         "canUseEnemies",
@@ -1408,7 +1408,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Sponge Bath Bull Boost",
+      "name": "Bull Boost",
       "note": "Position the Bull with beam shots before jumping into it."
     }
   ],

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -517,9 +517,9 @@
     {
       "id": 21,
       "link": [1, 2],
-      "name": "WS East Supers Robot Clip Run-In-Place",
+      "name": "Robot Clip Run-In-Place",
       "requires": [
-        {"notable": "WS East Supers Robot Clip Run-In-Place"},
+        {"notable": "Robot Clip Run-In-Place"},
         "canMidAirMorph",
         "canSlowShortCharge",
         "canKago",
@@ -569,9 +569,9 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "WS East Supers Crystal Flash Clip (Right to Left)",
+      "name": "Crystal Flash Clip (Right to Left)",
       "requires": [
-        {"notable": "WS East Supers Crystal Flash Clip (Right to Left)"},
+        {"notable": "Crystal Flash Clip (Right to Left)"},
         {"or": [
           "canTrivialMidAirMorph",
           "h_canUseSpringBall",
@@ -594,9 +594,9 @@
     {
       "id": 25,
       "link": [2, 1],
-      "name": "WS East Supers R-Mode Standup Clip (Right to Left)",
+      "name": "R-Mode Standup Clip (Right to Left)",
       "requires": [
-        {"notable": "WS East Supers R-Mode Standup Clip (Right to Left)"},
+        {"notable": "R-Mode Standup Clip (Right to Left)"},
         {"obstaclesCleared": ["A"]},
         "canCeilingClip",
         "canBePatient",
@@ -628,7 +628,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "WS East Supers Robot Clip Run-In-Place",
+      "name": "Robot Clip Run-In-Place",
       "note": [
         "Kago into the worker robot and start running away from the wall until the bomb blocks are broken with SpeedBooster.",
         "The short charge taps are extremely precise because gaining too much run speed and Samus will exit the robot."
@@ -636,7 +636,7 @@
     },
     {
       "id": 2,
-      "name": "WS East Supers Crystal Flash Clip (Right to Left)",
+      "name": "Crystal Flash Clip (Right to Left)",
       "note": [
         "Crystal flash to force a standup then spin jump up then morph to bypass the dead robot. Use Coverns to damage down if necessary.",
         "Note that if the Covern spawns on Samus while crystal flashing, it will deal large amounts of damage.",
@@ -645,7 +645,7 @@
     },
     {
       "id": 3,
-      "name": "WS East Supers R-Mode Standup Clip (Right to Left)",
+      "name": "R-Mode Standup Clip (Right to Left)",
       "note": [
         "In R-Mode, kill the Coverns until there is Energy in Samus's Reserves. Get into the Morph tunnel and go to the far left.",
         "Wait for Coverns to damage Samus down until Reserves trigger, forcing a stand up and enabling her to escape.",

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -1843,9 +1843,9 @@
     {
       "id": 90,
       "link": [7, 3],
-      "name": "Wrecked Ship Main Shaft Partial Covern Ice Clip",
+      "name": "Partial Covern Ice Clip",
       "requires": [
-        {"notable": "Wrecked Ship Main Shaft Partial Covern Ice Clip"},
+        {"notable": "Partial Covern Ice Clip"},
         "canTrickyUseFrozenEnemies",
         "canCeilingClip",
         {"not": "f_DefeatedPhantoon"},
@@ -2099,7 +2099,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Wrecked Ship Main Shaft Partial Covern Ice Clip",
+      "name": "Partial Covern Ice Clip",
       "note": [
         "Use the Covern to partial ceiling clip so your beam can reach the shot block of the ceiling at the end of the Morph tunnel to the left.",
         "It is possible to mid-air morph to get into the morph tunnel with nothing, from the Covern, the ground, or the stairs below."


### PR DESCRIPTION
This can help simplify strat and notable names. The room name can always be concatenated back onto the strat name when desired, which still has a benefit in that it can be done in a standardized way.