### PR TITLE
Shinecharge frame migration script

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -243,12 +243,16 @@ __Example:__
 
 #### shineChargeFrames object
 
-A `shineChargeFrames` object represents the need for Samus to have the given amount of shinecharge frames remaining; after this requirement, the new amount of shinecharge frames remaining is updated by subtracting away the given amount of frames.
+A `shineChargeFrames` object represents the need for Samus to have at least the given amount of shinecharge frames remaining. After this requirement, the new amount of shinecharge frames remaining is updated by subtracting away the given amount of frames.
 
-For this requirement to be satisfied, one of the following must be true:
-- It must be preceded by a `canShineCharge` requirement in the same strat.
-- The strat must have `startsWithShineCharge` set to true, and connect with an immediately preceding strat with `endsWithShineCharge` set to true.
-- The strat must have a `comeInShinecharged` or `comeInShinechargedJumping` entrance condition.
+The underlying idea is that shinecharge frames can be modeled as a resource, similar to energy or ammo. The level of this resource can be considered to be part of Samus' state at any given point in time. However, unlike energy or ammo, this resource is not treated as persisting across arbitrary sequences of strats. Samus' shinecharge frames are considered to be set to 180 at the point of a `canShinecharge` requirement; but in order to persist across strats, the strat must either be marked with `"endsWithShineCharge": true` or have a `leavesShinecharged` exit condition, and the following strat must be marked with `"startsWithShineCharge": true` or have a `comeInShinecharged` entrance condition. These restrictions are necessary because strats in general do not model the amount of frames consumed, so it would be invalid to assume that Samus' shinecharge frames can remain unchanged across strats that are not designed to model shinecharge frames.
+
+As an example, if a strat requires entering the room with at least 5 shinecharge frames remaining, it should have a requirement of `{"shineChargeFrames": 5}`. This is in spite of the fact that the amount of shinecharge frames would decrease only by 4 (from 5 to 1) between the time of entering the room and activating the spark. Conversely, if measuring the amount that the shinecharge timer decreases when executing a strat that ends in a shinespark, a value of 1 should be added to this amount to determine the minimum possible amount of logical `shineChargeFrames` that should be required.
+
+__Example:__
+```json
+{"shineChargeFrames": 100}
+```
 
 #### hibashiHits object
 A `hibashiHits` object represents the need for Samus to intentionally take a number of hits from the Norfair flame bursts (also called hibashi). This is meant to be converted to a flat health value based on item loadout. The vanilla damage per hibashi hit is 30 with Power Suit, 15 with Varia, and 7 with Gravity Suit.

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -208,7 +208,7 @@
           },
           "shineChargeFrames": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "maximum": 180,
             "title": "Shinecharge Frames",
             "description": "Fulfilled by spending the given amount of frames with an active shinecharge."

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -296,20 +296,10 @@
             "comeInShinecharged": {
               "type": "object",
               "title": "Come in Shinecharged",
-              "description": "Fulfilled by coming in through this door with a shinespark charge that has at least the given number of frames remaining.",
-              "required": [
-                "framesRequired"
-              ],
+              "description": "Fulfilled by coming in through this door with a shinecharge.",
+              "required": [],
               "additionalProperties": false,
-              "properties": {
-                "framesRequired": {
-                  "type": "integer",
-                  "minimum": 1,
-                  "maximum": 179,
-                  "title": "Frames Required",
-                  "description": "The minimal number of frames that must be left on the shinespark charge when coming in."
-                }
-              }
+              "properties": {}
             },
             "comeInShinechargedJumping": {
               "type": "object",
@@ -832,27 +822,10 @@
             "leaveShinecharged": {
               "type": "object",
               "title": "Leave Shinecharged",
-              "description": "Represents that Samus can leave through this door with a shinespark charge.",
-              "required": [
-                "framesRemaining"
-              ],
+              "description": "Represents that Samus can leave through this door with a shinecharge.",
+              "required": [],
               "additionalProperties": false,
-              "properties": {
-                "framesRemaining": {
-                  "anyOf": [
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string",
-                      "enum": ["auto"]
-                    }
-                  ],
-                  "title": "Frames Remaining",
-                  "minimum": 1,
-                  "description": "The number of frames remaining in the shinespark charge when leaving the room."
-                }
-              }
+              "properties": {}
             },
             "leaveWithTemporaryBlue": {
               "type": "object",

--- a/scripts/migrations/shinecharge_frames.py
+++ b/scripts/migrations/shinecharge_frames.py
@@ -1,7 +1,7 @@
 # Single-time-use script to migrate shinecharge frame requirements from "comeInShinecharged"/"leaveShinecharged"
 # entrance/exit conditions, into strat "requires" in the form of "shineChargeFrames" logical requirements.
 #
-# To use, run "python migrations/shinecharge_frames.py" from a working directory of "sm-json-data/scripts".
+# To use, run "python -m migrations.shinecharge_frames" from a working directory of "sm-json-data/scripts".
 import json
 from pathlib import Path
 

--- a/scripts/migrations/shinecharge_frames.py
+++ b/scripts/migrations/shinecharge_frames.py
@@ -1,0 +1,39 @@
+# Single-time-use script to migrate shinecharge frame requirements from "comeInShinecharged"/"leaveShinecharged"
+# entrance/exit conditions, into strat "requires" in the form of "shineChargeFrames" logical requirements.
+#
+# To use, run "python migrations/shinecharge_frames.py" from a working directory of "sm-json-data/scripts".
+import json
+from pathlib import Path
+
+import format_json
+
+for path in sorted(Path("../region/").glob("**/*.json")):
+    print(f"Processing {path}")
+    room_str = path.open("r").read()
+    room_json = json.loads(room_str)
+    if room_json.get("$schema") != "../../../schema/m3-room.schema.json":
+        continue
+
+    for strat in room_json["strats"]:
+        frames_used = None
+        
+        exit_condition = strat.get("exitCondition")
+        if exit_condition is not None and "leaveShinecharged" in exit_condition:
+            frames_remaining = exit_condition["leaveShinecharged"]["framesRemaining"]
+            del exit_condition["leaveShinecharged"]["framesRemaining"]
+            if frames_remaining != "auto":
+                frames_used = 180 - frames_remaining
+                strat["requires"] = strat["requires"] + [{"shineChargeFrames": frames_used}]
+        
+        entrance_condition = strat.get("entranceCondition")
+        if entrance_condition is not None and "comeInShinecharged" in entrance_condition:
+            if frames_used is not None:
+                raise RuntimeError("frames used in both entrance and exit condition")
+            frames_used = entrance_condition["comeInShinecharged"]["framesRequired"]
+            strat["requires"] = [{"shineChargeFrames": frames_used}] + strat["requires"]
+            del entrance_condition["comeInShinecharged"]["framesRequired"]
+
+    # Write the auto-formatted output:
+    new_room_str = format_json.format(room_json, indent=2)
+    if room_str != new_room_str:
+        path.write_text(new_room_str)

--- a/strats.md
+++ b/strats.md
@@ -136,12 +136,11 @@ When a `leaveWithRunway` conditions occurs on a door in a water environment, it 
 
 ### Leave Shinecharged
 
-A `leaveShinecharged` object represents that Samus can leave through this door with a shinecharge (shinespark charge).
+A `leaveShinecharged` object represents that Samus can leave through this door with a shinecharge (shinespark charge). It has no properties.
 
-`leaveShinecharged` has a single property:
-- _framesRemaining_: The number of frames remaining in the shinecharge when leaving the room. A special value "auto" may be used when the strat has a `comeInShinecharged` entrance condition: in this case, the frames remaining when leaving the room depends on how many frames are remaining when entering the room, with the `framesRequired` property of the `comeInShinecharged` indicating the amount of frames by which the shinecharge timer decreases between entering and exiting the room. Similarly, the "auto" value may be used when the strat has a property `startsWithShineCharge: true`, in which case the shinecharge frames used in the strat would be expressed by a `shineChargeFrames` logical requirement.
+A strat with a `leaveShinecharged` should include a logical requirement for obtaining the shinecharge, e.g. `canShineCharge`; alternatively, it may contain a `comeInShinecharged` or `comeInShinecharging` entrance condition or `startsWithShineCharge: true` property if the shinecharge is obtained as part of an earlier strat. It should also include a `shineChargeFrames` logical requirement to account for shinecharge frames that elapse before reaching the door transition. 
 
-A strat with a `leaveShinecharged` condition should either include a `canShinecharge` requirement in its `requires` or have a `comeInShinecharged` entrance condition or `"startsWithShinecharge": true` property. A `leaveShinecharged` condition implicitly requires `canShinechargeMovement` tech.
+A `leaveShinecharged` condition implicitly requires `canShinechargeMovement` tech.
 
 *Note*: Using a runway connected to a door to leave the room with a shinecharge is already covered by `leaveWithRunway`, so `leaveShinecharged` only needs to be used in cases where the shinecharge is obtained in another part of the room and then carried through the door.
 
@@ -752,11 +751,9 @@ Note that a `comeInGettingBlueSpeed` entrance condition is compatible with prese
 
 ### Come In Shinecharged
 
-A `comeInShinecharged` entrance condition represents the need for Samus to run or jump into the room with a shinecharge with a certain amount of time remaining before it would expire. It has the following property:
+A `comeInShinecharged` entrance condition represents the need for Samus to run or jump into the room with a shinecharge with a certain amount of time remaining before it would expire. It has no properties.
 
-- _framesRequired_: The number of frames that must be left on the shinespark charge when coming in. This must be a value between 1 and 179. Note that the shinecharge timer begins at 180 frames, and at least one frame must elapse between obtaining the shinecharge in the other room and crossing the door transition.
-
-A strat with a `comeInShinecharged` condition should include a `shinespark` requirement in its `requires`.
+A strat with a `comeInShinecharged` condition should include a `shinespark` requirement in its `requires`; alternatively it may include a `leaveShinecharged` exit condition or `"endsWithShineCharge": true` property, if the shinecharge is still active at the end of the strat. It should also include a `shineChargeFrames` logical requirement to account for shinecharge frames that are required in order to be able to position for the spark (or to reach the ending location of the strat, if the shinecharge is still active).
 
 A `comeInShinecharged` must match with either a `leaveShinecharged` condition or a `leaveWithRunway` condition on the other side of the door. 
 

--- a/strats.md
+++ b/strats.md
@@ -1506,7 +1506,7 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
 
 ## Starts With Shinecharge
 
-The `startsWithShineCharge` property indicates that a strat must start while in a shinecharge state, from a shinecharge obtained in an earlier strat. The amount of frames required is determined by `shineChargeFrames` requirements in this strat.
+The `startsWithShineCharge` property indicates that a strat must start while in a shinecharge state, from a shinecharge obtained in an earlier strat. The amount of frames required is determined by `shineChargeFrames` requirements in this strat. A strat with `"startsWithShineCharge": true` is only logically valid if it immediately follows a strat with `"endsWithShineCharge": true`.
 
 This property should not be combined with a `comeInShinecharged` entrance condition.
 

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -361,6 +361,18 @@ def has_reset_room(req):
             return False
 
 
+def covers_shinecharge_frames(req):
+    if isinstance(req, dict):
+        if "shineChargeFrames" in req:
+            return True
+        elif "or" in req:
+            return all(covers_shinecharge_frames(x) for x in req["or"])
+        elif "and" in req:
+            return any(covers_shinecharge_frames(x) for x in req["and"])
+        else:
+            return False
+
+
 keywords = []
 
 # load keywords
@@ -790,6 +802,11 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 msg = f"🔴ERROR: Strat has 'comesThroughToilet' but is not a vertical connection:{stratRef}"
                                 messages["reds"].append(msg)
                                 messages["counts"]["reds"] += 1
+                            if "comeInShinecharged" in strat["entranceCondition"]:
+                                if not covers_shinecharge_frames({"and": strat["requires"]}):
+                                    msg = f"🔴ERROR: Strat has comeInShinecharged entranceCondition without `shineChargeFrames` covering all cases:{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
                             if "comeInWithTemporaryBlue" in strat["entranceCondition"]:
                                 if (room["id"], fromNode) in vertical_door_nodes and "direction" not in strat["entranceCondition"]["comeInWithTemporaryBlue"]:
                                     msg = f"🔴ERROR: Strat has vertical comeInWithTemporaryBlue entranceCondition without 'direction':{stratRef}"
@@ -804,6 +821,11 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 msg = f"🔴ERROR: Strat has exitCondition but To Node is not door or exit:{stratRef}"
                                 messages["reds"].append(msg)
                                 messages["counts"]["reds"] += 1
+                            if "leaveShinecharged" in strat["exitCondition"]:
+                                if not covers_shinecharge_frames({"and": strat["requires"]}):
+                                    msg = f"🔴ERROR: Strat has leavesShinecharged exitCondition without `shineChargeFrames` covering all cases:{stratRef}"
+                                    messages["reds"].append(msg)
+                                    messages["counts"]["reds"] += 1
                             if "leaveWithTemporaryBlue" in strat["exitCondition"]:
                                 if (room["id"], toNode) in vertical_door_nodes and "direction" not in strat["exitCondition"]["leaveWithTemporaryBlue"]:
                                     msg = f"🔴ERROR: Strat has vertical leaveWithTemporaryBlue exitCondition without 'direction':{stratRef}"

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -804,12 +804,6 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 msg = f"🔴ERROR: Strat has exitCondition but To Node is not door or exit:{stratRef}"
                                 messages["reds"].append(msg)
                                 messages["counts"]["reds"] += 1
-                            if "leaveShinecharged" in strat["exitCondition"]:
-                                if strat["exitCondition"]["leaveShinecharged"]["framesRemaining"] == "auto":
-                                    if ("entranceCondition" not in strat or "comeInShinecharged" not in strat["entranceCondition"]) and strat.get("startsWithShineCharge") is not True:
-                                        msg = f"🔴ERROR: Strat has leaveShinecharged exitCondition with framesRemaining 'auto' but no comeInShinecharged entranceCondition or startsWithShineCharge:{stratRef}"
-                                        messages["reds"].append(msg)
-                                        messages["counts"]["reds"] += 1
                             if "leaveWithTemporaryBlue" in strat["exitCondition"]:
                                 if (room["id"], toNode) in vertical_door_nodes and "direction" not in strat["exitCondition"]["leaveWithTemporaryBlue"]:
                                     msg = f"🔴ERROR: Strat has vertical leaveWithTemporaryBlue exitCondition without 'direction':{stratRef}"


### PR DESCRIPTION
This script removes the `framesRemaining` and `framesRequired` properties from the exit condition `leaveShinecharged` and the entrance condition `comeInShinecharged`. These are converted into `shineChargeFrames` logical requirements within the strat `requires`. The docs are also updated, to clarify how the `shineChargeFrames` logical requirement should be used, in combination with `leaveShinecharged` and `comeInShinecharged`.

This PR adds the script and makes the related schema changes, but the output of running the script will be done in a separate PR. It is expected that the tests fail until running the scripts; so this can be done immediately after this PR is merged.

There are also several tests that I want to add related to shinecharge requirements, but this can be done after the migration as it will need fixes/adjustments in a number of strats.