### PR TITLE
Change enemy farms to use partialRefill throughout

### DIFF
--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -453,7 +453,9 @@
           "nodes": [2],
           "mustStayPut": false
         }},
-        {"refill": ["Missile", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 240}},
+        {"partialRefill": {"type": "Missile", "limit": 20}},
+        {"partialRefill": {"type": "Super", "limit": 4}}
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -157,7 +157,8 @@
           "nodes": [1],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Super", "limit": 8}},
+        {"refill": ["Energy", "Missile"]}
       ]
     },
     {

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -479,7 +479,8 @@
           "nodes": [1, 2],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 100}},
+        {"partialRefill": {"type": "Super", "limit": 5}}
       ]
     },
     {

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -340,7 +340,28 @@
           "nodes": [1, 2, 3],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 140}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 4}}
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Faster Sciser Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [1, 2, 3],
+          "mustStayPut": false
+        }},
+        {"or": [
+          "Wave",
+          "Spazer",
+          "Plasma",
+          "canUseGrapple",
+          "canPseudoScrew",
+          "ScrewAttack"
+        ]},
+        {"partialRefill": {"type": "Energy", "limit": 300}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 8}}
       ]
     },
     {

--- a/region/crateria/east/Forgotten Highway Kago Room.json
+++ b/region/crateria/east/Forgotten Highway Kago Room.json
@@ -68,7 +68,6 @@
       }
     },
     {
-      "id": 2,
       "link": [1, 1],
       "name": "Kago Farm",
       "requires": [
@@ -76,6 +75,21 @@
           "nodes": [1, 2],
           "mustStayPut": false
         }},
+        {"partialRefill": {"type": "Super", "limit": 8}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 8}},
+        {"refill": ["Energy", "Missile"]}
+      ]
+    },
+    {
+      "id": 2,
+      "link": [1, 1],
+      "name": "Kago Full Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [1, 2],
+          "mustStayPut": false
+        }},
+        "canBePatient",
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
       ]
     },

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -2677,6 +2677,19 @@
       "flashSuitChecked": true
     },
     {
+      "link": [13, 13],
+      "name": "Ripper2 Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [1, 4, 5],
+          "mustStayPut": false
+        }},
+        "ScrewAttack",
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"partialRefill": {"type": "Energy", "limit": 80}}
+      ]
+    },
+    {
       "id": 126,
       "link": [14, 10],
       "name": "Base",

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -305,8 +305,26 @@
           "Spazer",
           "Plasma"
         ]},
-        {"refill": ["Energy", "Missile"]}
+        {"partialRefill": {"type": "Energy", "limit": 400}},
+        {"partialRefill": {"type": "Missile", "limit": 20}}
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Beetom Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [2],
+          "mustStayPut": false
+        }},
+        "h_canUsePowerBombs",
+        {"or": [
+          "canMidAirMorph",
+          "h_canUseSpringBall"
+        ]},
+        {"partialRefill": {"type": "PowerBomb", "limit": 6}}
+      ],
+      "devNote": "Killing the beetoms will also clear the top pirate for small health gain."
     },
     {
       "id": 10,

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -81,6 +81,20 @@
           "nodes": [1, 2],
           "mustStayPut": false
         }},
+        {"partialRefill": {"type": "Super", "limit": 8}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 8}},
+        {"refill": ["Energy", "Missile"]}
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Kago Full Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [1, 2],
+          "mustStayPut": false
+        }},
+        "canBePatient",
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
       ]
     },

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -284,7 +284,7 @@
     {
       "id": 6,
       "link": [2, 2],
-      "name": "Fireflea Farm",
+      "name": "Fireflea and Fune Farm",
       "requires": [
         {"or": [
           "SpaceJump",
@@ -298,7 +298,9 @@
           ]}
         ]},
         "h_canUsePowerBombs",
-        {"refill": ["Energy", "PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 340}},
+        {"partialRefill": {"type": "Missile", "limit": 6}},
+        {"refill": ["PowerBomb"]}
       ]
     },
     {

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -862,7 +862,8 @@
         "h_heatProof",
         "canDodgeWhileShooting",
         "Plasma",
-        {"refill": ["Energy", "Super"]}
+        {"refill": ["Energy", "Super"]},
+        {"partialRefill": {"type": "Missile", "limit": 14}}
       ]
     },
     {
@@ -875,7 +876,8 @@
         "canDodgeWhileShooting",
         "canUseSpeedEchoes",
         "canHitbox",
-        {"refill": ["Energy", "Super"]}
+        {"refill": ["Energy", "Super"]},
+        {"partialRefill": {"type": "Missile", "limit": 14}}
       ],
       "note": [
         "Use the Echoes created by shinesparking to defeat the Metal Pirates.",

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -539,7 +539,9 @@
           "nodes": [1, 3, 4],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 200}},
+        {"partialRefill": {"type": "Missile", "limit": 10}},
+        {"partialRefill": {"type": "Super", "limit": 4}}
       ]
     },
     {

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -140,7 +140,9 @@
           "nodes": [1],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 200}},
+        {"partialRefill": {"type": "Missile", "limit": 10}},
+        {"partialRefill": {"type": "Super", "limit": 4}}
       ]
     },
     {

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -117,7 +117,9 @@
           "nodes": [1],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 160}},
+        {"partialRefill": {"type": "Missile", "limit": 6}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 2}}
       ],
       "note": "Stand (don't crouch) next to the door and shoot diagonally down into the sand until the puyos are killed."
     },

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -114,13 +114,15 @@
           "Wave",
           "Spazer",
           "Plasma",
-          "Grapple",
+          "canUseGrapple",
           {"and": [
             "ScrewAttack",
             "Gravity"
           ]}
         ]},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"partialRefill": {"type": "Energy", "limit": 200}},
+        {"partialRefill": {"type": "Missile", "limit": 10}}
       ]
     },
     {

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -135,7 +135,9 @@
         }},
         "SpaceJump",
         "ScrewAttack",
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"partialRefill": {"type": "Energy", "limit": 200}},
+        {"partialRefill": {"type": "Missile", "limit": 10}}
       ]
     },
     {

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1247,7 +1247,9 @@
           "nodes": [1, 2, 4],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"partialRefill": {"type": "Energy", "limit": 200}},
+        {"partialRefill": {"type": "Missile", "limit": 10}}
       ]
     },
     {

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -89,7 +89,8 @@
           "nodes": [1],
           "mustStayPut": false
         }},
-        {"refill": ["Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 140}},
+        {"partialRefill": {"type": "Super", "limit": 8}}
       ]
     },
     {
@@ -102,7 +103,30 @@
           "nodes": [1],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 300}},
+        {"partialRefill": {"type": "Super", "limit": 16}}
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Cacatac Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [1, 2],
+          "mustStayPut": false
+        }},
+        "Gravity",
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          "canUseFrozenEnemies",
+          "canGravityJump",
+          "canWalljump",
+          "HiJump",
+          "canSpringBallJumpMidAir",
+          "h_canFly",
+          "canSpringBallBombJump"
+        ]},
+        {"refill": ["Super", "Energy"]}
       ]
     },
     {
@@ -707,7 +731,8 @@
           "nodes": [2],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 300}},
+        {"partialRefill": {"type": "Super", "limit": 16}}
       ]
     },
     {

--- a/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
@@ -284,7 +284,30 @@
           "nodes": [1],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 140}},
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"partialRefill": {"type": "Missile", "limit": 20}}
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Fast Choot Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [1],
+          "mustStayPut": false
+        }},
+        {"or": [
+          "Wave",
+          "Spazer",
+          "Plasma",
+          "ScrewAttack",
+          "canUseGrapple",
+          "canPseudoScrew"
+        ]},
+        {"partialRefill": {"type": "Energy", "limit": 300}},
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"refill": ["Missile"]}
       ]
     },
     {

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -1916,7 +1916,8 @@
           "nodes": [3],
           "mustStayPut": false
         }},
-        {"refill": ["PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 100}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 4}}
       ]
     },
     {
@@ -3164,7 +3165,8 @@
           "nodes": [1, 2],
           "mustStayPut": false
         }},
-        {"refill": ["PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 100}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 4}}
       ]
     },
     {

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2586,7 +2586,8 @@
           "nodes": [4],
           "mustStayPut": false
         }},
-        {"refill": ["PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 100}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 4}}
       ]
     },
     {

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1044,7 +1044,8 @@
           "nodes": [2],
           "mustStayPut": false
         }},
-        {"refill": ["PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 140}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 6}}
       ]
     },
     {
@@ -3538,13 +3539,14 @@
         "Gravity",
         {"or": [
           "HiJump",
-          "SpaceJump"
+          "SpaceJump",
+          "Grapple"
         ]},
         {"resetRoom": {
           "nodes": [1, 2, 3],
           "mustStayPut": false
         }},
-        {"refill": ["Super"]}
+        {"partialRefill": {"type": "Super", "limit": 10}}
       ]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -572,7 +572,8 @@
           "nodes": [2],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile"]}
+        {"partialRefill": {"type": "Energy", "limit": 240}},
+        {"partialRefill": {"type": "Missile", "limit": 16}}
       ],
       "resetsObstacles": ["A", "B"],
       "note": "Shoot the Mellas when they first begin to come on screen, and they will not move."

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -3900,7 +3900,9 @@
           "nodes": [6, 7],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 160}},
+        {"partialRefill": {"type": "Super", "limit": 5}},
+        {"partialRefill": {"type": "Missile", "limit": 6}}
       ]
     },
     {
@@ -4212,6 +4214,18 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
+    },
+    {
+      "link": [9, 9],
+      "name": "Waver Farm",
+      "requires": [
+        {"resetRoom": {
+          "nodes": [2, 3],
+          "mustStayPut": false
+        }},
+        {"partialRefill": {"type": "Energy", "limit": 100}},
+        {"partialRefill": {"type": "Missile", "limit": 6}}
+      ]
     },
     {
       "id": 160,

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -456,6 +456,12 @@
       "requires": [
         "h_heatProof",
         {"or": [
+          "canDodgeWhileShooting",
+          "Plasma",
+          "ScrewAttack",
+          "Wave"
+        ]},
+        {"or": [
           {"and": [
             {"resetRoom": {
               "nodes": [1],
@@ -478,7 +484,10 @@
             ]}
           ]}
         ]},
-        {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
+        {"partialRefill": {"type": "Energy", "limit": 160}},
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"partialRefill": {"type": "Missile", "limit": 12}},
+        {"partialRefill": {"type": "PowerBomb", "limit": 10}}
       ]
     },
     {

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -459,7 +459,8 @@
           "canDodgeWhileShooting",
           "Plasma",
           "ScrewAttack",
-          "Wave"
+          "Wave",
+          "Spazer"
         ]},
         {"or": [
           {"and": [

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1563,7 +1563,9 @@
           "nodes": [2],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
+        {"partialRefill": {"type": "PowerBomb", "limit": 4}},
+        {"partialRefill": {"type": "Super", "limit": 4}},
+        {"refill": ["Energy", "Missile"]}
       ],
       "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
     },

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -99,7 +99,9 @@
           "nodes": [1, 2],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 200}},
+        {"partialRefill": {"type": "Super", "limit": 3}},
+        {"partialRefill": {"type": "Missile", "limit": 10}}
       ]
     },
     {

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -1357,7 +1357,8 @@
           "nodes": [1, 2, 3, 4],
           "mustStayPut": false
         }},
-        {"refill": ["Missile", "PowerBomb"]}
+        {"partialRefill": {"type": "Missile", "limit": 12}},
+        {"refill": ["PowerBomb"]}
       ]
     }
   ],

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -4668,7 +4668,9 @@
           "nodes": [1, 2, 3, 4, 5, 6, 7],
           "mustStayPut": false
         }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"partialRefill": {"type": "Energy", "limit": 500}},
+        {"partialRefill": {"type": "Super", "limit": 10}},
+        {"partialRefill": {"type": "Missile", "limit": 24}}
       ]
     },
     {


### PR DESCRIPTION
The numbers are mostly arbitrary, but represent not spending an excessive amount of time reloading the room to farm.  

Writing it this way would make it more dependent on the player estimating farm rates to know when farm thresholds are logical.  

Every partialRefill location could spend more time farming than expected to refill more than the indicated numbers. CanBeXXXPatient could be added for more refill thresholds.