### PR TITLE
Add min speed for Croc Speedway Reverse Speedball

### DIFF
--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -401,7 +401,8 @@
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 1,
-          "openEnd": 0
+          "openEnd": 0,
+          "minExtraRunSpeed": "$2.4"
         }
       },
       "requires": [
@@ -411,7 +412,10 @@
       ],
       "clearsObstacles": ["A"],
       "note": "Break the Speedway Speed blocks by jumping over the gap with speed and continuing through the room in mockball.",
-      "devNote": "FIXME: You can enter through 3 and speedball through the speedway."
+      "devNote": [
+        "A run speed of $2.3 can also work but with greater difficulty.",
+        "FIXME: You can enter through 3 and speedball through the speedway.",
+      ]
     },
     {
       "id": 17,

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -414,7 +414,7 @@
       "note": "Break the Speedway Speed blocks by jumping over the gap with speed and continuing through the room in mockball.",
       "devNote": [
         "A run speed of $2.3 can also work but with greater difficulty.",
-        "FIXME: You can enter through 3 and speedball through the speedway.",
+        "FIXME: You can enter through 3 and speedball through the speedway."
       ]
     },
     {


### PR DESCRIPTION
A minimum speed is needed here in order to jump across the gap.

In the case of a low-speed speedball, after breaking the speed blocks, heat frames are saved by unmorphing and running through the rest of the room. It can make a difference if the "heated blue speed" bug is patched, since if it's vanilla then you have to stop holding dash after getting blue, before reaching max speed, meaning more heat frames are required. We might eventually want to add a helper to model that.

I checked that the current heat frames in the strat are sound even with the vanilla mechanic; in the worst case (low-speed entry) it seems to need some arm pumping: https://videos.maprando.com/video/1102