### PR TITLE
More tests

### DIFF
--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -2013,7 +2013,8 @@
         "canShinechargeMovementComplex",
         "HiJump",
         "canWalljump",
-        "Morph"
+        "Morph",
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -2047,7 +2048,8 @@
         "canShinechargeMovementComplex",
         "HiJump",
         "canWalljump",
-        "Morph"
+        "Morph",
+        {"shinespark": {"frames": 3, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -423,6 +423,7 @@
       "link": [3, 3],
       "name": "Very Patient Zebbo and Viola Farm",
       "requires": [
+        {"heatFrames": 0},
         "canPauseAbuse",
         "Grapple",
         "canBeVeryPatient",
@@ -532,6 +533,7 @@
       "link": [4, 4],
       "name": "Very Patient Zebbo and Viola Farm",
       "requires": [
+        {"heatFrames": 0},
         "canPauseAbuse",
         "Grapple",
         "canBeVeryPatient",

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -429,7 +429,7 @@
       "link": [3, 3],
       "name": "Open Door",
       "requires": [
-        {"heatFrames": 0}
+        {"heatFrames": 20}
       ],
       "clearsObstacles": ["C"]
     },

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -292,15 +292,6 @@
       ]
     },
     {
-      "id": 7,
-      "link": [2, 2],
-      "name": "Leave Normally",
-      "exitCondition": {
-        "leaveNormally": {}
-      },
-      "requires": []
-    },
-    {
       "id": 8,
       "link": [2, 2],
       "name": "Shinespark",
@@ -437,7 +428,9 @@
       "id": 17,
       "link": [3, 3],
       "name": "Open Door",
-      "requires": [],
+      "requires": [
+        {"heatFrames": 0}
+      ],
       "clearsObstacles": ["C"]
     },
     {

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -456,7 +456,8 @@
       "name": "Reserve Trigger",
       "requires": [
         "canManageReserves",
-        {"autoReserveTrigger": {}}
+        {"autoReserveTrigger": {}},
+        {"heatFrames": 0}
       ],
       "flashSuitChecked": true,
       "note": "Riding the elevator without enough energy will cause a reserve trigger in the next room, reducing the total heat damage dealt.",
@@ -534,7 +535,8 @@
       "name": "Reserve Trigger",
       "requires": [
         "canManageReserves",
-        {"autoReserveTrigger": {}}
+        {"autoReserveTrigger": {}},
+        {"heatFrames": 0}
       ],
       "flashSuitChecked": true,
       "note": "Riding the elevator without enough energy will cause a reserve trigger in the next room, reducing the total heat damage dealt.",

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -333,7 +333,8 @@
         }
       },
       "requires": [
-        "canPrepareForNextRoom"
+        "canPrepareForNextRoom",
+        {"heatFrames": 0}
       ]
     },
     {
@@ -1768,6 +1769,7 @@
       "name": "Multiviola Clip (X-Ray Standup and Morph)",
       "requires": [
         {"notable": "Multiviola Ice Clip"},
+        "h_heatProof",
         "h_canXRayMorphIceClip"
       ],
       "flashSuitChecked": true,

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -393,15 +393,6 @@
       "note": "Entering from water or without a way to shoot both blocks simultaneously, pause abuse the first KiHunter and then stay ahead of the other two."
     },
     {
-      "id": 13,
-      "link": [2, 2],
-      "name": "Leave Normally",
-      "exitCondition": {
-        "leaveNormally": {}
-      },
-      "requires": []
-    },
-    {
       "id": 14,
       "link": [2, 2],
       "name": "Shinespark",
@@ -689,7 +680,8 @@
       "link": [3, 7],
       "name": "Screw Kill",
       "requires": [
-        "ScrewAttack"
+        "ScrewAttack",
+        {"heatFrames": 0}
       ]
     },
     {
@@ -1253,7 +1245,9 @@
       "id": 64,
       "link": [7, 3],
       "name": "Base",
-      "requires": []
+      "requires": [
+        {"heatFrames": 0}
+      ]
     },
     {
       "id": 65,

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -321,13 +321,16 @@
       "name": "Ridley without Heat Protection",
       "requires": [
         {"notable": "Ridley without Heat Protection"},
-        "canHeatRun",
+        {"heatFrames": 0},
         {"enemyKill": {
           "enemies": [["Ridley"]]
         }}
       ],
       "setsFlags": ["f_DefeatedRidley"],
-      "note": "Fight Ridley without immunity to heat damage."
+      "note": "Fight Ridley without immunity to heat damage.",
+      "devNote": [
+        "Heat frames are accounted for as part of the enemyKill."
+      ]
     },
     {
       "id": 13,

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -1267,7 +1267,9 @@
       "id": 45,
       "link": [6, 5],
       "name": "Base",
-      "requires": [],
+      "requires": [
+        {"heatFrames": 0}
+      ],
       "clearsObstacles": ["A"]
     }
   ],

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -722,7 +722,8 @@
       "requires": [
         "ScrewAttack",
         "canShinechargeMovementComplex",
-        {"heatFrames": 105}
+        {"heatFrames": 105},
+        {"shinespark": {"frames": 9, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -257,7 +257,9 @@
           "blockPositions": [[7, 2]]
         }
       },
-      "requires": []
+      "requires": [
+        {"heatFrames": 50}
+      ]
     },
     {
       "id": 6,
@@ -1107,7 +1109,10 @@
       "name": "Gamet Farm",
       "requires": [
         {"or": [
-          "canPauseAbuse",
+          {"and": [
+            {"heatFrames": 0},
+            "canPauseAbuse"
+          ]},
           {"heatFrames": 60}
         ]},
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -492,7 +492,9 @@
       "id": 21,
       "link": [3, 2],
       "name": "Leave with Runway",
-      "requires": [],
+      "requires": [
+        {"heatFrames": 15}
+      ],
       "exitCondition": {
         "leaveWithRunway": {
           "length": 7,
@@ -535,7 +537,10 @@
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"or": [
-          "canPauseAbuse",
+          {"and": [
+            {"heatFrames": 0},
+            "canPauseAbuse"
+          ]},
           {"heatFrames": 50}
         ]},
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
@@ -554,7 +559,10 @@
           "Grapple"
         ]},
         {"or": [
-          "canPauseAbuse",
+          {"and": [
+            {"heatFrames": 0},
+            "canPauseAbuse"
+          ]},
           {"heatFrames": 50}
         ]},
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -892,7 +892,9 @@
       "id": 41,
       "link": [4, 5],
       "name": "Base",
-      "requires": []
+      "requires": [
+        {"heatFrames": 0}
+      ]
     },
     {
       "id": 42,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -268,7 +268,8 @@
         }
       },
       "requires": [
-        "canTrickyJump"
+        "canTrickyJump",
+        {"heatFrames": 200}
       ],
       "devNote": "FIXME: Jumping fully over the platform, and killing the sova before landing on it is a little faster, with no movement items."
     },

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -867,7 +867,8 @@
       "name": "Reserve Trigger",
       "requires": [
         "canManageReserves",
-        {"autoReserveTrigger": {}}
+        {"autoReserveTrigger": {}},
+        {"heatFrames": 0}
       ],
       "note": "Riding the elevator without enough energy will cause a reserve trigger in the next room, reducing the total heat damage dealt.",
       "devNote": "FIXME: If the next room is also heated, the reserve won't trigger until after that elevator ride as well, but then the reserve will trigger during heat damage."

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -830,7 +830,9 @@
       "id": 31,
       "link": [4, 3],
       "name": "Base",
-      "requires": []
+      "requires": [
+        {"heatFrames": 0}
+      ]
     }
   ],
   "nextStratId": 43,

--- a/region/norfair/east/Purple Farming Room.json
+++ b/region/norfair/east/Purple Farming Room.json
@@ -83,7 +83,8 @@
       "link": [2, 1],
       "name": "Leave with Runway",
       "requires": [
-        "h_runOverRespawningEnemies"
+        "h_runOverRespawningEnemies",
+        {"heatFrames": 0}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -126,7 +127,10 @@
       "name": "Gamet Farm",
       "requires": [
         {"or": [
-          "canPauseAbuse",
+          {"and": [
+            {"heatFrames": 0},
+            "canPauseAbuse"
+          ]},
           {"heatFrames": 50}
         ]},
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -1076,7 +1076,10 @@
       "name": "Gamet Farm",
       "requires": [
         {"or": [
-          "canPauseAbuse",
+          {"and": [
+            {"heatFrames": 0},
+            "canPauseAbuse"
+          ]},
           {"heatFrames": 50}
         ]},
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -124,7 +124,9 @@
           "blockPositions": [[12, 12]]
         }
       },
-      "requires": []
+      "requires": [
+        {"heatFrames": 20}
+      ]
     },
     {
       "id": 5,

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -469,7 +469,8 @@
           "canPreciseReserveRefill",
           {"resourceConsumed": [{"type": "ReserveEnergy", "count": 15}]}
         ]},
-        {"resourceAtMost": [{"type": "RegularEnergy", "count": 1}]}
+        {"resourceAtMost": [{"type": "RegularEnergy", "count": 1}]},
+        {"heatFrames": 0}
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -484,15 +485,6 @@
         "We don't include a `h_ShinesparksCostEnergy` requirement here, because even if shinesparks don't cost energy, it is still possible to use heat damage to make the shinespark stop in the correct place.",
         "FIXME: the regular energy required could be reduced in that case."
       ]
-    },
-    {
-      "id": 11,
-      "link": [3, 3],
-      "name": "Leave Normally",
-      "exitCondition": {
-        "leaveNormally": {}
-      },
-      "requires": []
     },
     {
       "id": 12,
@@ -710,7 +702,8 @@
           "canPreciseReserveRefill",
           {"resourceConsumed": [{"type": "ReserveEnergy", "count": 15}]}
         ]},
-        {"resourceAtMost": [{"type": "RegularEnergy", "count": 1}]}
+        {"resourceAtMost": [{"type": "RegularEnergy", "count": 1}]},
+        {"heatFrames": 0}
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -1360,7 +1353,8 @@
           "canPreciseReserveRefill",
           {"resourceConsumed": [{"type": "ReserveEnergy", "count": 15}]}
         ]},
-        {"resourceAtMost": [{"type": "RegularEnergy", "count": 1}]}
+        {"resourceAtMost": [{"type": "RegularEnergy", "count": 1}]},
+        {"heatFrames": 0}
       ],
       "clearsObstacles": ["A"],
       "note": [

--- a/resources/app/manifests/pip_requirements.txt
+++ b/resources/app/manifests/pip_requirements.txt
@@ -1,5 +1,6 @@
 flatten_json
 jsonschema
+referencing
 numpy
 opencv-python
 pillow

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -244,7 +244,7 @@
           },
           "heatFrames": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "title": "Heat Frames",
             "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames in a heat room."
           },

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -748,8 +748,12 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 # Ok since there is implicit heat frames in leavesWithRunway, and it is normal
                                 # if no explicit ones to be present for a strat going from the door to itself.
                                 pass
-                            elif "comeInWithGMode" in strat.get("entranceCondition", []) or "gModeRegainMobility" in strat:
-                                # There is no heat damage in G-mode, so it is normal for these strats to not have heat frames.
+                            elif "comeInWithGMode" in strat.get("entranceCondition", []) and "leaveWithGMode" in strat.get("exitCondition", []):
+                                # Strats that come in with G-mode and leave with G-mode will be spending the entire time in G-mode,
+                                # so it is normal for these strats to not have heat frames.
+                                pass
+                            elif "gModeRegainMobility" in strat:
+                                # Regain mobility strats also take place entirely in G-mode.
                                 pass
                             elif "comeInWithGrappleTeleport" in strat.get("entranceCondition", []) and \
                                   strat.get("bypassesDoorShell") is True:

--- a/tests/asserts/validate.py
+++ b/tests/asserts/validate.py
@@ -6,8 +6,6 @@ import os
 import json
 import re
 from pathlib import Path
-import jsonschema.validators
-import referencing
 from referencing import Registry, Resource
 from jsonschema.validators import Draft7Validator
 from jsonschema import validate


### PR DESCRIPTION
This depends on #1794, so it should be merged first.

This adds tests to check that a `shinespark` logical requirement occurs in every strat with a `leaveWithSpark` exit condition, and that every `or` branch is covered. This turned up three strats that were missing a `shinespark`; these are fixed here.

Tests are also added to check for a `heatFrames` requirement for every strat in heated rooms, again ensuring that every `or` branch is covered. Here, "h_heatProof" and a number of helpers that indirectly include heat frames are also counted. Exceptions are carved out for common situations where it is normal for no heat frames to be included (such as "leaveWithRunway" at a door node, "comeInWithGMode", and grapple teleports that bypass a door lock). For all other "false positive" cases, I'm including a `{"heatFrames": 0}` to satisfy the test and also as a way of documenting that the lack of heat frames is intentional. 

The heat frames test turned up a few cases where heat frames were missing. The only really egregious case was the Cathedral "Tricky Platforming (Come In Running)" strat from 1 to 4, which I apparently messed up long ago. The other cases only involve relative small amounts of heat damage. One of the Multiviola ice clip strats (from 9 to 4) was missing a "h_heatProof" requirement, though it shouldn't be impactful since there's already a "h_heatProof" requirement in the 6 to 9 strat.

I also deleted a few useless "Leave Normally" strats here rather than adding `{"heatFrames": 0}` to them. The remaining "Leave Normally" strats (in unheated rooms) can be cleaned up in a separate pull request, when I'm planning to document the implicit leaveNormally and comeInNormally strats and add boolean properties to toggle them.