### PR TITLE
Rename canQuickCrumbleEscape to canQuickDrop

### DIFF
--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -243,7 +243,7 @@
           "openEnd": 0
         }},
         "canShinechargeMovementTricky",
-        "canQuickCrumbleEscape",
+        "canQuickDrop",
         {"shinespark": {"frames": 1}}
       ],
       "exitCondition": {
@@ -804,7 +804,7 @@
       "link": [3, 1],
       "name": "Quick Crumble Escape",
       "requires": [
-        "canQuickCrumbleEscape"
+        "canQuickDrop"
       ],
       "failures": [
         {

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -562,7 +562,7 @@
           "openEnd": 1
         }},
         "canShinechargeMovement",
-        "canQuickCrumbleEscape"
+        "canQuickDrop"
       ],
       "unlocksDoors": [
         {

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -716,7 +716,7 @@
       "name": "Mission Impossible",
       "requires": [
         {"notable": "Mission Impossible"},
-        "canQuickCrumbleEscape",
+        "canQuickDrop",
         "HiJump",
         "canPreciseWalljump",
         {"obstaclesCleared": ["A", "B"]}
@@ -740,7 +740,7 @@
       "name": "Mission Impossible Walljumpless",
       "requires": [
         {"notable": "Mission Impossible Walljumpless"},
-        "canQuickCrumbleEscape",
+        "canQuickDrop",
         "HiJump",
         "canCrumbleJump",
         {"obstaclesCleared": ["A", "B"]}
@@ -780,7 +780,7 @@
           ]}
         ]},
         "canShinechargeMovementComplex",
-        "canQuickCrumbleEscape",
+        "canQuickDrop",
         {"or": [
           {"shinespark": {"frames": 19, "excessFrames": 7}},
           {"and": [
@@ -810,7 +810,7 @@
       "name": "Mission Impossible Shinespark (Flash Suit)",
       "requires": [
         {"notable": "Mission Impossible Shinespark"},
-        "canQuickCrumbleEscape",
+        "canQuickDrop",
         {"useFlashSuit": {}},
         {"or": [
           {"shinespark": {"frames": 19, "excessFrames": 7}},

--- a/tech.json
+++ b/tech.json
@@ -637,10 +637,13 @@
         },
         {
           "id": 47,
-          "name": "canQuickCrumbleEscape",
+          "name": "canQuickDrop",
           "techRequires": [],
           "otherRequires": [],
-          "note": "The combination of a crumble quick drop, and landing on a lower surface and jumping back over the crumble block before it re-forms."
+          "note": [
+            "Using a momentum conserving turnaround on a crumble block, an opening doorshell, or any other breaking block, to preserve Samus' momentum.",
+            "This is often used when traversing with a shinecharge, or to quickly fall through a crumble block and jump back through it before it re-forms."
+          ]
         },
         {
           "id": 48,


### PR DESCRIPTION
This is a rename to help make this tech useful in more locations - specifically shinecharges through a vertical door.

This was discussed most recently in #1540.

Do we want to name it `canQuickDrop`? 
Or should it even just be combined with `canMomentumConservingTurnaround`?

After this is settled, I can look into adding the tech to a few more locations that were brought up in the issue.