### PR TITLE
Post Croc Farm Room shinecharges

### DIFF
--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -181,6 +181,102 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave Shinecharged (HiJump, Tricky Dash Jump, Wall Jump)",
+      "requires": [
+        "HiJump",
+        "h_runOverRespawningEnemies",
+        {"or": [
+          {"canShineCharge": {
+            "usedTiles": 16,
+            "openEnd": 1,
+            "gentleUpTiles": 2,
+            "gentleDownTiles": 4
+          }},
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"canShineCharge": {
+              "usedTiles": 17,
+              "openEnd": 1,
+              "gentleUpTiles": 2,
+              "gentleDownTiles": 4
+            }}
+          ]}
+        ]},
+        "canShinechargeMovementTricky",
+        "canTrickyDashJump",
+        "canWalljump"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 20
+        }
+      },
+      "unlocksDoors": [
+        {
+          "nodeId": 3,
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run right-to-left to gain a shinecharge, then use between 1 and 2 tiles of remaining runway to gain speed to reach the top-left with a wall jump."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spark (HiJump Speedy Jump, Bottom Position)",
+      "requires": [
+        "HiJump",
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 6, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge, then run back to the left to gain speed to reach the top-left."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spark (Tricky Dash Jump, Wall Jump, Bottom Position)",
+      "requires": [
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
+        "canShinechargeMovementTricky",
+        "canTrickyDashJump",
+        "canWalljump",
+        {"shinespark": {"frames": 12, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge, then run back to the left to gain speed to reach the top-left with a wall jump.",
+        "By leaving the right door closed and sliding into it, the frame window for the tricky dash jump will align with the last two possible frames to jump at the end of the runway."
+      ]
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -224,7 +320,7 @@
     {
       "id": 5,
       "link": [1, 4],
-      "name": "Enter Shinesparking",
+      "name": "Come In With Spark",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
@@ -235,13 +331,14 @@
     {
       "id": 6,
       "link": [1, 4],
-      "name": "Short Shinespark",
+      "name": "Come In Shinecharged, Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 45
         }
       },
       "requires": [
+        "canShinechargeMovement",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 29, "excessFrames": 5}}
       ],
@@ -250,7 +347,7 @@
     {
       "id": 7,
       "link": [1, 4],
-      "name": "SpaceJump across and Leave with Spark",
+      "name": "Come In Shinecharged, Leave With Spark (Space Jump)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 130
@@ -259,7 +356,6 @@
       "requires": [
         "SpaceJump",
         "canShinechargeMovementComplex",
-        "canMidairShinespark",
         {"shinespark": {"frames": 21}}
       ],
       "exitCondition": {
@@ -494,7 +590,7 @@
     {
       "id": 21,
       "link": [3, 1],
-      "name": "Speedy Jump up with HiJump and Leave while Shinecharged",
+      "name": "Come In Shinecharging, Leave Shinecharged (HiJump, Tricky Dash Jump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 10,
@@ -525,7 +621,12 @@
         }
       ],
       "flashSuitChecked": true,
-      "note": "Kill the Gamets with SpeedBooster and then jump directly up to the top left door."
+      "note": [
+        "Kill the Gamets with SpeedBooster and then jump directly up to the top left door.",
+        "It helps to have low run speed while gaining the shinecharge:",
+        "this makes it easier to control the position where Samus gains the shinecharge (which should be as far right as possible while still killing the Gamets);",
+        "and it minimizes the distance that Samus slides while gaining the shinecharge, allowing more runway to gain speed for the jump."
+      ]
     },
     {
       "id": 22,
@@ -599,74 +700,6 @@
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
         "Then X-ray climb to get up to the door transition, without needing to open the door."
       ]
-    },
-    {
-      "id": 26,
-      "link": [3, 2],
-      "name": "Come in Shinecharging to Leave while Shinecharged",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 10,
-          "openEnd": 0,
-          "gentleDownTiles": 4
-        }
-      },
-      "requires": [],
-      "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 120
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["super"],
-          "requires": []
-        },
-        {
-          "types": ["missiles", "powerbomb"],
-          "requires": [
-            "never"
-          ]
-        }
-      ],
-      "flashSuitChecked": true,
-      "devNote": "The Gamets are killed with SpeedBooster"
-    },
-    {
-      "id": 27,
-      "link": [3, 2],
-      "name": "Come in Shinecharging with Wave to Leave while Shinecharged",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 18,
-          "openEnd": 1,
-          "gentleDownTiles": 4,
-          "gentleUpTiles": 2
-        }
-      },
-      "requires": [
-        "Wave",
-        "canDodgeWhileShooting"
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 120
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["super"],
-          "requires": []
-        },
-        {
-          "types": ["missiles", "powerbomb"],
-          "requires": [
-            "never"
-          ]
-        }
-      ],
-      "flashSuitChecked": true,
-      "devNote": "The Gamets are killed with SpeedBooster"
     },
     {
       "id": 77,
@@ -745,7 +778,7 @@
     {
       "id": 31,
       "link": [3, 4],
-      "name": "Walljump up and Leave Shinecharged",
+      "name": "Come In Shinecharging, Leave Shinecharged (Wall Jump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 7,
@@ -780,7 +813,7 @@
     {
       "id": 32,
       "link": [3, 4],
-      "name": "SpaceJump up and Leave with Spark",
+      "name": "Come In Shinecharging, Leave With Spark (Space Jump, Bottom Position)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 7,
@@ -791,11 +824,12 @@
       "requires": [
         "SpaceJump",
         "canShinechargeMovementComplex",
-        "canMidairShinespark",
         {"shinespark": {"frames": 15}}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
       },
       "unlocksDoors": [
         {
@@ -813,12 +847,12 @@
     {
       "id": 33,
       "link": [3, 4],
-      "name": "Jump up with HiJump and Leave while Shinecharged",
+      "name": "Come In Shinecharging, Leave Shinecharged (HiJump)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 10,
+          "length": 6,
           "openEnd": 0,
-          "gentleDownTiles": 4
+          "gentleDownTiles": 2
         }
       },
       "requires": [
@@ -827,7 +861,7 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 45
+          "framesRemaining": 55
         }
       },
       "unlocksDoors": [
@@ -845,27 +879,22 @@
       "flashSuitChecked": true
     },
     {
-      "id": 34,
       "link": [3, 4],
-      "name": "Use HiJump and Wave to Leave while Shinecharged",
+      "name": "Come In Shinecharging, Leave With Spark (Space Jump, Tricky Movement)",
       "entranceCondition": {
         "comeInShinecharging": {
-          "length": 18,
-          "openEnd": 0,
-          "gentleDownTiles": 4,
-          "gentleUpTiles": 2
+          "length": 7,
+          "openEnd": 1,
+          "gentleDownTiles": 3
         }
       },
       "requires": [
-        "HiJump",
-        "Wave",
-        "canDodgeWhileShooting",
-        "canShinechargeMovementComplex"
+        "SpaceJump",
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 5}}
       ],
       "exitCondition": {
-        "leaveShinecharged": {
-          "framesRemaining": 15
-        }
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {
@@ -878,9 +907,7 @@
             "never"
           ]
         }
-      ],
-      "flashSuitChecked": true,
-      "note": "Shoot the Gamets while entering the room for more runway."
+      ]
     },
     {
       "id": 35,
@@ -957,7 +984,7 @@
     {
       "id": 40,
       "link": [4, 1],
-      "name": "Enter Shinesparking",
+      "name": "Come In With Spark",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
@@ -968,7 +995,7 @@
     {
       "id": 41,
       "link": [4, 1],
-      "name": "Short Shinespark",
+      "name": "Come In Shinecharged, Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 45
@@ -983,7 +1010,7 @@
     {
       "id": 42,
       "link": [4, 1],
-      "name": "SpaceJump across and Leave with Spark",
+      "name": "Come In Shinecharged, Leave With Spark (Space Jump)",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 130
@@ -992,7 +1019,6 @@
       "requires": [
         "SpaceJump",
         "canShinechargeMovementComplex",
-        "canMidairShinespark",
         {"shinespark": {"frames": 21}}
       ],
       "exitCondition": {
@@ -1125,6 +1151,87 @@
       ]
     },
     {
+      "link": [4, 4],
+      "name": "Leave With Spark (Wall Jump, Tricky Movement)",
+      "requires": [
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
+        "canWalljump",
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge.",
+        "Then jump onto the Kamer and use a wall jump to reach the top of the room and spark out."
+      ],
+      "devNote": [
+        "This is the trickier variant of the strat which allows getting close enough to the door to spark in top position."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Spark (Space Jump, Bottom Position)",
+      "requires": [
+        "SpaceJump",
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 15, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge.",
+        "Then jump onto the Kamer and use Space Jump to reach the top of the room and spark out."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Spark (Space Jump, Tricky Movement)",
+      "requires": [
+        "SpaceJump",
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 17,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge.",
+        "Then jump onto the Kamer and use Space Jump to reach the top of the room and spark out."
+      ],
+      "devNote": [
+        "This is the trickier variant of the strat which allows getting close enough to the door to spark in top position."
+      ]
+    },
+    {
       "id": 49,
       "link": [4, 4],
       "name": "G-Mode Setup - Get Hit By Gamet",
@@ -1221,6 +1328,7 @@
       "name": "Speedy Jump",
       "requires": [
         {"notable": "Speedy Jump"},
+        "h_runOverRespawningEnemies",
         "canTrickyDashJump",
         "canWalljump"
       ],
@@ -1297,31 +1405,17 @@
     {
       "id": 60,
       "link": [5, 1],
-      "name": "In-room Speedy Jump up with HiJump and Leave while Shinecharged",
+      "name": "Leave Shinecharged (HiJump)",
       "requires": [
         "HiJump",
-        "canShinechargeMovementComplex",
-        {"or": [
-          "canWalljump",
-          "canTrickyDashJump"
-        ]},
-        {"or": [
-          {"canShineCharge": {
-            "usedTiles": 18,
-            "openEnd": 1,
-            "gentleUpTiles": 4,
-            "gentleDownTiles": 2
-          }},
-          {"and": [
-            {"doorUnlockedAtNode": 3},
-            {"canShineCharge": {
-              "usedTiles": 19,
-              "openEnd": 1,
-              "gentleUpTiles": 4,
-              "gentleDownTiles": 2
-            }}
-          ]}
-        ]}
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
+        "canShinechargeMovementTricky"
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -1330,17 +1424,14 @@
       },
       "unlocksDoors": [
         {
-          "nodeId": 3,
-          "types": ["ammo"],
-          "requires": []
-        },
-        {
           "types": ["ammo"],
           "requires": []
         }
       ],
-      "flashSuitChecked": true,
-      "note": "Shortcharge to the right and then jump from below the floating platform to reach the top left door."
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge, then run left and jump (just underneath the Kamer) to the top-left ledge without needing to wall jump."
+      ]
     },
     {
       "id": 79,
@@ -1361,8 +1452,9 @@
     {
       "id": 62,
       "link": [5, 2],
-      "name": "Shortcharge to Leave with Shinecharge",
+      "name": "Leave Shinecharged",
       "requires": [
+        "h_runOverRespawningEnemies",
         {"or": [
           {"canShineCharge": {
             "usedTiles": 18,
@@ -1379,7 +1471,8 @@
               "gentleDownTiles": 4
             }}
           ]}
-        ]}
+        ]},
+        "canShinechargeMovement"
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -1397,7 +1490,9 @@
           "requires": []
         }
       ],
-      "flashSuitChecked": true
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning."
+      ]      
     },
     {
       "id": 63,
@@ -1517,85 +1612,67 @@
     {
       "id": 71,
       "link": [5, 4],
-      "name": "Shortcharge with HiJump and Leave Shinecharged",
+      "name": "Leave Shinecharged (HiJump)",
       "requires": [
         "HiJump",
-        "canShinechargeMovementComplex",
-        {"or": [
-          {"canShineCharge": {
-            "usedTiles": 18,
-            "openEnd": 1,
-            "gentleUpTiles": 2,
-            "gentleDownTiles": 4
-          }},
-          {"and": [
-            {"doorUnlockedAtNode": 3},
-            {"canShineCharge": {
-              "usedTiles": 19,
-              "openEnd": 0,
-              "gentleUpTiles": 2,
-              "gentleDownTiles": 4
-            }}
-          ]}
-        ]}
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
+        "canShinechargeMovementTricky"
       ],
       "exitCondition": {
         "leaveShinecharged": {
-          "framesRemaining": 10
+          "framesRemaining": 30
         }
       },
       "unlocksDoors": [
         {
-          "nodeId": 3,
-          "types": ["ammo"],
-          "requires": []
-        },
-        {
           "types": ["ammo"],
           "requires": []
         }
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge.",
+        "Then use HiJump to quickly reach the top-right door."
+      ]
     },
     {
       "id": 72,
       "link": [5, 4],
-      "name": "Shortcharge with Walljump and Leave Sparking",
+      "name": "Leave With Spark (Wall Jump, Bottom Position)",
       "requires": [
+        "h_runOverRespawningEnemies",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 1,
+          "gentleUpTiles": 2,
+          "gentleDownTiles": 4
+        }},
         "canWalljump",
         "canShinechargeMovementComplex",
-        {"or": [
-          {"canShineCharge": {
-            "usedTiles": 18,
-            "openEnd": 1,
-            "gentleUpTiles": 2,
-            "gentleDownTiles": 4
-          }},
-          {"and": [
-            {"doorUnlockedAtNode": 3},
-            {"canShineCharge": {
-              "usedTiles": 19,
-              "openEnd": 0,
-              "gentleUpTiles": 2,
-              "gentleDownTiles": 4
-            }}
-          ]}
-        ]},
-        {"shinespark": {"frames": 15}}
+        {"shinespark": {"frames": 15, "excessFrames": 0}}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
       },
       "unlocksDoors": [
-        {
-          "nodeId": 3,
-          "types": ["ammo"],
-          "requires": []
-        },
         {
           "types": ["ammo"],
           "requires": []
         }
+      ],
+      "note": [
+        "Leave Gamet drops uncollected to prevent them from respawning.",
+        "Run left-to-right to gain a shinecharge.",
+        "Then jump onto the Kamer and use a wall jump to reach the top of the room and spark out."
       ]
     },
     {


### PR DESCRIPTION
This adds several new shinecharge strats:
- In-room strat to leave shinecharged out the top-left door:
    - With a short right-to-left shortcharge and HiJump + wall jump, this can be done with 20 frames remaining.
    - For comparison, the in-room strat already in logic uses a shortcharge left-to-right and leaves with 10 frames remaining (but no wall jump required).    
- In-room strats to leave with a shinespark out the top-left door:
    - A HiJump version which is basically a more lenient (Very Hard-level) version of the strat that leaves with 10 frames remaining.
    - A (bootless) tricky dash jump wall jump version
- In-room strats to leave with a shinespark out the top-right door, with a wall jump or Space Jump.

Adjustments to existing strats:
- Some strats are renamed to follow the conventions that have been (mostly) used elsewhere.
- Added more detail to the note for the 3->1 HiJump tricky dash jump. I had a lot of trouble with this strat before realizing that I needed to maintain lower speed.
- For strats that gain a shinecharge left-to-right, removed the option for opening the door to gain an extra tile of runway, since this is generally not helpful.
- Removed the wall jump option from the in-room HiJump strat that leaves through the top-left with 10 frames remaining. From what I can tell, wall jumping seems to be too slow to work there (I can't get out with any frames remaining that way, much less 10), and getting the speed to make it onto the ledge is not difficult anyway. Also removed the `canTrickyDashJump` requirement from this, as the place where you jump isn't near a threshold where the jump speed would drop off.
- Tightened the frames for the in-room HiJump strat leaving shinecharged out the top-right; the logic had 10 but I could get 30.
- Tightened the frames for the 3->4 HiJump leaving shinecharged strat; the logic had 45 but I could get 55. To get this, it needed the runway to be shortened (in order to gain the shinecharge in the ideal place); with the longer runway I couldn't do any better than the in-room strat.

Removed strats:
- Cross-room strats that gain a shinecharge running in from the bottom-right door and leave through the bottom-left. The reasoning is that a shinespark strat that involves 3 rooms should be having a `canShinechargeMovementComplex` requirement, and at this level the player would be expected to do the in-room shortcharge instead.

There's some inconsistency in that some "leaveShinecharged" strats in this room now go from the door node to itself, while others start at the junction (node 5). I would like if they could all go from the door node to itself but didn't want to include that change in this PR, since moving the strats around would make it harder to review. Kyle also mentioned that node 5 could be deleted from this room (with node 1 taking on its role), so that could be a clean-up later.