### PR TITLE
Obstacle tests for resetRoom

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -402,7 +402,8 @@
           "nodes": [1]
         }},
         {"refill": ["Energy", "Missile"]}
-      ]
+      ],
+      "resetsObstacles": ["A", "B", "C", "D"]
     },
     {
       "id": 15,

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -460,6 +460,7 @@
         }},
         {"partialRefill": {"type": "Super", "limit": 4}}
       ],
+      "resetsObstacles": ["A"],
       "flashSuitChecked": true
     },
     {

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -1283,6 +1283,7 @@
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
       ],
       "flashSuitChecked": true,
+      "resetsObstacles": ["A", "B"],
       "devNote": [
         "FIXME: Node 3 could be used to reset the room, with additional requirements."
       ]

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -1283,7 +1283,8 @@
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
       ],
       "flashSuitChecked": true,
-      "resetsObstacles": ["A", "B"],
+      "resetsObstacles": ["B"],
+      "clearsObstacles": ["A"],
       "devNote": [
         "FIXME: Node 3 could be used to reset the room, with additional requirements."
       ]

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -193,6 +193,7 @@
         ]},
         {"refill": ["PowerBomb"]}
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": "Kill the Beetoms with Screw Attack or by freezing them and using Bombs or Power Bombs.",
       "devNote": [
@@ -299,6 +300,7 @@
         ]},
         "h_can10PowerBombCrystalFlash"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "devNote": "The resetRoom requirement is in case you need to farm a bit to get above health-bomb energy"
     },

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -5488,6 +5488,7 @@
         }},
         {"refill": ["Energy", "Missile", "Super"]}
       ],
+      "resetsObstacles": ["A"],
       "flashSuitChecked": true
     },
     {

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -624,6 +624,7 @@
         ]},
         {"refill": ["Energy", "Missile", "Super"]}
       ],
+      "clearsObstacles": ["A"],
       "devNote": "These two farms are combined, to allow an option of using using Supers farmed from Mini-Kraid to kill the Pirates."
     },
     {

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -113,6 +113,7 @@
         ]},
         {"refill": ["PowerBomb"]}
       ],
+      "clearsObstacles": ["A"],
       "note": "Kill the Beetoms with Screw Attack or by freezing or carefully avoiding them and using Bombs or Power Bombs.",
       "devNote": [
         "Health Bomb ends at 50 energy.",
@@ -286,6 +287,7 @@
         }},
         "h_can10PowerBombCrystalFlash"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "devNote": "Resetting the room could be required to farm a bit of energy to get above health-bomb range, to ensure a Power Bomb drop."
     },

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -107,6 +107,7 @@
         }},
         {"refill": ["Energy", "Missile", "Super"]}
       ],
+      "resetsObstacles": ["A"],
       "devNote": [
         "FIXME: Node 3 could be used to reset the room, with additional requirements."
       ]

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -157,7 +157,8 @@
         }},
         {"partialRefill": {"type": "Super", "limit": 8}},
         {"refill": ["Energy", "Missile"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 5,

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -1382,11 +1382,12 @@
       "name": "Zero Farm",
       "requires": [
         {"resetRoom": {
-          "nodes": [3]
+          "nodes": [2, 3]
         }},
         {"refill": ["PowerBomb"]}
       ],
-      "resetsObstacles": ["A", "B"],
+      "resetsObstacles": ["A"],
+      "clearsObstacles": ["B"],
       "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
     },
     {
@@ -2048,7 +2049,8 @@
         {"resetRoom": {
           "nodes": [5]
         }},
-        {"refill": ["Energy", "Super", "PowerBomb"]}
+        {"refill": ["Energy", "PowerBomb"]},
+        {"partialRefill": { "type": "Super", "limit": 10 }}
       ],
       "resetsObstacles": ["A", "B"],
       "devNote": "It is possible to roll off of the platform above to avoid a mid-air morph."

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -1386,6 +1386,7 @@
         }},
         {"refill": ["PowerBomb"]}
       ],
+      "resetsObstacles": ["A", "B"],
       "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
     },
     {
@@ -1812,6 +1813,7 @@
         }},
         {"refill": ["Energy", "Super"]}
       ],
+      "resetsObstacles": ["A", "B"],
       "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
     },
     {
@@ -2048,6 +2050,7 @@
         }},
         {"refill": ["Energy", "Super", "PowerBomb"]}
       ],
+      "resetsObstacles": ["A", "B"],
       "devNote": "It is possible to roll off of the platform above to avoid a mid-air morph."
     },
     {

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -721,7 +721,6 @@
       "exitCondition": {
         "leaveNormally": {}
       },
-      "clearsObstacles": ["A", "B"],
       "unlocksDoors": [
         {
           "types": ["super"],
@@ -2289,6 +2288,7 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
+      "resetsObstacles": ["A", "B"],
       "devNote": [
         "The Space Pirates (wall) drop Supers and Power Bombs each at a 0.4% rate, too low to put into logic.",
         "FIXME: Other nodes could be used to reset the room, with additional requirements."

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -437,7 +437,8 @@
           "nodes": [1, 2]
         }},
         {"refill": ["Energy", "Missile"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 20,

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -2679,7 +2679,8 @@
         "ScrewAttack",
         {"partialRefill": {"type": "Super", "limit": 4}},
         {"partialRefill": {"type": "Energy", "limit": 80}}
-      ]
+      ],
+      "resetsObstacles": ["A", "B"]
     },
     {
       "id": 126,

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -311,7 +311,8 @@
           "type": "Missile",
           "limit": 20
         }}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 77,
@@ -331,6 +332,7 @@
           "limit": 6
         }}
       ],
+      "clearsObstacles": ["A"],
       "devNote": "Killing the beetoms will also clear the top pirate for small health gain."
     },
     {
@@ -357,6 +359,7 @@
         }},
         "h_can10PowerBombCrystalFlash"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
         "Lay a Power Bomb on the floor to destroy the Power Bomb blocks.",
@@ -1341,6 +1344,7 @@
           "nodes": [2, 3, 4]
         }}
       ],
+      "resetsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
         "Shoot out only the lower 2 shot blocks on the side Samus will be climbing.",

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -2143,6 +2143,7 @@
         }},
         {"refill": ["PowerBomb"]}
       ],
+      "resetsObstacles": ["A"],
       "flashSuitChecked": true
     },
     {

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -560,7 +560,8 @@
           "limit": 10
         }},
         {"partialRefill": {"type": "Super", "limit": 4}}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 25,

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -296,6 +296,7 @@
           "nodes": [2]
         }}
       ],
+      "resetsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
         "Perform the Crystal Flash on the bottom part of the floating platform, to avoid taking damage.",
@@ -1287,7 +1288,8 @@
           "type": "Missile",
           "limit": 10
         }}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 55,

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -146,7 +146,8 @@
           "limit": 10
         }},
         {"partialRefill": {"type": "Super", "limit": 4}}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 4,

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -147,7 +147,7 @@
         }},
         {"partialRefill": {"type": "Super", "limit": 4}}
       ],
-      "resetsObstacles": ["A"]
+      "clearsObstacles": ["A"]
     },
     {
       "id": 4,

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -112,7 +112,8 @@
           "nodes": [1]
         }},
         {"refill": ["Energy", "Super"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 3,

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -219,7 +219,8 @@
           "nodes": [1]
         }},
         {"refill": ["Energy", "Missile"]}
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "id": 8,

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -214,7 +214,10 @@
       "name": "Space Pirate Farm",
       "requires": [
         "SpaceJump",
-        "ScrewAttack",
+        {"or": [
+          "ScrewAttack",
+          "Plasma"
+        ]},
         {"resetRoom": {
           "nodes": [1]
         }},

--- a/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
@@ -291,7 +291,8 @@
           "type": "Missile",
           "limit": 20
         }}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 67,
@@ -315,7 +316,8 @@
         }},
         {"partialRefill": {"type": "Super", "limit": 4}},
         {"refill": ["Missile"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 11,

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -172,7 +172,8 @@
           "nodes": [1]
         }},
         {"refill": ["PowerBomb"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 6,
@@ -444,7 +445,8 @@
           "nodes": [2]
         }},
         {"refill": ["Energy", "PowerBomb"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 23,

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -1922,7 +1922,8 @@
           "type": "PowerBomb",
           "limit": 4
         }}
-      ]
+      ],
+      "resetsObstacles": ["A", "B"]
     },
     {
       "id": 73,
@@ -2597,7 +2598,8 @@
           "type": "PowerBomb",
           "limit": 4
         }}
-      ]
+      ],
+      "resetsObstacles": ["A", "B"]
     },
     {
       "id": 104,
@@ -3182,7 +3184,8 @@
           "type": "PowerBomb",
           "limit": 4
         }}
-      ]
+      ],
+      "resetsObstacles": ["A", "B"]
     },
     {
       "id": 135,

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1030,7 +1030,8 @@
           "type": "PowerBomb",
           "limit": 6
         }}
-      ]
+      ],
+      "resetsObstacles": ["A", "B"]
     },
     {
       "id": 31,
@@ -1881,6 +1882,7 @@
         ]},
         {"ammo": {"type": "Super", "count": 1}}
       ],
+      "resetsObstacles": ["A", "B"],
       "note": "Knock the crab off the wall immediately and then freeze.",
       "devNote": "Kinda tough with no other beam/missile/super/movement."
     },
@@ -3529,7 +3531,8 @@
           "nodes": [1, 2, 3]
         }},
         {"partialRefill": {"type": "Super", "limit": 10}}
-      ]
+      ],
+      "resetsObstacles": ["A", "B"]
     },
     {
       "id": 152,

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -3924,7 +3924,8 @@
         }},
         {"partialRefill": {"type": "Super", "limit": 5}},
         {"partialRefill": {"type": "Missile", "limit": 6}}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 133,
@@ -4249,7 +4250,8 @@
           "limit": 100
         }},
         {"partialRefill": {"type": "Missile", "limit": 6}}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 160,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -727,7 +727,8 @@
         }},
         "h_heatProof",
         {"refill": ["Energy", "Missile", "Super"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 27,

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1032,7 +1032,6 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "clearsObstacles": ["A"],
       "note": [
         "Charge a spark along the bottom of the room and use it to spark through the right side door.",
         "Requires opening the door and shutter first."
@@ -1073,7 +1072,6 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "clearsObstacles": ["A"],
       "note": [
         "Charge a spark along the bottom of the room and use it to spark through the right side door.",
         "Requires opening the door and shutter first."
@@ -1598,6 +1596,7 @@
         {"partialRefill": {"type": "Super", "limit": 4}},
         {"refill": ["Energy", "Missile"]}
       ],
+      "resetsObstacles": ["A"],
       "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
     },
     {

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -557,6 +557,7 @@
         }},
         {"refill": ["PowerBomb"]}
       ],
+      "resetsObstacles": ["A"],
       "devNote": "FIXME: Resetting the room using door node 2 would also be possible if the obstacle is cleared."
     },
     {
@@ -1088,7 +1089,6 @@
           "gentleDownTiles": 4
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["missiles"],
@@ -1124,7 +1124,6 @@
           "gentleDownTiles": 4
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["missiles"],

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -180,7 +180,6 @@
           "openEnd": 1
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["missiles"],
@@ -235,7 +234,6 @@
           "framesRemaining": 145
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["super"],
@@ -266,7 +264,6 @@
           "openEnd": 1
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["super"],
@@ -461,7 +458,6 @@
           "openEnd": 1
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["missiles"],
@@ -506,7 +502,6 @@
           "framesRemaining": 145
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["super"],
@@ -537,7 +532,6 @@
           "openEnd": 1
         }
       },
-      "clearsObstacles": ["A"],
       "unlocksDoors": [
         {
           "types": ["super"],

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -1541,7 +1541,8 @@
           "nodes": [1, 3, 4, 5]
         }},
         {"refill": ["Energy", "Super"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]      
     },
     {
       "id": 41,

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -477,7 +477,8 @@
           "nodes": [1, 2]
         }},
         {"refill": ["Energy", "Missile", "Super"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 30,

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -127,6 +127,7 @@
         ]},
         "h_canCrystalFlash"
       ],
+      "resetsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
         "To avoid heavy Rinka damage, perform the Crystal Flash while backed against the left door or inside the open door frame.",

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -116,18 +116,29 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "Crystal Flash",
+      "name": "Crystal Flash (Come In Normally)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_canCrystalFlash"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "To avoid heavy Rinka damage, perform the Crystal Flash while backed against the left door or inside the open door frame.",
+        "Lay the Power Bomb immediately after destroying the Rinka with the closer spawn location."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Crystal Flash (Metroids Dead or Frozen)",
       "requires": [
         {"or": [
-          {"resetRoom": {
-            "nodes": [1]
-          }},
           "Ice",
           {"obstaclesCleared": ["A"]}
         ]},
         "h_canCrystalFlash"
       ],
-      "resetsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
         "To avoid heavy Rinka damage, perform the Crystal Flash while backed against the left door or inside the open door frame.",

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -491,7 +491,8 @@
           "nodes": [1, 2, 3]
         }},
         {"refill": ["Energy", "Missile", "Super"]}
-      ]
+      ],
+      "clearsObstacles": ["A"]
     },
     {
       "id": 19,
@@ -517,6 +518,7 @@
         }},
         {"refill": ["Energy", "Missile"]}
       ],
+      "clearsObstacles": ["A"],
       "devNote": [
         "With Plasma or Wave, there is no canRiskPermanentLossOfAccess, because a comparable farm is also available with power on."
       ]

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -421,7 +421,8 @@
           "nodes": [1, 2]
         }},
         {"refill": ["Energy", "Missile"]}
-      ]
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 22,

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -429,6 +429,7 @@
         }},
         {"refill": ["Energy", "Missile", "Super"]}
       ],
+      "resetsObstacles": ["A"],
       "note": [
         "It is possible to kill the trapped Atomics with any beam upgrade besides charge.",
         "Kill the atomics while waiting for the Coverns to respawn."

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -642,7 +642,8 @@
           "nodes": [3]
         }},
         {"refill": ["Energy", "Missile"]}
-      ]
+      ],
+      "resetsObstacles": ["A", "B", "C"]
     },
     {
       "id": 24,
@@ -1183,7 +1184,8 @@
           "nodes": [1, 2, 4, 5]
         }},
         {"refill": ["Energy", "Missile"]}
-      ]
+      ],
+      "resetsObstacles": ["A", "B", "C"]
     },
     {
       "id": 54,
@@ -1913,6 +1915,7 @@
         }},
         {"refill": ["Energy", "Missile", "Super"]}
       ],
+      "resetsObstacles": ["A", "B", "C"],
       "note": [
         "To shoot the Atomics with Ice or Plasma, crouch near the edge of the glass and shoot forward;",
         "angled shots downwards also work but from a tile further back."


### PR DESCRIPTION
This depends on #1794, so it should be merged first. I also expect this to have conflicts with #1784, so I can resolve this once that is merged.

A while ago we had a soundness bug in the past in PCJR, where logic thought you could enter shinecharged to break the speed blocks, use the Mella farm to refill, then use that energy to spark up. The problem was that a `resetRoom` requirement on its own does not affect the obstacle state, when in reality basically it always should. We fixed that specific case already but there has still been potential for the same type of error to happen in other places. To solve this problem, this PR adds a test to check that every strat with a `resetRoom` mentions every obstacle in the room in either the `resetsObstacles` or `clearsObstacles` of that strat. Usually the obstacles will be reset since that's what resetting the room does, but in some cases they may get cleared again as part of executing the strat, so that's why it allows either one, as long each obstacle is covered in one or the other. There were many cases where this test did not pass, and this PR fixes all of them.

The other thing is that there were some strats with an exit condition and also a `resetsObstacles` or `clearsObstacles`. A strat with an exit condition will have left the room at the end of the strat, so it does not make sense for it to be affecting the obstacle state. As far as the randomizer is concerned, these were probably harmless since it would have been ignoring these anyway, but it can create confusion so it seemed good to clean this up: the PR adds a test to check that an exit condition does not occur in the same strat with a `resetsObstacles` or `clearsObstacles`. The case where a strat has an exit condition is also an exception where the previous test does not apply: i.e., even if a strat has a `resetRoom` requirement, if it has an exit condition then it should not include `resetsObstacles` or `clearsObstacles`.