### PR TITLE
Update Plowerhouse

### DIFF
--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -387,7 +387,14 @@
       "link": [1, 3],
       "name": "Super Kill",
       "requires": [
-        "canDodgeWhileShooting",
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Holtz",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
         {"enemyKill": {
           "enemies": [["Holtz", "Holtz"]],
           "explicitWeapons": ["Super"]

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -678,7 +678,8 @@
         ]},
         {"heatFrames": 2400}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": "This strat is below the normal threshold for canBePatient, but it is particularly tedious."
     },
     {
       "id": 21,

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -170,7 +170,8 @@
           "openEnd": 0
         }
       },
-      "note": "This runway does not require taking care of the Holtzes."
+      "flashSuitChecked": true,
+      "note": "This partial runway does not require taking care of the Holtzes."
     },
     {
       "id": 2,
@@ -191,18 +192,59 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
-        {"heatFrames": 600},
+        {"heatFrames": 500},
         {"enemyDamage": {
           "enemy": "Holtz",
           "type": "contact",
-          "hits": 1
+          "hits": 2
         }},
         {"enemyDamage": {
           "enemy": "Zebbo",
           "type": "contact",
-          "hits": 2
+          "hits": 1
         }}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Acid run",
+      "requires": [
+        {"or": [
+          {"and": [
+            "SpeedBooster",
+            {"heatFrames": 265},
+            {"acidFrames": 112}
+          ]},
+          {"and": [
+            {"heatFrames": 300},
+            {"acidFrames": 145}
+          ]}
+        ]},
+        "Gravity",
+        "canSuitlessLavaDive"
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Acid Leave Shinecharged",
+      "requires": [
+        {"heatFrames": 300},
+        {"acidFrames": 133},
+        "Gravity",
+        "canSuitlessLavaDive",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 105
+        }
+      },
+      "flashSuitChecked": true,
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["super"], "requires": []},
+        {"nodeId": 2, "types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
     },
     {
@@ -210,26 +252,80 @@
       "link": [1, 2],
       "name": "Avoid the Holtzes",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "canCarefulJump",
+        "canTrickyJump",
+        "canHorizontalDamageBoost",
         {"enemyDamage": {
           "enemy": "Zebbo",
           "type": "contact",
           "hits": 1
         }},
-        {"heatFrames": 600}
+        {"heatFrames": 390}
       ],
       "note": [
         "Turn back to the left after entering the room then run under the Holtzes.",
         "Damage from a Zebbo from the right farm to gain invulnerability frames, then jump through the last two Holtzes."
-      ]
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Screw Attack and SpaceJump",
+      "requires": [
+        "SpaceJump",
+        "ScrewAttack",
+        {"heatFrames": 340}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Screw Attack and SpaceJump Running Entry",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        "ScrewAttack",
+        {"heatFrames": 240}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "SpaceJump with Blue Speed",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 190}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Shinesparking",
+      "entranceCondition": {
+        "comeInWithSpark": {}
+      },
+      "requires": [
+        {"heatFrames": 65},
+        {"shinespark": {"frames": 61, "excessFrames": 4}},
+        {"heatFrames": 95}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
       "link": [1, 3],
       "name": "Strong Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "Plasma",
           {"and": [
@@ -244,15 +340,15 @@
           "hits": 1
         }},
         {"heatFrames": 350}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
       "link": [1, 3],
       "name": "Strong Beam Avoid Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "canCarefulJump",
+        "canDodgeWhileShooting",
         {"or": [
           "Plasma",
           {"and": [
@@ -266,14 +362,14 @@
       "note": [
         "Turn back to the left after entering the room then run under the Holtzes.",
         "Avoid the third Holtz, then kill the fourth to clear the middle Zebbo farm."
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
       "link": [1, 3],
       "name": "Quick Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "ScrewAttack",
           {"and": [
@@ -283,27 +379,28 @@
           ]}
         ]},
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
       "link": [1, 3],
       "name": "Super Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "canDodgeWhileShooting",
         {"enemyKill": {
           "enemies": [["Holtz", "Holtz"]],
           "explicitWeapons": ["Super"]
         }},
         {"heatFrames": 300}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
       "link": [1, 3],
       "name": "Power Bomb Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Holtz", "Holtz"]],
           "explicitWeapons": ["PowerBomb"]
@@ -314,15 +411,15 @@
           "hits": 2
         }},
         {"heatFrames": 450}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
       "link": [1, 3],
       "name": "Power Bomb Avoid Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "canCarefulJump",
+        "canTrickyJump",
         {"enemyKill": {
           "enemies": [["Holtz", "Holtz"]],
           "explicitWeapons": ["PowerBomb"]
@@ -332,35 +429,112 @@
       "note": [
         "Place a power bomb near the door, then move right and jump under the Holtzes to the first platform.",
         "Continue placing power bombs while avoiding the Holtzes and avoiding luring the third one to the right."
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"enemyDamage": {
-          "enemy": "Zebbo",
+          "enemy": "Holtz",
           "type": "contact",
-          "hits": 1
+          "hits": 2
         }},
-        {"heatFrames": 800}
-      ]
+        {"heatFrames": 420}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
       "link": [2, 1],
       "name": "Quick Run Through",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "canCarefulJump",
+        "canTrickyJump",
+        "canHorizontalDamageBoost",
         {"enemyDamage": {
           "enemy": "Zebbo",
           "type": "contact",
           "hits": 1
         }},
-        {"heatFrames": 500}
+        {"heatFrames": 315}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Screw Attack and SpaceJump",
+      "requires": [
+        "SpaceJump",
+        "ScrewAttack",
+        {"heatFrames": 310}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Screw Attack and SpaceJump Running Entry",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        "ScrewAttack",
+        {"heatFrames": 230}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "SpaceJump with Blue Speed",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 200}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinesparking",
+      "entranceCondition": {
+        "comeInWithSpark": {}
+      },
+      "requires": [
+        {"heatFrames": 65},
+        {"shinespark": {"frames": 60, "excessFrames": 4}},
+        {"heatFrames": 95}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Acid Leave Shinecharged",
+      "requires": [
+        {"heatFrames": 390},
+        {"acidFrames": 133},
+        "Gravity",
+        "canSuitlessLavaDive",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 105
+        }
+      },
+      "flashSuitChecked": true,
+      "unlocksDoors": [
+        {"nodeId": 1, "types": ["super"], "requires": []},
+        {"nodeId": 1, "types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
     },
     {
@@ -377,7 +551,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -392,7 +567,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -409,7 +585,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[3, 12]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -426,7 +603,8 @@
         "leaveWithGrappleTeleport": {
           "blockPositions": [[3, 13]]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -438,7 +616,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -468,6 +647,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": "On entry lure both Holtz. Kill one and freeze the other in position.",
       "devNote": "FIXME: These heatFrames can likely be tightened."
     },
@@ -485,29 +665,32 @@
       "link": [2, 3],
       "name": "Power Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        {"or": [
+          "canBePatient",
+          "canDodgeWhileShooting"
+        ]},
         {"heatFrames": 2400}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
       "link": [2, 3],
       "name": "Intermediate Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "Wave",
           "Spazer"
         ]},
         {"heatFrames": 950}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
       "link": [2, 3],
       "name": "Strong Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "Plasma",
           {"and": [
@@ -517,14 +700,14 @@
           ]}
         ]},
         {"heatFrames": 500}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
       "link": [2, 3],
       "name": "Quick Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"or": [
           "ScrewAttack",
           {"and": [
@@ -534,30 +717,31 @@
           ]}
         ]},
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
       "link": [2, 3],
       "name": "Ammo Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Holtz", "Holtz"]],
           "explicitWeapons": ["Super", "PowerBomb"]
         }},
         {"heatFrames": 550}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
       "link": [2, 3],
       "name": "Trap the Holtzes",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "canCarefulJump",
+        "canTrickyJump",
         {"heatFrames": 400}
       ],
+      "flashSuitChecked": true,
       "note": [
         "One easy way to do this is by waiting for the first Holtz to go under the first platform.",
         "Immediately when it hits the platform, move forward to lure the second Holtz.",
@@ -569,6 +753,7 @@
       "link": [3, 1],
       "name": "Leave With Runway (Full Runway)",
       "requires": [
+        "h_heatResistant",
         {"heatFrames": 100}
       ],
       "exitCondition": {
@@ -594,7 +779,8 @@
             {"heatFrames": 60}
           ]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -607,7 +793,8 @@
       "note": [
         "Leaving from the farm node assumes killing all the Holtzes and farming to full before exiting.",
         "Gaining Energy from the farm requires some sort of heat reduction."
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -630,6 +817,7 @@
           "requires": []
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Assumes killing all the Holtzes except for one that can be frozen to extend the runway.",
         "Get the Holtz stuck under the platform then farming to full before freezing it to extend the runway.",
@@ -659,6 +847,7 @@
           "requires": []
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Assumes killing all the Holtzes then farming to full.",
         "Morph on the ground near the Zebbo spawner then quickly unmorph and shoot as it starts to move horizontally.",
@@ -672,10 +861,10 @@
       "link": [3, 2],
       "name": "Farm then Leave",
       "requires": [
-        "h_canNavigateHeatRooms",
         "h_heatResistant",
         {"heatFrames": 100}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Leaving from the farm node assumes killing all the Holtzes and farming to full before exiting.",
         "Gaining Energy from the farm requires some sort of heat reduction."
@@ -702,6 +891,7 @@
           "requires": []
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Assumes killing all the Holtzes except for one that can be frozen to extend the runway.",
         "Get the Holtz stuck under the platform then farming to full before freezing it to extend the runway.",
@@ -731,6 +921,7 @@
           "requires": []
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Assumes killing all the Holtzes then farming to full.",
         "Morph on the ground near the Zebbo spawner then quickly unmorph and shoot as it starts to move horizontally.",
@@ -746,7 +937,8 @@
       "requires": [
         "h_heatProof",
         {"refill": ["Energy", "Missile", "Super"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -766,7 +958,8 @@
           "mustStayPut": false
         }},
         {"refill": ["PowerBomb"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 35,


### PR DESCRIPTION
The main point is crossing the room as a pacifist should take more than a zebbo hit when below very hard.
I didn't look at the kill strats too much.
Spacejump and shinespark strats were missing.

Leave with temp blue and leave speedballing still missing.