### PR TITLE
Fast Pillars Setup Room shinecharges

### DIFF
--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -511,8 +511,7 @@
         {"heatFrames": 90}
       ],
       "note": [
-        "Come in with blue speed, killing the lower two Pirates, with enough momentum to jump all the way up to the door.",
-        "Then either quickly jump through the door before the top Pirate fires its laser, or wait for it to jump to the other side and then jump over it."
+        "Come in with blue speed, killing the lower two Pirates, with enough momentum to jump all the way up to the door."
       ],
       "devNote": [
         "This can also be done with lower run speeds in specific ranges, namely between $2.0 and $2.1 or between $2.E and $3.1, but this would be much more difficult."

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -497,6 +497,441 @@
       ]
     },
     {
+      "link": [1, 4],
+      "name": "Come In Getting Blue Speed, Big Speedy Jump",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 8,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$6.9"
+        }
+      },
+      "requires": [
+        "canCarefulJump",
+        {"heatFrames": 90}
+      ],
+      "note": [
+        "Come in with blue speed, killing the lower two Pirates, with enough momentum to jump all the way up to the door.",
+        "Then either quickly jump through the door before the top Pirate fires its laser, or wait for it to jump to the other side and then jump over it."
+      ],
+      "devNote": [
+        "This can also be done with lower run speeds in specific ranges, namely between $2.0 and $2.1 or between $2.E and $3.1, but this would be much more difficult."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come In Getting Blue Speed, Speedy Jump",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 8,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$3.E"
+        }
+      },
+      "requires": [
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Yellow Space Pirate (standing)",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"heatFrames": 135}
+      ],
+      "note": [
+        "Come in with blue speed, with enough momentum to jump, kill the lower two Pirates, and land on the platform above.",
+        "Then either quickly jump through the door before the top Pirate fires its laser, or wait for it to jump to the other side and then jump over it."
+      ],
+      "devNote": [
+        "This can also be done with lower run speeds in specific ranges, namely between $2.0 and $2.1 or between $2.E and $3.1, but this would be much more difficult."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come In Getting Blue Speed, Tricky Dash Jump",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 8,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canTrickyDashJump",
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {
+            "enemy": "Yellow Space Pirate (standing)",
+            "type": "contact",
+            "hits": 1
+          }}
+        ]},
+        {"heatFrames": 210}
+      ],
+      "note": [
+        "Come in with blue speed, run through the lowest Pirate, continuing with a short jump to kill the one on the right wall.",
+        "Next run a specific distance to get speed to jump onto the platform.",
+        "Then either quickly jump through the door before the top Pirate fires a laser, or wait for it to jump across the room and then jump over it."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come in Shinecharging, Leave Shinecharged (Pirate Dodge Wall Climb)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 8,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        "canTrickyDodgeEnemies",
+        {"heatFrames": 145}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 40
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Gain blue speed running into the room, run through the bottom Pirate to kill it, then gain a shinecharge.",
+        "Carefully jump around the Pirate above, and wall jump up to the door."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump Pirate Dodge Wall Climb)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 8,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        "canDodgeWhileShooting",
+        "canWalljump",
+        {"heatFrames": 115}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 70
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Gain blue speed running into the room, run through the bottom Pirate to kill it, then gain a shinecharge.",
+        "Carefully jump around the Pirate above, and wall jump up to the door."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump Screw Wall Climb)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 8,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "HiJump",
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        {"heatFrames": 105}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 80
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Gain blue speed running into the room, run through the bottom Pirate to kill it, then gain a shinecharge.",
+        "Use Screw Attack to jump through the Pirate above, and wall jump up to the door."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come in Shinecharging, Leave Shinecharged (HiJump Ledge Grab)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 8,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        {"heatFrames": 140}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 50
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Gain blue speed running into the room, run through the bottom Pirate to kill it, then gain a shinecharge.",
+        "Run and jump onto the platform above and then up to the door."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Come in Shinecharging, Leave Shinecharged (Screw Wall Climb)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 8,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "ScrewAttack",
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        {"heatFrames": 125}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 60
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Gain blue speed running into the room, run through the bottom Pirate to kill it, then gain a shinecharge.",
+        "Use Screw Attack to jump through the Pirate above, and wall jump up to the door."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Shinecharge (Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 135
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        "canDodgeWhileShooting",
+        {"heatFrames": 135}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Carry Shinecharge (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 100
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        "canDodgeWhileShooting",
+        {"heatFrames": 100}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Come In Shinecharged, Leave With Spark (HiJump)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 70
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementComplex",
+        "canDodgeWhileShooting",
+        {"heatFrames": 105},
+        {"shinespark": {"frames": 12, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Come In Shinecharged, Leave With Spark (Wall Jump, Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 95
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        "canDodgeWhileShooting",
+        {"heatFrames": 130},
+        {"shinespark": {"frames": 12, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Come In Shinecharged, Leave With Spark (Wall Jump, Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 105
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canWalljump",
+        "canDodgeWhileShooting",
+        {"heatFrames": 140},
+        {"shinespark": {"frames": 11, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 15,
       "link": [1, 5],
       "name": "Base",
@@ -641,6 +1076,96 @@
         }}
       ],
       "gModeRegainMobility": {},
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"heatFrames": 20}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 160
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 10
+        }
+      },
+      "requires": [
+        {"heatFrames": 60},
+        {"shinespark": {"frames": 21}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 55
+        }
+      },
+      "requires": [
+        {"heatFrames": 55}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
       "flashSuitChecked": true
     },
     {
@@ -836,6 +1361,96 @@
       "flashSuitChecked": true
     },
     {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"heatFrames": 20}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 160
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 10
+        }
+      },
+      "requires": [
+        {"heatFrames": 60},
+        {"shinespark": {"frames": 21}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 55
+        }
+      },
+      "requires": [
+        {"heatFrames": 55}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 34,
       "link": [3, 2],
       "name": "Transition with Stored Fall Speed",
@@ -1015,6 +1630,96 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 50}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [4, 1],
+      "name": "Come in Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"heatFrames": 115}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": 65
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [4, 1],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 115
+        }
+      },
+      "requires": [
+        {"heatFrames": 115}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {
+          "framesRemaining": "auto"
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [4, 1],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {
+          "framesRequired": 75
+        }
+      },
+      "requires": [
+        {"heatFrames": 110},
+        {"shinespark": {"frames": 14}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {
+          "types": ["super"],
+          "requires": []
+        },
+        {
+          "types": ["missiles", "powerbomb"],
+          "requires": [
+            "never"
+          ]
+        }
       ],
       "flashSuitChecked": true
     },


### PR DESCRIPTION
This also includes strats (not involving shinecharging) that gain blue speed running into the room and use it to kill the bottom two Pirates. There are several variations depending on the entry speed: in addition to using the blue speed to kill the Pirates, the momentum can be used to jump onto the platform or all the way up to the door; or just do a small jump to kill the Pirates and then do a separate tricky dash jump to get onto the platform.
