### PR TITLE
Remove useless airball strats in West Sand Hall

### DIFF
--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -376,9 +376,7 @@
         "canCarefulJump"
       ],
       "note": [
-        "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled.",
-        "With a short runway of 5 tiles in the adjacent room, it is required to jump as late as possible at the edge of the runway in this room.",
-        "With any longer of a runway, the jump is much less precise."
+        "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled."
       ],
       "devNote": "This is not technically a canCrossRoomJumpIntoWater, but it is used here because of the way the momentum changes as Samus enters the water."
     },
@@ -399,8 +397,7 @@
       ],
       "note": [
         "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled.",
-        "With a short runway of 5 tiles (with no open end) in the adjacent room, it is required to jump as late as possible at the edge of the runway in this room.",
-        "With any longer of a runway, the jump is much less precise.",
+        "With a short runway of 4 tiles (with an open end) in the adjacent room, it is required to jump as late as possible at the edge of the runway in this room.",
         "Shrinking Samus' hitbox before landing makes the jump a little easier."
       ],
       "devNote": "This is not technically a canCrossRoomJumpIntoWater, but it is used here because of the way the momentum changes as Samus enters the water."
@@ -429,49 +426,6 @@
         "Press pause while crossing the narrow first sandfall, then perform a lateral mid-air morph after exiting the sandfall.",
         "Equip both Spring Ball and Speed Booster, and perform a mid-air Spring Ball jump at somewhere close to the maximum height.",
         "Unequip Spring Ball while descending through the wide second sidefall."
-      ]
-    },
-    {
-      "id": 17,
-      "link": [1, 5],
-      "name": "Cross Room Jump into Air Ball",
-      "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": false,
-          "minTiles": 6
-        }
-      },
-      "requires": [
-        "canLateralMidAirMorph",
-        "canCrossRoomJumpIntoWater",
-        "canPlayInSand"
-      ],
-      "note": [
-        "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled.",
-        "Perform an air ball before hitting the ceiling in order to land on the first pillar.",
-        "Requires a runway of 6 tiles in the adjacent room."
-      ]
-    },
-    {
-      "id": 18,
-      "link": [1, 5],
-      "name": "Tricky Cross Room Jump into Air Ball",
-      "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": false,
-          "minTiles": 5
-        }
-      },
-      "requires": [
-        "canLateralMidAirMorph",
-        "canCrossRoomJumpIntoWater",
-        "canPlayInSand",
-        "canTrickyJump"
-      ],
-      "note": [
-        "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled.",
-        "Perform an air ball before hitting the ceiling in order to land on the first pillar.",
-        "Requires a runway of 5 tiles in the adjacent room."
       ]
     },
     {

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -376,7 +376,7 @@
         "canCarefulJump"
       ],
       "note": [
-        "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled."
+        "Gain momentum in the room to the left, then jump after entering this room in order to land on the first pillar. Ensure that Speed Booster is disabled."
       ],
       "devNote": "This is not technically a canCrossRoomJumpIntoWater, but it is used here because of the way the momentum changes as Samus enters the water."
     },


### PR DESCRIPTION
Without HiJump, doing an airball makes it harder to make it across to the pillar, compared to just doing a normal jump. This is already reflected in the "minTiles" for the airball strats which were a tile larger for the airball strats than the corresponding regular jump strats. So there doesn't seem to be a purpose for the airball strats to exist.

This also updates the description of the "Jump With Momentum" and "Tricky Jump With Momentum" strats to reflect the runway requirements currently in those strats.