### PR TITLE
Rename and Broaden h_EtecoonDoorSpawnFix

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -248,11 +248,13 @@
           ]
         },
         {
-          "name": "h_EtecoonDoorSpawnFix",
+          "name": "h_DoorImmediatelyClosedFix",
           "requires": [ "never" ],
           "devNote": [
-            "In Vanilla, there is a bug placing the door at the top of the Etecoon Shaft in the wrong location.",
-            "This primarily affects the closing animation and prevents return through the door while in direct g-mode."
+            "In Vanilla, there is a bug placing the closing door at the top of the Etecoon Shaft in the wrong location.",
+            "Additionally, the top right door in both Pink Brinstar Power Bomb Room and Halfie Climb Room are immediately closed.",
+            "This affects the closing animation and prevents return through the door while in direct g-mode.",
+            "This also prevents getting doorstuck, although that doesn't seem to be important on any of these locations."
           ]
         },
         {

--- a/helpers.json
+++ b/helpers.json
@@ -253,8 +253,8 @@
           "devNote": [
             "In Vanilla, there is a bug placing the closing door at the top of the Etecoon Shaft in the wrong location.",
             "Additionally, the top right door in both Pink Brinstar Power Bomb Room and Halfie Climb Room are immediately closed.",
-            "This affects the closing animation and prevents return through the door while in direct g-mode.",
-            "This also prevents getting doorstuck, although that doesn't seem to be important on any of these locations."
+            "This affects the closing animation and prevents return through the door while in direct G-mode.",
+            "This also prevents getting doorstuck, although that doesn't seem to be important in any of these locations."
           ]
         },
         {

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -3960,7 +3960,7 @@
         }
       },
       "requires": [
-        "h_EtecoonDoorSpawnFix"
+        "h_DoorImmediatelyClosedFix"
       ],
       "bypassesDoorShell": true,
       "exitCondition": {
@@ -3981,7 +3981,7 @@
         }
       },
       "requires": [
-        "h_EtecoonDoorSpawnFix"
+        "h_DoorImmediatelyClosedFix"
       ],
       "bypassesDoorShell": true,
       "exitCondition": {

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -313,6 +313,46 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 1],
+      "name": "Carry G-Mode Back through the Door",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "h_DoorImmediatelyClosedFix"
+      ],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Carry G-Mode Morph Back through the Door",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_DoorImmediatelyClosedFix"
+      ],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "flashSuitChecked": true
+    },
+    {
       "id": 13,
       "link": [1, 4],
       "name": "Tank the Damage while Running Through",

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -3352,6 +3352,46 @@
       "flashSuitChecked": true
     },
     {
+      "link": [4, 4],
+      "name": "Carry G-Mode Back through the Door",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "h_DoorImmediatelyClosedFix"
+      ],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "flashSuitChecked": true
+    },
+    {
+      "link": [4, 4],
+      "name": "Carry G-Mode Morph Back through the Door",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_DoorImmediatelyClosedFix"
+      ],
+      "bypassesDoorShell": true,
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": true
+        }
+      },
+      "flashSuitChecked": true
+    },
+    {
       "id": 129,
       "link": [4, 4],
       "name": "Leave With Grapple Teleport (Bottom Position)",


### PR DESCRIPTION
Currently Map Rando removes the misplaced door closing animation in Etecoon Shaft, and fixes the closing animation. This will enable a fix the closing animation of all 3 bad doors.

I think it would make sense for Map Rando to not use this helper and to revert back to the vanilla door close in Etecoon shaft (but fix the misplaced doorshell in Main Shaft).