### PR TITLE
Fast Ripper Room shinecharges

### DIFF
--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -127,6 +127,198 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Spark (Tank the Rippers)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "canHorizontalDamageBoost",
+        "canTrickyJump",
+        {"enemyDamage": {
+          "enemy": "Ripper 2 (red)",
+          "type": "contact",
+          "hits": 2
+        }},
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 0
+        }},
+        "canShinechargeMovement",
+        {"heatFrames": 525},
+        {"shinespark": {"frames": 43, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spark (Power Bomb Ripper Kill)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_canUsePowerBombs",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 0
+        }},
+        "canShinechargeMovement",
+        {"heatFrames": 630},
+        {"shinespark": {"frames": 43, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spark (Screw Ripper Kill)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "ScrewAttack",
+        {"canShineCharge": {
+          "usedTiles": 18,
+          "openEnd": 0
+        }},
+        "canShinechargeMovement",
+        {"heatFrames": 585},
+        {"or": [
+          "canTrickyJump",
+          {"heatFrames": 200}
+        ]},
+        {"shinespark": {"frames": 43, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spark (Super Ripper Kill, Bottom Position)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        {"ammo": {"type": "Super", "count": 2}},
+        {"or": [
+          {"canShineCharge": {
+            "usedTiles": 18,
+            "openEnd": 0
+          }},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"canShineCharge": {
+              "usedTiles": 28,
+              "openEnd": 0
+            }},
+            {"heatFrames": 100}
+          ]}
+        ]},
+        "canShinechargeMovement",
+        {"heatFrames": 645},
+        {"or": [
+          "canTrickyJump",
+          {"and": [
+            {"heatFrames": 200},
+            {"enemyDamage": {
+              "enemy": "Ripper 2 (red)",
+              "type": "contact",
+              "hits": 2
+            }}    
+          ]}
+        ]},
+        {"or": [
+          {"shinespark": {"frames": 43, "excessFrames": 0}},
+          {"and": [
+            "canShinechargeMovementComplex",
+            {"shinespark": {"frames": 27, "excessFrames": 0}},
+            {"heatFrames": 10}
+          ]},
+          {"and": [
+            "canShinechargeMovementTricky",
+            {"shinespark": {"frames": 17, "excessFrames": 0}},
+            {"heatFrames": 135}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Spark (Super Ripper Kill, Open Gate, Any Position)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        {"ammo": {"type": "Super", "count": 2}},
+        {"canShineCharge": {
+          "usedTiles": 17,
+          "openEnd": 1
+        }},
+        "canShinechargeMovementTricky",
+        {"heatFrames": 870},
+        {"shineChargeFrames": 175},
+        {"shinespark": {"frames": 15, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["ammo"],
+          "requires": []
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Use Supers to kill all the Rippers and open the green gate.",
+        "From the right door, run right-to-left to gain a shinecharge;",
+        "use the remaining runway (at least about 10 tiles) to gain speed to jump to the left and cross the room quickly."
+      ]
+    },
+    {
       "id": 4,
       "link": [1, 1],
       "name": "G-Mode Regain Mobility",


### PR DESCRIPTION
These are strats for coming in through the left door, crossing the room, and sparking back out the left door.

It would be possible to add 2->1 strats here as well, which could save some heat frames. But gate glitching and dealing with the Rippers from the right seems tricky enough that I don't want to try to figure it out.