### PR TITLE
Redefine h_UnderwaterCrouchJumpWithFlashSuit

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -614,9 +614,8 @@
           ]
         },
         {
-          "name": "h_canUnderwaterCrouchJump",
+          "name": "h_UnderwaterCrouchJumpWithFlashSuit",
           "requires": [
-            "canSuitlessMaridia",
             {"tech": "canCrouchJump"}
           ],
           "devNote": [
@@ -626,10 +625,10 @@
           ]
         },
         {
-          "name": "h_canUnderwaterCrouchJumpDownGrab",
+          "name": "h_UnderwaterMaxHeightSpringBallJumpWithFlashSuit",
           "requires": [
-            "h_canUnderwaterCrouchJump",
-            "canDownGrab"
+            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "canTrickySpringBallJump"
           ]
         },
         {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -1368,7 +1368,13 @@
         "canSuitlessMaridia",
         "canTrickyJump",
         "canNeutralDamageBoost",
-        "h_canUnderwaterCrouchJumpDownGrab",
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          {"and": [
+            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "canDownGrab"
+          ]}
+        ]},
         {"enemyDamage": {
           "enemy": "Skultera",
           "hits": 1,
@@ -1389,7 +1395,13 @@
       "name": "Use Flash Suit",
       "requires": [
         "canSuitlessMaridia",
-        "h_canUnderwaterCrouchJumpDownGrab",
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          {"and": [
+            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "canDownGrab"
+          ]}
+        ]},
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 9, "excessFrames": 4}}
       ],

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -1058,7 +1058,10 @@
         "canSuitlessMaridia",
         "canPlayInSand",
         "canInsaneJump",
-        "h_canUnderwaterCrouchJump",
+        {"or": [
+          "canCrouchJump",
+          "h_UnderwaterCrouchJumpWithFlashSuit"
+        ]},
         "canNeutralDamageBoost",
         {"or": [
           {"enemyDamage": {

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -350,7 +350,11 @@
           "HiJump",
           "canSpringBallJumpMidAir",
           "Gravity",
-          "h_canUnderwaterCrouchJumpDownGrab"
+          "h_canCrouchJumpDownGrab",
+          {"and": [
+            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "canDownGrab"
+          ]}
         ]},
         {"useFlashSuit": {}},
         {"or": [
@@ -458,7 +462,13 @@
         {"notable": "Mochtroid Ice Clip"},
         "canCeilingClip",
         "canUseFrozenEnemies",
-        "h_canUnderwaterCrouchJumpDownGrab",
+        {"or": [
+          "h_canCrouchJumpDownGrab",
+          {"and": [
+            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "canDownGrab"
+          ]}
+        ]},
         {"or": [
           "canTrickyJump",
           "canMorphTurnaround"

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -515,7 +515,10 @@
       "link": [1, 5],
       "name": "Use Flash Suit",
       "requires": [
-        "h_canUnderwaterCrouchJump",
+        {"or": [
+          "canCrouchJump",
+          "h_UnderwaterCrouchJumpWithFlashSuit"
+        ]},
         {"useFlashSuit": {}},
         {"or": [
           {"shinespark": {"frames": 13, "excessFrames": 3}},


### PR DESCRIPTION
As discussed in #1744.

Note that I removed the `can` and just named it `h_UnderwaterCrouchJumpWithFlashSuit`. We were thinking it could be nice to remove `can` from helpers, and reserve it for tech. 

Also created the very long named `h_UnderwaterMaxHeightSpringBallJumpWithFlashSuit`. I plan to use it the same way, in an OR.