### PR TITLE
Tighten framesRemaining in Etecoon ETank leaveShinecharged

### DIFF
--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -496,7 +496,7 @@
       "name": "Leave Shinecharged (Fall Through Crumbles)",
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 25
+          "framesRemaining": 45
         }
       },
       "requires": [
@@ -541,7 +541,7 @@
       "name": "Leave Shinecharged (Quick-Drop Through Crumbles)",
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 50
+          "framesRemaining": 65
         }
       },
       "requires": [


### PR DESCRIPTION
The new frames are based on sliding off the edge, like we've been doing in general since starting to use shinecharge frame leniency.

Videos:
- Fall through crumbles: https://videos.maprando.com/video/1248
- Quick drop: https://videos.maprando.com/video/1249