### PR TITLE
Remove Room Names From Strats

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -486,7 +486,7 @@
     {
       "id": 22,
       "link": [1, 3],
-      "name": "Ceiling E-Tank Jump Into IBJ",
+      "name": "Ceiling Item Jump Into IBJ",
       "requires": [
         "canJumpIntoIBJ",
         "canDoubleBombJump"
@@ -518,7 +518,7 @@
     {
       "id": 24,
       "link": [1, 3],
-      "name": "Ceiling E-Tank Speed Jump",
+      "name": "Ceiling Item Speed Jump",
       "requires": [
         "SpeedBooster",
         "canCarefulJump"
@@ -528,7 +528,7 @@
     {
       "id": 25,
       "link": [1, 3],
-      "name": "Ceiling E-Tank Unmorph Bomb Boost",
+      "name": "Ceiling Item Unmorph Bomb Boost",
       "requires": [
         "canCrouchJump",
         "canMidAirMorph",

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -634,7 +634,7 @@
     {
       "id": 26,
       "link": [1, 5],
-      "name": "Morph Ball Room Speedball (Left to Right)",
+      "name": "Speedball (Left to Right)",
       "requires": [
         {"obstaclesCleared": ["C"]},
         {"speedBall": {"length": 25, "openEnd": 0}}
@@ -1038,7 +1038,7 @@
     {
       "id": 52,
       "link": [5, 1],
-      "name": "Morph Ball Room Speedball (Right to Left)",
+      "name": "Speedball (Right to Left)",
       "requires": [
         {"obstaclesCleared": ["B"]},
         {"getBlueSpeed": {"usedTiles": 21, "openEnd": 1}},

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -313,7 +313,7 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Early Supers Crouch Gate Clip Jump",
+      "name": "Crouch Gate Clip Jump",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         "canCrouchGateClip",
@@ -875,7 +875,7 @@
     {
       "id": 35,
       "link": [3, 1],
-      "name": "Early Supers Quick Crumble Escape",
+      "name": "Quick Crumble Escape",
       "requires": [
         "canQuickCrumbleEscape"
       ],

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -229,7 +229,7 @@
       "requires": [],
       "collectsItems": [5],
       "flashSuitChecked": true,
-      "devNote": "Using the full length of this runway requires collecting the Energy Tank item."
+      "devNote": "Using the full length of this runway requires collecting the item."
     },
     {
       "id": 2,

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -5591,7 +5591,7 @@
     {
       "id": 236,
       "link": [13, 12],
-      "name": "Green Brinstar Main Shaft Ice Clip",
+      "name": "Ice Clip",
       "requires": [
         "h_canIceClip"
       ],

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -453,7 +453,7 @@
     {
       "id": 19,
       "link": [2, 4],
-      "name": "Kraid Entrance Wiggle",
+      "name": "Super Block Wiggle",
       "requires": [
         {"ammo": {"type": "Super", "count": 2}},
         {"or": [
@@ -467,7 +467,7 @@
     {
       "id": 20,
       "link": [2, 4],
-      "name": "Kraid Entrance Squeeze",
+      "name": "Super Block Squeeze",
       "requires": [
         {"ammo": {"type": "Super", "count": 2}},
         "canTwoTileSqueeze"
@@ -694,7 +694,7 @@
     {
       "id": 38,
       "link": [4, 3],
-      "name": "Kraid Entrance Walljump",
+      "name": "Walljump",
       "requires": [
         "canPreciseWalljump",
         "canDisableEquipment"
@@ -705,7 +705,7 @@
     {
       "id": 39,
       "link": [4, 3],
-      "name": "Kraid Entrance Speedjump",
+      "name": "Speedjump",
       "requires": [
         "canTrickyDashJump"
       ],

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -420,7 +420,7 @@
     {
       "id": 19,
       "link": [2, 5],
-      "name": "Warehouse Kihunter Room X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -946,7 +946,7 @@
     {
       "id": 30,
       "link": [4, 4],
-      "name": "Big Pink Crumble Path Leave With Shinecharge",
+      "name": "Crumble Path Leave With Shinecharge",
       "requires": [
         "Morph",
         {"canShineCharge": {
@@ -1152,7 +1152,7 @@
     {
       "id": 40,
       "link": [5, 4],
-      "name": "Big Pink Left-Side X-Ray Climb",
+      "name": "Left-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -1803,7 +1803,7 @@
     {
       "id": 77,
       "link": [8, 13],
-      "name": "Big Pink Right-Side X-Ray Climb",
+      "name": "Right-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -601,7 +601,7 @@
     {
       "id": 26,
       "link": [2, 1],
-      "name": "Pink Prinstar Power Bomb Grapple Teleport Inside Wall",
+      "name": "Grapple Teleport Inside Wall",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -659,7 +659,7 @@
         "canTrickyJump"
       ],
       "note": [
-        "Jump from the Spazer Room door with speed to break the bomb blocks.",
+        "Jump from the top right door with speed to break the bomb blocks.",
         "Time a precise shot during the jump to clear the shot block.",
         "Note: Spazer can trivially break the shot block by shooting forward before jumping."
       ]
@@ -855,7 +855,7 @@
       "id": 2,
       "name": "Jump Shot Speedball",
       "note": [
-        "Jump from the Spazer Room door with speed to break the bomb blocks.",
+        "Jump from the top right door with speed to break the bomb blocks.",
         "Time a precise shot during the jump to clear the shot block.",
         "Note: Spazer can trivially break the shot block by shooting forward before jumping."
       ]

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -1213,7 +1213,7 @@
     {
       "id": 40,
       "link": [2, 1],
-      "name": "Red Tower X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -742,7 +742,7 @@
         "canSpeedball"
       ],
       "note": [
-        "Using only the short runway and spike pit, use one or more SpeedKeeps to Speedball towards the Super Missile item location.",
+        "Using only the short runway and spike pit, use one or more SpeedKeeps to Speedball towards the item location.",
         "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike I-Frames expire."
       ]
     },
@@ -1347,7 +1347,7 @@
       "id": 2,
       "name": "In-Room SpeedKeep for Temporary Blue",
       "note": [
-        "Using only the short runway and spike pit, use one or more SpeedKeeps to Speedball towards the Super Missile item location.",
+        "Using only the short runway and spike pit, use one or more SpeedKeeps to Speedball towards the item location.",
         "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike I-Frames expire."
       ]
     },

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -1110,7 +1110,7 @@
     {
       "id": 45,
       "link": [4, 1],
-      "name": "Landing Site Blue Space Jump (Mid)",
+      "name": "Blue Space Jump (Mid)",
       "requires": [
         "canBlueSpaceJump",
         {"getBlueSpeed": {
@@ -1376,7 +1376,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Become doorstuck in the bottom right door of Landing Site, using a Crystal Flash to continue X-Ray climbing past the slope above the door.",
+        "Become doorstuck in the bottom right door, use a Crystal Flash to continue X-Ray climbing past the slope above the door.",
         "Start by climbing until the slope pushed Samus down.",
         "Then auto-spinjump towards the door, and Morph to perform the Crystal Flash.",
         "Finally, continue X-Ray climbing to the top door.",
@@ -1824,7 +1824,7 @@
       "id": 5,
       "name": "Crystal Flash X-Ray Climb",
       "note": [
-        "Become doorstuck in the bottom right door of Landing Site, using a Crystal Flash to continue X-Ray climbing past the slope above the door.",
+        "Become doorstuck in the bottom right door, use a Crystal Flash to continue X-Ray climbing past the slope above the door.",
         "Start by climbing until the slope pushed Samus down.",
         "Then auto-spinjump towards the door, and Morph to perform the Crystal Flash.",
         "Finally, continue X-Ray climbing to the top door.",

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -698,7 +698,7 @@
     {
       "id": 22,
       "link": [2, 8],
-      "name": "Parlor X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -1285,7 +1285,7 @@
     {
       "id": 55,
       "link": [5, 2],
-      "name": "G-Mode Morph through Parlor Save Morph Tunnel (from Alcatraz)",
+      "name": "G-Mode Morph through Left Door Morph Tunnel (from Alcatraz)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -2072,7 +2072,7 @@
     {
       "id": 94,
       "link": [7, 7],
-      "name": "Parlor Ice Moonfall Door Lock Skip",
+      "name": "Ice Moonfall Door Lock Skip",
       "requires": [
         "h_ZebesIsAwake",
         {"ammo": {"type": "Super", "count": 1}},
@@ -2170,7 +2170,7 @@
     {
       "id": 100,
       "link": [8, 1],
-      "name": "Parlor Quick Charge",
+      "name": "Quick Charge",
       "requires": [
         {"or": [
           {"and": [
@@ -2200,7 +2200,7 @@
     {
       "id": 101,
       "link": [8, 1],
-      "name": "Parlor Quick Charge, Leave Sparking",
+      "name": "Quick Charge, Leave Sparking",
       "requires": [
         {"or": [
           "canCarefulJump",

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -128,7 +128,7 @@
     {
       "id": "A",
       "obstacleType": "inanimate",
-      "name": "Pit Room Bomb Blocks"
+      "name": "Bomb Blocks"
     }
   ],
   "links": [

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -1042,7 +1042,7 @@
     {
       "id": 50,
       "link": [4, 2],
-      "name": "East Ocean Floor Jump Assist Shinecharge Right",
+      "name": "Ocean Floor Jump Assist Shinecharge Right",
       "requires": [
         "canShinechargeMovementComplex",
         "Gravity",
@@ -1074,7 +1074,7 @@
     {
       "id": 51,
       "link": [4, 2],
-      "name": "East Ocean Floor Walljump Shinespark Right",
+      "name": "Ocean Floor Walljump Shinespark Right",
       "requires": [
         "canShinechargeMovementComplex",
         "Gravity",

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -248,7 +248,7 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "Moat Continuous Walljump, Run Through the Door",
+      "name": "Continuous Walljump, Run Through the Door",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": false,
@@ -269,7 +269,7 @@
     {
       "id": 13,
       "link": [1, 2],
-      "name": "Moat Continuous Walljump, Open Doorway",
+      "name": "Continuous Walljump, Open Doorway",
       "requires": [
         "canCWJ",
         "canDisableEquipment",
@@ -730,7 +730,7 @@
     {
       "id": 37,
       "link": [2, 3],
-      "name": "Moat Reverse Jump",
+      "name": "Right to Left Jump",
       "requires": [
         "canDisableEquipment",
         "canCarefulJump",
@@ -751,7 +751,7 @@
     {
       "id": 38,
       "link": [2, 3],
-      "name": "Moat Reverse Jump, Run Through Door",
+      "name": "Right to Left Jump, Run Through Door",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": "any",
@@ -993,7 +993,7 @@
     {
       "id": 52,
       "link": [3, 2],
-      "name": "Moat Horizontal Bomb Jump",
+      "name": "Horizontal Bomb Jump",
       "requires": [
         "canHBJ",
         {"obstaclesNotCleared": ["A", "B", "C"]}
@@ -1012,7 +1012,7 @@
     {
       "id": 54,
       "link": [3, 2],
-      "name": "Moat Ceiling Bomb Jump",
+      "name": "Ceiling Bomb Jump",
       "requires": [
         "canCeilingBombJump",
         {"obstaclesNotCleared": ["A", "B", "C"]}

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1487,7 +1487,7 @@
     {
       "id": 60,
       "link": [5, 4],
-      "name": "West Ocean Grapple Fling",
+      "name": "Grapple Fling",
       "requires": [
         "canTrickyJump",
         "canPreciseGrapple"
@@ -2473,7 +2473,7 @@
     {
       "id": 117,
       "link": [13, 5],
-      "name": "West Ocean Platforming",
+      "name": "Over Ocean Platforming",
       "requires": [
         {"or": [
           "canCarefulJump",
@@ -2696,7 +2696,7 @@
     {
       "id": 128,
       "link": [14, 12],
-      "name": "Beat West Ocean Super Block Respawn",
+      "name": "Beat Super Block Respawn",
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canCarefulJump"

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -969,7 +969,7 @@
     {
       "id": 49,
       "link": [5, 7],
-      "name": "Norfair Fireflea Bug Boost Escape",
+      "name": "Bug Boost Escape",
       "requires": [
         "HiJump",
         "canHorizontalDamageBoost",
@@ -991,7 +991,7 @@
     {
       "id": 50,
       "link": [5, 7],
-      "name": "Lower Norfair Fireflea IBJ",
+      "name": "IBJ",
       "requires": [
         "canIBJ"
       ],
@@ -1000,7 +1000,7 @@
     {
       "id": 51,
       "link": [5, 7],
-      "name": "Fireflea Walljump Damage Boost",
+      "name": "Walljump Damage Boost",
       "requires": [
         "canStaggeredWalljump",
         "canCarefulJump",
@@ -1016,7 +1016,7 @@
     {
       "id": 52,
       "link": [5, 7],
-      "name": "Lower Norfair Fireflea Hjless Walljump",
+      "name": "HiJumpless Walljump",
       "requires": [
         "canConsecutiveWalljump",
         "canPreciseWalljump",

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -749,7 +749,7 @@
     {
       "id": 30,
       "link": [4, 3],
-      "name": "Spring Ball Maze - Hero Shot Shinespark through the Right Door",
+      "name": "Hero Shot Shinespark through the Right Door",
       "requires": [
         {"canShineCharge": {
           "usedTiles": 27,

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -697,7 +697,7 @@
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "note": [
-        "Carry Temporary Blue through the top door of Mickey Mouse to break the left side of the bomb blocks.",
+        "Carry Temporary Blue through the top door to break the left side of the bomb blocks.",
         "Morph while falling through the shot block to bounce on the crumble blocks towards the morph tunnel.",
         "Then unmorph near the wall to fall straight down with temporary blue, if needed."
       ],
@@ -722,7 +722,7 @@
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "note": [
-        "Carry Temporary Blue through the top door of Mickey Mouse to break the left side of the bomb blocks.",
+        "Carry Temporary Blue through the top door to break the left side of the bomb blocks.",
         "There is a small frame window where Samus can soft unmorph on the crumble blocks and jump again while retaining temporary blue."
       ],
       "devNote": "You could jump into the room for the initial Temporary Blue and turn around with XRay twice, but this room is heated so that would be costly."
@@ -909,7 +909,7 @@
     {
       "id": 38,
       "link": [4, 2],
-      "name": "Mickey Mouse Spring Ball IBJ",
+      "name": "Spring Ball IBJ",
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canJumpIntoIBJ",
@@ -1845,7 +1845,7 @@
       "id": 1,
       "name": "Multiviola Ice Clip",
       "note": [
-        "Guide the bottom right Multiviola from the bottom of Mickey Mouse room all the way to the crumble blocks and use it to ice clip through.",
+        "Guide the bottom right Multiviola from the bottom of the room all the way to the crumble blocks and use it to ice clip through.",
         "The Multiviola will bounce around the bottom area 4 times before it is able to pass through the shot block.",
         "The door to the left cannot be opened and the respawning shot blocks needs to be removed at the right time.",
         "Avoid damage by freezing the Multiviola, or letting it go off camera while setting up for the next step.",
@@ -1857,7 +1857,7 @@
       "id": 2,
       "name": "Temporary Blue Crumble Jump without SpringBall",
       "note": [
-        "Carry Temporary Blue through the top door of Mickey Mouse to break the left side of the bomb blocks.",
+        "Carry Temporary Blue through the top door to break the left side of the bomb blocks.",
         "There is a small frame window where Samus can soft unmorph on the crumble blocks and jump again while retaining temporary blue."
       ]
     },

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -480,7 +480,7 @@
         }
       ],
       "note": [
-        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Cross the room with Bombs and minimal damage.",
         "Some acid damage is expected, but any mistakes greatly increases the time spent in acid."
       ]
     },
@@ -530,7 +530,7 @@
         }
       ],
       "note": [
-        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Cross the room with Bombs and minimal damage.",
         "Acid damage is expected, but any mistakes greatly increases the time spent in acid."
       ]
     },
@@ -927,7 +927,7 @@
         }
       ],
       "note": [
-        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Cross the room with Bombs and minimal damage.",
         "Some acid damage is expected, but any mistakes greatly increases the time spent in acid."
       ]
     },
@@ -977,7 +977,7 @@
         }
       ],
       "note": [
-        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Cross the room with Bombs and minimal damage.",
         "Acid damage is expected, but any mistakes greatly increases the time spent in acid."
       ]
     },
@@ -1142,7 +1142,7 @@
       "id": 2,
       "name": "Bombs",
       "note": [
-        "Cross the Pillar Room with Bombs and minimal damage.",
+        "Cross the room with Bombs and minimal damage.",
         "Some acid damage is expected, but any mistakes greatly increases the time spent in acid."
       ]
     }

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -1127,7 +1127,7 @@
     {
       "id": 61,
       "link": [6, 7],
-      "name": "Red Kihunter Shaft X-Ray Clip",
+      "name": "X-Ray Clip",
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",
@@ -1161,7 +1161,7 @@
     {
       "id": 62,
       "link": [6, 7],
-      "name": "Red Kihunter Shaft Bomb Block X-Ray Climb",
+      "name": "Bomb Block X-Ray Climb",
       "requires": [
         "h_canNavigateHeatRooms",
         "h_canUsePowerBombs",

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -605,7 +605,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Climb Writg while avoiding wall pirates and Namihe flames.",
+        "Climb the room while avoiding wall pirates and Namihe flames.",
         "Immediately climb above the Namihe flames and wait for the wall pirate to jump across into Samus.",
         "Once the pirate starts going up, resume X-Ray climbing.",
         "This is a Two screen X-Ray climb.  Watch for enemies when fixing the camera after the climb."
@@ -1393,7 +1393,7 @@
     {
       "id": 59,
       "link": [6, 4],
-      "name": "Writg Springwall",
+      "name": "Springwall",
       "requires": [
         "h_HeatedSpringwall",
         "canConsecutiveWalljump",
@@ -1415,7 +1415,7 @@
     {
       "id": 60,
       "link": [6, 4],
-      "name": "Writg Hj Walljump",
+      "name": "HiJump Walljump",
       "requires": [
         "HiJump",
         "canPreciseWalljump",
@@ -1441,7 +1441,7 @@
     {
       "id": 61,
       "link": [6, 4],
-      "name": "Writg Hjless Walljump",
+      "name": "HiJumpless Walljump",
       "requires": [
         "canInsaneWalljump",
         "canConsecutiveWalljump",
@@ -1472,7 +1472,7 @@
       ],
       "clearsObstacles": ["A"],
       "note": [
-        "Break the bomb blocks in The Worst Room In The Game with extremely precise walljumps.",
+        "Break the bomb blocks with extremely precise walljumps.",
         "Either with a fully delayed max height jump from the wall, or with an instant turnaround after jumping from the lower layer of bomb blocks."
       ]
     },

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -316,7 +316,7 @@
     {
       "id": 9,
       "link": [1, 6],
-      "name": "Wasteland X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -260,7 +260,7 @@
     {
       "id": 5,
       "link": [1, 3],
-      "name": "Screw Attack Room Left-Side X-Ray Climb (to Top Door)",
+      "name": "Left-Side X-Ray Climb (to Top Door)",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -371,7 +371,7 @@
     {
       "id": 10,
       "link": [1, 5],
-      "name": "Screw Attack Room Left-Side X-Ray Climb (to Middle Door)",
+      "name": "Left-Side X-Ray Climb (to Middle Door)",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -738,7 +738,7 @@
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
-        "Jump into Screw Attack Room and spark diagonally once above the center of the door vertically.",
+        "Jump into the room and spark diagonally once above the center of the door vertically.",
         "Or diagonally spark anywhere that is not the bottom of the door in the previous room."
       ],
       "devNote": "TODO: Sparking diagonally through the door cannot be shown as an alternative."
@@ -1109,7 +1109,7 @@
       ],
       "clearsObstacles": ["A", "B", "C"],
       "flashSuitChecked": true,
-      "note": "Simultaneously store a shinespark and break through the bomb blocks down to the Screw Attack item location.",
+      "note": "Simultaneously store a shinespark and break through the bomb blocks down to the item location.",
       "devNote": "canShinechargeMovementTricky is to represent the difficulty of activating the shinecharge in a precise place near the edge."
     },
     {
@@ -1129,7 +1129,7 @@
         {"heatFrames": 170}
       ],
       "clearsObstacles": ["A", "B", "C"],
-      "note": "Store a shinespark then use screw to break through the bomb blocks down to the Screw Attack item location.",
+      "note": "Store a shinespark then use screw to break through the bomb blocks down to the item location.",
       "devNote": "Storing the spark on the left side of the runway takes fine control over shinecharge spacing, but that is ok at this difficulty."
     },
     {
@@ -1530,7 +1530,7 @@
       "id": 1,
       "name": "Descent and Shinespark Escape",
       "note": [
-        "Store a shinespark and break the Screw Attack Room bomb blocks from above in order to collect the item and shinespark out.",
+        "Store a shinespark and break the bomb blocks from above in order to collect the item and shinespark out.",
         "Screw Attack is easier to excute but has fewer shinespark frames to work with.",
         "Using Temporary Blue is difficult to initiate but moves through the room quickly."
       ]

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -599,7 +599,7 @@
     {
       "id": 21,
       "link": [1, 6],
-      "name": "Oasis Left-Side X-Ray Climb",
+      "name": "Left-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -1156,7 +1156,7 @@
     {
       "id": 45,
       "link": [2, 6],
-      "name": "Oasis Right-Side X-Ray Climb",
+      "name": "Right-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -163,7 +163,7 @@
     {
       "id": 3,
       "link": [1, 2],
-      "name": "Pants Room Left-Side X-Ray Climb",
+      "name": "Left-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -256,7 +256,7 @@
     {
       "id": 8,
       "link": [1, 5],
-      "name": "Pants Room Left-Side X-Ray Climb",
+      "name": "Left-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -332,7 +332,7 @@
     {
       "id": 14,
       "link": [3, 2],
-      "name": "Pants Room Right-Side X-Ray Climb",
+      "name": "Right-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -505,7 +505,7 @@
     {
       "id": 22,
       "link": [4, 5],
-      "name": "Pants Room Gravity with HiJump",
+      "name": "Gravity with HiJump",
       "requires": [
         "Gravity",
         "Grapple",
@@ -522,7 +522,7 @@
     {
       "id": 23,
       "link": [4, 5],
-      "name": "Pants Room Gravity MidAir SpringBall Jump",
+      "name": "Gravity MidAir SpringBall Jump",
       "requires": [
         "Gravity",
         "Grapple",
@@ -534,7 +534,7 @@
     {
       "id": 24,
       "link": [4, 5],
-      "name": "Pants Room IBJ",
+      "name": "IBJ",
       "requires": [
         "Gravity",
         "Grapple",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -2107,7 +2107,7 @@
     {
       "id": 91,
       "link": [5, 8],
-      "name": "Aqueduct Right-Side X-Ray Climb",
+      "name": "Right-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -2647,7 +2647,7 @@
         }}
       ],
       "note": [
-        "Use two snails to perform an 'Enemy Stuck Moonfall' to bypass the bomb blocks above the middle left door of Aqueduct.",
+        "Use two snails to perform an 'Enemy Stuck Moonfall' to bypass the bomb blocks above the middle left door.",
         "Position one snail on the above door shell, and the second above the corner of pipe below",
         "Samus will clip through the lower snail, taking damage, then continue through a segment of pipe where the crumble blocks can be reached.",
         "Facing both snails during the moonfall while positioning Samus for the clip can be precise",
@@ -2746,7 +2746,7 @@
     {
       "id": 128,
       "link": [9, 6],
-      "name": "Aqueduct Top Door Snailstep",
+      "name": "Top Door Snailstep",
       "requires": [
         "canUseEnemies"
       ],
@@ -2755,7 +2755,7 @@
     {
       "id": 129,
       "link": [9, 6],
-      "name": "Aqueduct Top Door Crouch Jump",
+      "name": "Top Door Crouch Jump",
       "requires": [
         "canCrouchJump",
         {"or": [
@@ -3000,7 +3000,7 @@
       "id": 9,
       "name": "Snail Stuck Moonfall",
       "note": [
-        "Use two snails to perform an 'Enemy Stuck Moonfall' to bypass the bomb blocks above the middle left door of Aqueduct.",
+        "Use two snails to perform an 'Enemy Stuck Moonfall' to bypass the bomb blocks above the middle left door.",
         "Position one snail on the above door shell, and the second above the corner of pipe below",
         "Samus will clip through the lower snail, taking damage, then continue through a segment of pipe where the crumble blocks can be reached.",
         "Facing both snails during the moonfall while positioning Samus for the clip can be precise",

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -391,7 +391,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
+        "Initiate a Shinespark 1 tile below the ceiling to cross all of the room.",
         "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
       ]
     },
@@ -439,7 +439,7 @@
         ]}
       ],
       "note": [
-        "Use Grapple Beam to cross the Colosseum. The first two room segments can be safely grappled across from in the water.",
+        "Use Grapple Beam to cross the room. The first two room segments can be safely grappled across from in the water.",
         "The third room segment grapple is tricky. It is possible to use the spikes as platforms instead."
       ]
     },
@@ -471,7 +471,7 @@
         ]}
       ],
       "note": [
-        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the Colosseum.",
+        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the room.",
         "Requires knowing the position of every spike in the room, and hitting the spikes while morphed can help.",
         "The first jump is particularly tough.  A SpringBallJump from the sand with HiJump, or Grapple can be used to get past it."
       ]
@@ -501,7 +501,7 @@
         ]}
       ],
       "note": [
-        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the Colosseum.",
+        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the room.",
         "Requires knowing the position of every spike in the room, and hitting the spikes while morphed can help.",
         "The first jump is particularly tough.  A springball rolling jump can be used to get past it."
       ]
@@ -1349,7 +1349,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
+        "Initiate a Shinespark 1 tile below the ceiling to cross all of the room.",
         "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
       ]
     },
@@ -1418,7 +1418,7 @@
         "canJumpIntoIBJ"
       ],
       "note": [
-        "Stay out of the water, and by extension the sand, of Colosseum by using the spikes as platforms.",
+        "Stay out of the water, and by extension the sand, of the room by using the spikes as platforms.",
         "Morphing before landing on the spikes helps to be able to control the knockback.",
         "The final spike jump (which would be the most difficult) is avoided by doing a crouch jump into spring ball jump into IBJ to reach the left door.",
         "Perform the spring ball jump near max height.",
@@ -1452,7 +1452,7 @@
         ]}
       ],
       "note": [
-        "Stay out of the water, and by extension the sand, of Colosseum by using the spikes as platforms.",
+        "Stay out of the water, and by extension the sand, of the room by using the spikes as platforms.",
         "Landing on spikes aiming down with no other direction pressed can help control the knockback.",
         "Requires knowing the position of every spike in the room.",
         "The final spike jump is very difficult."
@@ -1877,7 +1877,7 @@
       "id": 1,
       "name": "Spike Platforming with No Equipment",
       "note": [
-        "Cross the Colosseum by using the spikes as platforms to stay out of the water.",
+        "Cross the room by using the spikes as platforms to stay out of the water.",
         "Requires some very difficult jumps and excellent control over spike damage knockback."
       ]
     },
@@ -1885,7 +1885,7 @@
       "id": 2,
       "name": "Mochtroid Suitless, HiJumpless Ice Climb",
       "note": [
-        "Cross the Colosseum by using the Mochtroids as frozen platforms.",
+        "Cross the room by using the Mochtroids as frozen platforms.",
         "Some Mochtroids need to be led into the water either from the previous section of room or from jumping high in the current section.",
         "Mochtroids are most stable to climb when they are against a wall."
       ]
@@ -1894,7 +1894,7 @@
       "id": 4,
       "name": "Full Halfie Shinespark",
       "note": [
-        "Initiate a Shinespark 1 tile below the ceiling to cross all of Colosseum.",
+        "Initiate a Shinespark 1 tile below the ceiling to cross all of the room.",
         "Shinesparking too high or too low will crash and Samus will likely fall into the sand."
       ]
     },
@@ -1911,7 +1911,7 @@
       "id": 6,
       "name": "Spike Platforming with Move Assist (Left to Right)",
       "note": [
-        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the Colosseum.",
+        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the room.",
         "Requires knowing the position of every spike in the room, and hitting the spikes while morphed can help.",
         "The first jump is particularly tough.  A SpringBallJump from the sand with HiJump, or Grapple can be used to get past it."
       ]
@@ -1920,7 +1920,7 @@
       "id": 7,
       "name": "Spike Platforming with SpringBall (Left to Right)",
       "note": [
-        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the Colosseum.",
+        "Use the spikes, which are not in the water, to jump from platform to platform as a way to cross the room.",
         "Requires knowing the position of every spike in the room, and hitting the spikes while morphed can help.",
         "The first jump is particularly tough.  A springball rolling jump can be used to get past it."
       ]

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -424,7 +424,7 @@
         ]}
       ],
       "note": [
-        "Freeze a crab multiple times to climb the upper Crab Shaft.",
+        "Freeze a crab multiple times to climb the upper section.",
         "It may be easier to climb the left shaft by knocking the crab off the wall, or by bringing up a crab from the lower area."
       ]
     },
@@ -840,7 +840,7 @@
     {
       "id": 65,
       "link": [2, 1],
-      "name": "Lower Crab Shaft Hero Shot, Use Flash Suit",
+      "name": "Hero Shot, Use Flash Suit",
       "requires": [
         {"tech": "canCrouchJump"},
         "canHeroShot",

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -609,7 +609,7 @@
           "requires": []
         }
       ],
-      "note": "Charge a shinespark in the bottom of Draygon's room, then Gravity jump up in order to shinespark out of the right door."
+      "note": "Charge a shinespark in the bottom of the room, then Gravity jump up in order to shinespark out of the right door."
     },
     {
       "id": 44,
@@ -942,7 +942,7 @@
     {
       "id": 2,
       "name": "Shinespark out the Right with a Gravity Jump",
-      "note": "Charge a shinespark in the bottom of Draygon's room, then Gravity jump up in order to shinespark out of the right door."
+      "note": "Charge a shinespark in the bottom of the room, then Gravity jump up in order to shinespark out of the right door."
     },
     {
       "id": 3,

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -938,7 +938,7 @@
     {
       "id": 42,
       "link": [2, 1],
-      "name": "Halfie Climb X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -1936,7 +1936,7 @@
     {
       "id": 88,
       "link": [3, 1],
-      "name": "Halfie Climb Carry Shinecharge through Morph Tunnel to the Middle",
+      "name": "Carry Shinecharge through Morph Tunnel to the Middle",
       "requires": [
         "Morph",
         "Gravity",
@@ -2371,7 +2371,7 @@
     {
       "id": 111,
       "link": [3, 4],
-      "name": "Halfie Climb Carry Shinecharge through Morph Tunnel to the Top",
+      "name": "Carry Shinecharge through Morph Tunnel to the Top",
       "requires": [
         "Morph",
         "Gravity",

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -202,7 +202,7 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "Precious Room X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -230,7 +230,7 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "West Cac Alley Tricky Dash Cross Room Jump",
+      "name": "Tricky Dash Cross Room Jump",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -228,7 +228,7 @@
     {
       "id": 8,
       "link": [1, 7],
-      "name": "West Sand Hole Space Wall Climb",
+      "name": "Space Wall Climb",
       "requires": [
         "canSuitlessMaridia",
         "canPlayInSand",
@@ -504,7 +504,7 @@
     {
       "id": 20,
       "link": [5, 6],
-      "name": "West Sand Hole MidAir Morph",
+      "name": "MidAir Morph",
       "requires": [
         {"or": [
           "h_canFourTileJumpMorph",
@@ -686,7 +686,7 @@
         "canBombJumpWaterEscape",
         "canCrumbleJump"
       ],
-      "note": "Jump off of the crumble blocks consecutively while placing a bomb on the water line and convert that into an IBJ to climb the West Sand Hole maze."
+      "note": "Jump off of the crumble blocks consecutively while placing a bomb on the water line and convert that into an IBJ to climb to the dry morph tunnel."
     }
   ],
   "nextStratId": 39,
@@ -702,7 +702,7 @@
     {
       "id": 2,
       "name": "Suitless Bootless IBJ",
-      "note": "Jump off of the crumble blocks consecutively while placing a bomb on the water line and convert that into an IBJ to climb the West Sand Hole maze."
+      "note": "Jump off of the crumble blocks consecutively while placing a bomb on the water line and convert that into an IBJ to climb to the dry morph tunnel."
     }
   ],
   "nextNotableId": 3

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -1276,20 +1276,20 @@
       "id": 1,
       "name": "Sand Jumps",
       "note": [
-        "Cross the Bug Sand Hole with nothing while avoiding the enemies.",
+        "Cross the room with nothing while avoiding the enemies.",
         "Juke the Yapping Maw after entering and kill the Zoa to clear a path over the sand."
       ]
     },
     {
       "id": 2,
       "name": "Damage Boost",
-      "note": "Wait inside the door frame of the Bug Sand Hole room while a Zoa rises out of the sand. Then use it to cross the room."
+      "note": "Wait inside the door frame for a Zoa to rise out of the sand, then use it to cross the room."
     },
     {
       "id": 3,
       "name": "Speedy Jump Morph",
       "note": [
-        "With a fast enough jump into the Bug Sand Hole it is possible to cross over the water and land in the opposite door by morphing before reaching the ceiling."
+        "With a fast enough jump into the room it is possible to cross over the water and land in the opposite door by morphing before reaching the ceiling."
       ]
     }
   ],

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -256,7 +256,7 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Butterfly Room Suitless Sand Escape (Left to Right)",
+      "name": "Suitless Sand Escape (Left to Right)",
       "requires": [
         "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
@@ -404,7 +404,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Butterfly Room Suitless Sand Escape (Right to Left)",
+      "name": "Suitless Sand Escape (Right to Left)",
       "requires": [
         "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -704,12 +704,11 @@
     {
       "id": 28,
       "link": [2, 3],
-      "name": "Maridia Elevator Room Wall Climb",
+      "name": "Staggered Wall Climb",
       "requires": [
         "canPreciseWalljump",
         "canStaggeredWalljump"
-      ],
-      "note": "The walljumps are considered to require precision only if the Rippers are not killed"
+      ]
     },
     {
       "id": 29,

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -433,13 +433,13 @@
     {
       "id": 18,
       "link": [2, 1],
-      "name": "Frozen Wall Pirate Plasma Escape",
+      "name": "Frozen Wall Pirate Escape",
       "requires": [
         "canTrickyUseFrozenEnemies",
         "canPreciseWalljump"
       ],
       "note": [
-        "Shoot at a wall pirate from below to freeze it.  Plasma is not required for wall pirates.",
+        "Shoot at a wall pirate from below to freeze it. Plasma is not required for wall pirates.",
         "Firing at a Standing Pirate with anything will prevent it from shooting for a short time."
       ]
     },
@@ -492,7 +492,7 @@
     {
       "id": 22,
       "link": [2, 3],
-      "name": "Plasma Room Pseudo Screw",
+      "name": "Pseudo Screw Pirate Kill",
       "requires": [
         "canPseudoScrew",
         {"enemyDamage": {

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -309,7 +309,7 @@
     {
       "id": 18,
       "link": [4, 1],
-      "name": "Naked Watering Hole Escape",
+      "name": "Naked Wall Jump Escape",
       "requires": [
         "canSuitlessMaridia",
         "canStationarySpinJump",

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -643,7 +643,7 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Crab Hole Left-Side X-Ray Climb",
+      "name": "Left-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -1900,7 +1900,7 @@
     {
       "id": 83,
       "link": [3, 4],
-      "name": "Crab Hole Right-Side X-Ray Climb",
+      "name": "Right-Side X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -1882,7 +1882,7 @@
       "id": 1,
       "name": "Top Left Direct Jump",
       "note": [
-        "Jump into the Top-Left door of the Fish Tank room from the nearby ledge using one of Gravity, HiJump, or SpringBall.",
+        "Jump into the top left door from the nearby ledge using one of Gravity, HiJump, or SpringBall.",
         "This requires a very precise jump from the very edge of the ledge and risks falling into the Bottom-Left pit which may be difficult to climb back from."
       ]
     },

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -3329,7 +3329,7 @@
         ]}
       ],
       "note": [
-        "Using the slow global crab to ascend the top section of Main Street requires the speed blocks to not be broken.",
+        "Using the slow global crab to ascend the top section of the room requires the speed blocks to not be broken.",
         "If they are broken, the local fast crab can be used instead by letting it fall and climb the left wall.",
         "The trickiest part is getting to the second ledge. Freeze the crab when it is overhead and spring ball jump up onto it.",
         "Follow the crab up while using it as a platform multiple times."
@@ -3415,13 +3415,13 @@
     {
       "id": 1,
       "name": "Underwater Walljumps",
-      "note": "Climbing all of Main Street with only HiJump and Underwater Walljumps."
+      "note": "Climbing all of the room with only HiJump and Underwater Walljumps."
     },
     {
       "id": 2,
       "name": "Crab Climb with Only Ice and Supers",
       "note": [
-        "Climbing Main Street from the door to the Fish Tank Room to the top with only three supers and ice.",
+        "Climbing from the middle right door to the top with only three supers and ice.",
         "Requires very precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
         "Requires patience while waiting for the global crab."
       ]
@@ -3430,7 +3430,7 @@
       "id": 3,
       "name": "Crab Climb with Only Ice",
       "note": [
-        "Climbing Main Street from the very bottom to the top with only ice.",
+        "Climbing from the very bottom to the top of the room with only ice.",
         "Requires very precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
         "Requires a lot of patience while waiting for the global crab."
       ]

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -952,7 +952,7 @@
     {
       "id": 26,
       "link": [2, 1],
-      "name": "Mt. Everest Left Crab Climb",
+      "name": "Left Crab Climb",
       "requires": [
         "canSuitlessMaridia",
         "canTrickyJump",
@@ -1270,7 +1270,7 @@
       ],
       "note": [
         "Position 2 Scisers so that they can each be used for a Bomb-Grapple-Jump, back to back.",
-        "This gives a total of 3 jumps to climb from the bottom of Everest up to one of the lower peaks.",
+        "This gives a total of 3 jumps to climb from the bottom of the room up to one of the lower peaks.",
         "In the likely event of failure, the room will need to be reset and the crabs repositioned for the next attempt."
       ]
     },
@@ -3642,7 +3642,7 @@
     {
       "id": 158,
       "link": [7, 10],
-      "name": "Mt. Everest Insane Walljump",
+      "name": "Insane Walljump",
       "requires": [
         "Gravity",
         "canInsaneWalljump"
@@ -3654,7 +3654,7 @@
     {
       "id": 159,
       "link": [7, 10],
-      "name": "Mt. Everest Dash Jump",
+      "name": "Dash Jump",
       "requires": [
         "Gravity",
         "HiJump",
@@ -3737,9 +3737,9 @@
       ],
       "clearsObstacles": ["A", "B"],
       "note": [
-        "Climbing the right side of Mt. Everest with two supers, ice, and HiJump.",
+        "Climbing the right side of the room with two Supers, Ice, and HiJump.",
         "Requires luring 3 crabs; the third crab is from the morph tunnel to the left.",
-        "Use a super to knock off and freeze a crab midair. Stand on it and let the other crab climb, then jump up and follow it.",
+        "Use a Super to knock off and freeze a crab midair. Stand on it and let the other crab climb, then jump up and follow it.",
         "Be sure two crabs make it to the next section in order to crab climb further."
       ]
     },
@@ -3755,9 +3755,9 @@
       ],
       "clearsObstacles": ["A", "B"],
       "note": [
-        "Climbing the right side of Mt. Everest with two supers, ice, and Spring Ball.",
+        "Climbing the right side of the room with two Supers, Ice, and Spring Ball.",
         "Requires luring 3 crabs; the third crab is from the morph tunnel to the left.",
-        "Use a super to knock off and freeze a crab midair. Stand on it and let the other crab climb, then jump up and follow it.",
+        "Use a Super to knock off and freeze a crab midair. Stand on it and let the other crab climb, then jump up and follow it.",
         "Be sure two crabs make it to the next section in order to crab climb further."
       ]
     },
@@ -3775,7 +3775,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "note": [
-        "Climbing the right side of Mt. Everest with only two supers and ice. (As used in 14% Icebooster)",
+        "Climbing the right side of the room with only two supers and ice. (As used in 14% Icebooster)",
         "Requires luring 2 crabs. Use a super to knock off and freeze a crab midair. Be sure to lure a crab to the next section to crab climb further.",
         "If Samus has 2 supers, it is easier to bring 3 crabs; the third is from the morph tunnel to the left. Lure 2 crabs to the next section for a slightly easier crab climb.",
         "Note: The hardest part of this climb is the pixel precision when jumping around a ledge.",
@@ -3800,7 +3800,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "note": [
-        "Climbing the right side of Mt. Everest with only two supers and ice. (As used in 14% Icebooster)",
+        "Climbing the right side of the room with only two supers and ice. (As used in 14% Icebooster)",
         "Requires luring 3 crabs; the third crab is from the morph tunnel to the left.",
         "Use a super to knock off and freeze a crab midair. Be sure two crabs make it to the next section in order to crab climb further.",
         "Note: The hardest part of this climb is the pixel precision when jumping around a ledge.",
@@ -3827,7 +3827,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "note": [
-        "Climb the bottom right wall of Mt. Everest with Ice and HiJump while also luring a crab to the next platform to be used to ascend the next wall.",
+        "Climb the bottom right wall of the room with Ice and HiJump while also luring a crab to the next platform to be used to ascend the next wall.",
         "The trickiest part of the climb is getting past the final overhang.",
         "This can be done with an underwater wall jump if the crab is low, a precise crouch jump and down grab if it is higher, or a flatley jump off of the crab if it is higher still.",
         "Two crabs makes it significantly easier to lure one to the top - simply let one go ahead of Samus.",
@@ -4281,7 +4281,7 @@
     {
       "id": 194,
       "link": [10, 4],
-      "name": "Mt. Everest Top Walljump",
+      "name": "Top Walljump",
       "requires": [
         "Gravity",
         {"or": [
@@ -4301,7 +4301,7 @@
     {
       "id": 195,
       "link": [10, 4],
-      "name": "Mt. Everest Top Dash Jump",
+      "name": "Top Dash Jump",
       "requires": [
         "Gravity",
         "HiJump",
@@ -4407,7 +4407,7 @@
         "canTrickyJump"
       ],
       "note": [
-        "Climbing the right side of Mt. Everest with only two supers, ice, and HiJump.",
+        "Climbing the right side of the room with only two supers, ice, and HiJump.",
         "Requires originally luring 3 crabs. Two crabs and one super are needed from this location.",
         "Use a super to knock off and freeze a crab midair. Jump on it and freeze the second as a platform to jump up to the door."
       ],
@@ -4425,9 +4425,9 @@
         {"obstaclesCleared": ["A"]}
       ],
       "note": [
-        "Climbing the right side of Mt. Everest with only two supers, ice, and Spring Ball.",
-        "Requires originally luring 3 crabs. Two crabs and one super are needed from this location.",
-        "Use a super to knock off and freeze a crab midair. Jump on it and freeze the second as a platform to jump up to the door."
+        "Climbing the right side of the room with only two Supers, Ice, and Spring Ball.",
+        "Requires originally luring 3 crabs. Two crabs and one Super are needed from this location.",
+        "Use a Super to knock off and freeze a crab midair. Jump on it and freeze the second as a platform to jump up to the door."
       ]
     },
     {
@@ -4444,7 +4444,7 @@
         {"obstaclesCleared": ["A"]}
       ],
       "note": [
-        "Climbing the right side of Mt. Everest with only two supers and ice. (As used in 14% Icebooster)",
+        "Climbing the right side of the room with only two supers and ice. (As used in 14% Icebooster)",
         "Requires originally luring 3 crabs. Two crabs and one super are needed from this location.",
         "Use a super to knock off and freeze a crab midair. Once close to the upper platform, freeze the crab at knee height to stand on it to jump up.",
         "Note: The hardest part of this climb is the pixel precision when jumping around a ledge.",
@@ -4463,7 +4463,7 @@
         {"obstaclesCleared": ["B"]}
       ],
       "note": [
-        "Climbing the right side of Mt. Everest with only one super and ice. (A trickier version than that used in 14% Icebooster)",
+        "Climbing the right side of the room with only one super and ice. (A trickier version than that used in 14% Icebooster)",
         "Requires having already lured a crab to this location, likely from above the bottom right door.",
         "Once close to the upper platform, freeze the crab at knee height to stand on it to jump up.",
         "Note: The hardest part of this climb is the pixel precision when jumping around a ledge.",
@@ -4832,7 +4832,7 @@
       "id": 1,
       "name": "Right Crab Climb with Only HiJump or Springball",
       "note": [
-        "Using HiJump or SpringBallJumpMidAir and ice to freeze a crab and climb the right side of Mt. Everest.",
+        "Using HiJump or SpringBallJumpMidAir and ice to freeze a crab and climb the right side of the room.",
         "Requires precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs."
       ]
     },
@@ -4840,7 +4840,7 @@
       "id": 2,
       "name": "Right Crab Climb with Only 2 Supers",
       "note": [
-        "Climbing the right side of Mt. Everest with only two supers and ice. (As used in 14% Icebooster)",
+        "Climbing the right side of the room with only two supers and ice. (As used in 14% Icebooster)",
         "Requires very precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
         "Requires luring 3 crabs; the third crab is from the morph tunnel to the left.",
         "Use a super to knock off and freeze a crab midair twice in the climb."
@@ -4850,9 +4850,9 @@
       "id": 3,
       "name": "Right Crab Climb with Only 1 Super",
       "note": [
-        "A harder version of 'Mt. Everest Right Crab Climb with Only 2 Supers'",
+        "A harder version of 'Right Crab Climb with Only 2 Supers'",
         "Requires extremely precise platforming to climb around protruding ledges while carefully manipulating and freezing crabs.",
-        "Climbing the right side of Mt. Everest with only one super and ice. (A trickier version than that used in 14% Icebooster)",
+        "Climbing the right side of the room with only one super and ice. (A trickier version than that used in 14% Icebooster)",
         "Requires only luring 2 crabs. Only one crab and no supers are useable for the second half of the climb."
       ]
     },
@@ -4929,7 +4929,7 @@
       "name": "Double Crab Bomb-Grapple-Jump",
       "note": [
         "Position 2 Scisers so that they can each be used for a Bomb-Grapple-Jump, back to back.",
-        "This gives a total of 3 jumps to climb from the bottom of Everest up to one of the lower peaks.",
+        "This gives a total of 3 jumps to climb from the bottom of the room up to one of the lower peaks.",
         "In the likely event of failure, the room will need to be reset and the crabs repositioned for the next attempt."
       ]
     }

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -555,7 +555,7 @@
     {
       "id": 23,
       "link": [1, 4],
-      "name": "Grapple Tutorial Gamet Boost",
+      "name": "Gamet Boost",
       "requires": [
         "h_canNavigateUnderwater",
         "canHorizontalDamageBoost",

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -308,8 +308,8 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Store a shinespark near the Grapple Room door and use the remaining runway to jump as far as possible to the right.",
-        "Once near the acid platforms, Shinespark diagonally to reach the Missile Location."
+        "Store a shinespark near the left door and use the remaining runway to jump as far as possible to the right.",
+        "Once near the acid platforms, Shinespark diagonally to reach the item location."
       ]
     },
     {
@@ -432,7 +432,7 @@
     {
       "id": 18,
       "link": [2, 1],
-      "name": "PCJR Wall Jump Shinespark to Left Door",
+      "name": "Wall Jump Shinespark to Left Door",
       "requires": [
         "canWalljump",
         "canShinechargeMovementComplex",
@@ -1016,7 +1016,7 @@
     {
       "id": 51,
       "link": [5, 1],
-      "name": "PCJR Door IBJ",
+      "name": "Jump into IBJ",
       "requires": [
         "canJumpIntoIBJ"
       ]
@@ -1053,7 +1053,7 @@
     {
       "id": 55,
       "link": [5, 1],
-      "name": "PCJR Frozen Mella Door",
+      "name": "Frozen Mella Door",
       "requires": [
         "canTrickyUseFrozenEnemies",
         "canManipulateMellas",
@@ -1205,7 +1205,7 @@
     {
       "id": 60,
       "link": [5, 3],
-      "name": "PCJR Speedjump SpringBall",
+      "name": "Speedjump SpringBall",
       "requires": [
         "HiJump",
         "canTrickyDashJump",
@@ -1431,8 +1431,8 @@
       "id": 4,
       "name": "Left Side Diagonal Shinespark",
       "note": [
-        "Store a shinespark near the Grapple Room door and use the remaining runway to jump as far as possible to the right.",
-        "Once near the acid platforms, Shinespark diagonally to reach the Missile Location."
+        "Store a shinespark near the left door and use the remaining runway to jump as far as possible to the right.",
+        "Once near the acid platforms, Shinespark diagonally to reach the item location."
       ]
     },
     {

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -2768,7 +2768,7 @@
     {
       "id": 91,
       "link": [5, 9],
-      "name": "Bubble Mountain Ice Clip",
+      "name": "Ice Clip",
       "requires": [
         "h_canIceClip"
       ],
@@ -4046,7 +4046,7 @@
     {
       "id": 143,
       "link": [9, 1],
-      "name": "Bubble Mountain Springwall",
+      "name": "Springwall",
       "requires": [
         "canSpringwall"
       ]
@@ -4054,7 +4054,7 @@
     {
       "id": 144,
       "link": [9, 1],
-      "name": "Bubble Mountain HiJump Walljump (Left)",
+      "name": "HiJump Walljump (Left)",
       "requires": [
         "HiJump",
         "canPreciseWalljump"
@@ -4064,7 +4064,7 @@
     {
       "id": 145,
       "link": [9, 1],
-      "name": "Bubble Mountain Hjless Walljump (Left)",
+      "name": "HiJumpless Walljump (Left)",
       "requires": [
         "canInsaneWalljump"
       ],
@@ -4286,7 +4286,7 @@
     {
       "id": 1,
       "name": "Damage Boost",
-      "note": "Crossing between the topmost doors of Bubble Mountain by damage boosting using a Waver."
+      "note": "Crossing between the topmost doors by damage boosting using a Waver."
     },
     {
       "id": 2,

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -604,7 +604,7 @@
     {
       "id": 32,
       "link": [4, 1],
-      "name": "Cathedral Entrance Hero Shot Shinespark",
+      "name": "Hero Shot Shinespark",
       "requires": [
         "canHeroShot",
         {"canShineCharge": {

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1038,7 +1038,7 @@
       },
       "clearsObstacles": ["A"],
       "note": [
-        "Charge a spark along the bottom of Double Chamber and use it to spark through the right side door.",
+        "Charge a spark along the bottom of the room and use it to spark through the right side door.",
         "Requires opening the door and shutter first."
       ],
       "devNote": [
@@ -1079,7 +1079,7 @@
       },
       "clearsObstacles": ["A"],
       "note": [
-        "Charge a spark along the bottom of Double Chamber and use it to spark through the right side door.",
+        "Charge a spark along the bottom of the room and use it to spark through the right side door.",
         "Requires opening the door and shutter first."
       ]
     },
@@ -1156,7 +1156,7 @@
     {
       "id": 51,
       "link": [3, 4],
-      "name": "Double Chamber Spike SpringBall",
+      "name": "Spike SpringBall",
       "requires": [
         "canIframeSpikeJump",
         {"spikeHits": 1},
@@ -1184,7 +1184,7 @@
     {
       "id": 53,
       "link": [3, 4],
-      "name": "Double Chamber Spike HiJump",
+      "name": "Spike HiJump",
       "requires": [
         "canIframeSpikeJump",
         {"spikeHits": 1},
@@ -1224,7 +1224,7 @@
     {
       "id": 56,
       "link": [3, 4],
-      "name": "Double Chamber Spike Speedjump",
+      "name": "Spike Speedjump",
       "requires": [
         "canIframeSpikeJump",
         {"spikeHits": 1},
@@ -1592,7 +1592,7 @@
       "id": 2,
       "name": "Shinespark through Wave Beam Door",
       "note": [
-        "Charge a spark along the bottom of Double Chamber and use it to spark through the right side door.",
+        "Charge a spark along the bottom of the room and use it to spark through the right side door.",
         "Requires opening the door and shutter first."
       ]
     },

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -141,7 +141,7 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "Suitless Volcano Dive",
+      "name": "Suitless Lava Dive",
       "requires": [
         "canSuitlessLavaDive",
         "Morph",

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -362,7 +362,7 @@
     {
       "id": 18,
       "link": [2, 3],
-      "name": "Croc Escape Jump IBJ",
+      "name": "Jump into IBJ",
       "requires": [
         "canJumpIntoIBJ",
         "canBombHorizontally",
@@ -372,7 +372,7 @@
     {
       "id": 19,
       "link": [2, 3],
-      "name": "Croc Escape Lava IBJ",
+      "name": "Lava IBJ",
       "requires": [
         "h_heatProof",
         "Gravity",
@@ -426,7 +426,7 @@
     {
       "id": 23,
       "link": [2, 3],
-      "name": "Croc Escape HiJump Freeze",
+      "name": "HiJump Freeze",
       "requires": [
         "canTrickyUseFrozenEnemies",
         "HiJump",
@@ -501,7 +501,7 @@
     {
       "id": 27,
       "link": [2, 3],
-      "name": "Croc Escape Short Short Charge",
+      "name": "Short Short Charge",
       "requires": [
         "canHorizontalShinespark",
         {"canShineCharge": {

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -335,8 +335,7 @@
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
-        "Spark left through the speed blocks through Croc Speedway.",
-        "Then run to the right and back to get speed to go through the rest.",
+        "Spark left through the speed blocks, then run to the right and back to get speed to go through the rest.",
         "The shinespark expects to kill the crumble bridge pirate, to be safe."
       ]
     },
@@ -411,7 +410,7 @@
         {"heatFrames": 570}
       ],
       "clearsObstacles": ["A"],
-      "note": "Break the Speedway Speed blocks by jumping over the gap with speed and continuing through the room in mockball.",
+      "note": "Break the speed blocks by jumping over the gap with blue speed and continuing through the room with a speedball.",
       "devNote": [
         "A run speed of $2.3 can also work but with greater difficulty.",
         "FIXME: You can enter through 3 and speedball through the speedway."
@@ -436,8 +435,7 @@
       ],
       "clearsObstacles": ["A"],
       "note": [
-        "Spark left through the speed blocks through Croc Speedway.",
-        "Then run to the right and back to get speed to go through the rest.",
+        "Spark left through the speed blocks, then run to the right and back to get speed to go through the rest.",
         "The shinespark expects to kill the crumble bridge pirate, to be safe."
       ]
     },
@@ -457,8 +455,7 @@
       ],
       "clearsObstacles": ["A"],
       "note": [
-        "Spark left through the speed blocks through Croc Speedway.",
-        "Then run to the right and back to get speed to go through the rest.",
+        "Spark left through the speed blocks, then run to the right and back to get speed to go through the rest.",
         "The shinespark expects to kill the crumble bridge pirate, to be safe."
       ]
     },
@@ -1061,7 +1058,7 @@
     {
       "id": 1,
       "name": "Reverse Spark",
-      "note": "Spark left through the speed blocks through Croc Speedway. Then run to the right and back to get speed to go through the rest."
+      "note": "Spark left through the speed blocks, then run to the right and back to get speed to go through the rest."
     },
     {
       "id": 2,
@@ -1076,7 +1073,7 @@
     {
       "id": 3,
       "name": "Reverse Speedball",
-      "note": "Break the Speedway Speed blocks by jumping over the gap with speed and continuing through the room in mockball."
+      "note": "Break the speed blocks by jumping over the gap with blue speed and continuing through the room with a speedball."
     }
   ],
   "nextNotableId": 4

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -117,7 +117,7 @@
     {
       "id": 4,
       "link": [1, 3],
-      "name": "Crumble Shaft Top Item Crumble Jump",
+      "name": "Top Item Crumble Jump",
       "requires": [
         "canCrumbleJump",
         {"heatFrames": 150}
@@ -127,7 +127,7 @@
     {
       "id": 5,
       "link": [1, 3],
-      "name": "Crumble Shaft Top Item Crumble Spin Jump",
+      "name": "Top Item Crumble Spin Jump",
       "requires": [
         "canCrumbleJump",
         "canTrickyJump",
@@ -208,7 +208,7 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Crumble Shaft HiJump Climb",
+      "name": "HiJump Climb",
       "requires": [
         "HiJump",
         "canConsecutiveWalljump",
@@ -219,7 +219,7 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "Crumble Shaft HiJumpless Climb",
+      "name": "HiJumpless Climb",
       "requires": [
         "canPreciseWalljump",
         "canConsecutiveWalljump",
@@ -230,7 +230,7 @@
     {
       "id": 13,
       "link": [2, 1],
-      "name": "Crumble Shaft Consecutive Crumble Climb",
+      "name": "Consecutive Crumble Jump Climb",
       "requires": [
         "canCrumbleJump",
         "canTrickyJump",
@@ -242,7 +242,7 @@
     {
       "id": 14,
       "link": [2, 1],
-      "name": "Crumble Shaft Wall/Crumble Climb",
+      "name": "Wall Jump Climb Crumble Jump",
       "requires": [
         "canCrumbleJump",
         "canConsecutiveWalljump",
@@ -284,7 +284,7 @@
     {
       "id": 18,
       "link": [2, 1],
-      "name": "Crumble Shaft IBJ (Right)",
+      "name": "IBJ (Right)",
       "requires": [
         "canIBJ",
         "canStaggeredIBJ",
@@ -299,7 +299,7 @@
     {
       "id": 19,
       "link": [2, 1],
-      "name": "Heatproof Crumble Shaft IBJ",
+      "name": "Heatproof IBJ",
       "requires": [
         "h_heatProof",
         "canIBJ"
@@ -340,7 +340,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Crumble Shaft Frozen Climb",
+      "name": "Frozen Sova Climb",
       "requires": [
         "canTrickyUseFrozenEnemies",
         "canConsecutiveWalljump",
@@ -351,7 +351,7 @@
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Crumble Shaft X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -521,7 +521,7 @@
     {
       "id": 33,
       "link": [2, 3],
-      "name": "Crumble Shaft IBJ (Left)",
+      "name": "IBJ (Left)",
       "requires": [
         "canIBJ",
         "canStaggeredIBJ",
@@ -532,7 +532,7 @@
     {
       "id": 34,
       "link": [2, 3],
-      "name": "Heatproof Crumble Shaft IBJ",
+      "name": "Heatproof IBJ",
       "requires": [
         "h_heatProof",
         "canIBJ"
@@ -542,7 +542,7 @@
     {
       "id": 35,
       "link": [2, 3],
-      "name": "Crumble Shaft Shinespark Climb",
+      "name": "Shinespark Climb",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 30
@@ -558,7 +558,7 @@
     {
       "id": 36,
       "link": [3, 1],
-      "name": "Crumble Shaft Top Door Crumble Jump",
+      "name": "Top Door Crumble Jump",
       "requires": [
         "canCrumbleJump",
         {"heatFrames": 200}

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -706,7 +706,7 @@
     {
       "id": 36,
       "link": [5, 3],
-      "name": "HiJump Etank X-Ray Clip",
+      "name": "X-Ray Clip",
       "requires": [
         "Morph",
         "canXRayStandUp",

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -237,7 +237,7 @@
     {
       "id": 6,
       "link": [2, 1],
-      "name": "Ice Beam Gate Room X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -1214,7 +1214,7 @@
     {
       "id": 56,
       "link": [3, 2],
-      "name": "Metroid Room 1 Spring Ball Bounce (Left to Right)",
+      "name": "Spring Ball Bounce (Left to Right)",
       "requires": [
         "h_canUseSpringBall",
         "canSpringBallBounce",

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -123,7 +123,7 @@
         {"or": [
           "canMetroidAvoid",
           "Ice",
-          "f_KilledMetroidRoom1"
+          "f_KilledMetroidRoom2"
         ]}
       ],
       "exitCondition": {
@@ -143,7 +143,7 @@
         {"or": [
           "canMetroidAvoid",
           "Ice",
-          "f_KilledMetroidRoom1"
+          "f_KilledMetroidRoom2"
         ]}
       ],
       "exitCondition": {
@@ -167,7 +167,7 @@
         {"or": [
           "canMetroidAvoid",
           "Ice",
-          "f_KilledMetroidRoom1"
+          "f_KilledMetroidRoom2"
         ]}
       ],
       "exitCondition": {
@@ -269,7 +269,7 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "Metroid Room 2 PB Dodge Kill",
+      "name": "Power Bomb Dodge Kill",
       "requires": [
         {"enemyKill": {
           "enemies": [["Metroid", "Metroid"]],
@@ -1156,7 +1156,7 @@
         {"or": [
           "canMetroidAvoid",
           "Ice",
-          "f_KilledMetroidRoom1"
+          "f_KilledMetroidRoom2"
         ]}
       ],
       "exitCondition": {
@@ -1176,7 +1176,7 @@
         {"or": [
           "canMetroidAvoid",
           "Ice",
-          "f_KilledMetroidRoom1"
+          "f_KilledMetroidRoom2"
         ]}
       ],
       "exitCondition": {
@@ -1201,7 +1201,7 @@
         {"or": [
           "canMetroidAvoid",
           "Ice",
-          "f_KilledMetroidRoom1"
+          "f_KilledMetroidRoom2"
         ]}
       ],
       "exitCondition": {
@@ -1226,7 +1226,7 @@
         {"or": [
           "canMetroidAvoid",
           "Ice",
-          "f_KilledMetroidRoom1"
+          "f_KilledMetroidRoom2"
         ]}
       ],
       "exitCondition": {

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -231,7 +231,7 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Metroid Room 4 Safe Six PB Kill",
+      "name": "Safe Six Power Bomb Kill",
       "requires": [
         {"enemyKill": {
           "enemies": [

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -545,7 +545,7 @@
         ]}
       ],
       "note": [
-        "Navigate Leodox Room in reverse by killing or distracting the right side pirates and manipulating or dodging the left side pirates during the shaft climb.",
+        "Navigate the room in reverse by killing or distracting the right side pirates and manipulating or dodging the left side pirates during the shaft climb.",
         "The acid starts rising when Samus is at the bottom of the long climb.",
         "The right-side pirates can be killed while going down to prevent having to dodge their lasers during the climb.",
         "Alternatively, jump and force the pirates to shoot just before starting to climb."
@@ -554,9 +554,9 @@
     {
       "id": 30,
       "link": [3, 1],
-      "name": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump (Longer Acid Dip)",
+      "name": "Reverse Bootless Walljumpless Space Jump (Longer Acid Dip)",
       "requires": [
-        {"notable": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump"},
+        {"notable": "Reverse Bootless Walljumpless Space Jump"},
         "SpaceJump",
         "canTrickyJump",
         {"acidFrames": 90}
@@ -595,9 +595,9 @@
     {
       "id": 31,
       "link": [3, 1],
-      "name": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump (Short Acid Dip)",
+      "name": "Reverse Bootless Walljumpless Space Jump (Short Acid Dip)",
       "requires": [
-        {"notable": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump"},
+        {"notable": "Reverse Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         "canTrickyJump",
         {"acidFrames": 50}
@@ -637,9 +637,9 @@
     {
       "id": 32,
       "link": [3, 1],
-      "name": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump (Plasma)",
+      "name": "Reverse Bootless Walljumpless Space Jump (Plasma)",
       "requires": [
-        {"notable": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump"},
+        {"notable": "Reverse Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         "canTrickyJump",
         "Plasma",
@@ -685,9 +685,9 @@
     {
       "id": 33,
       "link": [3, 1],
-      "name": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump (Super)",
+      "name": "Reverse Bootless Walljumpless Space Jump (Super)",
       "requires": [
-        {"notable": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump"},
+        {"notable": "Reverse Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         {"enemyKill": {
           "enemies": [["Tourian Space Pirate (all)"]],
@@ -725,9 +725,9 @@
     {
       "id": 34,
       "link": [3, 1],
-      "name": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump (Left-Side Fall)",
+      "name": "Reverse Bootless Walljumpless Space Jump (Left-Side Fall)",
       "requires": [
-        {"notable": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump"},
+        {"notable": "Reverse Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         {"or": [
           {"and": [
@@ -955,7 +955,7 @@
       "id": 1,
       "name": "Reverse Dodge While Climbing",
       "note": [
-        "Navigate Leodox Room in reverse by killing or distracting the right side pirates and manipulating or dodging the left side pirates during the shaft climb.",
+        "Navigate the room in reverse by killing or distracting the right side pirates and manipulating or dodging the left side pirates during the shaft climb.",
         "The acid starts rising when Samus is at the bottom of the long climb.",
         "The right-side pirates can be killed while going down to prevent having to dodge their lasers during the climb.",
         "Alternatively, jump and force the pirates to shoot just before starting to climb."
@@ -976,7 +976,7 @@
     },
     {
       "id": 4,
-      "name": "Reverse Tourian Escape Room 4 Bootless Walljumpless Space Jump",
+      "name": "Reverse Bootless Walljumpless Space Jump",
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "It is possible to climb faster by releasing jump early, rather than doing full-height jumps, in order to be able to Space Jump again more quickly."

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -544,7 +544,7 @@
     {
       "id": 29,
       "link": [2, 3],
-      "name": "Basement Speedball (Phantoon Dead)",
+      "name": "Speedball (Phantoon Dead)",
       "requires": [
         "canSpeedball",
         "f_DefeatedPhantoon",
@@ -559,7 +559,7 @@
     {
       "id": 30,
       "link": [2, 3],
-      "name": "Basement Speedball (Phantoon Alive)",
+      "name": "Speedball (Phantoon Alive)",
       "requires": [
         "canSpeedball",
         {"getBlueSpeed": {"usedTiles": 22, "openEnd": 0}}

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -712,7 +712,7 @@
     {
       "id": 30,
       "link": [2, 6],
-      "name": "Bowling Spike Run",
+      "name": "Spike Run",
       "requires": [
         {"spikeHits": 6}
       ]

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -335,7 +335,7 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "Naked Spiky Death Room (Left to Right)",
+      "name": "Naked Traversal (Left to Right)",
       "requires": [
         "canSuitlessMaridia",
         "canCarefulJump"
@@ -477,7 +477,7 @@
     {
       "id": 21,
       "link": [2, 1],
-      "name": "Naked Spiky Death Room (Right to Left)",
+      "name": "Naked Traversal (Right to Left)",
       "requires": [
         "canSuitlessMaridia",
         "canCarefulJump"

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -364,7 +364,7 @@
     {
       "id": 20,
       "link": [1, 2],
-      "name": "Sponge Bath In-Room Speedjump",
+      "name": "In-Room Speedjump",
       "requires": [
         "canSuitlessMaridia",
         "canTrickyDashJump",

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -496,7 +496,7 @@
     {
       "id": 20,
       "link": [1, 2],
-      "name": "WS East Supers Robot Clip (Left to Right)",
+      "name": "Robot Clip (Left to Right)",
       "requires": [
         "canMidAirMorph",
         "h_canDestroyBombWalls",
@@ -537,7 +537,7 @@
     {
       "id": 22,
       "link": [1, 2],
-      "name": "WS East Supers Robot Clip, Use Flash Suit",
+      "name": "Robot Clip, Use Flash Suit",
       "requires": [
         "canMidAirMorph",
         "canKago",

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -191,7 +191,7 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Wrecked Ship E-Tank Platforming",
+      "name": "Platforming",
       "requires": [
         "canCarefulJump",
         "f_DefeatedPhantoon"
@@ -205,7 +205,7 @@
     {
       "id": 9,
       "link": [1, 2],
-      "name": "Wrecked Ship E-Tank Spring Ball Bounce",
+      "name": "Spring Ball Bounce",
       "requires": [
         "canSpringBallBounce",
         "f_DefeatedPhantoon"


### PR DESCRIPTION
- Removed room names from strat names and many of the descriptions
- Occasional cleanup on descriptions; mainly capitalization and referring to specific item references instead of general references
- Fixed several instances of Metroid Room 2 referencing Metroid 1 flag