### PR TITLE
Migrate json schema validation to use 'referencing' instead of RefResolver

### DIFF
--- a/resources/app/manifests/pip_requirements.txt
+++ b/resources/app/manifests/pip_requirements.txt
@@ -1,5 +1,6 @@
 flatten_json
 jsonschema
+referencing
 numpy
 opencv-python
 pillow

--- a/tests/asserts/validate.py
+++ b/tests/asserts/validate.py
@@ -6,8 +6,6 @@ import os
 import json
 import re
 from pathlib import Path
-import jsonschema.validators
-import referencing
 from referencing import Registry, Resource
 from jsonschema.validators import Draft7Validator
 from jsonschema import validate


### PR DESCRIPTION
The validation script has been giving warnings that RefResolver is deprecated in favor of the `referencing` package. This PR migrates over to the new, recommended package.

What prompted this is that since #1789 fixed the top-level `$id` property, the RefResolver started recognizing it and fetching the schema files using HTTP GET requests, treating the `$id` as a URL, and using the responses as the schemas to apply  in validation. This initially appeared to work because those URLs actually are valid references to the schema files on GitHub. But once we start introducing schema changes locally, then it doesn't work because it's using the schemas from the master branch instead of the local copies. This was considered a bad behavior of the RefResolver, and it no longer happens after switching to the `referencing` implementation: https://python-jsonschema.readthedocs.io/en/stable/referencing/#other-key-functional-differences.