### PR TITLE
Enemies Cleanup - Remove dropRequires, farmCycles

### DIFF
--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -68,14 +68,7 @@
       "groupName": "Early Supers Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -96,48 +96,21 @@
       "groupName": "Etecoon E-Tank Left Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [7],
-      "farmCycles": [
-        {
-          "name": "Crouch two tiles above spawn point",
-          "cycleFrames": 130,
-          "requires": [
-            {"obstaclesCleared": ["A"]}
-          ]
-        }
-      ]
+      "homeNodes": [7]
     },
     {
       "id": "e3",
       "groupName": "Etecoon E-Tank Middle Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [7],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": [
-            {"obstaclesCleared": ["A"]}
-          ]
-        }
-      ]
+      "homeNodes": [7]
     },
     {
       "id": "e4",
       "groupName": "Etecoon E-Tank Right Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [7],
-      "farmCycles": [
-        {
-          "name": "Crouch two tiles above spawn point",
-          "cycleFrames": 130,
-          "requires": [
-            {"obstaclesCleared": ["A"]}
-          ]
-        }
-      ]
+      "homeNodes": [7]
     },
     {
       "id": "e5",

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -64,70 +64,35 @@
       "groupName": "Green Hill Zone Top Geega",
       "enemyName": "Geega",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Single Geega Farm",
-          "cycleFrames": 160,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Green Hill Zone Top-Middle Geega",
       "enemyName": "Geega",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Single Geega Farm",
-          "cycleFrames": 160,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e3",
       "groupName": "Green Hill Zone Middle Geega",
       "enemyName": "Geega",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Single Geega Farm",
-          "cycleFrames": 160,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e4",
       "groupName": "Green Hill Zone Bottom-Middle Geega",
       "enemyName": "Geega",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Single Geega Farm",
-          "cycleFrames": 160,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e5",
       "groupName": "Green Hill Zone Bottom Geega",
       "enemyName": "Geega",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Single Geega Farm",
-          "cycleFrames": 160,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e6",

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -42,14 +42,7 @@
       "groupName": "Kraid Eye Door Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     }
   ],
   "links": [

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -180,42 +180,21 @@
       "groupName": "Big Pink Top Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [13],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [13]
     },
     {
       "id": "e2",
       "groupName": "Big Pink Middle Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [13],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [13]
     },
     {
       "id": "e3",
       "groupName": "Big Pink Bottom Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [13],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [13]
     },
     {
       "id": "e4",

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -40,29 +40,14 @@
       "groupName": "Spore Spawn Farming Room Left Zebs",
       "enemyName": "Zeb",
       "quantity": 2,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Alternating Farm",
-          "cycleFrames": 120,
-          "requires": [],
-          "note": "Getting the two spawners to desynch and jumping back and forth between the two."
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e3",
       "groupName": "Spore Spawn Farming Room Right Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     }
   ],
   "links": [

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -41,14 +41,7 @@
       "groupName": "Spore Spawn Supers Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     }
   ],
   "links": [

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -33,50 +33,21 @@
       "groupName": "Hellway Left Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Crouch two tiles above spawn point",
-          "cycleFrames": 130,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Hellway Middle Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Crouch two tiles above spawn point",
-          "cycleFrames": 130,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e3",
       "groupName": "Hellway Right Zebbos",
       "enemyName": "Zebbo",
       "quantity": 2,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Turnaround two tiles above spawn",
-          "cycleFrames": 240,
-          "requires": [],
-          "note": "Involves tiny hops to get the drops as well"
-        },
-        {
-          "name": "Grapple turnaround two tiles above spawn",
-          "cycleFrames": 175,
-          "requires": [
-            "Grapple"
-          ]
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e4",

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -52,8 +52,7 @@
       "groupName": "Red Brinstar Fireflea Room Left Yapping Maws",
       "enemyName": "Yapping Maw",
       "quantity": 2,
-      "betweenNodes": [1, 2],
-      "dropRequires": ["never"]
+      "betweenNodes": [1, 2]
     },
     {
       "id": "e3",

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -99,15 +99,7 @@
       "groupName": "Red Tower Geegas",
       "enemyName": "Geega",
       "quantity": 2,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Alternating Geega Pipes",
-          "cycleFrames": 180,
-          "requires": [],
-          "note": "Standing on the platform next to the right spawner, must jump to get Geegas to spawn from the left one."
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -187,14 +187,7 @@
       "groupName": "West Ocean Zeb",
       "enemyName": "Zeb",
       "quantity": 1,
-      "homeNodes": [6],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [6]
     },
     {
       "id": "e2",

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -87,21 +87,7 @@
       "groupName": "Gauntlet E-Tank Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Grapple three tiles away",
-          "cycleFrames": 130,
-          "requires": [
-            "Grapple"
-          ]
-        },
-        {
-          "name": "Shoot and jump three tiles away",
-          "cycleFrames": 160,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -71,53 +71,42 @@
       "groupName": "Amphitheatre Top Pirate",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e2",
       "groupName": "Amphitheatre Bottom Left Acid Pirate",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 1,
-      "betweenNodes": [3, 5],
-      "dropRequires": ["never"],
-      "note": "Technically you can get the drops but you likely won't"
+      "betweenNodes": [3, 5]
     },
     {
       "id": "e3",
       "groupName": "Amphitheatre Bottom Center Acid Pirate",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 1,
-      "homeNodes": [3],
-      "dropRequires": ["never"],
-      "note": "Technically you can get the drops but you likely won't"
+      "homeNodes": [3]
     },
     {
       "id": "e4",
       "groupName": "Amphitheatre Right Acid Pirates",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 2,
-      "betweenNodes": [3, 4],
-      "dropRequires": ["never"],
-      "note": "Technically you can get the drops but you likely won't"
+      "betweenNodes": [3, 4]
     },
     {
       "id": "e5",
       "groupName": "Amphitheatre Center Platform Pirates",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 2,
-      "homeNodes": [4],
-      "dropRequires": ["never"],
-      "note": "Technically you can get the drops but you likely won't"
+      "homeNodes": [4]
     },
     {
       "id": "e6",
       "groupName": "Amphitheatre Top Left Pirates",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 2,
-      "betweenNodes": [4, 2],
-      "dropRequires": ["never"],
-      "note": "Technically you can get the drops but you likely won't"
+      "betweenNodes": [4, 2]
     }
   ],
   "obstacles": [

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -72,24 +72,21 @@
       "groupName": "Fast Pillars Standing Pirates",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 1,
-      "homeNodes": [1, 4],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1, 4]
     },
     {
       "id": "e2",
       "groupName": "Fast Pillars Wall Pirates",
       "enemyName": "Yellow Space Pirate (wall)",
       "quantity": 2,
-      "homeNodes": [1, 4],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1, 4]
     },
     {
       "id": "e3",
       "groupName": "Fast Pillars Violas",
       "enemyName": "Viola",
       "quantity": 2,
-      "homeNodes": [5],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [5]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -46,127 +46,35 @@
       "groupName": "Lower Norfair Farming Left Zebbos",
       "enemyName": "Zebbo",
       "quantity": 2,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Turnaround two tiles above spawn",
-          "cycleFrames": 240,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "h_heatResistant",
-            {"heatFrames": 240}
-          ],
-          "note": "Involves tiny hops to get the drops as well"
-        },
-        {
-          "name": "Grapple turnaround two tiles above spawn",
-          "cycleFrames": 175,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "canUseGrapple",
-            {"or": [
-              "canTrickyJump",
-              "h_heatResistant"
-            ]},
-            {"heatFrames": 175}
-          ],
-          "devNote": "Gaining health with only Grapple is tricky."
-        }
-      ]
+      "homeNodes": [3]
     },
     {
       "id": "e2",
       "groupName": "Lower Norfair Farming Middle Zebbos",
       "enemyName": "Zebbo",
       "quantity": 2,
-      "betweenNodes": [3, 4],
-      "farmCycles": [
-        {
-          "name": "Turnaround two tiles above spawn",
-          "cycleFrames": 240,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "h_heatResistant",
-            {"heatFrames": 240}
-          ],
-          "note": "Involves tiny hops to get the drops as well"
-        },
-        {
-          "name": "Grapple turnaround two tiles above spawn",
-          "cycleFrames": 175,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "canUseGrapple",
-            {"or": [
-              "canTrickyJump",
-              "h_heatResistant"
-            ]},
-            {"heatFrames": 175}
-          ],
-          "devNote": "Gaining health with only Grapple is tricky."
-        }
-      ]
+      "betweenNodes": [3, 4]
     },
     {
       "id": "e3",
       "groupName": "Lower Norfair Farming Right Zebbos",
       "enemyName": "Zebbo",
       "quantity": 2,
-      "homeNodes": [4],
-      "farmCycles": [
-        {
-          "name": "Turnaround two tiles above spawn",
-          "cycleFrames": 240,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "h_heatResistant",
-            {"heatFrames": 240}
-          ],
-          "note": "Involves tiny hops to get the drops as well"
-        },
-        {
-          "name": "Grapple turnaround two tiles above spawn",
-          "cycleFrames": 175,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "canUseGrapple",
-            {"or": [
-              "canTrickyJump",
-              "h_heatResistant"
-            ]},
-            {"heatFrames": 175}
-          ],
-          "devNote": "Gaining health with only Grapple is tricky."
-        }
-      ]
+      "homeNodes": [4]
     },
     {
       "id": "e4",
       "groupName": "Lower Norfair Farming Room Left Violas",
       "enemyName": "Viola",
       "quantity": 3,
-      "homeNodes": [3],
-      "dropRequires": [
-        "h_canNavigateHeatRooms",
-        {"or": [
-          "canUseGrapple",
-          "canCarefulJump"
-        ]}
-      ]
+      "homeNodes": [3]
     },
     {
       "id": "e5",
       "groupName": "Lower Norfair Farming Room Right Violas",
       "enemyName": "Viola",
       "quantity": 2,
-      "homeNodes": [4],
-      "dropRequires": [
-        "h_canNavigateHeatRooms",
-        {"or": [
-          "canUseGrapple",
-          "canCarefulJump"
-        ]}
-      ]
+      "homeNodes": [4]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -111,16 +111,14 @@
       "groupName": "Lower Norfair Bottom Mid-Left Fireflea",
       "enemyName": "Fireflea",
       "quantity": 1,
-      "homeNodes": [5],
-      "dropRequires": ["Grapple"]
+      "homeNodes": [5]
     },
     {
       "id": "e7",
       "groupName": "Lower Norfair Bottom Mid-Right Fireflea",
       "enemyName": "Fireflea",
       "quantity": 1,
-      "homeNodes": [4],
-      "dropRequires": ["Grapple"]
+      "homeNodes": [4]
     },
     {
       "id": "e8",

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -70,24 +70,21 @@
       "groupName": "Lower Norfair Spring Ball Maze Room Spike Pit Alcoons",
       "enemyName": "Alcoon",
       "quantity": 2,
-      "betweenNodes": [3, 7],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [3, 7]
     },
     {
       "id": "e2",
       "groupName": "Lower Norfair Spring Ball Maze Room Bottom Left Alcoon",
       "enemyName": "Alcoon",
       "quantity": 1,
-      "homeNodes": [7],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [7]
     },
     {
       "id": "e3",
       "groupName": "Lower Norfair Spring Ball Maze Room Top Alcoon",
       "enemyName": "Alcoon",
       "quantity": 1,
-      "betweenNodes": [4, 6],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [4, 6]
     }
   ],
   "obstacles": [

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -55,8 +55,7 @@
       "groupName": "Main Hall Dragons",
       "enemyName": "Dragon",
       "quantity": 5,
-      "betweenNodes": [1, 3],
-      "dropRequires": ["Grapple", "h_heatProof"]
+      "betweenNodes": [1, 3]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -64,8 +64,7 @@
       "groupName": "Metal Pirates",
       "enemyName": "Space Pirate (fighting)",
       "quantity": 2,
-      "homeNodes": [3],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [3]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -149,32 +149,28 @@
       "groupName": "Mickey Mouse Bottom Multiviolas",
       "enemyName": "Multiviola",
       "quantity": 2,
-      "betweenNodes": [7, 8],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [7, 8]
     },
     {
       "id": "e2",
       "groupName": "Mickey Mouse Left Dessgeegas",
       "enemyName": "Dessgeega",
       "quantity": 3,
-      "betweenNodes": [7, 8],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [7, 8]
     },
     {
       "id": "e3",
       "groupName": "Mickey Mouse Top Multiviolas",
       "enemyName": "Multiviola",
       "quantity": 5,
-      "betweenNodes": [6, 4],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [6, 4]
     },
     {
       "id": "e4",
       "groupName": "Mickey Mouse Right Dessgeegas",
       "enemyName": "Dessgeega",
       "quantity": 2,
-      "homeNodes": [6, 7],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [6, 7]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -46,8 +46,7 @@
       "groupName": "Pillar Room Puromis",
       "enemyName": "Puromi",
       "quantity": 2,
-      "betweenNodes": [1, 2],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [1, 2]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -46,81 +46,42 @@
       "groupName": "Plowerhouse Room Middle Holtzes",
       "enemyName": "Holtz",
       "quantity": 2,
-      "homeNodes": [3],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [3]
     },
     {
       "id": "e2",
       "groupName": "Plowerhouse Room Left Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "h_heatResistant",
-            {"heatFrames": 120}
-          ],
-          "note": "The farm is too slow to heal faster than the heat damage without some heat reduction."
-        }
-      ]
+      "homeNodes": [3]
     },
     {
       "id": "e3",
       "groupName": "Plowerhouse Room Middle Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "h_heatResistant",
-            {"heatFrames": 120}
-          ],
-          "note": "The farm is too slow to heal faster than the heat damage without some heat reduction."
-        }
-      ]
+      "homeNodes": [3]
     },
     {
       "id": "e4",
       "groupName": "Plowerhouse Room Right Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Crouch over spawn point",
-          "cycleFrames": 120,
-          "requires": [
-            "h_canNavigateHeatRooms",
-            "h_heatResistant",
-            {"heatFrames": 120}
-          ],
-          "note": "The farm is too slow to heal faster than the heat damage without some heat reduction."
-        }
-      ]
+      "homeNodes": [3]
     },
     {
       "id": "e5",
       "groupName": "Plowerhouse Room Left Holtzes",
       "enemyName": "Holtz",
       "quantity": 2,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1]
     },
     {
       "id": "e6",
       "groupName": "Plowerhouse Room Right Holtzes",
       "enemyName": "Holtz",
       "quantity": 2,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -72,16 +72,14 @@
       "groupName": "Red Kihunter Shaft Bottom Kihunter",
       "enemyName": "Kihunter (red)",
       "quantity": 1,
-      "homeNodes": [3],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [3]
     },
     {
       "id": "e2",
       "groupName": "Red Kihunter Shaft Top Kihunters",
       "enemyName": "Kihunter (red)",
       "quantity": 2,
-      "betweenNodes": [3, 5],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [3, 5]
     }
   ],
   "obstacles": [

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -68,32 +68,28 @@
       "groupName": "Writg Wall Pirates",
       "enemyName": "Yellow Space Pirate (wall)",
       "quantity": 3,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e2",
       "groupName": "Writg Bottom Namihe",
       "enemyName": "Namihe",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e3",
       "groupName": "Writg Top Namihes",
       "enemyName": "Namihe",
       "quantity": 4,
-      "homeNodes": [4, 5],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [4, 5]
     },
     {
       "id": "e4",
       "groupName": "Writg Standing Pirates",
       "enemyName": "Yellow Space Pirate (standing)",
       "quantity": 3,
-      "homeNodes": [4, 5],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [4, 5]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -59,8 +59,7 @@
       "groupName": "Three Musketeers",
       "enemyName": "Kihunter (red)",
       "quantity": 3,
-      "betweenNodes": [1, 4],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [1, 4]
     }
   ],
   "links": [

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -94,16 +94,14 @@
       "groupName": "Wasteland Left Dessgeega",
       "enemyName": "Dessgeega",
       "quantity": 1,
-      "homeNodes": [4],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [4]
     },
     {
       "id": "e2",
       "groupName": "Wasteland Right Dessgeegas",
       "enemyName": "Dessgeega",
       "quantity": 3,
-      "betweenNodes": [4, 7],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [4, 7]
     }
   ],
   "links": [

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -70,16 +70,14 @@
       "groupName": "Acid Statue Room Holtzes",
       "enemyName": "Holtz",
       "quantity": 3,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e2",
       "groupName": "Acid Statue Room Magdollite",
       "enemyName": "Magdollite",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["Grapple", "h_heatProof"]
+      "homeNodes": [2]
     }
   ],
   "links": [

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -47,8 +47,7 @@
       "groupName": "Fast Rippers",
       "enemyName": "Ripper 2 (red)",
       "quantity": 6,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1]
     }
   ],
   "links": [

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -46,45 +46,21 @@
       "groupName": "Below Botwoon E-Tank Left Zoas",
       "enemyName": "Zoa",
       "quantity": 3,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Zoa Power Beam spam",
-          "cycleFrames": 150,
-          "requires": [],
-          "note": "Doable without getting in the sand here"
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Below Botwoon E-Tank Middle Zoa",
       "enemyName": "Zoa",
       "quantity": 1,
-      "homeNodes": [2],
-      "farmCycles": [
-        {
-          "name": "Zoa Power Beam spam",
-          "cycleFrames": 150,
-          "requires": [],
-          "note": "Doable without getting in the sand here, as long as you can reach the node."
-        }
-      ]
+      "homeNodes": [2]
     },
     {
       "id": "e3",
       "groupName": "Below Botwoon E-Tank Right Zoa",
       "enemyName": "Zoa",
       "quantity": 1,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Zoa Power Beam spam",
-          "cycleFrames": 150,
-          "requires": [],
-          "note": "Doable without getting in the sand here, as long as you can reach the node."
-        }
-      ]
+      "homeNodes": [3]
     },
     {
       "id": "e4",

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -90,31 +90,7 @@
       "groupName": "Botwoon E-Tank Zoas",
       "enemyName": "Zoa",
       "quantity": 5,
-      "homeNodes": [4],
-      "farmCycles": [
-        {
-          "name": "Zoa Power Beam spam",
-          "cycleFrames": 150,
-          "requires": [
-            "Gravity"
-          ],
-          "note": "Needs Gravity to get into the sand"
-        },
-        {
-          "name": "Zoa Power Beam suitless back and forth",
-          "cycleFrames": 300,
-          "requires": [
-            "canSuitlessMaridia"
-          ]
-        },
-        {
-          "name": "Zoa diagonal Grapple",
-          "cycleFrames": 150,
-          "requires": [
-            "Grapple"
-          ]
-        }
-      ]
+      "homeNodes": [4]
     }
   ],
   "links": [

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -41,14 +41,7 @@
       "groupName": "Botwoon Hallway Middle Mochtroid",
       "enemyName": "Mochtroid",
       "quantity": 1,
-      "betweenNodes": [1, 2],
-      "dropRequires": [
-        {"or": [
-          "Morph",
-          "Grapple"
-        ]}
-      ],
-      "note": "It's stuck in a prison and you need morph to enter."
+      "betweenNodes": [1, 2]
     },
     {
       "id": "e3",

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -56,17 +56,7 @@
       "groupName": "Bug Sand Hole Zoa",
       "enemyName": "Zoa",
       "quantity": 1,
-      "homeNodes": [1, 3],
-      "farmCycles": [
-        {
-          "name": "Forget it",
-          "cycleFrames": 120,
-          "requires": [
-            "never"
-          ],
-          "devNote": "Leaving this logically unfarmable until further notice because it sucks"
-        }
-      ]
+      "homeNodes": [1, 3]
     },
     {
       "id": "e2",

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -56,42 +56,14 @@
       "groupName": "Butterfly Room Right Zoas",
       "enemyName": "Zoa",
       "quantity": 2,
-      "homeNodes": [2],
-      "farmCycles": [
-        {
-          "name": "Farm 2 Zoas out of 3",
-          "cycleFrames": 225,
-          "requires": []
-        },
-        {
-          "name": "Grapple",
-          "cycleFrames": 175,
-          "requires": [
-            "Grapple"
-          ]
-        }
-      ]
+      "homeNodes": [2]
     },
     {
       "id": "e2",
       "groupName": "Butterfly Room Left Zoa",
       "enemyName": "Zoa",
       "quantity": 1,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Farm 1 Zoa out of 3",
-          "cycleFrames": 225,
-          "requires": []
-        },
-        {
-          "name": "Grapple",
-          "cycleFrames": 175,
-          "requires": [
-            "Grapple"
-          ]
-        }
-      ]
+      "homeNodes": [1]
     }
   ],
   "links": [

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -41,15 +41,7 @@
       "groupName": "Watering Hole Zebs",
       "enemyName": "Zeb",
       "quantity": 2,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Half-screen back and forth",
-          "cycleFrames": 200,
-          "requires": [],
-          "note": "Running back and forth with proper timing can be a bit faster than camping just one of them"
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -62,42 +62,21 @@
       "groupName": "Boyon Gate Hall Left Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [4],
-      "farmCycles": [
-        {
-          "name": "Jump two tiles above spawn point",
-          "cycleFrames": 130,
-          "requires": []
-        }
-      ]
+      "homeNodes": [4]
     },
     {
       "id": "e4",
       "groupName": "Boyon Gate Hall Middle Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Jump two tiles above spawn point",
-          "cycleFrames": 130,
-          "requires": []
-        }
-      ]
+      "homeNodes": [3]
     },
     {
       "id": "e5",
       "groupName": "Boyon Gate Hall Right Zebbo",
       "enemyName": "Zebbo",
       "quantity": 1,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Jump two tiles above spawn point",
-          "cycleFrames": 130,
-          "requires": []
-        }
-      ]
+      "homeNodes": [3]
     }
   ],
   "links": [

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -120,34 +120,14 @@
       "groupName": "Mt. Everest Left Powamp",
       "enemyName": "Powamp",
       "quantity": 1,
-      "homeNodes": [8],
-      "dropRequires": [
-        "Gravity",
-        {"or": [
-          "Grapple",
-          "HiJump",
-          "SpaceJump",
-          "canSpringBallJumpMidAir",
-          "canGravityJump"
-        ]}
-      ]
+      "homeNodes": [8]
     },
     {
       "id": "e2",
       "groupName": "Mt. Everest Right Powamps",
       "enemyName": "Powamp",
       "quantity": 2,
-      "homeNodes": [7],
-      "dropRequires": [
-        "Gravity",
-        {"or": [
-          "Grapple",
-          "HiJump",
-          "SpaceJump",
-          "canSpringBallJumpMidAir",
-          "canGravityJump"
-        ]}
-      ]
+      "homeNodes": [7]
     },
     {
       "id": "e3",

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -39,34 +39,7 @@
       "groupName": "Red Fish Room Zebbos",
       "enemyName": "Zebbo",
       "quantity": 3,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "3 Zebbos power beam desync",
-          "cycleFrames": 260,
-          "requires": [],
-          "note": "Run back and forth from the door to the spawner, alternately spawning and killing 1 Zebbo then 2."
-        },
-        {
-          "name": "Screw attack same spawn 3 enemies",
-          "cycleFrames": 180,
-          "requires": [
-            "ScrewAttack"
-          ]
-        },
-        {
-          "name": "Farm top of 3 Zebbos",
-          "cycleFrames": 180,
-          "requires": [
-            {"or": [
-              "Wave",
-              "Spazer",
-              "Plasma",
-              "Grapple"
-            ]}
-          ]
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -46,14 +46,7 @@
       "groupName": "Grapple Tutorial Room 3 Gamets",
       "enemyName": "Gamet",
       "quantity": 5,
-      "homeNodes": [1],
-      "farmCycles": [
-        {
-          "name": "Crouch over Gamets",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [1]
     },
     {
       "id": "e2",

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -72,14 +72,7 @@
       "groupName": "Post Crocomire Farming Room Gamets",
       "enemyName": "Gamet",
       "quantity": 5,
-      "homeNodes": [5],
-      "farmCycles": [
-        {
-          "name": "Crouch over Gamets",
-          "cycleFrames": 120,
-          "requires": []
-        }
-      ]
+      "homeNodes": [5]
     }
   ],
   "links": [

--- a/region/norfair/crocomire/Post Crocomire Missile Room.json
+++ b/region/norfair/crocomire/Post Crocomire Missile Room.json
@@ -47,15 +47,7 @@
       "groupName": "Cosine Room Gamets",
       "enemyName": "Gamet",
       "quantity": 5,
-      "homeNodes": [2],
-      "farmCycles": [
-        {
-          "name": "Crouch 3 tiles over Gamets",
-          "cycleFrames": 165,
-          "requires": []
-        }
-      ],
-      "devNote": "With the gamets spawning over acid, there probably isn't a more effective strat."
+      "homeNodes": [2]
     }
   ],
   "links": [

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -49,25 +49,7 @@
       "groupName": "Acid Snakes Tunnel Gamets",
       "enemyName": "Gamet",
       "quantity": 5,
-      "homeNodes": [4],
-      "farmCycles": [
-        {
-          "name": "Crouch 3 tiles over Gamets",
-          "cycleFrames": 165,
-          "requires": [
-            {"heatFrames": 165}
-          ]
-        },
-        {
-          "name": "Lava Gamets down shots",
-          "cycleFrames": 120,
-          "requires": [
-            {"heatFrames": 120},
-            {"lavaFrames": 120}
-          ],
-          "note": "Works fine with lava immunity"
-        }
-      ]
+      "homeNodes": [4]
     },
     {
       "id": "e2",
@@ -75,7 +57,6 @@
       "enemyName": "Dragon",
       "quantity": 2,
       "homeNodes": [4, 2],
-      "dropRequires": ["h_heatProof"],
       "note": "Drops can be reached from land"
     }
   ],

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -40,24 +40,14 @@
       "groupName": "Bat Cave Skrees",
       "enemyName": "Skree",
       "quantity": 3,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Bat Cave Gamets",
       "enemyName": "Gamet",
       "quantity": 5,
-      "homeNodes": [3],
-      "farmCycles": [
-        {
-          "name": "Crouch over Gamets",
-          "cycleFrames": 120,
-          "requires": [
-            {"heatFrames": 120}
-          ]
-        }
-      ]
+      "homeNodes": [3]
     }
   ],
   "obstacles": [

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -53,16 +53,14 @@
       "groupName": "Cathedral Entrance Sovas",
       "enemyName": "Sova",
       "quantity": 4,
-      "homeNodes": [3],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [3]
     },
     {
       "id": "e2",
       "groupName": "Cathedral Entrance Small Dessgeegas",
       "enemyName": "Sm. Dessgeega",
       "quantity": 2,
-      "betweenNodes": [3, 5],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [3, 5]
     }
   ],
   "links": [

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -55,32 +55,28 @@
       "groupName": "Cathedral Left Sovas",
       "enemyName": "Sova",
       "quantity": 3,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Cathedral Left Geruta",
       "enemyName": "Geruta",
       "quantity": 1,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1]
     },
     {
       "id": "e3",
       "groupName": "Cathedral Right Sova",
       "enemyName": "Sova",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e4",
       "groupName": "Cathedral Right Gerutas",
       "enemyName": "Geruta",
       "quantity": 2,
-      "homeNodes": [4],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [4]
     }
   ],
   "links": [

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -64,24 +64,21 @@
       "groupName": "Double Chamber Funes",
       "enemyName": "Fune",
       "quantity": 2,
-      "betweenNodes": [1, 2],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [1, 2]
     },
     {
       "id": "e2",
       "groupName": "Double Chamber Ripper 2",
       "enemyName": "Ripper 2 (green)",
       "quantity": 1,
-      "betweenNodes": [3, 5],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [3, 5]
     },
     {
       "id": "e3",
       "groupName": "Double Chamber Kago",
       "enemyName": "Kago",
       "quantity": 1,
-      "homeNodes": [5],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [5]
     }
   ],
   "links": [

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -42,8 +42,7 @@
       "groupName": "Green Bubbles Missile Room Geruta",
       "enemyName": "Geruta",
       "quantity": 1,
-      "homeNodes": [2, 3],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2, 3]
     }
   ],
   "links": [

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -65,16 +65,14 @@
       "groupName": "Kronic Boost Room Bottom Violas",
       "enemyName": "Viola",
       "quantity": 3,
-      "homeNodes": [3],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [3]
     },
     {
       "id": "e2",
       "groupName": "Kronic Boost Room Top Viola",
       "enemyName": "Viola",
       "quantity": 1,
-      "homeNodes": [1, 4],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1, 4]
     }
   ],
   "links": [

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -54,32 +54,28 @@
       "groupName": "Lava Dive Center Top Namihe",
       "enemyName": "Namihe",
       "quantity": 1,
-      "homeNodes": [3],
-      "dropRequires": ["h_heatProof", "h_lavaProof"]
+      "homeNodes": [3]
     },
     {
       "id": "e2",
       "groupName": "Lava Dive Right Namihes",
       "enemyName": "Namihe",
       "quantity": 2,
-      "betweenNodes": [2, 5],
-      "dropRequires": ["h_heatProof", "h_lavaProof"]
+      "betweenNodes": [2, 5]
     },
     {
       "id": "e3",
       "groupName": "Lava Dive Center Bottom Namihe",
       "enemyName": "Namihe",
       "quantity": 1,
-      "homeNodes": [5],
-      "dropRequires": ["h_heatProof", "h_lavaProof"]
+      "homeNodes": [5]
     },
     {
       "id": "e4",
       "groupName": "Lava Dive Left Namihes",
       "enemyName": "Namihe",
       "quantity": 2,
-      "homeNodes": [4],
-      "dropRequires": ["h_heatProof", "h_lavaProof"]
+      "homeNodes": [4]
     }
   ],
   "links": [

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -34,22 +34,14 @@
       "groupName": "Magdollite Tunnel Multiviolas",
       "enemyName": "Multiviola",
       "quantity": 2,
-      "homeNodes": [1, 2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1, 2]
     },
     {
       "id": "e2",
       "groupName": "Magdollite Tunnel Magdollites",
       "enemyName": "Magdollite",
       "quantity": 3,
-      "homeNodes": [1, 2],
-      "dropRequires": [
-        "h_heatProof",
-        {"or": [
-          "Gravity",
-          "Grapple"
-        ]}
-      ]
+      "homeNodes": [1, 2]
     }
   ],
   "links": [

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -47,30 +47,21 @@
       "groupName": "Norfair Reserve Dragons",
       "enemyName": "Dragon",
       "quantity": 3,
-      "betweenNodes": [1, 4],
-      "dropRequires": [
-        "h_heatProof",
-        {"or": [
-          "h_lavaProof",
-          "Grapple"
-        ]}
-      ]
+      "betweenNodes": [1, 4]
     },
     {
       "id": "e2",
       "groupName": "Norfair Reserve Missile Sova",
       "enemyName": "Sova",
       "quantity": 1,
-      "homeNodes": [4],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [4]
     },
     {
       "id": "e3",
       "groupName": "Norfair Reserve Right Sovas",
       "enemyName": "Sova",
       "quantity": 2,
-      "betweenNodes": [1, 4],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [1, 4]
     }
   ],
   "obstacles": [

--- a/region/norfair/east/Purple Farming Room.json
+++ b/region/norfair/east/Purple Farming Room.json
@@ -31,16 +31,7 @@
       "groupName": "Purple Farming Room Gamets",
       "enemyName": "Gamet",
       "quantity": 5,
-      "homeNodes": [2],
-      "farmCycles": [
-        {
-          "name": "Crouch over Gamets",
-          "cycleFrames": 120,
-          "requires": [
-            {"heatFrames": 120}
-          ]
-        }
-      ]
+      "homeNodes": [2]
     }
   ],
   "links": [

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -34,30 +34,21 @@
       "groupName": "Rising Tide Sovas",
       "enemyName": "Sova",
       "quantity": 5,
-      "betweenNodes": [1, 2],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [1, 2]
     },
     {
       "id": "e2",
       "groupName": "Rising Tide Dragons",
       "enemyName": "Dragon",
       "quantity": 4,
-      "betweenNodes": [1, 2],
-      "dropRequires": [
-        "h_heatProof",
-        {"or": [
-          "Gravity",
-          "Grapple"
-        ]}
-      ]
+      "betweenNodes": [1, 2]
     },
     {
       "id": "e3",
       "groupName": "Rising Tide Squeepts",
       "enemyName": "Squeept",
       "quantity": 2,
-      "betweenNodes": [1, 2],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [1, 2]
     }
   ],
   "links": [

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -68,48 +68,42 @@
       "groupName": "Single Chamber Top Alcoons",
       "enemyName": "Alcoon",
       "quantity": 2,
-      "homeNodes": [6],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [6]
     },
     {
       "id": "e2",
       "groupName": "Single Chamber Top Multiviola",
       "enemyName": "Multiviola",
       "quantity": 1,
-      "homeNodes": [6],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [6]
     },
     {
       "id": "e3",
       "groupName": "Single Chamber Middle Alcoon",
       "enemyName": "Alcoon",
       "quantity": 1,
-      "betweenNodes": [3, 4],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [3, 4]
     },
     {
       "id": "e4",
       "groupName": "Single Chamber Middle Multiviola",
       "enemyName": "Multiviola",
       "quantity": 1,
-      "betweenNodes": [3, 4],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [3, 4]
     },
     {
       "id": "e5",
       "groupName": "Single Chamber Bottom Alcoon",
       "enemyName": "Alcoon",
       "quantity": 1,
-      "betweenNodes": [2, 3],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [2, 3]
     },
     {
       "id": "e6",
       "groupName": "Single Chamber Bottom Multiviola",
       "enemyName": "Multiviola",
       "quantity": 1,
-      "betweenNodes": [2, 3],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [2, 3]
     }
   ],
   "links": [

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -54,17 +54,14 @@
       "groupName": "Speed Booster Hall Metarees",
       "enemyName": "Metaree",
       "quantity": 2,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Speed Booster Hall Gerutas",
       "enemyName": "Geruta",
       "quantity": 3,
-      "betweenNodes": [1, 2],
-      "dropRequires": ["Gravity", "h_heatProof"],
-      "devNote": "Accessible without Gravity going left to right but not right to left with speedbooster. Letting it slide"
+      "betweenNodes": [1, 2]
     }
   ],
   "links": [

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -34,9 +34,7 @@
       "groupName": "Spiky Acid Snakes Tunnel Yapping Maws",
       "enemyName": "Yapping Maw",
       "quantity": 3,
-      "betweenNodes": [1, 2],
-      "dropRequires": ["never"],
-      "note": "Possible but requires multiple spikehits in most configurations so rarely worth it"
+      "betweenNodes": [1, 2]
     }
   ],
   "links": [

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -34,16 +34,14 @@
       "groupName": "Spiky Platforms Tunnel Left Tripper",
       "enemyName": "Tripper",
       "quantity": 1,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof", "Gravity"]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Spiky Platforms Tunnel Right Tripper",
       "enemyName": "Tripper",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof", "Gravity"]
+      "homeNodes": [2]
     }
   ],
   "links": [

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -62,8 +62,7 @@
       "groupName": "Upper Norfair Farming Room Fune",
       "enemyName": "Fune",
       "quantity": 1,
-      "homeNodes": [5],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [5]
     },
     {
       "id": "e2",
@@ -71,17 +70,7 @@
       "enemyName": "Gamet",
       "quantity": 5,
       "homeNodes": [5],
-      "note": "Can't be farmed quite as quickly as other spots without requirements",
-      "farmCycles": [
-        {
-          "name": "Gamet down shots",
-          "cycleFrames": 120,
-          "requires": [
-            {"heatFrames": 120}
-          ],
-          "note": "Just crouching over them is slower because they have to rise a bit after spawning. "
-        }
-      ]
+      "note": "Can't be farmed quite as quickly as other spots without requirements"
     }
   ],
   "links": [

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -56,16 +56,14 @@
       "groupName": "Volcano Room Top Funes",
       "enemyName": "Fune",
       "quantity": 5,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Volcano Room Bottom Fune",
       "enemyName": "Fune",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof", "Gravity"]
+      "homeNodes": [2]
     }
   ],
   "links": [

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -43,22 +43,14 @@
       "groupName": "Crocomire Escape Geruta",
       "enemyName": "Geruta",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e2",
       "groupName": "Crocomire Escape Dragons",
       "enemyName": "Dragon",
       "quantity": 5,
-      "homeNodes": [2],
-      "dropRequires": [
-        "h_heatProof",
-        {"or": [
-          "Gravity",
-          "Grapple"
-        ]}
-      ]
+      "homeNodes": [2]
     }
   ],
   "obstacles": [

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -75,32 +75,28 @@
       "groupName": "Crocomire Speedway Left Pirates",
       "enemyName": "Red Space Pirate (standing)",
       "quantity": 3,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e2",
       "groupName": "Crocomire Speedway Multiviolas",
       "enemyName": "Multiviola",
       "quantity": 4,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     },
     {
       "id": "e3",
       "groupName": "Crocomire Speedway Right Pirates",
       "enemyName": "Red Space Pirate (standing)",
       "quantity": 2,
-      "betweenNodes": [2, 6],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [2, 6]
     },
     {
       "id": "e4",
       "groupName": "Crocomire Speedway Cacatacs",
       "enemyName": "Cacatac",
       "quantity": 2,
-      "betweenNodes": [5, 6],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [5, 6]
     }
   ],
   "links": [

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -49,8 +49,7 @@
       "groupName": "Crumble Shaft Sovas",
       "enemyName": "Sova",
       "quantity": 6,
-      "homeNodes": [1, 2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [1, 2]
     }
   ],
   "links": [

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -34,9 +34,7 @@
       "groupName": "Ice Beam Acid Room Trippers",
       "enemyName": "Tripper",
       "quantity": 3,
-      "homeNodes": [1, 2],
-      "dropRequires": ["h_heatProof"],
-      "note": "Drops can be reached from land without issues"
+      "homeNodes": [1, 2]
     }
   ],
   "links": [

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -55,16 +55,14 @@
       "groupName": "Ice Beam Snake Room Funes",
       "enemyName": "Fune",
       "quantity": 4,
-      "betweenNodes": [1, 3],
-      "dropRequires": ["h_heatProof"]
+      "betweenNodes": [1, 3]
     },
     {
       "id": "e2",
       "groupName": "Ice Beam Snake Room Sovas",
       "enemyName": "Sova",
       "quantity": 3,
-      "homeNodes": [2, 3, 4],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2, 3, 4]
     }
   ],
   "links": [

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -34,16 +34,14 @@
       "groupName": "Ice Beam Tutorial Room Boyons",
       "enemyName": "Boyon",
       "quantity": 3,
-      "homeNodes": [1],
-      "dropRequires": ["h_heatProof", "Gravity"]
+      "homeNodes": [1]
     },
     {
       "id": "e2",
       "groupName": "Ice Beam Tutorial Room Ripper 2",
       "enemyName": "Ripper 2 (red)",
       "quantity": 1,
-      "homeNodes": [2],
-      "dropRequires": ["h_heatProof"]
+      "homeNodes": [2]
     }
   ],
   "links": [

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -124,11 +124,6 @@ A room can have an array of enemies. This is the list of enemies that may be pre
 * _betweenNodes:_ An array of exactly two nodes, indicating that the enemy is encountered while travelling between those two nodes. Mutually exclusive with `homeNodes`.
 * _spawn:_ The `spawn` property lists [logical requirements](../logicalRequirements.md) that must be fulfilled in order for the enemy to spawn in the room. If this is missing, the enemy can spawn in the room from game start.
 * _stopSpawn:_ The `stopSpawn` property lists [logical requirements](../logicalRequirements.md) that must be fulfilled in order for the enemy to no longer spawn in the room. If this is missing, the enemy will never stop spawning in the room after its spawn conditions have been met.
-* _dropRequires:_ This property defines additional [logical requirements](../logicalRequirements.md) that must be fulfilled to actually reach the enemies' drops without taking damage, after the enemies have been reached and killed. This is mutually exclusive with `farmCycles`
-* _farmCycles:_ This property is a list of different ways respawning enemies can be farmed. This is mutually exclusive with `dropRequires`. Each object in this list has the following properties:
-  * _name:_ The name of this the farm cycle. Only needs to be unique for the enemy it's on, and identical executions on different enemies should share the same name.
-  * _cycleFrames:_ The number of frames it takes to wait for the enemies to spawn, kill them, and grab their drops
-  * _requires:_ The [logical requirements](../logicalRequirements.md) that must be fulfilled in order to execute a cycle of farming on the enemies.
 
 ### Links
 A room has an array of links. Links define how Samus can navigate within a room. Each link has a `from` property that defines the node where Samus must be to use it, and a `to` property which is an array of possible destinations. Each destination of a link has the following properties:

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -2212,26 +2212,6 @@
                 [ "betweenNodes" ]
               }
             ]
-          },
-          {
-            "oneOf": [
-              {
-                "required": ["dropRequires"]
-              },
-              {
-                "required": ["farmCycles"]
-              },
-              {
-                "allOf": [
-                  {
-                    "not": {"required": ["dropRequires"]}
-                  },
-                  {
-                    "not": {"required": ["farmCycles"]}
-                  }
-                ]
-              }
-            ]
           }
         ],
         "additionalProperties": false,
@@ -2310,56 +2290,6 @@
             "$id": "#/properties/enemies/items/properties/stopSpawn",
             "title": "Stop Spawning Requirements",
             "description": "Equipment, tech, and flag requirements for this enemy to stop spawning. If null, enemy can always spawn once its spawn requirements have been met."
-          },
-          "dropRequires": {
-            "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
-            "$id": "#/properties/enemies/items/properties/dropRequires",
-            "title": "Drop Requires",
-            "description": "Equipment, tech, and flag requirements that are needed to obtain the drop from this enemy without taking any damage. These go on top of what's needed to reach and kill the enemy."
-          },
-          "farmCycles": {
-            "$id": "#/properties/enemies/items/properties/farmCycles",
-            "type": "array",
-            "title": "Farm Cycles",
-            "description": "Only for respawning enemy groups. A list of objects, each of which describes requirements to farm this group of enemies as well as duration of a farm cycle.",
-            "items": {
-              "$id": "#/properties/enemies/items/properties/farmCycles/items",
-              "type": "object",
-              "required": [
-                "name",
-                "cycleFrames",
-                "requires"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "$id": "#/properties/enemies/items/properties/farmCycles/items/properties/name",
-                  "type": "string",
-                  "title": "Cycle Name",
-                  "description": "A name to identify this farming cycle. Only needs to be unique within the enemy group, not globally, and comparable farming cycles executions on different enemy groups should share the same name."
-                },
-                "cycleFrames": {
-                  "$id": "#/properties/enemies/items/properties/farmCycles/items/properties/cycleFrames",
-                  "type": "integer",
-                  "title": "Cycle Frames",
-                  "description": "The number of frames between two full sets of drop pickups for this farming cycle."
-                },
-                "requires": {
-                  "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
-                  "$id": "#/properties/enemies/items/properties/farmCycles/items/properties/requires",
-                  "title": "Farming Cycle Requirements",
-                  "description": "Equipment, tech, and flag requirements to perform this type of farm."
-                },
-                "note": {
-                  "$ref" : "m3-note.schema.json#/definitions/note",
-                  "$id": "#/properties/enemies/items/properties/farmCycles/items/properties/note"
-                },
-                "devNote": {
-                  "$ref" : "m3-note.schema.json#/definitions/devNote",
-                  "$id": "#/properties/enemies/items/properties/farmCycles/items/properties/devNote"
-                }
-              }
-            }
           },
           "note": {
             "$ref" : "m3-note.schema.json#/definitions/note",


### PR DESCRIPTION
These farming properties are not used, and the new farming methods won't be in this format. Is it worth removing them or should we keep them in case it has some use as a reference?