### PR TITLE
Screw Attack Room shinecharges

### DIFF
--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -68,11 +68,6 @@
       "id": "B",
       "name": "Bottom Bomb Blocks",
       "obstacleType": "inanimate"
-    },
-    {
-      "id": "C",
-      "name": "Shinecharge from Above",
-      "obstacleType": "abstract"
     }
   ],
   "enemies": [],
@@ -160,7 +155,6 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        {"obstaclesNotCleared": ["C"]},
         {"heatFrames": 10},
         "h_canHeatedCrystalFlash",
         {"heatFrames": 10}
@@ -241,18 +235,215 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come In Shinecharging, Leave Shinecharged (HiJump, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "HiJump",
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 125}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 55
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come In Shinecharging, Leave Shinecharged (Wall Jump, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canWalljump",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 155}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 20
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come In Shinecharging, Leave With Spark (Wall Jump, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canWalljump",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 170},
+        {"shinespark": {"frames": 2, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come In Shinecharged, Leave With Spark (Wall Jump, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 145
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canWalljump",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 170},
+        {"shinespark": {"frames": 2, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come In Shinecharged, Leave With Spark (HiJump, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 110
+        }
+      },
+      "requires": [
+        "HiJump",
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 135},
+        {"shinespark": {"frames": 3, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Carry Shinecharge (HiJump, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "HiJump",
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 135}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
       "id": 4,
       "link": [1, 3],
       "name": "Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 50
+          "framesRequired": 35
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
-        {"heatFrames": 250},
-        {"shinespark": {"frames": 41, "excessFrames": 4}}
+        {"heatFrames": 210},
+        {"or": [
+          {"shinespark": {"frames": 41, "excessFrames": 4}},
+          {"and": [
+            "canMidairShinespark",
+            {"shinespark": {"frames": 37, "excessFrames": 4}}
+          ]}
+        ]}
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true
@@ -331,6 +522,60 @@
       ]
     },
     {
+      "link": [1, 4],
+      "name": "Come In Shinecharging, End Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"heatFrames": 50},
+        {"shineChargeFrames": 50}
+      ],
+      "endsWithShineCharge": true,
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come In Shinecharged, End Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 55
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"heatFrames": 55}
+      ],
+      "endsWithShineCharge": true,
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
       "id": 78,
       "link": [1, 5],
       "name": "Direct jump with Screw Attack",
@@ -381,6 +626,102 @@
       ],
       "flashSuitChecked": true,
       "note": "Climb up half a screen."
+    },
+    {
+      "link": [2, 1],
+      "name": "Come In Shinecharging, Leave Shinecharged (Temporary Blue)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canTemporaryBlue",
+        {"heatFrames": 115}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 65
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "In the previous room, press down precisely to gain the shinecharge while sliding off the ledge.",
+        "Maintain the temporary blue state to break through the blocks at the bottom of the room."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Carry Shinecharge (Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 110
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 110}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come In Shinecharged, Leave With Spark (Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 75
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 105}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
     },
     {
       "id": 11,
@@ -707,13 +1048,12 @@
       "name": "Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 50
+          "framesRequired": 55
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
-        {"heatFrames": 250},
-        {"shinespark": {"frames": 35, "excessFrames": 4}}
+        {"heatFrames": 215},
+        {"shinespark": {"frames": 31, "excessFrames": 4}}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -724,16 +1064,13 @@
       "name": "Jump into Room Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 15
+          "framesRequired": 5
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
-        "canMidairShinespark",
-        "canShinechargeMovement",
-        "canPrepareForNextRoom",
-        {"heatFrames": 250},
-        {"shinespark": {"frames": 18, "excessFrames": 4}}
+        "canShinechargeMovementComplex",
+        {"heatFrames": 180},
+        {"shinespark": {"frames": 19, "excessFrames": 4}}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -842,7 +1179,7 @@
     {
       "id": 30,
       "link": [2, 4],
-      "name": "Temporary Blue",
+      "name": "Temporary Blue (Come In With Temporary Blue)",
       "entranceCondition": {
         "comeInWithTemporaryBlue": {}
       },
@@ -850,13 +1187,11 @@
         {"heatFrames": 75}
       ],
       "clearsObstacles": ["B"],
-      "flashSuitChecked": true,
-      "note": "This expects the more controlled Temporary Blue to fall though the blocks, not storing a shinecharge through the door."
+      "flashSuitChecked": true
     },
     {
-      "id": 31,
       "link": [2, 4],
-      "name": "Temporary Blue Descent and Shinespark Escape Middle Door Part 1",
+      "name": "Temporary Blue (Come In Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 0,
@@ -864,33 +1199,54 @@
         }
       },
       "requires": [
-        {"notable": "Descent and Shinespark Escape"},
+        "canShinechargeMovementTricky",
         "canTemporaryBlue",
-        "canPrepareForNextRoom",
-        {"heatFrames": 75}
+        {"heatFrames": 80}
       ],
-      "clearsObstacles": ["B", "C"],
+      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
-      "note": "Store the shinecharge while hitting the door transition to maintain the ability to break blocks."
+      "devNote": [
+        "If the previous room is heated and canXRayCancelShinecharge is not an option, then this strat saves heat frames compared to waiting out the shinecharge frames in the other room."
+      ]
+    },
+    {
+      "id": 31,
+      "link": [2, 4],
+      "name": "Come In Shinecharging, End Shinecharged (Temporary Blue)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canTemporaryBlue",
+        {"heatFrames": 80},
+        {"shineChargeFrames": 80}
+      ],
+      "clearsObstacles": ["B"],
+      "endsWithShineCharge": true,
+      "flashSuitChecked": true,
+      "note": "Store the shinecharge just before the door transition, so that Samus slides off the ledge, to gain a temporary blue state to break the blocks."
     },
     {
       "id": 32,
       "link": [2, 4],
-      "name": "Screw Descent and Shinespark Escape Middle Door Part 1",
+      "name": "Come In Shinecharged, End Shinecharged (Screw Attack)",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 125
+          "framesRequired": 85
         }
       },
       "requires": [
-        {"notable": "Descent and Shinespark Escape"},
         "ScrewAttack",
-        "canShinechargeMovement",
-        {"heatFrames": 120}
+        "canShinechargeMovementComplex",
+        {"heatFrames": 85},
+        {"shineChargeFrames": 85}
       ],
-      "clearsObstacles": ["B", "C"],
-      "flashSuitChecked": true,
-      "note": "Enter with a shinespark stored and screw attack down to the item."
+      "clearsObstacles": ["B"],
+      "endsWithShineCharge": true,
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -940,6 +1296,138 @@
       ],
       "clearsObstacles": ["A"],
       "note": "Run in the adjacent room and jump through the door, to place a Bomb to break the top bomb blocks."
+    },
+    {
+      "link": [3, 1],
+      "name": "Come In Shinecharging, Leave With Spark (Temporary Blue)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canTemporaryBlue",
+        {"heatFrames": 170},
+        {"shinespark": {"frames": 3, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Press down precisely to gain the shinecharge while sliding off the ledge.",
+        "Maintain the temporary blue state to break through the blocks at the bottom of the room."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come In Shinecharging, Leave Shinecharged (Temporary Blue)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canTemporaryBlue",
+        {"heatFrames": 175}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 20
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Press down precisely to gain the shinecharge while sliding off the ledge.",
+        "Maintain the temporary blue state to break through the blocks at the bottom of the room."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come In Shinecharged, Leave With Spark (Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 165},
+        {"shinespark": {"frames": 7, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come In Shinecharging, Leave With Spark (Full Runway, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementTricky",
+        {"heatFrames": 230},
+        {"shinespark": {"frames": 7, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
     },
     {
       "id": 36,
@@ -1007,6 +1495,168 @@
           "requires": [
             "canPrepareForNextRoom"
           ]
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharging, Leave Shinecharged (Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canWalljump",
+        {"heatFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 35
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Press down precisely to gain the shinecharge while sliding off the ledge."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharging, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"heatFrames": 130},
+        {"shinespark": {"frames": 4, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Press down somewhat precisely to gain the shinecharge while breaking the bomb block."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharged, Leave With Spark (Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 90
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 120},
+        {"shinespark": {"frames": 4, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharging, Leave With Spark (Full Runway, Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 180},
+        {"shinespark": {"frames": 4, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharging, Leave Shinecharged (Full Runway, Screw Attack, Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        {"heatFrames": 200}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 35
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
         },
         {
           "types": ["missiles", "powerbomb"],
@@ -1094,7 +1744,7 @@
     {
       "id": 45,
       "link": [3, 4],
-      "name": "Temporary Blue Descent and Shinespark Escape Top Door Part 1",
+      "name": "Come In Shinecharging, End Shinecharged (Temporary Blue)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -1102,20 +1752,35 @@
         }
       },
       "requires": [
-        {"notable": "Descent and Shinespark Escape"},
         "canTemporaryBlue",
         "canShinechargeMovementTricky",
-        {"heatFrames": 130}
+        {"heatFrames": 155},
+        {"shineChargeFrames": 140}
       ],
-      "clearsObstacles": ["A", "B", "C"],
-      "flashSuitChecked": true,
-      "note": "Simultaneously store a shinespark and break through the bomb blocks down to the item location.",
-      "devNote": "canShinechargeMovementTricky is to represent the difficulty of activating the shinecharge in a precise place near the edge."
+      "endsWithShineCharge": true,
+      "clearsObstacles": ["A", "B"],
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Press down precisely to gain the shinecharge while sliding off the ledge.",
+        "Maintain the temporary blue state to break through the blocks at the bottom of the room.",
+        "Reach the item while still having a shinecharge."
+      ]
     },
     {
       "id": 46,
       "link": [3, 4],
-      "name": "Screw Descent and Shinespark Escape Top Door Part 1",
+      "name": "Come In Shinecharging, End Shinecharged (Full Runway, Screw Attack)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 12,
@@ -1123,14 +1788,78 @@
         }
       },
       "requires": [
-        {"notable": "Descent and Shinespark Escape"},
         "ScrewAttack",
-        "canShinechargeMovement",
-        {"heatFrames": 170}
+        "canShinechargeMovementTricky",
+        {"heatFrames": 205},
+        {"shineChargeFrames": 155},
+        {"or": [
+          "canMoonfall",
+          {"and": [
+            {"heatFrames": 5},
+            {"shineChargeFrames": 5}
+          ]}
+        ]}
       ],
-      "clearsObstacles": ["A", "B", "C"],
-      "note": "Store a shinespark then use screw to break through the bomb blocks down to the item location.",
-      "devNote": "Storing the spark on the left side of the runway takes fine control over shinecharge spacing, but that is ok at this difficulty."
+      "endsWithShineCharge": true,
+      "clearsObstacles": ["B"],
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Store a shinecharge then use Screw Attack to break through the bomb blocks down to the item location.",
+        "Reach the item while still having a shinecharge.",
+        "Doing a moonfall can save a few frames."
+      ],
+      "devNote": "Storing the shinecharge on the left side of the runway takes fine control over shinecharge spacing, but that is ok at this difficulty."
+    },
+    {
+      "link": [3, 4],
+      "name": "Come In Shinecharged, End Shinecharged (Screw Attack)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 140
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canTemporaryBlue",
+        {"heatFrames": 140},
+        {"or": [
+          "canMoonfall",
+          {"and": [
+            {"heatFrames": 5},
+            {"shineChargeFrames": 5}
+          ]}
+        ]}
+      ],
+      "endsWithShineCharge": true,
+      "clearsObstacles": ["A", "B"],
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Enter with a shinecharge, and use Screw Attack to break the bomb blocks and descend quickly.",
+        "Reach the item while still having a shinecharge.",
+        "Doing a moonfall can save a few frames."
+      ]
     },
     {
       "id": 47,
@@ -1247,17 +1976,90 @@
       ]
     },
     {
+      "link": [4, 1],
+      "name": "Start Shinecharged, Leave Shinecharged",
+      "startsWithShineCharge": true,
+      "requires": [
+        "canShinechargeMovementTricky",
+        {"heatFrames": 60},
+        {"shineChargeFrames": 60}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Start Shinecharged, Leave With Spark",
+      "startsWithShineCharge": true,
+      "requires": [
+        "canShinechargeMovementTricky",
+        {"heatFrames": 70},
+        {"shineChargeFrames": 25},
+        {"shinespark": {"frames": 15, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
       "id": 55,
       "link": [4, 2],
-      "name": "Shinespark Escape Mid Door Part 2",
+      "name": "Start Shinecharged, Shinespark",
+      "startsWithShineCharge": true,
       "requires": [
-        {"notable": "Descent and Shinespark Escape"},
-        "canShinechargeMovement",
-        {"obstaclesCleared": ["C"]},
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 40},
         {"heatFrames": 240},
-        {"shinespark": {"frames": 31, "excessFrames": 10}}
+        {"shinespark": {"frames": 27, "excessFrames": 10}}
       ],
       "clearsObstacles": ["B"],
+      "note": "Diagonally shinespark towards the middle door."
+    },
+    {
+      "link": [4, 2],
+      "name": "Start Shinecharged, Leave With Spark (Wall Jump)",
+      "startsWithShineCharge": true,
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        {"or": [
+          "ScrewAttack",
+          {"obstaclesCleared": ["B"]}
+        ]},
+        {"shineChargeFrames": 120},
+        {"heatFrames": 140},
+        {"shinespark": {"frames": 2, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
       "unlocksDoors": [
         {
           "types": ["super"],
@@ -1270,33 +2072,124 @@
           ]
         }
       ],
-      "note": "Diagonally shinespark towards the middle door.",
-      "devNote": [
-        "Obstacle C is indicating that Samus has a shinecharge ready to be used.",
-        "Useful only if you cannot reach the door at 2."
+      "note": "Diagonally shinespark towards the middle door."
+    },
+    {
+      "link": [4, 2],
+      "name": "Start Shinecharged, Leave With Spark (HiJump, Bottom Position)",
+      "startsWithShineCharge": true,
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          {"obstaclesCleared": ["B"]}
+        ]},
+        {"shineChargeFrames": 80},
+        {"heatFrames": 105},
+        {"shinespark": {"frames": 2, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Start Shinecharged, Leave With Spark (HiJump, Top Position)",
+      "startsWithShineCharge": true,
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          {"obstaclesCleared": ["B"]}
+        ]},
+        {"shineChargeFrames": 95},
+        {"heatFrames": 120},
+        {"shinespark": {"frames": 2, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Start Shinecharged, Leave Shinecharged (HiJump)",
+      "startsWithShineCharge": true,
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"or": [
+          "ScrewAttack",
+          {"obstaclesCleared": ["B"]}
+        ]},
+        {"shineChargeFrames": 110},
+        {"heatFrames": 105}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
       ]
     },
     {
       "id": 56,
       "link": [4, 3],
-      "name": "Shinespark Escape Top Door Part 2",
+      "name": "Start Shinecharged, Shinespark",
+      "startsWithShineCharge": true,
       "requires": [
-        {"notable": "Descent and Shinespark Escape"},
-        "canShinechargeMovement",
-        {"obstaclesCleared": ["C"]},
-        {"heatFrames": 270},
-        {"shinespark": {"frames": 41, "excessFrames": 4}}
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 20},
+        {"heatFrames": 190},
+        {"shinespark": {"frames": 40, "excessFrames": 4}}
       ],
-      "clearsObstacles": ["A", "B"],
-      "note": "Carry a shinecharge down though the bomb blocks and shinespark back up.",
-      "devNote": "Obstacle C is indicating that Samus has a shinecharge ready to be used."
+      "clearsObstacles": ["A", "B"]
     },
     {
       "id": 57,
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        {"obstaclesNotCleared": ["C"]},
         "h_canHeatedCrystalFlash"
       ],
       "clearsObstacles": ["B"],
@@ -1526,15 +2419,6 @@
   ],
   "nextStratId": 82,
   "notables": [
-    {
-      "id": 1,
-      "name": "Descent and Shinespark Escape",
-      "note": [
-        "Store a shinespark and break the bomb blocks from above in order to collect the item and shinespark out.",
-        "Screw Attack is easier to excute but has fewer shinespark frames to work with.",
-        "Using Temporary Blue is difficult to initiate but moves through the room quickly."
-      ]
-    },
     {
       "id": 2,
       "name": "Transition Screwjump",

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -1221,6 +1221,7 @@
       },
       "requires": [
         "canTemporaryBlue",
+        "canShinechargeMovementTricky",
         {"heatFrames": 80},
         {"shineChargeFrames": 80}
       ],
@@ -1831,6 +1832,7 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
+        "ScrewAttack",
         "canTemporaryBlue",
         {"heatFrames": 140},
         {"or": [

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -1317,7 +1317,7 @@
       "requires": [
         "canShinechargeMovementTricky",
         "canTemporaryBlue",
-        {"heatFrames": 170},
+        {"heatFrames": 165},
         {"shinespark": {"frames": 3, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -1352,7 +1352,7 @@
       "requires": [
         "canShinechargeMovementTricky",
         "canTemporaryBlue",
-        {"heatFrames": 175}
+        {"heatFrames": 160}
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -1418,7 +1418,7 @@
       "requires": [
         "ScrewAttack",
         "canShinechargeMovementTricky",
-        {"heatFrames": 230},
+        {"heatFrames": 190},
         {"shinespark": {"frames": 7, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -1524,7 +1524,7 @@
       "requires": [
         "canShinechargeMovementTricky",
         "canWalljump",
-        {"heatFrames": 150}
+        {"heatFrames": 145}
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -1559,7 +1559,7 @@
       "requires": [
         "canShinechargeMovementTricky",
         "canResetFallSpeed",
-        {"heatFrames": 125}
+        {"heatFrames": 120}
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -1594,7 +1594,7 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
-        {"heatFrames": 130},
+        {"heatFrames": 125},
         {"shinespark": {"frames": 4, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -1658,7 +1658,7 @@
       "requires": [
         "ScrewAttack",
         "canShinechargeMovementComplex",
-        {"heatFrames": 180},
+        {"heatFrames": 130},
         {"shinespark": {"frames": 4, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -1690,7 +1690,7 @@
         "ScrewAttack",
         "canShinechargeMovementComplex",
         "canWalljump",
-        {"heatFrames": 200}
+        {"heatFrames": 145}
       ],
       "exitCondition": {
         "leaveShinecharged": {
@@ -1798,7 +1798,7 @@
       "requires": [
         "canTemporaryBlue",
         "canShinechargeMovementTricky",
-        {"heatFrames": 155},
+        {"heatFrames": 140},
         {"shineChargeFrames": 140}
       ],
       "endsWithShineCharge": true,
@@ -1834,7 +1834,7 @@
       "requires": [
         "ScrewAttack",
         "canShinechargeMovementTricky",
-        {"heatFrames": 205},
+        {"heatFrames": 155},
         {"shineChargeFrames": 155},
         {"or": [
           "canMoonfall",

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -1549,6 +1549,42 @@
     },
     {
       "link": [3, 2],
+      "name": "Come In Shinecharging, Leave Shinecharged (Reset Fall Speed)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        "canResetFallSpeed",
+        {"heatFrames": 125}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 60
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "note": [
+        "Press down somewhat precisely to gain the shinecharge while breaking the bomb block.",
+        "Then morph, roll off the edge, and unmorph near the door to shoot it open."
+      ]
+    },
+    {
+      "link": [3, 2],
       "name": "Come In Shinecharging, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharging": {

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -368,7 +368,7 @@
       "name": "Come In Shinecharged, Leave With Spark (HiJump, Screw Attack)",
       "entranceCondition": {
         "comeInShinecharged": {
-          "framesRequired": 110
+          "framesRequired": 100
         }
       },
       "requires": [
@@ -376,7 +376,11 @@
         "ScrewAttack",
         "canShinechargeMovementComplex",
         {"heatFrames": 135},
-        {"shinespark": {"frames": 3, "excessFrames": 0}}
+        {"shinespark": {"frames": 3, "excessFrames": 0}},
+        {"or": [
+          {"shinespark": {"frames": 3, "excessFrames": 0}},
+          {"shineChargeFrames": 10}
+        ]}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -392,6 +396,9 @@
             "never"
           ]
         }
+      ],
+      "note": [
+        "To get up most quickly, after using Screw Attack to break up through the bomb blocks, use the next bomb blocks as a platform."
       ]
     },
     {
@@ -1982,7 +1989,7 @@
       "name": "Start Shinecharged, Leave Shinecharged",
       "startsWithShineCharge": true,
       "requires": [
-        "canShinechargeMovementTricky",
+        "canShinechargeMovementComplex",
         {"heatFrames": 60},
         {"shineChargeFrames": 60}
       ],
@@ -2009,7 +2016,7 @@
       "name": "Start Shinecharged, Leave With Spark",
       "startsWithShineCharge": true,
       "requires": [
-        "canShinechargeMovementTricky",
+        "canShinechargeMovementComplex",
         {"heatFrames": 70},
         {"shineChargeFrames": 25},
         {"shinespark": {"frames": 15, "excessFrames": 0}}
@@ -2073,8 +2080,7 @@
             "never"
           ]
         }
-      ],
-      "note": "Diagonally shinespark towards the middle door."
+      ]
     },
     {
       "link": [4, 2],

--- a/strats.md
+++ b/strats.md
@@ -156,7 +156,7 @@ When a `leaveWithRunway` conditions occurs on a door in a water environment, it 
 A `leaveShinecharged` object represents that Samus can leave through this door with a shinecharge (shinespark charge).
 
 `leaveShinecharged` has a single property:
-- _framesRemaining_: The number of frames remaining in the shinecharge when leaving the room. A special value "auto" may be used when the strat has a `comeInShinecharged` entrance condition: in this case, the frames remaining when leaving the room depends on how many frames are remaining when entering the room, with the `framesRequired` property of the `comeInShinecharged` indicating the amount of frames by which the shinecharge timer decreases between entering and exiting the room.
+- _framesRemaining_: The number of frames remaining in the shinecharge when leaving the room. A special value "auto" may be used when the strat has a `comeInShinecharged` entrance condition: in this case, the frames remaining when leaving the room depends on how many frames are remaining when entering the room, with the `framesRequired` property of the `comeInShinecharged` indicating the amount of frames by which the shinecharge timer decreases between entering and exiting the room. Similarly, the "auto" value may be used when the strat has a property `startsWithShineCharge: true`, in which case the shinecharge frames used in the strat would be expressed by a `shineChargeFrames` logical requirement.
 
 A strat with a `leaveShinecharged` condition should either include a `canShinecharge` requirement in its `requires` or have a `comeInShinecharged` entrance condition.
 

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -748,8 +748,8 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 messages["counts"]["reds"] += 1
                             if "leaveShinecharged" in strat["exitCondition"]:
                                 if strat["exitCondition"]["leaveShinecharged"]["framesRemaining"] == "auto":
-                                    if "entranceCondition" not in strat or "comeInShinecharged" not in strat["entranceCondition"]:
-                                        msg = f"🔴ERROR: Strat has leaveShinecharged exitCondition with framesRemaining 'auto' but no comeInShinecharged entranceCondition:{stratRef}"
+                                    if ("entranceCondition" not in strat or "comeInShinecharged" not in strat["entranceCondition"]) and strat.get("startsWithShineCharge") is not True:
+                                        msg = f"🔴ERROR: Strat has leaveShinecharged exitCondition with framesRemaining 'auto' but no comeInShinecharged entranceCondition or startsWithShineCharge:{stratRef}"
                                         messages["reds"].append(msg)
                                         messages["counts"]["reds"] += 1
                             if "leaveWithTemporaryBlue" in strat["exitCondition"]:


### PR DESCRIPTION
This overhauls the shinecharge/shinespark strats in this room, removing the obstacle "C" in favor of the newer `startsWithShineCharge`/`endsWithShineCharge` strat properties used in The Moat. This allows us to express many more strats that collect the item while holding a shinecharge, as well as more ways of using the shinecharge afterward.

As part of this, I got rid of the notable "Descent and Shinespark Escape". It seemed maybe unnecessary now that we have `canShinechargeMovementTricky` and shinecharge frame leniency to express the strat difficulties. There are many different possible difficulties depending on the combination of strats used here (ranging from Very Hard to Extreme), and not all of them involve a descent since you can also enter shinecharged/shinecharging from the left door.