### PR TITLE
Remove unusable tile from SpaceJump Speedball runway

### DIFF
--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -496,15 +496,14 @@
       "name": "SpaceJump Speedball",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
-          "length": 4,
+          "length": 5,
           "openEnd": 1
         }
       },
       "requires": [
         "canSpeedball",
         "canBlueSpaceJump"
-      ],
-      "devNote": "There is 1 unusable tile in this runway."
+      ]
     },
     {
       "id": 18,


### PR DESCRIPTION
The runway already has leniency based on shortcharge skill assumptions, so the extra tile here is adding too much.

At some point it may be good to more explicitly model what happens after getting blue speed, i.e. jumping before the end of runway vs. pressing down to get a shortcharge (optionally sliding off). I could be wrong but I don't think there's any difference in the frame window between those two, just a difference of pressing jump vs. pressing down at the end, so no need to adjust the runway length.