### PR TITLE
Slightly Refine canSuitlessMaridia

### DIFF
--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -875,7 +875,6 @@
       "link": [3, 1],
       "name": "Bomb Jump Water Escape",
       "requires": [
-        "canSuitlessMaridia",
         "canBombJumpWaterEscape"
       ]
     },

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -811,7 +811,6 @@
       "link": [3, 1],
       "name": "Base Suitless",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump"
       ]
     },
@@ -820,7 +819,6 @@
       "link": [3, 1],
       "name": "Suitless with Space Jump",
       "requires": [
-        "canSuitlessMaridia",
         "canSpaceJumpWaterBounce",
         {"or": [
           "canWalljump",
@@ -983,7 +981,6 @@
       "link": [3, 4],
       "name": "Base Suitless",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump"
       ]
     },
@@ -1066,7 +1063,6 @@
       "link": [4, 2],
       "name": "Suitless Frozen Choot, Spring Ball, Space Jump",
       "requires": [
-        "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         "canTrickySpringBallJump",
         {"or": [
@@ -1336,7 +1332,6 @@
       "link": [4, 3],
       "name": "Base Suitless",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump"
       ]
     },

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -986,7 +986,6 @@
       "name": "Gravity Jump",
       "requires": [
         "canGravityJump",
-        "canSuitlessMaridia",
         {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -1383,7 +1383,6 @@
       "link": [5, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
         {"or": [
           "h_canUsePowerBombs",
           {"and": [
@@ -1412,7 +1411,6 @@
       "link": [5, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
         {"obstaclesCleared": ["A"]},
         {"or": [
           "Gravity",

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -1340,10 +1340,6 @@
           "HiJump",
           "canSpringBallJumpMidAir"
         ]}
-      ],
-      "devNote": [
-        "This isn't requiring canSuitlessMaridia because it reduces the likelihood of entering from the top being a logical softlock.",
-        "Also it's not very elaborate suitless execution"
       ]
     },
     {

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -703,7 +703,6 @@
       "link": [5, 2],
       "name": "Suitless",
       "requires": [
-        "canSuitlessMaridia",
         {"or": [
           {"and": [
             "canSpaceJumpWaterBounce",

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -178,7 +178,6 @@
       "link": [2, 1],
       "name": "Suitless Space Jump",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump",
         "canSpaceJumpWaterBounce",
         "can4HighMidAirMorph"
@@ -190,7 +189,6 @@
       "link": [2, 1],
       "name": "Suitless, Bootless, Bomb into Springball Jump",
       "requires": [
-        "canSuitlessMaridia",
         "canSunkenTileWideWallClimb",
         "canUnderwaterBombIntoSpringBallJump",
         "canWallJumpInstantMorph"
@@ -206,7 +204,6 @@
       "name": "Escape - Suitless, Bootless, Space Jump",
       "requires": [
         {"notable": "Escape - Suitless, Bootless, Space Jump"},
-        "canSuitlessMaridia",
         "canSpringBallJumpMidAir",
         "canSunkenTileWideWallClimb",
         "canTrickyJump",

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -80,7 +80,6 @@
       "link": [1, 2],
       "name": "Spring Ball",
       "requires": [
-        "h_canNavigateUnderwater",
         "h_canUseSpringBall"
       ]
     },
@@ -89,7 +88,6 @@
       "link": [1, 2],
       "name": "R Jump",
       "requires": [
-        "h_canNavigateUnderwater",
         "canXRayStandUp",
         "canPartialFloorClip",
         "canRJump"

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -319,7 +319,6 @@
       "name": "Insane Bomb Jump",
       "requires": [
         {"notable": "Insane Bomb Jump"},
-        "canSuitlessMaridia",
         "canTrickyJump",
         "canSandfallBounce",
         "h_canUseMorphBombs",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -939,9 +939,7 @@
       "id": 34,
       "link": [2, 4],
       "name": "Base",
-      "requires": [
-        "h_canNavigateUnderwater"
-      ]
+      "requires": []
     },
     {
       "id": 35,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -643,7 +643,6 @@
         }
       },
       "requires": [
-        "canSuitlessMaridia",
         "h_canUsePowerBombs",
         "canStutterWaterShineCharge",
         "canShinechargeMovement",
@@ -820,7 +819,6 @@
         }
       },
       "requires": [
-        "canSuitlessMaridia",
         "canShinechargeMovementComplex",
         "canStutterWaterShineCharge",
         "h_canShineChargeMaxRunway",
@@ -922,7 +920,6 @@
         }
       },
       "requires": [
-        "canSuitlessMaridia",
         "canShinechargeMovementComplex",
         "canWaterShineCharge",
         "canHorizontalShinespark",
@@ -2627,7 +2624,6 @@
       "link": [9, 1],
       "name": "Suitless",
       "requires": [
-        "canSuitlessMaridia",
         "h_canBombThings"
       ]
     },

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -339,9 +339,7 @@
       "id": 12,
       "link": [1, 2],
       "name": "Base",
-      "requires": [
-        "h_canNavigateUnderwater"
-      ]
+      "requires": []
     },
     {
       "id": 13,

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -637,6 +637,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canHorizontalShinespark",
+        "canShinechargeMovement",
         {"shinespark": {
           "frames": 159,
           "excessFrames": 43
@@ -1093,7 +1094,6 @@
       "name": "Sand Grapple Boost",
       "requires": [
         {"notable": "Sand Grapple Boost"},
-        "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
         "canSandGrappleBoost",
         "canInsaneJump",
@@ -1114,7 +1114,6 @@
       "link": [1, 5],
       "name": "Sand Bomb Boost",
       "requires": [
-        "canSuitlessMaridia",
         "canDownGrab",
         "canSandBombBoost",
         "canInsaneJump"
@@ -1252,6 +1251,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canHorizontalShinespark",
+        "canShinechargeMovement",
         {"shinespark": {
           "frames": 147,
           "excessFrames": 15
@@ -1970,7 +1970,6 @@
       "link": [4, 6],
       "name": "Sand Grapple Boost",
       "requires": [
-        "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
         "canSandGrappleBoost",
         "canInsaneJump"
@@ -1987,7 +1986,6 @@
       "link": [4, 6],
       "name": "Sand Bomb Boost",
       "requires": [
-        "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
         "canSandBombBoost",
         "canInsaneJump"

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -378,8 +378,7 @@
             "hits": 2
           }}
         ]}
-      ],
-      "devNote": "No water involved here, so no need for Gravity or canSuitlessMaridia."
+      ]
     },
     {
       "id": 14,

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -525,7 +525,6 @@
       "link": [2, 4],
       "name": "Suitless HiJump Space Jump Break Free",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump",
         {"or": [
           "canSpaceJumpWaterEscape",
@@ -905,7 +904,6 @@
       "link": [3, 1],
       "name": "Suitless Spacejump",
       "requires": [
-        "canSuitlessMaridia",
         {"or": [
           {"and": [
             "canSpaceJumpWaterBounce",
@@ -944,7 +942,6 @@
       "link": [3, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
         {"or": [
           "h_canUseSpringBall",
           {"and": [
@@ -1136,10 +1133,6 @@
             "canJumpIntoIBJ",
             "h_canUseSpringBall"
           ]},
-          {"and": [
-            "canIBJ",
-            "canBombJumpWaterEscape"
-          ]},
           {"spikeHits": 1}
         ]}
       ],
@@ -1182,10 +1175,6 @@
             "canJumpIntoIBJ",
             "h_canUseSpringBall"
           ]},
-          {"and": [
-            "canIBJ",
-            "canBombJumpWaterEscape"
-          ]},
           {"spikeHits": 1}
         ]}
       ],
@@ -1221,18 +1210,15 @@
         "canSuitlessMaridia",
         {"or": [
           {"spikeHits": 1},
-          "canSpringBallJumpMidAir",
+          "canTrickySpringBallJump",
           {"and": [
             "HiJump",
             {"or": [
               "canWalljump",
               "h_canCrouchJumpDownGrab",
-              "canSpaceJumpWaterEscape"
+              "canSpaceJumpWaterEscape",
+              "canSpringBallJumpMidAir"
             ]}
-          ]},
-          {"and": [
-            "canIBJ",
-            "canBombJumpWaterEscape"
           ]}
         ]},
         {"or": [

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -1126,6 +1126,7 @@
         "HiJump",
         {"spikeHits": 1},
         {"or": [
+          "Gravity",
           "canWalljump",
           "canSpaceJumpWaterEscape",
           "canSpringBallJumpMidAir",
@@ -1147,8 +1148,9 @@
       "name": "Suitless Bootless Jump",
       "requires": [
         "canSuitlessMaridia",
-        "canDisableEquipment",
-        "canCarefulJump",
+        {"disableEquipment": "HiJump"},
+        {"disableEquipment": "Gravity"},
+        "canTrickyJump",
         {"or": [
           "Gravity",
           "HiJump",
@@ -1178,11 +1180,7 @@
           {"spikeHits": 1}
         ]}
       ],
-      "note": "This can be done by turning off Gravity and HiJump to jump over both spike pits.",
-      "devNote": [
-        "This strat is only used if the player doesn't have canCarefulJump, because otherwise the Suitless Bootless strat will be used,",
-        "because canSpringBallJumpMidAir requires canDisableEquipment."
-      ]
+      "note": "This can be done by turning off Gravity and HiJump to jump over both spike pits."
     },
     {
       "id": 66,
@@ -1215,7 +1213,7 @@
             "HiJump",
             {"or": [
               "canWalljump",
-              "h_canCrouchJumpDownGrab",
+              "canDownGrab",
               "canSpaceJumpWaterEscape",
               "canSpringBallJumpMidAir"
             ]}
@@ -1246,8 +1244,9 @@
       "name": "Suitless Bootless",
       "requires": [
         "canSuitlessMaridia",
-        "canDisableEquipment",
-        "canCarefulJump"
+        {"disableEquipment": "HiJump"},
+        {"disableEquipment": "Gravity"},
+        "canTrickyJump"
       ],
       "note": "This can be done by turning off Gravity and HiJump to jump over both spike pits."
     }

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -258,7 +258,6 @@
       "name": "Sandfall Bounce",
       "requires": [
         {"notable": "Sandfall Bounce"},
-        "canSuitlessMaridia",
         "canSandfallBounce",
         "canTrickySpringBallJump",
         "canTrickyJump"
@@ -605,7 +604,6 @@
       "link": [5, 3],
       "name": "HiJump Space Jump",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump",
         "canSpaceJumpWaterEscape"
       ]
@@ -615,7 +613,6 @@
       "link": [5, 3],
       "name": "HiJump IBJ",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump",
         "canCrouchJump",
         "canBombJumpWaterEscape",
@@ -628,7 +625,6 @@
       "name": "Suitless HiJump Perfect Bomb Boost",
       "requires": [
         {"notable": "Suitless HiJump Perfect Bomb Boost"},
-        "canSuitlessMaridia",
         "HiJump",
         "canCrouchJump",
         "canBombJumpWaterEscape"

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -772,7 +772,6 @@
       "link": [1, 4],
       "name": "Break Free",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump",
         {"or": [
           {"and": [

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -123,8 +123,7 @@
         {"or": [
           "h_canNavigateUnderwater",
           "Grapple",
-          "SpaceJump",
-          "canCarefulJump"
+          "SpaceJump"
         ]}
       ]
     },
@@ -651,8 +650,7 @@
         {"or": [
           "h_canNavigateUnderwater",
           "Grapple",
-          "SpaceJump",
-          "canCarefulJump"
+          "SpaceJump"
         ]}
       ]
     }

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -120,7 +120,12 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        {"or": [
+          "h_canNavigateUnderwater",
+          "Grapple",
+          "SpaceJump",
+          "canCarefulJump"
+        ]}
       ]
     },
     {
@@ -643,7 +648,12 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        {"or": [
+          "h_canNavigateUnderwater",
+          "Grapple",
+          "SpaceJump",
+          "canCarefulJump"
+        ]}
       ]
     }
   ],

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -230,7 +230,6 @@
       "link": [1, 7],
       "name": "Space Wall Climb",
       "requires": [
-        "canSuitlessMaridia",
         "canPlayInSand",
         "HiJump",
         "canConsecutiveWalljump",
@@ -435,17 +434,14 @@
       },
       "requires": [
         "Morph",
+        "h_canNavigateUnderwater",
         {"or": [
           "Gravity",
           {"and": [
-            "canSuitlessMaridia",
             "HiJump",
             "h_canCrouchJumpDownGrab"
           ]},
-          {"and": [
-            "canSuitlessMaridia",
-            "h_canMaxHeightSpringBallJump"
-          ]}
+          "h_canMaxHeightSpringBallJump"
         ]}
       ],
       "flashSuitChecked": true,
@@ -681,7 +677,6 @@
       "name": "Suitless Bootless IBJ",
       "requires": [
         {"notable": "Suitless Bootless IBJ"},
-        "canSuitlessMaridia",
         "canJumpIntoIBJ",
         "canBombJumpWaterEscape",
         "canCrumbleJump"

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -200,16 +200,10 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "Gravity"
-      ]
-    },
-    {
-      "id": 7,
-      "link": [1, 2],
-      "name": "Suitless",
-      "requires": [
-        "canSuitlessMaridia",
-        "HiJump"
+        {"or": [
+          "Gravity",
+          "HiJump"
+        ]}
       ]
     },
     {
@@ -258,7 +252,6 @@
       "link": [1, 2],
       "name": "Suitless Sand Escape (Left to Right)",
       "requires": [
-        "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
         "canEscapeSand"
       ],
@@ -348,16 +341,10 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "Gravity"
-      ]
-    },
-    {
-      "id": 18,
-      "link": [2, 1],
-      "name": "Suitless",
-      "requires": [
-        "canSuitlessMaridia",
-        "HiJump"
+        {"or": [
+          "Gravity",
+          "HiJump"
+        ]}
       ]
     },
     {
@@ -406,7 +393,6 @@
       "link": [2, 1],
       "name": "Suitless Sand Escape (Right to Left)",
       "requires": [
-        "canSuitlessMaridia",
         "h_canCrouchJumpDownGrab",
         "canEscapeSand"
       ],
@@ -586,7 +572,10 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        {"or": [
+          "h_canNavigateUnderwater",
+          "HiJump"
+        ]}
       ]
     },
     {
@@ -594,7 +583,10 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        {"or": [
+          "h_canNavigateUnderwater",
+          "HiJump"
+        ]}
       ]
     }
   ],

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -531,7 +531,10 @@
       "requires": [
         {"or": [
           "Gravity",
-          "HiJump"
+          {"and": [
+            "canSuitlessMaridia",
+            "HiJump"
+          ]}
         ]}
       ]
     },

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -529,20 +529,26 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "Gravity"
+        {"or": [
+          "Gravity",
+          "HiJump"
+        ]}
       ]
     },
     {
       "id": 18,
       "link": [2, 3],
-      "name": "Suitless Jump Assist",
+      "name": "Suitless Spring Ball",
       "requires": [
         "canSuitlessMaridia",
+        "canSpringBallJumpMidAir",
         {"or": [
-          "HiJump",
-          "canSpringBallJumpMidAir"
+          "canWalljump",
+          "h_canCrouchJumpDownGrab",
+          "canTrickySpringBallJump"
         ]}
-      ]
+      ],
+      "note": "Wall jump when the water is low or crouch jump + down grab when it is high."
     },
     {
       "id": 19,

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -496,7 +496,7 @@
         {"or": [
           "h_hasBeamUpgrade",
           "canDodgeWhileShooting",
-          "Grapple",
+          "canUseGrapple",
           "ScrewAttack",
           "canBePatient",
           {"resourceCapacity": [{"type": "Missile", "count": 1}]},
@@ -644,7 +644,7 @@
         {"or": [
           "h_hasBeamUpgrade",
           "canDodgeWhileShooting",
-          "Grapple",
+          "canUseGrapple",
           "ScrewAttack",
           "canBePatient",
           {"resourceCapacity": [{"type": "Missile", "count": 1}]},

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -275,10 +275,16 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        {"or": [
-          "canWalljump",
-          "h_canCrouchJumpDownGrab"
-        ]}
+        "canDownGrab"
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Suitless HiJump Springball",
+      "requires": [
+        "canSuitlessMaridia",
+        "HiJump",
+        "canSpringBallJumpMidAir"
       ]
     },
     {

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -110,7 +110,6 @@
         }
       },
       "requires": [
-        "canSuitlessMaridia",
         "canShinechargeMovementComplex",
         "canStutterWaterShineCharge",
         {"shinespark": {"frames": 3}}
@@ -142,7 +141,6 @@
         }
       },
       "requires": [
-        "canSuitlessMaridia",
         "canShinechargeMovementTricky",
         "canStutterWaterShineCharge"
       ],
@@ -253,7 +251,6 @@
       },
       "requires": [
         {"notable": "Stutter Shinecharge Through The Gate"},
-        "canSuitlessMaridia",
         "canShinechargeMovementComplex",
         "canStutterWaterShineCharge",
         "canDodgeWhileShooting",

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -1684,9 +1684,7 @@
       "id": 69,
       "link": [5, 6],
       "name": "Base",
-      "requires": [
-        "h_canNavigateUnderwater"
-      ]
+      "requires": []
     },
     {
       "id": 70,
@@ -1699,19 +1697,19 @@
       "link": [6, 5],
       "name": "Base",
       "requires": [
-        "Gravity"
+        {"or": [
+          "Gravity",
+          "HiJump"
+        ]}
       ]
     },
     {
       "id": 72,
       "link": [6, 5],
-      "name": "Suitless With Jump Assist",
+      "name": "Suitless Spring Ball",
       "requires": [
         "canSuitlessMaridia",
-        {"or": [
-          "HiJump",
-          "canSpringBallJumpMidAir"
-        ]}
+        "canSpringBallJumpMidAir"
       ]
     },
     {
@@ -1836,7 +1834,6 @@
       "link": [7, 3],
       "name": "Suitless",
       "requires": [
-        "canSuitlessMaridia",
         {"or": [
           "HiJump",
           "canSpringBallJumpMidAir"

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -532,7 +532,6 @@
             "h_canArtificialMorphMovement"
           ]},
           {"and": [
-            "canSuitlessMaridia",
             "h_canArtificialMorphSpringBall",
             "HiJump"
           ]}
@@ -779,7 +778,6 @@
             "h_canArtificialMorphMovement"
           ]},
           {"and": [
-            "canSuitlessMaridia",
             "h_canArtificialMorphSpringBall",
             "HiJump"
           ]}
@@ -1768,8 +1766,7 @@
       "requires": [
         "f_MaridiaTubeBroken",
         "HiJump"
-      ],
-      "note": "Doesn't require canSuitlessMaridia because there is no risk, nor anything tricky whatsoever."
+      ]
     },
     {
       "id": 76,
@@ -1778,7 +1775,7 @@
       "requires": [
         "f_MaridiaTubeBroken",
         "canSuitlessMaridia",
-        "canSpringBallJumpMidAir"
+        "canTrickySpringBallJump"
       ]
     },
     {
@@ -1798,7 +1795,7 @@
     {
       "id": 79,
       "link": [6, 4],
-      "name": "Suitless Base",
+      "name": "Suitless HiJump",
       "requires": [
         "HiJump"
       ],
@@ -1807,15 +1804,13 @@
           "types": ["ammo"],
           "requires": []
         }
-      ],
-      "note": "Doesn't require canSuitlessMaridia because there is no risk, nor anything tricky whatsoever."
+      ]
     },
     {
       "id": 80,
       "link": [6, 4],
-      "name": "Suitless",
+      "name": "Suitless Spring Ball",
       "requires": [
-        "canSuitlessMaridia",
         "canSpringBallJumpMidAir"
       ],
       "unlocksDoors": [

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -1811,14 +1811,17 @@
       "link": [6, 4],
       "name": "Suitless Spring Ball",
       "requires": [
-        "canSpringBallJumpMidAir"
+        "canSuitlessMaridia",
+        "canTrickySpringBallJumpMidAir",
+        "canTrickyJump"
       ],
       "unlocksDoors": [
         {
           "types": ["ammo"],
           "requires": []
         }
-      ]
+      ],
+      "note": "Unmorph at the top of the jump to touch the transition. A crouch jump can help."
     },
     {
       "id": 81,

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -1812,7 +1812,7 @@
       "name": "Suitless Spring Ball",
       "requires": [
         "canSuitlessMaridia",
-        "canTrickySpringBallJumpMidAir",
+        "canTrickySpringBallJump",
         "canTrickyJump"
       ],
       "unlocksDoors": [

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -500,7 +500,6 @@
       "link": [1, 5],
       "name": "Suitless Climb the Right Wall",
       "requires": [
-        "canSuitlessMaridia",
         "HiJump",
         "canDownGrab",
         {"or": [
@@ -733,7 +732,6 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
         {"or": [
           "Gravity",
           {"obstaclesNotCleared": ["A"]},

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -3568,11 +3568,11 @@
       "link": [7, 8],
       "name": "Suitless Jump Assist",
       "requires": [
-        "canSuitlessMaridia",
         {"or": [
           "HiJump",
           {"and": [
             "canTrickySpringBallJump",
+            "canSuitlessMaridia",
             {"or": [
               "canTrickyJump",
               "canSpringFling",
@@ -4655,10 +4655,9 @@
       "link": [11, 1],
       "name": "Suitless Jump Assist",
       "requires": [
-        "canSuitlessMaridia",
         {"or": [
           "HiJump",
-          "canSpringBallJumpMidAir"
+          "canTrickySpringBallJump"
         ]}
       ]
     },

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -350,7 +350,6 @@
       "link": [2, 3],
       "name": "Suitless Space Jump",
       "requires": [
-        "canSuitlessMaridia",
         {"or": [
           {"and": [
             "canSpaceJumpWaterBounce",

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -238,7 +238,6 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",

--- a/tech.json
+++ b/tech.json
@@ -1377,6 +1377,7 @@
           "id": 100,
           "name": "canBombJumpWaterEscape",
           "techRequires": [
+            "canSuitlessMaridia",
             "canMidAirMorph"
           ],
           "otherRequires": [

--- a/tech.json
+++ b/tech.json
@@ -935,6 +935,7 @@
                   "id": 68,
                   "name": "canUnderwaterBombIntoSpringBallJump",
                   "techRequires": [
+                    "canSuitlessMaridia",
                     "canTrickySpringBallJump",
                     "canJumpIntoIBJ"
                   ],


### PR DESCRIPTION
Looked through all of the `canSuitlessMaridia/h_canNavigateUnderwater` to see what should be allowed in Map Rando's `Basic`. Most of these changes are actually that a strat required `canSuitlessMaridia` and another tech that relied on it.

I wasn't consistent with underwater spring ball jumps, but I'm kind of leaning towards having very simple underwater spring ball jumps not require `canSuitlessMaridia`, since underwater actually makes them easier - thoughts?

I was wondering if it might be useful to add `canSuitlessMaridia` to some tech and helpers, like crab/snail/mochtroid climbs, and the double spring + HiJump helper - thoughts?

This will definitely need a second pass after I get your feedback, and then I was thinking it could be nice to rename `canSuitlessMaridia`. Maybe `canSuitlessUnderwaterPlatform`?