### PR TITLE
Rename canIframeSpikeJump to canUseIFrames, Cleanup

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -368,9 +368,8 @@
         {
           "name": "h_IBJFromThorns",
           "requires": [
-            "canIframeSpikeJump",
+            "canUseIFrames",
             "canJumpIntoIBJ",
-            "canCarefulJump",
             {"thornHits": 1},
             {"or":[
               "canTrickyJump",
@@ -381,9 +380,8 @@
         {
           "name": "h_IBJFromSpikes",
           "requires": [
-            "canIframeSpikeJump",
+            "canUseIFrames",
             "canJumpIntoIBJ",
-            "canCarefulJump",
             {"spikeHits": 1},
             {"or":[
               "canTrickyJump",
@@ -394,9 +392,8 @@
         {
           "name": "h_HeatedIBJFromSpikes",
           "requires": [
-            "canIframeSpikeJump",
+            "canUseIFrames",
             "canJumpIntoIBJ",
-            "canCarefulJump",
             {"spikeHits": 1},
             {"heatFrames": 100},
             {"or":[

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -672,7 +672,8 @@
         }
       },
       "requires": [
-        "h_ZebesIsAwake"
+        "h_ZebesIsAwake",
+        "canUseIFrames"
       ],
       "flashSuitChecked": true,
       "devNote": "The immobile case is included as a separate strat, since the Geemer hit to restore mobility provides i-frames eliminating a need to account for a subsequent Geemer hit (or a way to evade it)."

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -1037,7 +1037,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Maintain IFrames by using X-Ray whenever a thorn would deal damage.",
+        "Maintain i-frames by using X-Ray whenever a thorn would deal damage.",
         "Move by alternating between X-Ray turnarounds and normal turnarounds.",
         "Simply crouch again following any accidental X-Ray Standups."
       ]
@@ -1464,7 +1464,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Maintain IFrames by using X-Ray whenever a thorn would deal damage.",
+        "Maintain i-frames by using X-Ray whenever a thorn would deal damage.",
         "Move by alternating between X-Ray turnarounds and normal turnarounds.",
         "Simply crouch again following any accidental X-Ray Standups."
       ]
@@ -1668,7 +1668,7 @@
       "name": "Spikeway X-Ray Wiggle",
       "note": [
         "Slowly move through the thorns by alternating between X-Ray turnarounds and normal turnarounds.",
-        "Maintain IFrames by using X-Ray whenever a thorn would deal damage."
+        "Maintain i-frames by using X-Ray whenever a thorn would deal damage."
       ]
     },
     {

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -453,6 +453,7 @@
       "name": "Speed Kill",
       "requires": [
         "h_getBlueSpeedMaxRunway",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Mini-Kraid",
           "type": "spike",
@@ -460,7 +461,7 @@
         }}
       ],
       "clearsObstacles": ["A"],
-      "note": "Gain Iframes by taking damage then run left to create enough space to run back to the right with speedbooster."
+      "note": "Gain i-frames by taking damage then run left to create enough space to run back to the right with speedbooster."
     },
     {
       "id": 20,

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -149,7 +149,7 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "Leave Shinecharged (Spike I-frames, Unbroken Super Block)",
+      "name": "Leave Shinecharged (Spike I-Frames, Unbroken Super Block)",
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"obstaclesNotCleared": ["B"]},
@@ -158,7 +158,7 @@
           "openEnd": 0
         }},
         {"spikeHits": 1},
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canShinechargeMovementComplex"
       ],
       "exitCondition": {
@@ -776,7 +776,7 @@
               "openEnd": 0
             }},
             {"spikeHits": 1},
-            "canIframeSpikeJump"
+            "canUseIFrames"
           ]}
         ]},
         "canShinechargeMovementComplex",

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -495,7 +495,7 @@
         }
       },
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canNeutralDamageBoost",
         "canTrickyJump",
         {"thornHits": 5},
@@ -527,7 +527,7 @@
         }
       },
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canNeutralDamageBoost",
         "canInsaneJump",
         {"thornHits": 2},

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -165,7 +165,7 @@
       "name": "Leave With Runway (Tank the Damage)",
       "requires": [
         {"obstaclesNotCleared": ["B"]},
-        "canHitbox",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Sidehopper",
           "type": "contact",
@@ -188,7 +188,7 @@
       },
       "note": [
         "Open the door in advance, then lure the Sidehoopers to left wall. This is much easier with Morph ball.",
-        "Take a hit, then start running with the iframes."
+        "Take a hit, then start running with the i-frames."
       ]
     },
     {
@@ -519,7 +519,7 @@
           ]},
           {"and": [
             "canNeutralDamageBoost",
-            "canIframeSpikeJump",
+            "canUseIFrames",
             {"thornHits": 1}
           ]},
           {"and": [
@@ -531,7 +531,7 @@
       "flashSuitChecked": true,
       "note": [
         "Use the Solid Blocks next to the Samus Eater to clip up through the Power Bomb Blocks.",
-        "Carefully jump around the thorns, use HiJump to jump over them, or walk through them using IFrames."
+        "Carefully jump around the thorns, use HiJump to jump over them, or walk through them using i-frames."
       ]
     },
     {

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -137,7 +137,7 @@
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"or": [
           "SpaceJump",
           "h_XModeSpikeHit"
@@ -298,7 +298,7 @@
         }},
         {"or": [
           {"and": [
-            "canIframeSpikeJump",
+            "canUseIFrames",
             "canTrickyJump"
           ]},
           {"enemyDamage": {
@@ -321,7 +321,7 @@
       "requires": [
         {"spikeHits": 4},
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           {"spikeHits": 3}
         ]}
       ],
@@ -539,7 +539,7 @@
         "canCarefulJump",
         {"spikeHits": 3},
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           {"spikeHits": 3}
         ]}
       ],
@@ -964,7 +964,7 @@
       "requires": [
         "HiJump",
         "canPreciseWalljump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 2}
       ],
       "note": "Jump from on top of the lower spikes, wall jump on the overhang, and land on the upper spikes."
@@ -982,7 +982,7 @@
         }},
         "canHorizontalDamageBoost",
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           {"spikeHits": 1}
         ]}
       ],
@@ -1005,7 +1005,7 @@
       "link": [3, 4],
       "name": "Spike Run",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"or": [
           {"and": [
             "canInsaneJump",
@@ -1116,7 +1116,7 @@
         {"or": [
           "canTrickySpringBallJump",
           {"and": [
-            "canIframeSpikeJump",
+            "canUseIFrames",
             {"spikeHits": 1}
           ]}
         ]}
@@ -1140,7 +1140,7 @@
             {"spikeHits": 1},
             "canHorizontalDamageBoost",
             "canPreciseWalljump",
-            "canIframeSpikeJump"
+            "canUseIFrames"
           ]}
         ]}
       ],

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -183,7 +183,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canShinechargeMovement",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "h_canShineChargeMaxRunway"
       ],
       "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount).",
@@ -274,7 +274,7 @@
       "requires": [
         {"spikeHits": 1},
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           {"spikeHits": 1}
         ]}
       ]
@@ -354,7 +354,7 @@
       "link": [1, 4],
       "name": "Pause Abuse Spike Damage",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "h_pauseAbuseMinimalReserveRefill"
       ]
     },
@@ -439,7 +439,7 @@
               {"and": [
                 {"spikeHits": 1},
                 {"or": [
-                  "canIframeSpikeJump",
+                  "canUseIFrames",
                   {"spikeHits": 1}
                 ]}
               ]}
@@ -481,7 +481,7 @@
           {"and": [
             {"spikeHits": 1},
             {"or": [
-              "canIframeSpikeJump",
+              "canUseIFrames",
               {"spikeHits": 1}
             ]}
           ]}
@@ -522,7 +522,7 @@
               {"and": [
                 {"spikeHits": 1},
                 {"or": [
-                  "canIframeSpikeJump",
+                  "canUseIFrames",
                   {"spikeHits": 1}
                 ]}
               ]}
@@ -789,7 +789,7 @@
       ],
       "note": [
         "Using only the short runway and spike pit, use one or more SpeedKeeps to Speedball towards the item location.",
-        "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike I-Frames expire."
+        "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike i-frames expire."
       ]
     },
     {
@@ -1277,7 +1277,7 @@
       "requires": [
         {"spikeHits": 1},
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           {"spikeHits": 1}
         ]}
       ]
@@ -1287,7 +1287,7 @@
       "link": [4, 1],
       "name": "Pause Abuse Spike Damage",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "h_pauseAbuseMinimalReserveRefill"
       ]
     },
@@ -1498,7 +1498,7 @@
       "name": "In-Room SpeedKeep for Temporary Blue",
       "note": [
         "Using only the short runway and spike pit, use one or more SpeedKeeps to Speedball towards the item location.",
-        "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike I-Frames expire."
+        "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike i-frames expire."
       ]
     },
     {

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -328,7 +328,7 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Shinecharged DamageBoost",
+      "name": "Come in Shinecharged, Damage Boost",
       "entranceCondition": {
         "comeInShinecharged": {
           "framesRequired": 140
@@ -338,7 +338,7 @@
         "canShinechargeMovementTricky",
         "canHorizontalDamageBoost",
         "canTrickyJump",
-        "canHitbox",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Waver",
           "type": "contact",
@@ -364,7 +364,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Use a Waver to damage boost across part of the room, then pass through any remaining enemies while IFrames are active.",
+        "Use a Waver to damage boost across part of the room, then pass through any remaining enemies while i-frames are active.",
         "Killing the first waver and damage boosting with the second may be easier."
       ]
     },
@@ -630,7 +630,7 @@
         "canShinechargeMovementTricky",
         "canHorizontalDamageBoost",
         "canTrickyJump",
-        "canHitbox",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Choot",
           "type": "contact",
@@ -655,7 +655,7 @@
         }
       ],
       "flashSuitChecked": true,
-      "note": "Jump into the Choot to damage boost across part of the room, then pass through any remaining enemies while IFrames are active."
+      "note": "Jump into the Choot to damage boost across part of the room, then pass through any remaining enemies while i-frames are active."
     },
     {
       "id": 24,

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -403,10 +403,22 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 4],
+      "name": "Tank the Damage",
+      "requires": [
+        {"enemyDamage": {
+          "enemy": "Green Space Pirate (standing)",
+          "type": "contact",
+          "hits": 5
+        }}
+      ]
+    },
+    {
       "id": 13,
       "link": [2, 4],
       "name": "Tank the Damage (Use I-Frames to Reduce Damage)",
       "requires": [
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Green Space Pirate (standing)",
           "type": "contact",
@@ -904,20 +916,13 @@
       "link": [4, 2],
       "name": "Tank the Damage (Use I-Frames to Reduce Damage)",
       "requires": [
-        "canCarefulJump",
+        "canUseIFrames",
+        "canTrickyJump",
         {"enemyDamage": {
           "enemy": "Green Space Pirate (standing)",
           "type": "contact",
           "hits": 3
-        }},
-        {"or": [
-          "canTrickyJump",
-          {"enemyDamage": {
-            "enemy": "Green Space Pirate (standing)",
-            "type": "contact",
-            "hits": 1
-          }}
-        ]}
+        }}
       ],
       "note": "FIXME: This could use a ledge grab tech to avoid the 4th pirate hit.",
       "devNote": "A shinespark could be used to kill the bottom two pirates."

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -652,7 +652,7 @@
               "hits": 1
             }},
             "canKago",
-            "canHitbox"
+            "canUseIFrames"
           ]},
           {"and": [
             "Ice",
@@ -662,7 +662,7 @@
       ],
       "note": [
         "Roll under the top Fune fireball then roll off the edge to avoid the first Boulder.",
-        "Kill a Fune or use the Boulder for IFrames to get through the tricky section.",
+        "Kill a Fune or use the Boulder for i-frames to get through the tricky section.",
         "It is also possible to Kago the Fune to save health compared to taking a Boulder hit."
       ]
     },
@@ -853,7 +853,7 @@
     {
       "id": 38,
       "link": [4, 5],
-      "name": "Use iframes",
+      "name": "Use I-Frames",
       "requires": [
         {"enemyDamage": {
           "enemy": "Fireflea",
@@ -861,7 +861,7 @@
           "hits": 1
         }},
         "canUseEnemies",
-        "canIframeSpikeJump"
+        "canUseIFrames"
       ]
     },
     {
@@ -897,7 +897,7 @@
     {
       "id": 42,
       "link": [5, 4],
-      "name": "Use iframes",
+      "name": "Use I-Frames",
       "requires": [
         {"enemyDamage": {
           "enemy": "Fireflea",
@@ -905,7 +905,7 @@
           "hits": 1
         }},
         "canUseEnemies",
-        "canIframeSpikeJump"
+        "canUseIFrames"
       ]
     },
     {

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -448,7 +448,7 @@
       "clearsObstacles": ["C", "E", "F"],
       "note": [
         "Time Plasma shots so that Samus can run through the first two Dessgeegas and gain blue speed.",
-        "Shooting into the floor can give more control over the enemy iframes."
+        "Shooting into the floor can give more control over the enemy i-frames."
       ]
     },
     {
@@ -1099,7 +1099,7 @@
         {"or": [
           {"obstaclesCleared": ["F"]},
           {"and": [
-            "canHitbox",
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Dessgeega",
               "type": "contact",

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -621,7 +621,7 @@
         {"or": [
           {"and": [
             "canInsaneJump",
-            "canHitbox",
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Kihunter (red)",
               "type": "contact",
@@ -640,7 +640,7 @@
         {"heatFrames": 470}
       ],
       "clearsObstacles": ["A"],
-      "note": "Jump over the first Kihunter and attempt to either use IFrames to pass through the top Kihunter, or dodge it if possible."
+      "note": "Jump over the first KiHunter and attempt to either use i-frames to pass through the top KiHunter, or dodge it if possible."
     },
     {
       "id": 29,

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -481,7 +481,7 @@
           "type": "contact",
           "hits": 1
         }},
-        "canHitbox",
+        "canUseIFrames",
         "canShinechargeMovementComplex",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 40}},
@@ -489,7 +489,7 @@
       ],
       "clearsObstacles": ["D"],
       "note": [
-        "Use I-Frames from the first Dessgeega to run through the remaining enemies and store a shinespark.",
+        "Use i-frames from the first Dessgeega to run through the remaining enemies and store a shinespark.",
         "1-tap Shortcharge, then run back towards the Hoppers and try to hit all three at once by shinesparking horizontally as the ceiling hopper jumps down."
       ]
     },
@@ -761,6 +761,7 @@
       "name": "Kzan Double Kago",
       "requires": [
         "canKago",
+        "canUseIFrames",
         "canResetFallSpeed",
         {"enemyDamage": {
           "enemy": "Kzan",
@@ -769,7 +770,7 @@
         }},
         {"heatFrames": 180}
       ],
-      "note": "Morph Kago through the top Spike platform and use the I-Frames to Kago again through the second.",
+      "note": "Morph Kago through the top Spike platform and use the i-frames to Kago again through the second.",
       "devNote": "Useful when enemy damage can be reduced while still taking full heat damage."
     },
     {
@@ -1038,7 +1039,7 @@
         "canPartialFloorClip",
         "canCeilingClip",
         "canHorizontalDamageBoost",
-        "canHitbox",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Dessgeega",
           "type": "contact",
@@ -1052,7 +1053,7 @@
         "Partially clip beneath the Power Bomb blocks and the sold tiles beneath.",
         "Wait for a Dessgeega to jump over head and jump into it.",
         "The left ceiling Dessgeega works better.",
-        "Damage boost to the right and use I-Frames to run through all of the enemies."
+        "Damage boost to the right and use i-frames to run through all of the enemies."
       ]
     },
     {
@@ -1067,7 +1068,7 @@
         "canPartialFloorClip",
         "canCeilingClip",
         "canHorizontalDamageBoost",
-        "canHitbox",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Dessgeega",
           "type": "contact",
@@ -1082,7 +1083,7 @@
         "Wait for a Dessgeega to jump over head and jump into it.",
         "The left ceiling Dessgeega works better.",
         "Aim down after jumping in order to fully boost over the solid statue.",
-        "Damage boost to the right and use I-Frames to run through all of the enemies."
+        "Damage boost to the right and use i-frames to run through all of the enemies."
       ]
     },
     {
@@ -1097,7 +1098,7 @@
         "canPartialFloorClip",
         "canCeilingClip",
         "canHorizontalDamageBoost",
-        "canHitbox",
+        "canUseIFrames",
         "canSpeedball",
         {"getBlueSpeed": {"usedTiles": 16, "openEnd": 1}},
         {"enemyDamage": {
@@ -1117,7 +1118,7 @@
         "Partially clip beneath the Power Bomb blocks and the sold tiles beneath.",
         "Wait for a Dessgeega to jump over head and jump into it.",
         "The left ceiling Dessgeega works better.",
-        "Damage boost to the right and use I-Frames to run through all of the enemies.",
+        "Damage boost to the right and use i-frames to run through all of the enemies.",
         "Begin shortcharging while running through the Dessgeegas for a speedball.",
         "It may help to end the damage boost early, but then it becomes more difficult to stutter for the shortcharge."
       ]
@@ -1134,7 +1135,7 @@
         "canCeilingClip",
         "canTrickyJump",
         "canHorizontalDamageBoost",
-        "canHitbox",
+        "canUseIFrames",
         "canSpeedball",
         {"getBlueSpeed": {"usedTiles": 16, "openEnd": 1}},
         {"enemyDamage": {
@@ -1155,7 +1156,7 @@
         "Wait for a Dessgeega to jump over head and jump into it.",
         "The left ceiling Dessgeega works better.",
         "Aim down after jumping in order to fully boost over the solid statue.",
-        "Damage boost to the right and use I-Frames to run through all of the enemies.",
+        "Damage boost to the right and use i-frames to run through all of the enemies.",
         "Begin shortcharging while running through the Dessgeegas for a speedball.",
         "It may help to end the damage boost early, but then it becomes more difficult to stutter for the shortcharge."
       ]
@@ -1593,7 +1594,7 @@
           "type": "contact",
           "hits": 1
         }},
-        "canHitbox",
+        "canUseIFrames",
         "canMidairShinespark",
         "canShinechargeMovementComplex",
         {"shinespark": {"frames": 40}},
@@ -1601,7 +1602,7 @@
       ],
       "clearsObstacles": ["D"],
       "note": [
-        "Use I-Frames from the first Dessgeega to run through the remaining enemies and store a shinespark.",
+        "Use i-frames from the first Dessgeega to run through the remaining enemies and store a shinespark.",
         "It helps to run towards the first hopper to take damage and then not stutter.",
         "Mid-air spark to kill all three at once."
       ]
@@ -1772,7 +1773,7 @@
         "Partially clip between the Power Bomb blocks and the solid tiles beneath.",
         "Wait for a Dessgeega to jump over head and jump into it.",
         "The left ceiling Dessgeega works better.",
-        "Damage boost to the right and use I-Frames to run through all of the enemies."
+        "Damage boost to the right and use i-frames to run through all of the enemies."
       ]
     },
     {
@@ -1784,7 +1785,7 @@
         "Wait for a Dessgeega to jump over head and jump into it.",
         "The left ceiling Dessgeega works better.",
         "Aim down after jumping in order to fully boost over the solid statue.",
-        "Damage boost to the right and use I-Frames to run through all of the enemies."
+        "Damage boost to the right and use i-frames to run through all of the enemies."
       ]
     },
     {

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -443,7 +443,7 @@
           "canTrickyJump",
           {"and": [
             "canHorizontalDamageBoost",
-            "canCarefulJump",
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Magdollite",
               "type": "flame",
@@ -453,7 +453,7 @@
         ]},
         {"heatFrames": 330}
       ],
-      "note": "Wait for the first Holtz to attack then either use the Magdollite for IFrames, or avoid the projectiles and continue dodging bats."
+      "note": "Wait for the first Holtz to attack then either use the Magdollite for i-frames, or avoid the projectiles and continue dodging bats."
     },
     {
       "id": 20,
@@ -655,7 +655,7 @@
           "canTrickyJump",
           {"and": [
             "canHorizontalDamageBoost",
-            "canCarefulJump",
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Magdollite",
               "type": "flame",
@@ -665,7 +665,7 @@
         ]},
         {"heatFrames": 375}
       ],
-      "note": "Wait for the Magdollite to attack then either use it for IFrames, or jump over the swooping Holtzes."
+      "note": "Wait for the Magdollite to attack then either use it for i-frames, or jump over the swooping Holtzes."
     },
     {
       "id": 34,

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -459,8 +459,7 @@
         {"notable": "Spike Platforming with Move Assist (Left to Right)"},
         "canWalljump",
         "Morph",
-        "canCarefulJump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"or": [
           "Grapple",
           {"and": [
@@ -498,8 +497,7 @@
         {"notable": "Spike Platforming with SpringBall (Left to Right)"},
         "canWalljump",
         "Morph",
-        "canCarefulJump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "h_canUseSpringBall",
         "canMockball",
         {"spikeHits": 3},
@@ -523,7 +521,7 @@
         "canWalljump",
         "canInsaneJump",
         "canHorizontalDamageBoost",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 3},
         {"or": [
           "Morph",
@@ -1407,7 +1405,7 @@
         {"notable": "Bomb Jump Water Escape"},
         "HiJump",
         "canPreciseWalljump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1},
         "canNeutralDamageBoost",
         {"or": [
@@ -1451,7 +1449,7 @@
         {"notable": "Spike Platforming with No Equipment"},
         "canPreciseWalljump",
         "canInsaneJump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 3},
         "canNeutralDamageBoost",
         {"or": [

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -1108,7 +1108,7 @@
       "requires": [
         "Gravity",
         "canHorizontalDamageBoost",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Cacatac",
           "hits": 1,
@@ -1117,7 +1117,7 @@
       ],
       "note": [
         "Jump into the ceiling Cacatac and damage boost onto the platform between spike pits.",
-        "Use IFrames to cross the second set of spikes."
+        "Use i-frames to cross the second set of spikes."
       ]
     },
     {

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -291,14 +291,14 @@
         "HiJump",
         "SpeedBooster",
         "canWalljump",
-        "canCarefulJump",
+        "canUseIFrames",
         {"enemyDamage": {
           "enemy": "Pink Space Pirate (standing)",
           "hits": 1,
           "type": "laser"
         }}
       ],
-      "note": "Take a hit from the pirate to gain iframes for running through the pirate to use for a longer runway."
+      "note": "Take a hit from the pirate to gain i-frames for running through the pirate to use for a longer runway."
     },
     {
       "id": 15,
@@ -325,6 +325,7 @@
               "type": "contact",
               "hits": 1
             }},
+            "canUseIFrames",
             {"canShineCharge": {
               "usedTiles": 21,
               "openEnd": 0
@@ -401,6 +402,7 @@
               "openEnd": 0
             }},
             {"shinespark": {"frames": 3, "excessFrames": 3}},
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Pink Space Pirate (standing)",
               "type": "laser",
@@ -424,7 +426,7 @@
       ],
       "note": [
         "Using the bottom of the room, shortcharge to use the echoes created by shinesparking to kill all of the Standing Pirates.",
-        "Either lead the pirate to the left wall or take a hit to gain iframes to use the full runway to charge a spark",
+        "Either lead the pirate to the left wall or take a hit to gain i-frames to use the full runway to charge a spark",
         "To lead a pirate, have it shoot in the direction you want it to go. Then jump overhead and crouch on the other side.",
         "Or, jump and aim down while on the sloped tiles just above to lower the camera and wait for the pirate to move to the correct spot.",
         "Turn around and diagonal spark the ceiling to kill the lowest pirate, and later the middle pirates.",

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -907,7 +907,7 @@
             "enemies": [["Boyon"]]
           }},
           {"and": [
-            "canNeutralDamageBoost",
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Boyon",
               "hits": 1,

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -1073,7 +1073,7 @@
         "Wait for the global Sova to begin climbing the wall below the door.",
         "Have Reserves set to manual and couch jump up above the Sova as it turns the lip of the ledge.",
         "Before touching the Sova, pause, so that Samus will recieve a small damage boost followed by pause screen appearing.",
-        "Set Reserves back to auto which will end Samus' IFrames enabling a second damage boost.",
+        "Set Reserves back to auto which will end Samus' i-frames enabling a second damage boost.",
         "Without Morphball, this requires a blind damage boost."
       ]
     },

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1158,7 +1158,7 @@
       "link": [3, 4],
       "name": "Spike SpringBall",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1},
         "canSpringBallJumpMidAir",
         {"heatFrames": 300}
@@ -1186,7 +1186,7 @@
       "link": [3, 4],
       "name": "Spike HiJump",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1},
         "canWalljump",
         "HiJump",
@@ -1228,7 +1228,7 @@
       "link": [3, 4],
       "name": "Spike Speedjump",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1},
         "SpeedBooster",
         "HiJump",
@@ -1241,7 +1241,7 @@
       "name": "Hijumpless Spike Speedjump",
       "requires": [
         {"notable": "Hijumpless Spike Speedjump"},
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1},
         "SpeedBooster",
         "canTrickyDashJump",
@@ -1286,7 +1286,7 @@
         "h_heatProof",
         "canInsaneWalljump",
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           "canCrumbleJump"
         ]},
         {"enemyDamage": {
@@ -1490,7 +1490,7 @@
       "link": [4, 3],
       "name": "MidAir SpringBall",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1},
         "canSpringBallJumpMidAir",
         {"heatFrames": 300}
@@ -1501,7 +1501,7 @@
       "link": [4, 3],
       "name": "Speedjump",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1},
         "HiJump",
         "SpeedBooster",
@@ -1518,7 +1518,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canTrickyJump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canMidairShinespark",
         "h_canShineChargeMaxRunway",
         {"heatFrames": 480},

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -727,7 +727,7 @@
         "canSuitlessLavaDive",
         "canInsaneWalljump",
         "canInsaneJump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canStaggeredWalljump",
         "canFastWalljumpClimb",
         "canUseEnemies",
@@ -742,7 +742,7 @@
       ],
       "note": [
         "Enter the Bottom-Left Namihe by Kagoing inside of it.",
-        "Wait for a second hit to gain I-Frames and then very quickly walljump up the spikes and across to the right side wall."
+        "Wait for a second hit to gain i-frames and then very quickly walljump up the spikes and across to the right side wall."
       ]
     },
     {
@@ -963,7 +963,7 @@
       "requires": [
         {"notable": "HiJumpless Dive"},
         "canSuitlessLavaDive",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canStaggeredWalljump",
         "canFastWalljumpClimb",
         "canUseEnemies",
@@ -1105,7 +1105,7 @@
       "name": "HiJumpless Nahime Morph Kago",
       "note": [
         "Enter the Bottom-Left Namihe by Kagoing inside of it.",
-        "Wait for a second hit to gain I-Frames and then very quickly walljump up the spikes and across to the right side wall."
+        "Wait for a second hit to gain i-frames and then very quickly walljump up the spikes and across to the right side wall."
       ]
     },
     {

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -129,7 +129,7 @@
         {"heatFrames": 520},
         {"lavaFrames": 80},
         {"spikeHits": 3},
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canHorizontalDamageBoost"
       ],
       "note": "Damage boosts can be used to save energy - delay the damage boost from the spikes slightly in order to rise above the lava before moving."
@@ -145,7 +145,7 @@
         {"lavaFrames": 100},
         {"spikeHits": 2},
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           {"and": [
             {"spikeHits": 2},
             {"heatFrames": 50}
@@ -326,7 +326,7 @@
             {"heatFrames": 240}
           ]}
         ]},
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 2},
         {"lavaFrames": 15},
         {"heatFrames": 580}
@@ -404,7 +404,7 @@
         {"heatFrames": 520},
         {"lavaFrames": 80},
         {"spikeHits": 3},
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "canHorizontalDamageBoost"
       ],
       "note": "Damage boosts can be used to save energy - delay the damage boost from the spikes slightly in order to rise above the lava before moving."
@@ -420,7 +420,7 @@
         {"lavaFrames": 100},
         {"spikeHits": 2},
         {"or": [
-          "canIframeSpikeJump",
+          "canUseIFrames",
           {"and": [
             {"spikeHits": 2},
             {"heatFrames": 50}
@@ -600,7 +600,7 @@
             {"heatFrames": 240}
           ]}
         ]},
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 2},
         {"lavaFrames": 15},
         {"heatFrames": 580}

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -344,7 +344,7 @@
             "hits": 1
           }},
           {"and": [
-            "canIframeSpikeJump",
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Dragon",
               "type": "fireball",

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -358,7 +358,7 @@
         {"or": [
           {"and": [
             "canTrickyJump",
-            "canHitbox"
+            "canUseIFrames"
           ]},
           {"enemyDamage": {
             "enemy": "Blue Sidehopper",
@@ -384,7 +384,7 @@
         }
       ],
       "note": [
-        "Wait for the left hopper to move right so it does not follow Samus as IFrames run out.",
+        "Wait for the left hopper to move right so it does not follow Samus as i-frames run out.",
         "A damage boost using the top hopper also moves through the room fast enough to be safe."
       ]
     },

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -1497,7 +1497,7 @@
           {"obstaclesCleared": ["A"]},
           {"and": [
             "canMetroidAvoid",
-            "canHitbox"
+            "canUseIFrames"
           ]}
         ]},
         {"or": [
@@ -1523,7 +1523,7 @@
         "Killing the lower Rinka shortly before killing the higher Rinka will synchronize their respawn timers so that Samus can jump when the lower Rinka reappears in order to get a good angle on the higher Rinka.",
         "Jump to the floating platform ahead of the high Rinka, jumping extra high to lead the Metroid out of the way if it is alive.",
         "Jump into the Rinka once it reaches the left edge of the platform to reach the next platform.",
-        "Then use I-frames to pass through the Metroid if it is still alive."
+        "Then use i-frames to pass through the Metroid if it is still alive."
       ]
     },
     {

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -330,7 +330,7 @@
         {"or": [
           "canTrickyJump",
           {"and": [
-            "canCarefulJump",
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Rinka",
               "type": "contact",
@@ -345,7 +345,7 @@
           "openEnd": 1
         }
       },
-      "note": "Carefully dodge the Rinkas, or take a hit, while carefully avoiding falling off, then use the I-Frames to use the runway."
+      "note": "Carefully dodge the Rinkas, or take a hit, while carefully avoiding falling off, then use the i-frames to use the runway."
     },
     {
       "id": 38,
@@ -394,6 +394,7 @@
       "name": "Ice Zebetite Skip",
       "requires": [
         {"notable": "Ice Zebetite Skip"},
+        "canUseIFrames",
         "canTrickyUseFrozenEnemies",
         "Morph",
         {"or": [
@@ -451,6 +452,7 @@
       },
       "requires": [
         {"notable": "Speed Zebetite Skip"},
+        "canUseIFrames",
         {"shinespark": {"frames": 4}},
         {"enemyDamage": {
           "enemy": "Rinka",
@@ -476,6 +478,7 @@
       },
       "requires": [
         {"notable": "Speed Zebetite Skip"},
+        "canUseIFrames",
         {"shinespark": {"frames": 4}},
         {"enemyDamage": {
           "enemy": "Rinka",
@@ -497,6 +500,7 @@
       "name": "Speed Zebetite Skip (Use Flash Suit)",
       "requires": [
         {"notable": "Speed Zebetite Skip"},
+        "canUseIFrames",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 4}},
         {"enemyDamage": {

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -307,6 +307,7 @@
             "canHitbox"
           ]},
           {"and": [
+            "canUseIFrames",
             {"enemyDamage": {
               "enemy": "Tourian Space Pirate (all)",
               "type": "contact",

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -438,7 +438,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "h_canShineChargeMaxRunway",
         "canShinechargeMovement"
       ],
@@ -669,7 +669,7 @@
         "canTrickyJump",
         "canSpringFling",
         "canLateralMidAirMorph",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 1}
       ],
       "note": [
@@ -683,7 +683,7 @@
       "name": "2-hit Bowling",
       "requires": [
         "canTrickyJump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 2}
       ],
       "note": "This is doable even without any momentum from a previous room, but pretty tight."
@@ -693,8 +693,7 @@
       "link": [2, 6],
       "name": "2-hit Speed Bowling",
       "requires": [
-        "canCarefulJump",
-        "canIframeSpikeJump",
+        "canUseIFrames",
         "SpeedBooster",
         {"spikeHits": 2}
       ],
@@ -705,7 +704,7 @@
       "link": [2, 6],
       "name": "3-hit Bowling",
       "requires": [
-        "canIframeSpikeJump",
+        "canUseIFrames",
         {"spikeHits": 3}
       ]
     },
@@ -785,7 +784,10 @@
           {"and": [
             "canOffScreenMovement",
             {"or": [
-              {"spikeHits": 1},
+              {"and": [
+                {"spikeHits": 1},
+                "canUseIFrames"
+              ]},
               "Grapple",
               {"and": [
                 "SpaceJump",

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -320,8 +320,7 @@
       "requires": [
         {"thornHits": 1},
         {"or": [
-          "canIframeSpikeJump",
-          "canCarefulJump",
+          "canUseIFrames",
           {"thornHits": 1}
         ]},
         "canWalljump",
@@ -483,7 +482,7 @@
             {"or": [
               "HiJump",
               "canWalljump",
-              "canIframeSpikeJump",
+              "canUseIFrames",
               "Grapple",
               "canHorizontalDamageBoost",
               {"thornHits": 1}

--- a/tech.json
+++ b/tech.json
@@ -245,7 +245,8 @@
               "id": 19,
               "name": "canPauseAbuse",
               "techRequires": [
-                "canManageReserves"
+                "canManageReserves",
+                "canUseIFrames"
               ],
               "otherRequires": [],
               "note": [
@@ -855,12 +856,16 @@
         },
         {
           "id": 62,
-          "name": "canIframeSpikeJump",
+          "name": "canUseIFrames",
           "techRequires": [
             "canCarefulJump"
           ],
           "otherRequires": [],
-          "note": "Take damage to gain invincibility frames so that Samus can run and jump on spike floors or setup a wall jump from a spike wall.  Enemies provide more i-frames than spikes."
+          "note": [
+            "Take damage to gain invulnerability frames so that Samus can run through enemies and on spike floors or wall jump from a spike wall.",
+            "Enemies and their projectiles provide 95 i-frames, while spikes and thorns provide 60."
+          ],
+          "devNote": "Spikes seem to have collision oscillation which can make them have 59-60 frames, thorns seem to always have 59."
         },
         {
           "id": 63,
@@ -1672,8 +1677,8 @@
           "techRequires": [],
           "otherRequires": [],
           "note": [
-            "The ability to pass through some enemies undamaged by shooting.",
-            "May involve running through the enemy after making its hitbox inactive (e.g. Metal Pirates) or while the enemy has iframes (e.g. using Plasma)."
+            "The ability to move through some enemies undamaged by timing a hit on them.",
+            "This can be done with a Plasma shot, a well timed Power Bomb explosion, or a normal shot against Metal Pirates."
           ]
         },
         {
@@ -1962,7 +1967,7 @@
           "name": "canSpeedKeep",
           "techRequires": [
             "canBounceBall",
-            "canIframeSpikeJump"
+            "canUseIFrames"
           ],
           "otherRequires": [
             "SpeedBooster"


### PR DESCRIPTION
Standardized the spelling to `i-frame`, since there were many variations. Let me know if you think the tech name or standardization should be done differently. 

I was thinking it might make sense to rename `canHitbox`, since it is obscurely named and I'm not really sure you are manipulating the enemy hitboxes - thoughts?