### PR TITLE
Red Brin Elevator Room spark

### DIFF
--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -202,6 +202,33 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 1],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 65
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 4, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": ["never"]
+        }
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "This can spark up through either the left or right side of the doorway.",
+        "Sparking up through the center would need slightly different requirements, but there's no known application where that would be needed."
+      ]
+    },
+    {
       "id": 11,
       "link": [2, 2],
       "name": "Carry G-Mode Down Elevator",

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -202,6 +202,33 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 1],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 65
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 4, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": ["never"]
+        }
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "This can spark up through either the left or right side of the doorway.",
+        "Sparking up through the center would need slightly different requirements, but there's no known application where that would be needed."
+      ]
+    },
+    {
       "id": 11,
       "link": [2, 2],
       "name": "Carry G-Mode Down Elevator",


### PR DESCRIPTION
This PR applies to both Red Brinstar Elevator Room and Forgotten Highway Elevator Room, which have identical layouts. Here there is an existing "Carry Shinecharge" strat, but it is useful to add a "Come In Shinecharged, Leave With Spark" strat since it requires fewer shinecharge frames.

Video: https://videos.maprando.com/video/1242
