### PR TITLE
Fix speedbooster req in Crab Hole

### DIFF
--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -814,7 +814,7 @@
       "name": "Cross Room Jump Damageless Turnaround (No Speedbooster)",
       "entranceCondition": {
         "comeInJumping": {
-          "speedBooster": true,
+          "speedBooster": "any",
           "minTiles": 5.4375
         }
       },


### PR DESCRIPTION
This fix won't generally have a logical impact, because this strat was already effectively covered by the airball variant. But it could matter if `canMomentumConservingMorph` were to be disabled while the tech in this strat is all enabled. 

Bug reported by Tilimorf in the Discord: https://discord.com/channels/1053421401354285129/1053434532973510748/1302952163995156511