### PR TITLE
Parlor shinecharge updates & new strats

### DIFF
--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -610,14 +610,16 @@
     {
       "id": 18,
       "link": [2, 3],
-      "name": "Leave With Spark (Come In Shinecharged)",
+      "name": "Come In Shinecharging, Leave With Spark",
       "entranceCondition": {
-        "comeInShinecharged": {
-          "framesRequired": 170
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
         }
       },
       "requires": [
-        "canShinechargeMovementComplex",
+        "Morph",
+        "canShinechargeMovementTricky",
         {"shinespark": {"frames": 6}}
       ],
       "exitCondition": {
@@ -657,20 +659,117 @@
       ]
     },
     {
+      "link": [2, 6],
+      "name": "Come In Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Morph",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 35
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 20,
       "link": [2, 6],
       "name": "Carry Shinecharge",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 150
+          "framesRequired": 145
         }
       },
       "requires": [
+        "Morph",
         "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 6],
+      "name": "Come In Shinecharged, Leave With Spark (Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 120
+        }
+      },
+      "requires": [
+        "Morph",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 7, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 6],
+      "name": "Come In Shinecharged, Leave With Spark (Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
+        }
+      },
+      "requires": [
+        "Morph",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
         }
       },
       "unlocksDoors": [
@@ -780,7 +879,8 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
-        "HiJump"
+        "HiJump",
+        "Morph"
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -800,6 +900,73 @@
         }
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharged, Leave With Spark (Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 150
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "HiJump",
+        "Morph",
+        {"shinespark": {"frames": 3, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharged, Leave With Spark (Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "HiJump",
+        "Morph",
+        {"shinespark": {"frames": 4, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": "If needing to spark low through the door, hold angle-down while activating the spark, in order to avoid getting extra height from a crouch jump."
     },
     {
       "id": 28,
@@ -899,7 +1066,7 @@
       "name": "Carry Shinecharge",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 110
+          "framesRequired": 105
         }
       },
       "requires": [
@@ -908,6 +1075,72 @@
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [3, 6],
+      "name": "Come in Shinecharged, Leave With Spark (Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 20
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 22, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Shoot while entering the room, to open the door.",
+        "Activate the spark immediately after landing, at a position low enough to pass underneath the platform."
+      ]
+    },
+    {
+      "link": [3, 6],
+      "name": "Come in Shinecharged, Leave With Spark (Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 90
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
         }
       },
       "unlocksDoors": [
@@ -1743,11 +1976,78 @@
       "requires": [
         "canShinechargeMovementComplex",
         "HiJump",
-        "canWalljump"
+        "canWalljump",
+        "Morph"
       ],
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [6, 2],
+      "name": "Come in Shinecharged, Leave With Spark (Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 145
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "HiJump",
+        "canWalljump",
+        "Morph"
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [6, 2],
+      "name": "Come in Shinecharged, Leave With Spark (Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 155
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "HiJump",
+        "canWalljump",
+        "Morph"
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
         }
       },
       "unlocksDoors": [
@@ -1770,7 +2070,7 @@
       "name": "Carry Shinecharge",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 110
+          "framesRequired": 105
         }
       },
       "requires": [
@@ -1779,6 +2079,72 @@
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [6, 3],
+      "name": "Come in Shinecharged, Leave With Spark (Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 20
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 22, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Shoot while entering the room, to open the door.",
+        "Activate the spark immediately after landing, at a position low enough to pass underneath the platform."
+      ]
+    },
+    {
+      "link": [6, 3],
+      "name": "Come in Shinecharged, Leave With Spark (Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 80
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 9, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
         }
       },
       "unlocksDoors": [
@@ -1966,19 +2332,49 @@
       "name": "Carry Shinecharge",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 135
+          "framesRequired": 125
         },
         "comesThroughToilet": "any"
       },
       "requires": [
         "HiJump",
-        "canWalljump",
         "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": "auto"
         }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [7, 3],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 8, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {
@@ -2019,18 +2415,83 @@
       "name": "Carry Shinecharge",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 135
+          "framesRequired": 125
         },
         "comesThroughToilet": "any"
       },
       "requires": [
         "HiJump",
-        "canWalljump",
         "canShinechargeMovementComplex"
       ],
       "exitCondition": {
         "leaveShinecharged": {
           "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [7, 6],
+      "name": "Come In Shinecharged, Leave With Spark (Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 90
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 12, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [7, 6],
+      "name": "Come In Shinecharged, Leave With Spark (Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 115
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
         }
       },
       "unlocksDoors": [

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1136,6 +1136,7 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
+        "canCarefulJump",
         {"shinespark": {"frames": 5, "excessFrames": 0}}
       ],
       "exitCondition": {


### PR DESCRIPTION
- Tighten shinecharge frames on several existing strats
- Add many new shinecharge/shinespark strats
- Add missing Morph requirements
- Remove a couple unnecessary `canWalljump` requirements.
- In one case (strat 18), convert "Come In Shinecharged" require to "Come in Shinecharging". This makes the strat a bit more useful since the extra runway can now logically be used. Because the strat required 170 frames remaining, it was always going to require a runway connected to the door in the other room, so there's no reason for it not to be "Come In Shinecharging".