### PR TITLE
Add detail in shinespark tech descriptions and docs

### DIFF
--- a/strats.md
+++ b/strats.md
@@ -141,7 +141,7 @@ A `leaveShinecharged` object represents that Samus can leave through this door w
 `leaveShinecharged` has a single property:
 - _framesRemaining_: The number of frames remaining in the shinecharge when leaving the room. A special value "auto" may be used when the strat has a `comeInShinecharged` entrance condition: in this case, the frames remaining when leaving the room depends on how many frames are remaining when entering the room, with the `framesRequired` property of the `comeInShinecharged` indicating the amount of frames by which the shinecharge timer decreases between entering and exiting the room. Similarly, the "auto" value may be used when the strat has a property `startsWithShineCharge: true`, in which case the shinecharge frames used in the strat would be expressed by a `shineChargeFrames` logical requirement.
 
-A strat with a `leaveShinecharged` condition should either include a `canShinecharge` requirement in its `requires` or have a `comeInShinecharged` entrance condition.
+A strat with a `leaveShinecharged` condition should either include a `canShinecharge` requirement in its `requires` or have a `comeInShinecharged` entrance condition or `"startsWithShinecharge": true` property. A `leaveShinecharged` condition implicitly requires `canShinechargeMovement` tech.
 
 *Note*: Using a runway connected to a door to leave the room with a shinecharge is already covered by `leaveWithRunway`, so `leaveShinecharged` only needs to be used in cases where the shinecharge is obtained in another part of the room and then carried through the door.
 
@@ -205,7 +205,7 @@ The `leaveWithSpark` object has the following property:
 
 The direction of the spark is assumed to be horizontal when sparking through horizontal door transitions, or vertical when sparking through vertical door transitions. There is an implicit requirement of `canHorizontalShinespark` when sparking through a horizontal door.
 
-*Note*: Using a runway connected to a door to leave the room with a shinespark is already covered by `leaveWithRunway`. Likewise `leaveShinecharged` implicitly includes the possibility of leaving the room with a shinespark. It is only necessary to use `leaveWithSpark` in cases where it would not be possible to reach the door before the shinecharge timer expires.
+*Note*: Using a runway connected to a door to leave the room with a shinespark is already covered by `leaveWithRunway`. Likewise `leaveShinecharged` implicitly includes the possibility of leaving the room with a shinespark. It is only necessary to use `leaveWithSpark` in cases where it would not be possible to reach the door before the shinecharge timer expires, or, to account for the possibility of shinecharge frame leniency, where the door can only be reached with less than about 30 shinecharge frames remaining.
 
 #### Example
 ```json
@@ -767,6 +767,8 @@ A `comeInShinecharged` must match with either a `leaveShinecharged` condition or
   - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as in `comeInShinecharging`, except here with `comeInShinecharged` there is no second runway to combine with. An extra 10 heat frames are assumed for leaving the room after the shinecharge is obtained.
   - If the previous door environment is water, then `Gravity` is required.
 
+In every case, a `comeInShinecharged` condition comes with an implicit requirement of `canShinechargeMovement` tech. 
+
 #### Position and Momentum Details
 
 A `comeInShinecharged` object does not provide any way to specify Samus' position or momentum through the door transition, but these details can affect the execution of the strat. As a way of normalizing the requirements, we make the following assumptions:
@@ -801,7 +803,7 @@ A `comeInShinechargedJumping` entrance condition represents the need for Samus t
 
 A strat with a `comeInShinechargedJumping` condition should include a `shinespark` requirement in its `requires`.
 
-The conditions for `comeInShinechargedJumping` are the same as for `comeInShinecharged`, with the added condition that the other side of the door must be an air environment.
+The conditions for `comeInShinechargedJumping` are the same as for `comeInShinecharged`, with the added condition that the other side of the door must be an air environment. As with `comeInShinecharged`, it comes with an implicit requirement of `canShinechargeMovement` tech. 
 
 ### Come In With Spark
 
@@ -817,13 +819,13 @@ A strat with a `comeInWithSpark` condition should include a `shinespark` require
 A `comeInWithSpark` condition must match with either a `leaveWithSpark`, `leaveShinecharged`, or `leaveWithRunway` condition on the other side of the door:
 
 - A match with `leaveWithSpark` is valid as long as the `position` properties are compatible. The `position` properties of a `leaveWithSpark` and `comeInWithSpark` are compatible if they are equal or if at least one of them are unspecified.
-- A match with `leaveShinecharged` is always valid.
+- A match with `leaveShinecharged` is always valid. It comes with an implicit requirement of `canShinechargeMovement`.
 - A match with `leaveWithRunway` comes with the following implicit requirements (the same as for `comeInShinecharged`) for actions to be performed in the previous room:
   - A `canShinecharge` requirement is included based on the runway length. This includes a `SpeedBooster` item requirement as well as a check that the effective runway length is enough that charging a shinespark is possible.
   - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room. The minimally required heat frames are calculated the same way as in `comeInShinecharging`, except here with `comeInShinecharged` there is no second runway to combine with.
   - If the previous door environment is water, then `Gravity` is required.
 
-In all three cases, there is an implicit requirement of `canHorizontalShinespark` when sparking through a horizontal door.
+In all three cases, there is an implicit requirement of `canHorizontalShinespark` when sparking through a horizontal door. There is also an implicit requirement of `canMidairShinespark` if the `position` property is "top" in either the `comeInWithSpark` or a matching `leaveWithSpark`.
 
 #### Example
 ```json
@@ -1506,7 +1508,7 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
 
 The `startsWithShineCharge` property indicates that a strat must start while in a shinecharge state, from a shinecharge obtained in an earlier strat. The amount of frames required is determined by `shineChargeFrames` requirements in this strat.
 
-This property should not be combined with a `leaveShinecharged` exit condition.
+This property should not be combined with a `comeInShinecharged` entrance condition.
 
 ## Ends With Shinecharge
 

--- a/tech.json
+++ b/tech.json
@@ -1842,7 +1842,8 @@
           "otherRequires": [],
           "note": [
             "The ability to use the Speed Booster to store a shinecharge, then fly in a direction until an obstacle is hit or Samus gets down to 29 energy.",
-            "Assumes Samus can shinespark vertically or diagonally from the ground."
+            "This is done by gaining enough speed that Samus turns blue, pressing down to gain a shinecharge, then pressing jump after Samus has come to a stop.",
+            "Holding angle-up while pressing jump will cause Samus to shinespark diagonally instead of vertically."
           ],
           "devNote": "SpeedBooster is not required to Shinespark, only to Shinecharge.",
           "extensionTechs": [
@@ -1857,7 +1858,8 @@
                 "The ability to shinespark horizontally from the ground.",
                 "This can be achieved by starting without horizontal momentum and pressing jump and then forward while still holding jump (or repressing jump).",
                 "These inputs can be done in rapid succession or with a short delay.",
-                "Shinesparking in water can be done the same way, but requires a slightly longer delay between the jump and forward presses, and it is particularly important to ensure Samus has no horizontal momentum."
+                "Shinesparking in water can be done the same way, but requires a slightly longer delay between the jump and forward presses.",
+                "If needing to spark near ground level, avoid being crouched when pressing jump, as crouch jumping will boost Samus vertically and result in a higher position for the spark."
               ],
               "extensionTechs": [
                 {
@@ -1868,11 +1870,17 @@
                   ],
                   "otherRequires": [],
                   "note": [
-                    "The ability to jump and shinespark mid-air: vertically, horizontally, or diagonally.",
-                    "Mid-air horizontal sparks are the most tricky.",
-                    "They can be performed by spin jumping, breaking spin, initiating the shinespark without holding jump, then pressing jump and forward.",
-                    "One of the easiest methods is to hold forward the entire time, spin jump, release jump at the desired height, tap either up or the diagonal up angle button,",
-                    "then tap or press jump again (while up/angle is no longer pressed). The timing of the jump after the up/angle is fairly lenient and doesn't need to be rushed.",
+                    "The ability to jump and shinespark mid-air: vertically, diagonally, or horizontally.",
+                    "From a spin jump, a shinespark wind-up is triggered by releasing either forward or jump (or both) and pressing either up or angle-up.",
+                    "The wind-up' is a brief period during which the player can control the direction of the spark.",
+                    "During the wind-up, if jump is pressed together with up, angle-up, or forward, Samus will immediately spark up, diagonally, or horizontally, respectively.",
+                    "If the wind-up expires, Samus will default to a vertical spark.",
+                    "If jump is held when activating the wind-up by pressing up or angle-up, then the wind-up is effectively skipped as the spark activates immediately.",
+                    "For a mid-air horizontal spark (the trickiest case), the sequence is to spin-jump, release jump, tap up or angle-up to activate the wind-up, then press forward and jump to spark;",
+                    "it is also possible to hold forward the entire time;",
+                    "either way, the important points are to be sure to release jump before activating the wind-up,",
+                    "and be sure to release up/angle-up (pressing forward instead) before repressing jump to activate the spark.",
+                    "The wind-up period is fairly lenient, so the timing of the jump input after the up/angle doesn't need to be rushed.",
                     "Note that mid-air shinesparks can't be performed from a fall, only from a jump."
                   ],
                   "extensionTechs": [
@@ -1901,8 +1909,10 @@
               ],
               "otherRequires": [],
               "note": [
-                "The ability to perform simple jumps with a shinespark charge timer running to get into position to shinespark.",
-                "This reposition may be necessary to avoid obstacles, conserve energy, etc."
+                "The ability to perform simple movement with a shinespark charge timer running to get into position to shinespark.",
+                "This reposition may be necessary to avoid obstacles, conserve energy, etc.",
+                "After moving, be sure to wait for Samus to come to a complete stop before pressing jump to spark,",
+                "because if Samus has horizontal momentum then jumping will cause Samus to spin jump instead of sparking."
               ],
               "extensionTechs": [
                 {
@@ -1927,7 +1937,7 @@
                       "otherRequires": [],
                       "note": [
                         "The ability to make precise and potentially unintuitive movement actions with a shinespark charge timer running to get into position to shinespark.",
-                        "A common example is using the Shinespark Wind-Up animation to wait for a hero shot to open an off-camera door."
+                        "A common example is using the shinespark wind-up period to wait for a hero shot to open an off-camera door."
                       ]
                     }
                   ]


### PR DESCRIPTION
- Implicit "canShinechargeMovement" tech on "leaveShinecharged" and "comeInShinecharged" exit/entrance conditions. I think we've been trying to put the "canShinechargeMovement" requirement explicitly on the strat with the "comeInShinecharged", but it's easy to forget. It should be less error-prone to have it be an implicit requirement on the exit/entrance conditions. Moving through a door transition with a stored shinecharge should always fit the description of "canShinechargeMovement" so I think it makes sense to have it always there. This is in contrast to "comeInShinecharging" which doesn't always need it.
- Implicit "canMidairShinespark" on "comeInWithSpark" in top position. There are some cases where you can stand on an elevated platform near a door to leave in top position without a mid-air spark, but these are niche enough that I think we can lump in it as part of the "canMidairShinespark" knowledge expectation. In Medium (where you have "canHorizontalShinespark" but not "canMidairShinespark") it would seem a little questionable to assume the player would think about taking advantage of a platform like that.
- Knowing not to crouch jump, to spark in bottom position. This is maybe questionable for Medium, but I wanted to document it somewhere so I put it in the "canHorizontalShinespark" note.

Out of scope for what this PR is trying to do, but just to discuss the bottom position sparks, I haven't looked at all the examples are, but the Reverse Croc Speedway one is a Hard notable and that makes some sense. In cases like Waterway you're doing some movement that already ensures you're not crouched so that seems more clearly fine in Medium. In general, with cross-room strats, I don't know how to separate these kinds of cases. If we didn't want Medium to expect knowing not to crouch-jump the spark, then I guess the safe thing would be to say that "bottom"-position "comeInWithSpark" also require a Hard tech, and only the "any"-position would be ok in Medium in that case. Though I'm not sure what Hard tech we would use or if we need to make a new one. Something along the line of "canControlledHeightHorizontalSpark"? But I don't know if it's really necessary either.