### PR TITLE
Halfie Climb grapple teleport into grapple clip

### DIFF
--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -3385,22 +3385,6 @@
       ]
     },
     {
-      "link": [4, 1],
-      "name": "Grapple Teleport",
-      "entranceCondition": {
-        "comeInWithGrappleTeleport": {
-          "blockPositions": [
-            [5, 3],
-            [7, 2]
-          ]
-        }
-      },
-      "requires": [],
-      "note": [
-        "After teleporting, allow Samus to swing right before releasing Grapple."
-      ]
-    },
-    {
       "id": 116,
       "link": [4, 1],
       "name": "Grapple Teleport Door Lock Skip",

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -2646,9 +2646,25 @@
       "devNote": "Jumping into a diagonal spark saves a little energy from both the jump and hitting the slightly lower ceiling by the door."
     },
     {
-      "id": 89,
       "link": [3, 1],
       "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [
+            [5, 3],
+            [7, 2]
+          ]
+        }
+      },
+      "requires": [],
+      "note": [
+        "After teleporting, allow Samus to swing right before releasing Grapple."
+      ]
+    },
+    {
+      "id": 89,
+      "link": [3, 1],
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [
@@ -3369,9 +3385,25 @@
       ]
     },
     {
-      "id": 116,
       "link": [4, 1],
       "name": "Grapple Teleport",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [
+            [5, 3],
+            [7, 2]
+          ]
+        }
+      },
+      "requires": [],
+      "note": [
+        "After teleporting, allow Samus to swing right before releasing Grapple."
+      ]
+    },
+    {
+      "id": 116,
+      "link": [4, 1],
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -2663,6 +2663,42 @@
       "bypassesDoorShell": true
     },
     {
+      "link": [3, 1],
+      "name": "Grapple Teleport Into Grapple Clip (From Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "canGrappleClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "After teleporting, release Grapple and turn around repeatedly to wiggle out to the left and fall into the air space behind the Grapple blocks.",
+        "Press right against the wall, angle up, use Grapple, and release to clip into the door transition."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport Into Grapple Clip (From Red Brinstar Firefleas)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3]]
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canGrappleClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "After teleporting, quickly press and hold down to extend Grapple to push Samus to the left.",
+        "Release Grapple, and turn around repeatedly to wiggle out to the left and fall into the air space behind the Grapple blocks.",
+        "Press right against the wall, angle up, use Grapple, and release to clip into the door transition."
+      ]
+    },
+    {
       "id": 90,
       "link": [3, 1],
       "name": "Carry Grapple Teleport (Top Position)",
@@ -3348,6 +3384,42 @@
       },
       "requires": [],
       "bypassesDoorShell": true
+    },
+    {
+      "link": [4, 1],
+      "name": "Grapple Teleport Into Grapple Clip (From Moat)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[7, 2]]
+        }
+      },
+      "requires": [
+        "canGrappleClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "After teleporting, release Grapple and turn around repeatedly to wiggle out to the left and fall into the air space behind the Grapple blocks.",
+        "Press right against the wall, angle up, use Grapple, and release to clip into the door transition."
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Grapple Teleport Into Grapple Clip (From Red Brinstar Firefleas)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[5, 3]]
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canGrappleClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "After teleporting, quickly press and hold down to extend Grapple to push Samus to the left.",
+        "Release Grapple, and turn around repeatedly to wiggle out to the left and fall into the air space behind the Grapple blocks.",
+        "Press right against the wall, angle up, use Grapple, and release to clip into the door transition."
+      ]
     },
     {
       "id": 117,


### PR DESCRIPTION
Some grapple teleport strats in Halfie Climb that were missed in the first pass. These all involve getting into the air space in the top left and then grapple clipping to bypass the door shell.

Videos:
- original find by SamLittlehorns: https://videos.maprando.com/video/1470
- from Moat to top-right door (on-camera): https://videos.maprando.com/video/1648
- from Moat to bottom-right door (off-camera): https://videos.maprando.com/video/1649
- from Red Brin Firefleas to top-right door (on-camera): https://videos.maprando.com/video/1651
- from Red Brin Firefleas to bottom-right door (off-camera): https://videos.maprando.com/video/1652
