### PR TITLE
Forgotten Highway Elbow shinecharge

### DIFF
--- a/region/crateria/east/Forgotten Highway Elbow.json
+++ b/region/crateria/east/Forgotten Highway Elbow.json
@@ -104,6 +104,31 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 125
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 5,
       "link": [1, 2],
       "name": "Come in Shinecharging, Leave With Temporary Blue",


### PR DESCRIPTION
This room had a "Carry Shinecharge" strat but was missing a "Come in Shinecharging, Leave Shinecharged". It's a minor difference but allows logically using the extra runway and slightly reduced shinecharge frames.

The turnaround momentum conservation saves about 15 frames, so I was thinking it should be ok fitting within the Expert shinecharge leniency. We could add a separate case to model it explicitly though if wanted.

Video: https://videos.maprando.com/video/1241