### PR TITLE
Samus Eater temp blue strats

### DIFF
--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -105,7 +105,33 @@
           "framesRemaining": 100
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Land in the Samus Eater while moving forward.",
+        "Continue holding dash and forward to gain a shinecharge while running in place inside the Samus Eater."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue (Samus Eater)",
+      "requires": [
+        "canSamusEaterStandUp",
+        {"samusEaterFrames": 160},
+        "h_canShineChargeMaxRunway",
+        "canXRayCancelShinecharge",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "flashSuitChecked": true,
+      "note": [
+        "Land in the far left side of the Samus Eater while moving forward to the right.",
+        "Continue holding dash, forward, and angle-up or angle-down to gain a shinecharge while running in place inside the Samus Eater.",
+        "The down press for the shinecharge must be precisely timed to occur after the Samus Eater releases Samus but before running into the wall (~2-frame window).",
+        "Then use X-Ray to cancel the shinecharge frames, in order to jump out with temporary blue before the Samus Eater begins another cycle.",
+        "If the down press for the shinecharge occurs too early, Samus will end up in an aim-down pose before landing and will not be able to gain temporary blue."
+      ]
     },
     {
       "id": 3,

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -179,7 +179,34 @@
           "framesRemaining": 80
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Land in the Samus Eater while moving forward.",
+        "Continue holding dash and forward to gain a shinecharge while running in place inside the Samus Eater."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Temporary Blue (Samus Eater)",
+      "requires": [
+        "canSamusEaterStandUp",
+        {"samusEaterFrames": 160},
+        "h_canShineChargeMaxRunway",
+        "canXRayCancelShinecharge",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "flashSuitChecked": true,
+      "note": [
+        "Land in the far right side of the Samus Eater while moving forward to the left.",
+        "Continue holding dash, forward, and angle-up or angle-down to gain a shinecharge while running in place inside the Samus Eater.",
+        "The down press for the shinecharge must be precisely timed to occur after the Samus Eater releases Samus but before running into the wall (~2-frame window).",
+        "Then use X-Ray to cancel the shinecharge frames, in order to jump out with temporary blue before the Samus Eater begins another cycle.",
+        "If the down press for the shinecharge occurs too early, Samus will end up in an aim-down pose before landing and will not be able to gain temporary blue.",
+        "In order to prevent Zebbos from interfering, spawn a drop and leave it uncollected in an out-of-the-way place."
+      ]
     },
     {
       "id": 6,
@@ -436,7 +463,34 @@
           "framesRemaining": 70
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Land in the Samus Eater while moving forward.",
+        "Continue holding dash and forward to gain a shinecharge while running in place inside the Samus Eater."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue (Samus Eater)",
+      "requires": [
+        "canSamusEaterStandUp",
+        {"samusEaterFrames": 160},
+        "h_canShineChargeMaxRunway",
+        "canXRayCancelShinecharge",
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "flashSuitChecked": true,
+      "note": [
+        "Use the Samus Eater second-closest to the right door, jumping into its far left side while moving forward to the right.",
+        "Continue holding dash, forward, and angle-up or angle-down to gain a shinecharge while running in place inside the Samus Eater.",
+        "The down press for the shinecharge must be precisely timed to occur after the Samus Eater releases Samus but before running into the wall (~2-frame window).",
+        "Then use X-Ray to cancel the shinecharge frames, in order to jump out with temporary blue before the Samus Eater begins another cycle.",
+        "If the down press for the shinecharge occurs too early, Samus will end up in an aim-down pose before landing and will not be able to gain temporary blue.",
+        "In order to prevent Zebbos from interfering, spawn a drop and leave it uncollected in an out-of-the-way place."
+      ]
     },
     {
       "id": 22,

--- a/tech.json
+++ b/tech.json
@@ -1453,6 +1453,7 @@
               "otherRequires": [],
               "note": [
                 "The ability to gain a shinecharge in place while captured by a Samus Eater.",
+                "This is done by landing in the Samus Eater while moving forward.",
                 "Note that Samus maintains control of most of her abilities while captured by a Samus Eater."
               ]
             },


### PR DESCRIPTION
- This adds new strats in Alpha Power Bomb Room and Hellway for using a Samus Eater to gain temporary blue. Insomniaspeed recently showed us how to do this.
- A little more detail is added to the note for the `canSamusEater` tech and its applications, to clarify what the trick is for making it work.