### PR TITLE
Crateria Supers spark strats

### DIFF
--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -908,37 +908,60 @@
       "requires": [
         "canTrivialUseFrozenEnemies",
         "h_canShineChargeMaxRunway",
-        {"shinespark": {"frames": 130, "excessFrames": 6}}
+        {"shinespark": {"frames": 128, "excessFrames": 6}}
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Frozen Boyon Runway (Mid-Air Spark)",
+      "requires": [
+        "canTrivialUseFrozenEnemies",
+        "h_canShineChargeMaxRunway",
+        "canMidairShinespark",
+        {"or": [
+          {"shinespark": {"frames": 118, "excessFrames": 6}},
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 113, "excessFrames": 6}}
+          ]}
+        ]}
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Frozen Boyon Runway (Speedy Jump Spark)",
+      "requires": [
+        "canTrivialUseFrozenEnemies",
+        "h_canShineChargeMaxRunway",
+        "canShinechargeMovementComplex",
+        {"or": [
+          {"shinespark": {"frames": 111, "excessFrames": 6}},
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 103, "excessFrames": 6}}
+          ]}
+        ]}
       ]
     },
     {
       "id": 36,
       "link": [2, 3],
-      "name": "Frozen Boyon Runway and Fast Walljumps",
+      "name": "Frozen Boyon Runway (Fast Walljumps)",
       "requires": [
         "canTrivialUseFrozenEnemies",
         "canShinechargeMovementComplex",
         "canFastWalljumpClimb",
         "h_canShineChargeMaxRunway",
-        {"shinespark": {"frames": 98, "excessFrames": 6}}
+        {"or": [
+          {"shinespark": {"frames": 93, "excessFrames": 6}},
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 83, "excessFrames": 6}}
+          ]}
+        ]}
       ],
       "note": [
         "Quickly Walljump to conserve health on the shinespark."
-      ]
-    },
-    {
-      "id": 37,
-      "link": [2, 3],
-      "name": "Frozen Boyon Runway and HiJump",
-      "requires": [
-        "canTrivialUseFrozenEnemies",
-        "canShinechargeMovement",
-        "HiJump",
-        "h_canShineChargeMaxRunway",
-        {"shinespark": {"frames": 108, "excessFrames": 6}}
-      ],
-      "note": [
-        "Use an extra speedy jump or walljump to conserve health on the shinespark."
       ]
     },
     {
@@ -951,13 +974,42 @@
           "usedTiles": 25,
           "openEnd": 2
         }},
-        {"shinespark": {"frames": 130, "excessFrames": 6}},
+        {"shinespark": {"frames": 128, "excessFrames": 6}},
         {"obstaclesCleared": ["A"]}
       ],
       "clearsObstacles": ["A"],
       "note": [
+        "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
+        "Use the remaining runway to gain speed to clear the pits with a single jump.",
+        "Then spark vertically or diagonally."
+      ],
+      "devNote": [
         "This is doable without a short charge, but it's essentially harder than the bluesuit jump.",
         "With a quick charge, it can serve as a less scary strat."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Dead Boyon Quick Charge (Mid-Air Spark)",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "canShinechargeMovementComplex",
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "openEnd": 2
+        }},
+        {"or": [
+          {"shinespark": {"frames": 118, "excessFrames": 6}},
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 113, "excessFrames": 6}}
+          ]}
+        ]}
+      ],
+      "note": [
+        "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
+        "Use the remaining runway to gain speed to clear the pits with a single jump.",
+        "Spark mid-air to conserve energy."
       ]
     },
     {
@@ -965,22 +1017,52 @@
       "link": [2, 3],
       "name": "Screw Attack Jump",
       "requires": [
-        "canCarefulJump",
         "canShinechargeMovement",
-        "ScrewAttack",
+        "canCarefulJump",
         {"canShineCharge": {
-          "usedTiles": 34,
-          "openEnd": 0
+          "usedTiles": 23,
+          "openEnd": 2
         }},
-        {"shinespark": {"frames": 130, "excessFrames": 6}}
+        "ScrewAttack",
+        {"shinespark": {"frames": 128, "excessFrames": 6}}
       ],
-      "note": "Store a Shinespark and then jump through the Boyons using Screw Attack.",
+      "note": [
+        "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
+        "Use the remaining runway to gain speed to clear the pits with a single jump, using Screw Attack to avoid Boyon damage.",
+        "Then spark vertically or diagonally."
+      ],
+      "devNote": "There could be another tile if the door is open, but it shouldn't matter at this runway length with canCarefulJump."
+    },
+    {
+      "link": [2, 3],
+      "name": "Screw Attack Jump (Mid-Air Spark)",
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canCarefulJump",
+        {"canShineCharge": {
+          "usedTiles": 23,
+          "openEnd": 2
+        }},
+        "ScrewAttack",
+        {"or": [
+          {"shinespark": {"frames": 118, "excessFrames": 6}},
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 113, "excessFrames": 6}}
+          ]}
+        ]}
+      ],
+      "note": [
+        "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
+        "Use the remaining runway to gain speed to clear the pits with a single jump, using Screw Attack to avoid Boyon damage.",
+        "Then spark vertically or diagonally."
+      ],
       "devNote": "There could be another tile if the door is open, but it shouldn't matter at this runway length with canCarefulJump."
     },
     {
       "id": 40,
       "link": [2, 3],
-      "name": "BlueSuit Jump through Boyons",
+      "name": "Blue Speed Jump through Boyons",
       "requires": [
         "canCarefulJump",
         "canShinechargeMovementComplex",
@@ -988,9 +1070,9 @@
           "usedTiles": 34,
           "openEnd": 0
         }},
-        {"shinespark": {"frames": 130, "excessFrames": 6}}
+        {"shinespark": {"frames": 128, "excessFrames": 6}}
       ],
-      "note": "Charge a Shinespark running left, then get blue suit speed by running back to the right to jump through the Boyons."
+      "note": "Charge a Shinespark running left, then get blue speed by running back to the right to jump through the Boyons."
     },
     {
       "id": 41,

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -293,7 +293,7 @@
     {
       "id": 9,
       "link": [1, 4],
-      "name": "Shinespark, Come in Shinecharging",
+      "name": "Come in Shinecharging, Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -310,6 +310,41 @@
             {"shinespark": {"frames": 41, "excessFrames": 4}}
           ]}
         ]}
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come in Shinecharged, Tricky Shinespark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 80
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canDownGrab",
+        {"shinespark": {"frames": 38, "excessFrames": 0}}
+      ],
+      "note": [
+        "Run, jump, and spark mid-air at a specific height to be able to down-grab onto the ledge."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come in Shinecharging, Tricky Shinespark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 5,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canDownGrab",
+        {"shinespark": {"frames": 35, "excessFrames": 0}}
+      ],
+      "note": [
+        "After gaining a shinecharge, run back to the door, then run right, jump, and spark mid-air at a specific height to be able to down-grab onto the ledge."
       ]
     },
     {


### PR DESCRIPTION
This adds a couple new "tricky" strats which make it possible to spark across the top of the room left-to-right while conserving enough energy to be able to survive a spike hit tankless on the way back. Later when we have schema support for coming in shinecharged with momentum, lower-difficulty strats for doing this could also be added.

Videos:
- comeInShinecharged: https://videos.maprando.com/video/1314
- comeInShinecharging: https://videos.maprando.com/video/1315

The strats for sparking up the room from the bottom are also refined/tightened.