### PR TITLE
Update West Ocean hero shot spark

### DIFF
--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1096,14 +1096,15 @@
       "link": [4, 5],
       "name": "Hero Shot Spark",
       "entranceCondition": {
-        "comeInShinecharged": {
-          "framesRequired": 170
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
         }
       },
       "requires": [
-        "canShinechargeMovementComplex",
+        "canShinechargeMovementTricky",
         "canHeroShot",
-        {"shinespark": {"frames": 22}}
+        {"shinespark": {"frames": 26}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}


### PR DESCRIPTION
This strat had a `comeInShinecharged` requirement with 170 frames required. Given the assumption of spending 10 frames in the previous room after getting the shinecharge, this leaves no room for leniency so this is currently in Insane. 

It makes more sense to slide through the transition while getting the shinecharge, which we represent by a `comeInShinecharging` entrance condition with zero runway length. With this change we're moving the strat down into Expert, via a `canShinechargeMovementTricky` requirement.

I'm also increasing the shinespark frames from 22 to 26. When trying it now, I couldn't get even close to 22 while leaving in top position; I suspect the previous value may have just been based on bottom position.