### PR TITLE
Use collectsItems Throughout

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -59,7 +59,8 @@
           "requires": [ "Bombs" ],
           "devNote": [
             "In the vanilla game, Bomb Torizo is activated by having collected Bombs.",
-            "This may be changed in randomizers, e.g. to make it activate when collecting the (randomized) item in Bomb Torizo Room."
+            "This may be changed in randomizers, e.g. to make it activate when collecting the (randomized) item in Bomb Torizo Room.",
+            "Note that this change would also require adding a 'collectsItems' to the Bomb Torizo fight (although it doesn't matter much)."
           ]
         },
         {

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -1184,6 +1184,7 @@
         "h_canArtificialMorphMovement"
       ],
       "clearsObstacles": ["D"],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "note": [
         "Touch the item to either roll back to the left before exiting G-Mode and remotely collect it,",

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -847,6 +847,7 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -232,6 +232,17 @@
       "devNote": "Using the full length of this runway requires collecting the item."
     },
     {
+      "link": [1, 1],
+      "name": "Leave with Runway, Avoid Item",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 4,
+          "openEnd": 0
+        }
+      }
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged (Full Runway)",
@@ -348,6 +359,7 @@
       "link": [1, 5],
       "name": "Base",
       "requires": [],
+      "collectsItems": [5],
       "flashSuitChecked": true
     },
     {
@@ -703,6 +715,7 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [],
+      "collectsItems": [5],
       "flashSuitChecked": true
     },
     {

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -359,7 +359,6 @@
       "link": [1, 5],
       "name": "Base",
       "requires": [],
-      "collectsItems": [5],
       "flashSuitChecked": true
     },
     {
@@ -715,7 +714,6 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [],
-      "collectsItems": [5],
       "flashSuitChecked": true
     },
     {

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1452,6 +1452,7 @@
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphMovement"
       ],
+      "collectsItems": [11],
       "flashSuitChecked": true,
       "note": "Carefully roll off of the edge and land on the platform holding the item. Roll through it until PLMs are overloaded, then roll through the bomb blocks and down below."
     },
@@ -1796,6 +1797,7 @@
         "canRiskPermanentLossOfAccess",
         "h_canArtificialMorphSpringBall"
       ],
+      "collectsItems": [11],
       "flashSuitChecked": true,
       "note": "Roll through it until PLMs are overloaded, then roll through the bomb blocks and down below.",
       "devNote": "With more items, the strat with camera scroll blocks will be used."

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1449,8 +1449,7 @@
       },
       "requires": [
         {"itemNotCollectedAtNode": 11},
-        "canRiskPermanentLossOfAccess",
-        "h_canArtificialMorphMovement"
+        "canRiskPermanentLossOfAccess"
       ],
       "collectsItems": [11],
       "flashSuitChecked": true,

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -87,6 +87,19 @@
           "length": 45,
           "openEnd": 1
         }
+      },
+      "collectsItems": [3]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave with Runway, Avoid Item",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "gentleUpTiles": 2,
+          "openEnd": 0
+        }
       }
     },
     {
@@ -161,6 +174,7 @@
           ]
         }
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -190,6 +204,7 @@
           ]
         }
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -225,6 +240,7 @@
           ]
         }
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -254,6 +270,7 @@
           ]
         }
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -2114,7 +2114,6 @@
       "requires": [
         "canXRayClimb"
       ],
-      "collectsItems": [8],
       "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
@@ -2600,8 +2599,7 @@
       "id": 114,
       "link": [7, 8],
       "name": "Base",
-      "requires": [],
-      "collectsItems": [7]
+      "requires": []
     },
     {
       "id": 115,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -2114,6 +2114,7 @@
       "requires": [
         "canXRayClimb"
       ],
+      "collectsItems": [8],
       "flashSuitChecked": true,
       "note": "Climb up 1 screen."
     },
@@ -2599,7 +2600,8 @@
       "id": 114,
       "link": [7, 8],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "collectsItems": [7]
     },
     {
       "id": 115,

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1000,7 +1000,8 @@
         "Morph",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 5, "excessFrames": 2}}
-      ]
+      ],
+      "collectsItems": [5]
     },
     {
       "id": 40,
@@ -1033,6 +1034,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "collectsItems": [5],
       "flashSuitChecked": true,
       "note": "Be careful not to touch or bomb the sand in order to grab the item before PLMs are overloaded."
     },
@@ -1065,6 +1067,7 @@
           ]}
         ]}
       ],
+      "collectsItems": [5],
       "flashSuitChecked": true
     },
     {
@@ -1077,6 +1080,7 @@
         "canBombGrappleJump",
         "canCrouchJump"
       ],
+      "collectsItems": [5],
       "note": [
         "Lure a Puyo close to the sand and use it to Bomb-Grapple-Jump up to the Morph Ball maze.",
         "It helps to predict the jump pattern of the enemy."
@@ -1094,6 +1098,7 @@
         "canInsaneJump",
         "canMidAirMorph"
       ],
+      "collectsItems": [5],
       "note": [
         "Lure a Puyo close to the sand to use for a Sand Grapple Boost.",
         "As it is close to entering the sand, land on the sand and crouch.",
@@ -1113,6 +1118,7 @@
         "canSandBombBoost",
         "canInsaneJump"
       ],
+      "collectsItems": [5],
       "note": [
         "Stand on the edge of the sand and place a Bomb and wait briefly before entering the sand.",
         "Let the Bomb explosion push Samus up for a few frames before simultaneously jumping and aiming down.",
@@ -1763,6 +1769,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "collectsItems": [5],
       "flashSuitChecked": true,
       "note": [
         "Be careful not to touch or bomb the sand in order to grab the item before PLMs are overloaded.",
@@ -1794,6 +1801,7 @@
           ]}
         ]}
       ],
+      "collectsItems": [5],
       "flashSuitChecked": true,
       "note": "With bombs, kill the Zoas and they will stop spawning."
     },

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -651,6 +651,7 @@
         ]},
         {"obstaclesCleared": ["B"]}
       ],
+      "collectsItems": [2],
       "note": "Get a bit of run speed on the block and jump to the right ledge. If you miss the ledge, try to shoot the block to still collect the item."
     },
     {

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1207,8 +1207,7 @@
         "canHorizontalShinespark",
         {"heatFrames": 140},
         {"shinespark": {"frames": 45, "excessFrames": 14}}
-      ],
-      "collectsItems": [4]
+      ]
     },
     {
       "id": 55,
@@ -1221,7 +1220,8 @@
         {"heatFrames": 140},
         {"shinespark": {"frames": 51, "excessFrames": 14}}
       ],
-      "collectsItems": [4]
+      "collectsItems": [4],
+      "devNote": "The item will not be forced to be collected if the spark was in the top position."
     },
     {
       "id": 56,

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1207,7 +1207,8 @@
         "canHorizontalShinespark",
         {"heatFrames": 140},
         {"shinespark": {"frames": 45, "excessFrames": 14}}
-      ]
+      ],
+      "collectsItems": [4]
     },
     {
       "id": 55,
@@ -1219,7 +1220,8 @@
       "requires": [
         {"heatFrames": 140},
         {"shinespark": {"frames": 51, "excessFrames": 14}}
-      ]
+      ],
+      "collectsItems": [4]
     },
     {
       "id": 56,
@@ -1272,7 +1274,7 @@
         {"shinespark": {"frames": 12, "excessFrames": 4}}
       ],
       "flashSuitChecked": true,
-      "note": "A short hop from the door can bounce on the crumbles.  Just be careful of being pushed back onto the crumble blocks by the spikes.",
+      "note": "A short hop from the door can bounce on the crumbles. Just be careful of being pushed back onto the crumble blocks by the spikes.",
       "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
     },
     {
@@ -1340,7 +1342,8 @@
       "requires": [
         "canWalljump",
         {"heatFrames": 300}
-      ]
+      ],
+      "collectsItems": [4]
     },
     {
       "id": 64,
@@ -1391,7 +1394,8 @@
             {"heatFrames": 110}
           ]
         }
-      ]
+      ],
+      "collectsItems": [4]
     },
     {
       "id": 67,
@@ -1489,7 +1493,8 @@
         "HiJump",
         "SpeedBooster",
         {"heatFrames": 250}
-      ]
+      ],
+      "collectsItems": [4]
     },
     {
       "id": 72,

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -326,9 +326,8 @@
         ]},
         {"heatFrames": 200}
       ],
-      "devNote": [
-        "The Wave and Power Bomb options ride the rising tower, to avoid a mid-air morph."
-      ]
+      "collectsItems": [3],
+      "devNote": "The Wave and Power Bomb options ride the rising tower, to avoid a mid-air morph."
     },
     {
       "id": 13,
@@ -354,7 +353,8 @@
             {"heatFrames": 80}
           ]
         }
-      ]
+      ],
+      "collectsItems": [3]
     },
     {
       "id": 14,
@@ -386,7 +386,8 @@
             {"heatFrames": 80}
           ]
         }
-      ]
+      ],
+      "collectsItems": [3]
     },
     {
       "id": 15,
@@ -395,6 +396,7 @@
       "requires": [
         "h_canHeatedCrystalFlash"
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true
     }
   ],

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -477,7 +477,6 @@
         "canShinechargeMovementComplex",
         {"heatFrames": 300}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
       "note": "Run left on the middle platform before jumping right, to manipulate the Geruta into swooping left."
     },
@@ -503,6 +502,7 @@
           "canInsaneJump"
         ]}
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "note": [
         "Move quickly to avoid being hit by the Geruta before sparking.",
@@ -526,7 +526,6 @@
         "canShinechargeMovementComplex",
         {"heatFrames": 310}
       ],
-      "collectsItems": [3],
       "note": [
         "To safely avoid Geruta damage, run left on the middle platform before jumping right, to manipulate the Geruta into swooping left.",
         "Alternatively, activate the spark quickly enough to avoid taking a Geruta hit."

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -465,7 +465,7 @@
     {
       "id": 25,
       "link": [2, 3],
-      "name": "Enter with Shinespark Stored",
+      "name": "Come In Shinecharged",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 110
@@ -477,13 +477,14 @@
         "canShinechargeMovementComplex",
         {"heatFrames": 330}
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "note": "Watch out for the Geruda. Running left before jumping to bring it on camera will make it swoop left."
     },
     {
       "id": 26,
       "link": [2, 3],
-      "name": "Enter Shinecharging",
+      "name": "Come In Shinecharging",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -496,6 +497,7 @@
         "canShinechargeMovementComplex",
         {"heatFrames": 330}
       ],
+      "collectsItems": [3],
       "note": "Watch out for the Geruda. Running left before jumping to bring it on camera will make it swoop left."
     },
     {
@@ -604,6 +606,47 @@
             {"heatFrames": 120}
           ]
         }
+      ],
+      "collectsItems": [3]
+    },
+    {
+      "link": [3, 1],
+      "name": "Leave with Runway, Avoid Item",
+      "requires": [
+        {"or": [
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"heatFrames": 160}
+          ]},
+          {"and": [
+            {"obstaclesCleared": ["A"]},
+            {"heatFrames": 50}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["missiles"],
+          "requires": [
+            {"heatFrames": 70}
+          ]
+        },
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["powerbomb"],
+          "requires": [
+            {"heatFrames": 120}
+          ]
+        }
       ]
     },
     {
@@ -633,6 +676,7 @@
         "SpeedBooster",
         {"heatFrames": 500}
       ],
+      "collectsItems": [3],
       "note": "This can be done from the top right, single tile block."
     },
     {
@@ -743,7 +787,8 @@
             {"heatFrames": 60}
           ]
         }
-      ]
+      ],
+      "collectsItems": [3]
     },
     {
       "id": 39,

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -638,8 +638,7 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ],
-      "collectsItems": [4]
+      ]
     },
     {
       "id": 30,
@@ -663,7 +662,6 @@
           {"obstaclesCleared": ["C"]}
         ]}
       ],
-      "collectsItems": [4],
       "clearsObstacles": ["C"]
     },
     {

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -407,6 +407,7 @@
         "h_canArtificialMorphPowerBomb",
         "canOffScreenMovement"
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "note": [
         "Placing a Power Bomb a 0.5 to 1 tile away from the item plinth to bounce Samus onto it (where the right item usually is) while also overloading PLMs as the explosion hits the left item.",
@@ -434,6 +435,7 @@
         ]},
         "canOffScreenMovement"
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "note": "Overload PLMs by rolling through the item then go through the crumble blocks. The camera will not scroll to the left side of the room.",
       "devNote": "FIXME: This item will be remote acquired, but it is ignored here since will require an obstacle and the strat is canRiskPermanentLossOfAccess."
@@ -636,7 +638,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "collectsItems": [4]
     },
     {
       "id": 30,
@@ -646,6 +649,7 @@
         "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {
@@ -659,6 +663,7 @@
           {"obstaclesCleared": ["C"]}
         ]}
       ],
+      "collectsItems": [4],
       "clearsObstacles": ["C"]
     },
     {
@@ -669,6 +674,7 @@
         "canEnterGMode",
         {"obstaclesCleared": ["D"]}
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "note": "Overload PLMs by rolling through the item, then go through the bomb block and exit G-Mode to obtain the item.",
       "devNote": "This does not include canRiskPermanentLossOfAccess as every strat that gets here could instead overload PLMs in the bottom morph tunnel."

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -916,6 +916,7 @@
       "requires": [
         "h_canBombThings"
       ],
+      "collectsItems": [4],
       "note": "If using PBs, place it far enough right to reach the shot blocks."
     },
     {
@@ -927,6 +928,7 @@
         "Morph",
         "Plasma"
       ],
+      "collectsItems": [4],
       "note": "Plasma or Charged Spazer can reach the shot blocks through the tunnel while crouched.",
       "devNote": [
         "Plasma is somewhat known as a way to reach the blocks.",
@@ -946,6 +948,7 @@
         "canCameraManip",
         "canHeroShot"
       ],
+      "collectsItems": [4],
       "note": [
         "Break the shot blocks with Power Beam by first rolling into the morph tunnel to unlock camera scroll for this room.",
         "The blocks can now be cleared from the left side by shooting and quickly scrolling the camera to the right a small amount.",
@@ -965,6 +968,7 @@
         "canCameraManip",
         "canHeroShot"
       ],
+      "collectsItems": [4],
       "note": [
         "Land on the crumble blocks while unmorphing, in order to retain temporary blue while falling, breaking the bomb blocks",
         "Roll most of the way into the morph tunnel to unlock the camera scroll, then roll back left, crouch, fire a shot, and follow it to the right, to clear the shot blocks."
@@ -1244,7 +1248,8 @@
           {"obstaclesNotCleared": ["B"]},
           "canOffScreenMovement"
         ]}
-      ]
+      ],
+      "collectsItems": [4]
     },
     {
       "id": 53,
@@ -1257,7 +1262,8 @@
           "canOffScreenMovement"
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "collectsItems": [4]
     },
     {
       "id": 54,

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -916,7 +916,6 @@
       "requires": [
         "h_canBombThings"
       ],
-      "collectsItems": [4],
       "note": "If using PBs, place it far enough right to reach the shot blocks."
     },
     {
@@ -928,7 +927,6 @@
         "Morph",
         "Plasma"
       ],
-      "collectsItems": [4],
       "note": "Plasma or Charged Spazer can reach the shot blocks through the tunnel while crouched.",
       "devNote": [
         "Plasma is somewhat known as a way to reach the blocks.",
@@ -948,7 +946,6 @@
         "canCameraManip",
         "canHeroShot"
       ],
-      "collectsItems": [4],
       "note": [
         "Break the shot blocks with Power Beam by first rolling into the morph tunnel to unlock camera scroll for this room.",
         "The blocks can now be cleared from the left side by shooting and quickly scrolling the camera to the right a small amount.",
@@ -968,7 +965,6 @@
         "canCameraManip",
         "canHeroShot"
       ],
-      "collectsItems": [4],
       "note": [
         "Land on the crumble blocks while unmorphing, in order to retain temporary blue while falling, breaking the bomb blocks",
         "Roll most of the way into the morph tunnel to unlock the camera scroll, then roll back left, crouch, fire a shot, and follow it to the right, to clear the shot blocks."
@@ -1013,6 +1009,7 @@
         "canTemporaryBlue",
         "canSpringBallBounce"
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "note": [
         "Use Temporary Blue to bounce into the Morph Tunnel with temp blue then continue to the bomb block using SpringBall.",
@@ -1062,6 +1059,7 @@
           "requires": []
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "note": [
         "Gain temporary blue, and bounce into the morph tunnel, using Spring Ball to reach the left side while retaining temporary blue.",
@@ -1248,8 +1246,7 @@
           {"obstaclesNotCleared": ["B"]},
           "canOffScreenMovement"
         ]}
-      ],
-      "collectsItems": [4]
+      ]
     },
     {
       "id": 53,
@@ -1262,8 +1259,7 @@
           "canOffScreenMovement"
         ]}
       ],
-      "clearsObstacles": ["A"],
-      "collectsItems": [4]
+      "clearsObstacles": ["A"]
     },
     {
       "id": 54,

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -165,7 +165,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -196,7 +196,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -227,7 +227,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -251,7 +251,7 @@
           "requires": []
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -281,7 +281,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -311,7 +311,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -397,7 +397,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -428,7 +428,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -459,7 +459,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -483,7 +483,7 @@
           "requires": []
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -513,7 +513,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -543,7 +543,7 @@
           ]
         }
       ],
-      "collectsItems": [4],
+      "collectsItems": [3],
       "flashSuitChecked": true
     },
     {
@@ -606,7 +606,7 @@
           "openEnd": 0
         }
       },
-      "collectsItems": [4]
+      "collectsItems": [3]
     },
     {
       "id": 24,
@@ -628,7 +628,7 @@
           "requires": []
         }
       ],
-      "collectsItems": [4]
+      "collectsItems": [3]
     },
     {
       "link": [2, 2],

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -91,7 +91,8 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "collectsItems": [3]
     },
     {
       "id": 2,
@@ -112,7 +113,8 @@
           "types": ["ammo"],
           "requires": []
         }
-      ]
+      ],
+      "collectsItems": [3]
     },
     {
       "id": 3,
@@ -122,6 +124,18 @@
         "h_canCrystalFlash"
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave with Runway, Avoid Item",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 6,
+          "openEnd": 0
+        }
+      },
+      "devNote": "It is also possible to use the full runway if Phantoon is alive."
     },
     {
       "id": 4,
@@ -151,6 +165,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -181,6 +196,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -211,6 +227,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -234,6 +251,7 @@
           "requires": []
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {
@@ -263,6 +281,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {
@@ -292,6 +311,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {
@@ -377,6 +397,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -407,6 +428,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -437,6 +459,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true,
       "devNote": "FIXME: Requires the item to have been collected."
     },
@@ -460,6 +483,7 @@
           "requires": []
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {
@@ -489,6 +513,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {
@@ -518,6 +543,7 @@
           ]
         }
       ],
+      "collectsItems": [4],
       "flashSuitChecked": true
     },
     {
@@ -579,7 +605,8 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "collectsItems": [4]
     },
     {
       "id": 24,
@@ -600,7 +627,20 @@
           "types": ["ammo"],
           "requires": []
         }
-      ]
+      ],
+      "collectsItems": [4]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Runway, Avoid Item",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "devNote": "It is also possible to use the full runway if Phantoon is alive."
     },
     {
       "id": 25,


### PR DESCRIPTION
This adds `collectsItems` throughout. 
- Strats could be added to avoid the item in many of these instances.
- Some of the strats in heated rooms, where I didn't add `collectsItems`, would have more heatFrames if they were to avoid the items.
- It's also possible that I missed some strats if the entire node was avoided, but it's pretty uncommon to skip item nodes with those kinds of strats