### PR TITLE
Green Brin shinecharge updates

### DIFF
--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -392,7 +392,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 80
+          "framesRemaining": 95
         }
       },
       "flashSuitChecked": true,

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -721,11 +721,12 @@
         {"canShineCharge": {
           "usedTiles": 25,
           "openEnd": 1
-        }}
+        }},
+        "canShinechargeMovement"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 40
+          "framesRemaining": 85
         }
       },
       "unlocksDoors": [
@@ -736,38 +737,6 @@
       ],
       "flashSuitChecked": true,
       "note": "Use the runway on the screen above to gain a shinecharge near the edge of the runway."
-    },
-    {
-      "id": 27,
-      "link": [2, 2],
-      "name": "Leave Shinecharged (Run Above and Slide Off)",
-      "requires": [
-        {"or": [
-          "canWalljump",
-          "HiJump",
-          "h_canFly",
-          "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab"
-        ]},
-        {"canShineCharge": {
-          "usedTiles": 25,
-          "openEnd": 1
-        }},
-        "canShinechargeMovementComplex"
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 70
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["ammo"],
-          "requires": []
-        }
-      ],
-      "flashSuitChecked": true,
-      "note": "Use the runway on the screen above to gain a shinecharge near the edge of the runway, sliding off quickly."
     },
     {
       "id": 28,

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -376,11 +376,12 @@
         {"canShineCharge": {
           "usedTiles": 39,
           "openEnd": 2
-        }}
+        }},
+        "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 110
+          "framesRemaining": 145
         }
       },
       "unlocksDoors": [
@@ -406,49 +407,6 @@
         }
       ],
       "flashSuitChecked": true
-    },
-    {
-      "id": 14,
-      "link": [1, 2],
-      "name": "Leave Shinecharged (Speed Through and Slide Off)",
-      "requires": [
-        {"obstaclesNotCleared": ["A"]},
-        {"canShineCharge": {
-          "usedTiles": 39,
-          "openEnd": 2
-        }},
-        "canShinechargeMovementComplex"
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 140
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["super"],
-          "requires": []
-        },
-        {
-          "types": ["missiles", "powerbomb"],
-          "requires": [
-            {"or": [
-              "canWalljump",
-              "HiJump",
-              "h_canFly",
-              "canSpringBallJumpMidAir",
-              "h_canCrouchJumpDownGrab"
-            ]},
-            {"resetRoom": {
-              "nodes": [1],
-              "mustStayPut": false
-            }}
-          ]
-        }
-      ],
-      "flashSuitChecked": true,
-      "note": "Gain the shinecharge near the edge of the runway so that you slide off quickly, while shooting the door open.",
-      "devNote": "FIXME: Door 2 can probably be opened with a PB from below, bypassing a wall jump or alternative to get back to the left. (Here and many other strats.)"
     },
     {
       "id": 15,

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -88,6 +88,25 @@
       "devNote": "Three thorns hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
     },
     {
+      "name": "Leave With Spark",
+      "link": [1, 1],
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 16,
+          "openEnd": 1
+        }},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 13, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "note": [
+        "Gain a shinecharge running left-to-right at the top of the room.",
+        "Then run to the left, jump across the room, and shinespark through the door."
+      ]
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave With Mockball",


### PR DESCRIPTION
- This tightens shinecharge strats in Brinstar Pre-Map Room and Early Supers.
- It eliminates some redundant strats in Early Supers. We had separate strats here for sliding off the ledge while gaining the shinecharge, but this is unnecessary since it can be taken into account with shinecharge frame leniency, like we do everywhere else.
- It adds a new "Leave With Spark" strat in Green Brinstar Fireflea Room. If I remember, this was pointed out by insomniaspeed a while back.

Videos for the new and updated strats on https://videos.maprando.com.