### PR TITLE
Another Blue Boulder shinecharge strat

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -250,6 +250,33 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Leave Shinecharged (Shorter Shortcharge)",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 16,
+          "openEnd": 1
+        }},
+        "canShinechargeMovementTricky",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 100
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Gain a shinecharge running left to right, leaving about 3 tiles of runway to gain speed to jump directly into the doorway."
+      ]
+    },
+    {
       "id": 10,
       "link": [1, 2],
       "name": "Leave With Mockball",


### PR DESCRIPTION
This one leaves with 40 more frames remaining compared to the existing suitless strat.

Video: https://videos.maprando.com/video/1201

