### PR TITLE
Refine Croc Escape comeInShinecharged

### DIFF
--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -465,7 +465,7 @@
     {
       "id": 25,
       "link": [2, 3],
-      "name": "Enter with Shinespark Stored",
+      "name": "Come in Shinecharged, Shinespark (Safe Geruta Manipulation)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 110
@@ -475,10 +475,39 @@
         "canHorizontalShinespark",
         {"shinespark": {"frames": 70, "excessFrames": 12}},
         "canShinechargeMovementComplex",
-        {"heatFrames": 330}
+        {"heatFrames": 300}
       ],
       "flashSuitChecked": true,
-      "note": "Watch out for the Geruda. Running left before jumping to bring it on camera will make it swoop left."
+      "note": "Run left on the middle platform before jumping right, to manipulate the Geruta into swooping left."
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharged, Shinespark (Fast Method)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "canHorizontalShinespark",
+        {"shinespark": {"frames": 70, "excessFrames": 12}},
+        "canShinechargeMovementTricky",
+        {"heatFrames": 290},
+        {"or": [
+          {"enemyDamage": {
+            "enemy": "Geruta",
+            "type": "contact",
+            "hits": 1
+          }},
+          "canInsaneJump"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Move quickly to avoid being hit by the Geruta before sparking.",
+        "Samus can still take damage from the Geruta during the shinespark wind-up;",
+        "this can be avoided by activating the spark quickly enough."
+      ]
     },
     {
       "id": 26,

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -512,7 +512,7 @@
     {
       "id": 26,
       "link": [2, 3],
-      "name": "Enter Shinecharging",
+      "name": "Come In Shinecharging, Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -523,9 +523,12 @@
         "canHorizontalShinespark",
         {"shinespark": {"frames": 70, "excessFrames": 12}},
         "canShinechargeMovementComplex",
-        {"heatFrames": 330}
+        {"heatFrames": 310}
       ],
-      "note": "Watch out for the Geruda. Running left before jumping to bring it on camera will make it swoop left."
+      "note": [
+        "To safely avoid Geruta damage, run left on the middle platform before jumping right, to manipulate the Geruta into swooping left.",
+        "Alternatively, activate the spark quickly enough to avoid taking a Geruta hit."
+      ]
     },
     {
       "id": 27,


### PR DESCRIPTION
This is a relatively minor tweak to the `comeInShinecharged` strat to cross right-to-left in Crocomire Escape:

- The heat frames are tightened. The new values are still probably conservative in that they're allowing time to get back to the item location. Regardless of whether of you want to go left or right after collecting the item, being at the Super gate is probably the more favorable position (to be able to open the gate quicker, or gain more run speed for jumping to the right). So we could probably tighten the heatframes further by measuring just to the time when landing after the shinespark crash; I just wasn't 100% confident in case there may be something I'm overlooking.
- A variant is added that goes fast enough to beat the Geruta into the position where you activate the spark, making it unnecessary to manipulate it into swooping left. This is treated as `canInsaneJump` (Extreme) to do fast enough to avoid damage, or `canShinechargeMovementTricky` (Expert) to do fast enough that you can get the spark off but take damage during the wind-up.
- The strats are renamed to follow the convention that we've been using in most other places.
- I didn't add a separate "fast Geruta dodge" variant for the `comeInShinecharging` version, because in this case there are plenty of shinecharge frames available, and the extra time taken for the safe strat seems like it can be covered well enough in the heat frame leniency.