### PR TITLE
Add more comprehensive tests on shinecharge, blue, and shinespark states

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -547,6 +547,38 @@
           ]
         },
         {
+          "name": "h_shinechargeSlideTemporaryBlue",
+          "requires": [
+            "canTemporaryBlue",
+            "canShinechargeMovementTricky"
+          ],
+          "devNote": [
+            "This represents sliding off the ledge while gaining a shinecharge, which leaves Samus falling with temporary blue."
+          ]
+        },
+        {
+          "name": "h_waterGetBlueSpeed",
+          "requires": [
+            {"tech": "canWaterShineCharge"},
+            "SpeedBooster"
+          ],
+          "devNote": [
+            "This is a way to require the `canWaterShineCharge` tech but gaining only blue speed, not a shinecharge.",
+            "A flash suit can be maintained through this."
+          ]
+        },
+        {
+          "name": "h_stutterWaterGetBlueSpeed",
+          "requires": [
+            {"tech": "canStutterWaterShineCharge"},
+            "SpeedBooster"
+          ],
+          "devNote": [
+            "This is a way to require the `canStutterWaterShineCharge` tech but gaining only blue speed, not a shinecharge.",
+            "A flash suit can be maintained through this."
+          ]
+        },
+        {
           "name": "h_canGateGlitch",
           "requires": [
             "canGateGlitch",

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -718,13 +718,13 @@
         {"or": [
           {"and": [
             "canSlowShortCharge",
-            "canSpeedball",
-            {"getBlueSpeed": {"usedTiles": 17, "openEnd": 0}}
+            {"getBlueSpeed": {"usedTiles": 17, "openEnd": 0}},
+            "canSpeedball"
           ]},
           {"and": [
+            {"canShineCharge": {"usedTiles": 30, "openEnd": 1}},
             "canTemporaryBlue",
-            "canLateralMidAirMorph",
-            {"canShineCharge": {"usedTiles": 30, "openEnd": 1}}
+            "canLateralMidAirMorph"
           ]}
         ]}
       ],

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1980,14 +1980,14 @@
       "link": [13, 1],
       "name": "Speedball (In-Room)",
       "requires": [
-        "canSpeedball",
         {"or": [
           {"getBlueSpeed": {"usedTiles": 16, "openEnd": 1}},
           {"and": [
             {"doorUnlockedAtNode": 2},
             {"getBlueSpeed": {"usedTiles": 17, "openEnd": 1}}
           ]}
-        ]}
+        ]},
+        "canSpeedball"
       ],
       "clearsObstacles": ["A"],
       "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
@@ -2003,15 +2003,15 @@
       "link": [13, 1],
       "name": "Temporary Blue with SpringBall Bounce",
       "requires": [
-        "canChainTemporaryBlue",
-        "canSpringBallBounce",
         {"or": [
           {"and": [
-            "canXRayTurnaround",
-            {"canShineCharge": {"usedTiles": 25, "openEnd": 0}}
+            {"canShineCharge": {"usedTiles": 25, "openEnd": 0}},
+            "canXRayTurnaround"
           ]},
           {"canShineCharge": {"usedTiles": 21, "openEnd": 0}}
-        ]}
+        ]},
+        "canChainTemporaryBlue",
+        "canSpringBallBounce"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -2344,11 +2344,11 @@
       "name": "Speedball Jump into Raised Bomb Blocks",
       "requires": [
         {"notable": "Speedball into Raised Bomb Blocks"},
+        "canSlowShortCharge",
+        {"getBlueSpeed": {"usedTiles": 20, "openEnd": 2}},
         "canSpeedball",
         "canLateralMidAirMorph",
-        "canSlowShortCharge",
         "canTrickyJump",
-        {"getBlueSpeed": {"usedTiles": 20, "openEnd": 2}},
         "canOffScreenSuperShot"
       ],
       "clearsObstacles": ["F"],
@@ -2360,10 +2360,10 @@
       "name": "Temporary Blue Bounce into Raised Bomb Blocks",
       "requires": [
         {"notable": "Speedball into Raised Bomb Blocks"},
-        "canTrickyJump",
-        "canTemporaryBlue",
-        "canLateralMidAirMorph",
         {"canShineCharge": {"usedTiles": 22, "openEnd": 2}},
+        "canTemporaryBlue",
+        "canTrickyJump",
+        "canLateralMidAirMorph",
         "canOffScreenSuperShot"
       ],
       "clearsObstacles": ["F"],

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -276,9 +276,10 @@
       "link": [2, 1],
       "name": "Roll Under Door",
       "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
-          "minTiles": 26
+        "comeInGettingBlueSpeed": {
+          "length": 20,
+          "openEnd": 0,
+          "minExtraRunSpeed": "$7.0"
         }
       },
       "requires": [

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -224,6 +224,7 @@
       "name": "Leave With Temporary Blue (Gravity)",
       "requires": [
         "Gravity",
+        "h_getBlueSpeedMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -2404,17 +2404,24 @@
       "id": 119,
       "link": [10, 1],
       "name": "Leave With Temporary Blue",
-      "requires": [],
+      "requires": [
+        "h_getBlueSpeedMaxRunway"
+      ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": [
+        "FIXME: The h_getBlueSpeedMaxRunway is to satisfy tests for now.",
+        "We should add a proper way to represent that the blue state carries over from the previous strat."
+      ]
     },
     {
       "id": 120,
       "link": [10, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
+        "h_getBlueSpeedMaxRunway",
         "canLongChainTemporaryBlue",
         "canXRayTurnaround",
         "can4HighMidAirMorph",
@@ -2426,6 +2433,10 @@
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
+      ],
+      "devNote": [
+        "FIXME: The h_getBlueSpeedMaxRunway is to satisfy tests for now.",
+        "We should add a proper way to represent that the blue state carries over from the previous strat."
       ]
     },
     {
@@ -2433,6 +2444,7 @@
       "link": [10, 3],
       "name": "Leave With Temporary Blue",
       "requires": [
+        "h_getBlueSpeedMaxRunway",
         "canLongChainTemporaryBlue",
         "canXRayTurnaround",
         "canOffScreenMovement"
@@ -2440,13 +2452,18 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": [
+        "FIXME: The h_getBlueSpeedMaxRunway is to satisfy tests for now.",
+        "We should add a proper way to represent that the blue state carries over from the previous strat."
+      ]
     },
     {
       "id": 122,
       "link": [10, 4],
       "name": "Leave With Temporary Blue",
       "requires": [
+        "h_getBlueSpeedMaxRunway",
         "canLongChainTemporaryBlue",
         "canXRayTurnaround",
         "canOffScreenMovement"
@@ -2454,7 +2471,11 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": [
+        "FIXME: The h_getBlueSpeedMaxRunway is to satisfy tests for now.",
+        "We should add a proper way to represent that the blue state carries over from the previous strat."
+      ]
     }
   ],
   "nextStratId": 123,

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -1969,11 +1969,11 @@
       "name": "Temporary Blue Chain Through Bomb Blocks to Top",
       "requires": [
         {"notable": "Temporary Blue Chain Through Bomb Blocks"},
+        {"canShineCharge": {"usedTiles": 27.5, "openEnd": 0}},
         "canLongChainTemporaryBlue",
         "canXRayTurnaround",
         "canTrickyJump",
         "canBePatient",
-        {"canShineCharge": {"usedTiles": 27.5, "openEnd": 0}},
         "canInsaneJump",
         {"obstaclesCleared": ["A"]},
         {"or": [
@@ -2075,10 +2075,10 @@
       "name": "Temporary Blue Chain Through Bomb Blocks (Bottom Left to Bottom)",
       "requires": [
         {"notable": "Temporary Blue Chain Through Bomb Blocks"},
+        {"canShineCharge": {"usedTiles": 27.5, "openEnd": 0}},
         "canChainTemporaryBlue",
         "canXRayTurnaround",
         "canTrickyJump",
-        {"canShineCharge": {"usedTiles": 27.5, "openEnd": 0}},
         {"obstaclesCleared": ["A"]},
         {"or": [
           "h_ClimbWithoutLava",
@@ -2095,13 +2095,10 @@
       "name": "Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, In-Room)",
       "requires": [
         {"notable": "Temporary Blue Chain Through Bomb Blocks"},
-        "canChainTemporaryBlue",
         {"or": [
           "HiJump",
           "canTrickySpringBallJump"
         ]},
-        "canTrickyJump",
-        {"obstaclesCleared": ["A"]},
         {"or": [
           {"canShineCharge": {"usedTiles": 18, "openEnd": 0}},
           {"and": [
@@ -2109,6 +2106,9 @@
             {"doorUnlockedAtNode": 2}
           ]}
         ]},
+        "canChainTemporaryBlue",
+        "canTrickyJump",
+        {"obstaclesCleared": ["A"]},
         {"or": [
           "h_ClimbWithoutLava",
           {"obstaclesNotCleared": ["B"]}

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -641,6 +641,7 @@
       },
       "requires": [
         "canSuperJump",
+        {"shinespark": {"frames": 7, "excessFrames": 0}},
         {"spikeHits": 3},
         {"or": [
           {"spikeHits": 3},
@@ -1397,6 +1398,7 @@
       "link": [6, 3],
       "name": "Jump Over the Speed Blocks",
       "requires": [
+        "h_getBlueSpeedMaxRunway",
         "canChainTemporaryBlue",
         {"or": [
           "canTrickyJump",
@@ -1409,6 +1411,10 @@
         "Unmorph on the leftmost edge of the Speed blocks and jump across.",
         "Landing on the right side Speedblock, and the solid tile, gives enough time to run to the item and fall before the block respawns.",
         "Or jump fully over the Speed blocks and turn around using X-Ray after collecting the item."
+      ],
+      "devNote": [
+        "FIXME: The h_getBlueSpeedMaxRunway is to satisfy tests for now.",
+        "We should add a proper way to represent that the blue state carries over from the previous strat."
       ]
     },
     {

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -649,14 +649,14 @@
       "name": "Shinespark through Door",
       "requires": [
         {"obstaclesCleared": ["C"]},
-        {"shinespark": {"frames": 125}},
         {"or": [
           {"canShineCharge": {"usedTiles": 30, "openEnd": 1, "steepUpTiles": 9}},
           {"and": [
             {"canShineCharge": {"usedTiles": 31, "openEnd": 1, "steepUpTiles": 9}},
             {"doorUnlockedAtNode": 3}
           ]}
-        ]}
+        ]},
+        {"shinespark": {"frames": 125}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -946,13 +946,13 @@
       "name": "Shinespark through Door",
       "requires": [
         {"obstaclesCleared": ["C"]},
-        {"shinespark": {"frames": 125}},
         {"canShineCharge": {
           "usedTiles": 19,
           "steepUpTiles": 2,
           "steepDownTiles": 1,
           "openEnd": 2
-        }}
+        }},
+        {"shinespark": {"frames": 125}}
       ],
       "exitCondition": {
         "leaveWithSpark": {

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -2344,6 +2344,12 @@
       "link": [8, 1],
       "name": "Quick Charge, Leave Sparking",
       "requires": [
+        {"canShineCharge": {
+          "usedTiles": 25,
+          "steepUpTiles": 3,
+          "steepDownTiles": 3,
+          "openEnd": 1
+        }},
         {"or": [
           "canCarefulJump",
           {"and": [
@@ -2351,12 +2357,6 @@
             {"shinespark": {"frames": 2}}
           ]}
         ]},
-        {"canShineCharge": {
-          "usedTiles": 25,
-          "steepUpTiles": 3,
-          "steepDownTiles": 3,
-          "openEnd": 1
-        }},
         {"shinespark": {"frames": 28}}
       ],
       "exitCondition": {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -289,8 +289,6 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        "canLongChainTemporaryBlue",
-        "can4HighMidAirMorph",
         {"canShineCharge": {
           "usedTiles": 20,
           "openEnd": 0,
@@ -298,6 +296,8 @@
           "steepDownTiles": 2,
           "startingDownTiles": 1
         }},
+        "canLongChainTemporaryBlue",
+        "can4HighMidAirMorph",
         {"or": [
           "HiJump",
           "canGravityJump"

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -818,10 +818,15 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"obstaclesNotCleared": ["B", "C"]},
+        "h_canShineChargeMaxRunway",
         {"shinespark": {"frames": 19, "excessFrames": 19}}
       ],
       "resetsObstacles": ["A"],
-      "devNote": "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark."
+      "devNote": [
+        "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark.",
+        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "we should add a proper way to represent that the shinespark carries over from the previous strat."
+      ]
     },
     {
       "id": 45,
@@ -830,6 +835,7 @@
       "requires": [
         {"obstaclesCleared": ["A", "C"]},
         {"obstaclesNotCleared": ["B"]},
+        "h_canShineChargeMaxRunway",
         {"shinespark": {"frames": 21, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -841,7 +847,11 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "devNote": "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark."
+      "devNote": [
+        "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark.",
+        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "we should add a proper way to represent that the shinespark carries over from the previous strat."
+      ]
     },
     {
       "id": 46,
@@ -966,9 +976,14 @@
       "requires": [
         {"obstaclesCleared": ["B"]},
         {"obstaclesNotCleared": ["A", "C"]},
+        "h_canShineChargeMaxRunway",
         {"shinespark": {"frames": 23, "excessFrames": 7}}
       ],
-      "resetsObstacles": ["B"]
+      "resetsObstacles": ["B"],
+      "devNote": [
+        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "we should add a proper way to represent that the shinespark carries over from the previous strat."
+      ]
     },
     {
       "id": 56,
@@ -977,6 +992,7 @@
       "requires": [
         {"obstaclesCleared": ["B", "C"]},
         {"obstaclesNotCleared": ["A"]},
+        "h_canShineChargeMaxRunway",
         {"shinespark": {"frames": 23, "excessFrames": 7}}
       ],
       "exitCondition": {
@@ -987,6 +1003,10 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": [
+        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },
     {

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -377,7 +377,8 @@
             "h_canDestroyBombWalls",
             {"doorUnlockedAtNode": 1}
           ]}
-        ]}
+        ]},
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "clearsObstacles": ["B", "D"],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -93,14 +93,14 @@
         {"obstaclesCleared": ["A"]},
         "canMidairShinespark",
         "canShinechargeMovement",
-        {"shinespark": {"frames": 45}},
         {"canShineCharge": {
           "usedTiles": 18,
           "openEnd": 1,
           "startingDownTiles": 0,
           "steepDownTiles": 1,
           "steepUpTiles": 2
-        }}
+        }},
+        {"shinespark": {"frames": 45}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -122,14 +122,14 @@
         {"enemyKill": {
           "enemies": [["Yapping Maw"]]
         }},
-        {"shinespark": {"frames": 45}},
         {"canShineCharge": {
           "usedTiles": 21,
           "openEnd": 0,
           "startingDownTiles": 1,
           "steepDownTiles": 2,
           "steepUpTiles": 2
-        }}
+        }},
+        {"shinespark": {"frames": 45}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -145,14 +145,14 @@
         {"obstaclesCleared": ["A"]},
         "canMidairShinespark",
         "canUseFrozenEnemies",
-        {"shinespark": {"frames": 45}},
         {"canShineCharge": {
           "usedTiles": 21,
           "openEnd": 0,
           "startingDownTiles": 1,
           "steepDownTiles": 2,
           "steepUpTiles": 2
-        }}
+        }},
+        {"shinespark": {"frames": 45}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -855,14 +855,14 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canMidairShinespark",
-        {"shinespark": {"frames": 45}},
         {"canShineCharge": {
           "usedTiles": 18,
           "openEnd": 1,
           "startingDownTiles": 2,
           "steepDownTiles": 3,
           "steepUpTiles": 1
-        }}
+        }},
+        {"shinespark": {"frames": 45}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -881,14 +881,14 @@
         {"enemyKill": {
           "enemies": [["Yapping Maw"]]
         }},
-        {"shinespark": {"frames": 45}},
         {"canShineCharge": {
           "usedTiles": 22,
           "openEnd": 0,
           "startingDownTiles": 2,
           "steepDownTiles": 3,
           "steepUpTiles": 2
-        }}
+        }},
+        {"shinespark": {"frames": 45}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -905,14 +905,14 @@
         {"obstaclesCleared": ["A"]},
         "canMidairShinespark",
         "canCameraManip",
-        {"shinespark": {"frames": 45}},
         {"canShineCharge": {
           "usedTiles": 22,
           "openEnd": 0,
           "startingDownTiles": 2,
           "steepDownTiles": 3,
           "steepUpTiles": 2
-        }}
+        }},
+        {"shinespark": {"frames": 45}}
       ],
       "exitCondition": {
         "leaveWithSpark": {

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -963,10 +963,10 @@
       "requires": [
         {"notable": "Air Speedball"},
         "h_canNavigateHeatRooms",
-        "h_canUseSpringBall",
+        {"getBlueSpeed": {"usedTiles": 26, "gentleDownTiles": 2, "openEnd": 1}},
         "canSpeedball",
         "canLateralMidAirMorph",
-        {"getBlueSpeed": {"usedTiles": 26, "gentleDownTiles": 2, "openEnd": 1}},
+        "h_canUseSpringBall",
         {"heatFrames": 160}
       ],
       "clearsObstacles": ["B"],

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -621,9 +621,9 @@
       "link": [4, 8],
       "name": "Speedball",
       "requires": [
-        "canSpeedball",
         {"obstaclesCleared": ["D"]},
         {"getBlueSpeed": {"usedTiles": 20, "openEnd": 1}},
+        "canSpeedball",
         {"or": [
           "h_canUseSpringBall",
           {"hibashiHits": 1}
@@ -1018,8 +1018,8 @@
         "canCeilingClip",
         "canHorizontalDamageBoost",
         "canUseIFrames",
-        "canSpeedball",
         {"getBlueSpeed": {"usedTiles": 16, "openEnd": 1}},
+        "canSpeedball",
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
         {"heatFrames": 390},
         {"or": [
@@ -1051,8 +1051,8 @@
         "canTrickyJump",
         "canHorizontalDamageBoost",
         "canUseIFrames",
-        "canSpeedball",
         {"getBlueSpeed": {"usedTiles": 16, "openEnd": 1}},
+        "canSpeedball",
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
         {"heatFrames": 390},
         {"or": [

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -333,11 +333,11 @@
         "ScrewAttack",
         "canShinechargeMovementComplex",
         {"heatFrames": 135},
-        {"shinespark": {"frames": 3, "excessFrames": 0}},
         {"or": [
           {"shinespark": {"frames": 3, "excessFrames": 0}},
           {"shineChargeFrames": 10}
-        ]}
+        ]},
+        {"shinespark": {"frames": 3, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -565,8 +565,7 @@
         }
       },
       "requires": [
-        "canShinechargeMovementTricky",
-        "canTemporaryBlue",
+        "h_shinechargeSlideTemporaryBlue",
         {"heatFrames": 115},
         {"shineChargeFrames": 115}
       ],
@@ -1094,8 +1093,7 @@
         }
       },
       "requires": [
-        "canTemporaryBlue",
-        "canShinechargeMovementTricky",
+        "h_shinechargeSlideTemporaryBlue",
         {"heatFrames": 80},
         {"shineChargeFrames": 80}
       ],
@@ -1182,8 +1180,7 @@
         }
       },
       "requires": [
-        "canShinechargeMovementTricky",
-        "canTemporaryBlue",
+        "h_shinechargeSlideTemporaryBlue",
         {"heatFrames": 165},
         {"shinespark": {"frames": 3, "excessFrames": 0}}
       ],
@@ -1210,8 +1207,7 @@
         }
       },
       "requires": [
-        "canShinechargeMovementTricky",
-        "canTemporaryBlue",
+        "h_shinechargeSlideTemporaryBlue",
         {"heatFrames": 160},
         {"shineChargeFrames": 160}
       ],
@@ -1567,8 +1563,7 @@
         }
       },
       "requires": [
-        "canTemporaryBlue",
-        "canShinechargeMovementTricky",
+        "h_shinechargeSlideTemporaryBlue",
         {"heatFrames": 140},
         {"shineChargeFrames": 140}
       ],
@@ -1631,7 +1626,6 @@
         {"shineChargeFrames": 140},
         "canShinechargeMovementTricky",
         "ScrewAttack",
-        "canTemporaryBlue",
         {"heatFrames": 140},
         {"or": [
           "canMoonfall",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -731,6 +731,7 @@
         }
       },
       "requires": [
+        "h_waterGetBlueSpeed",
         "HiJump",
         "canLongChainTemporaryBlue",
         "canBeExtremelyPatient",
@@ -1056,6 +1057,7 @@
       "requires": [
         {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
+        "h_waterGetBlueSpeed",
         "h_canDoubleSpringBallJumpWithHiJump",
         "canChainTemporaryBlue",
         {"or": [
@@ -1409,7 +1411,7 @@
         {"or": [
           {"and": [
             "canDisableEquipment",
-            "canStutterWaterShineCharge"
+            "h_stutterWaterGetBlueSpeed"
           ]},
           {"and": [
             {"getBlueSpeed": {"usedTiles": 20, "openEnd": 2}},

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1166,7 +1166,7 @@
         }
       },
       "requires": [
-        "canWaterShineCharge"
+        "h_waterGetBlueSpeed"
       ],
       "clearsObstacles": ["A"],
       "devNote": [
@@ -1185,7 +1185,7 @@
         }
       },
       "requires": [
-        "canStutterWaterShineCharge"
+        "h_stutterWaterGetBlueSpeed"
       ],
       "clearsObstacles": ["A"]
     },

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -439,8 +439,8 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        "canChainTemporaryBlue",
-        {"canShineCharge": {"usedTiles": 15, "openEnd": 1}}
+        {"canShineCharge": {"usedTiles": 15, "openEnd": 1}},
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -2161,7 +2161,6 @@
       },
       "requires": [
         "canStutterWaterShineCharge",
-        "h_canShineChargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -2175,7 +2174,6 @@
             ]}
           ]}
         ]},
-        {"shinespark": {"frames": 39, "excessFrames": 4}},
         "canXRayTurnaround",
         "HiJump",
         "canGravityJump",

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -253,9 +253,10 @@
       "link": [1, 2],
       "name": "Shinespark Deep Stuck X-Ray Climb",
       "entranceCondition": {
-        "comeInWithDoorStuckSetup": {}
+        "comeInShinecharged": {}
       },
       "requires": [
+        {"shineChargeFrames": 1},
         "canShinesparkDeepStuck",
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canXRayClimb",

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -287,8 +287,9 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "canGravityJump",
-        "canLongChainTemporaryBlue"
+        {"getBlueSpeed": {"usedTiles": 24, "openEnd": 1}},
+        "canLongChainTemporaryBlue",
+        "canGravityJump"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
@@ -1242,8 +1243,9 @@
       "link": [3, 3],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "canGravityJump",
+        {"getBlueSpeed": {"usedTiles": 24, "openEnd": 1}},
         "canLongChainTemporaryBlue",
+        "canGravityJump",
         "canXRayTurnaround"
       ],
       "exitCondition": {
@@ -1428,8 +1430,9 @@
       "link": [4, 4],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "canGravityJump",
-        "canChainTemporaryBlue"
+        {"getBlueSpeed": {"usedTiles": 24, "openEnd": 1}},
+        "canChainTemporaryBlue",
+        "canGravityJump"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2584,9 +2584,9 @@
         }
       },
       "requires": [
+        "canStutterWaterShineCharge",
         "canChainTemporaryBlue",
         "canXRayTurnaround",
-        "canStutterWaterShineCharge",
         {"or": [
           "Gravity",
           {"and": [

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -2417,8 +2417,6 @@
       "link": [4, 4],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "canChainTemporaryBlue",
-        "canGravityJump",
         {"or": [
           {"and": [
             {"canShineCharge": {
@@ -2448,7 +2446,9 @@
               "steepDownTiles": 1
             }}
           ]}
-        ]}
+        ]},
+        "canChainTemporaryBlue",
+        "canGravityJump"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -663,7 +663,7 @@
         {"useFlashSuit": {}},
         {"or": [
           {"shinespark": {"frames": 31, "excessFrames": 7}},
-          {"or": [
+          {"and": [
             "SpeedBooster",
             {"shinespark": {"frames": 6, "excessFrames": 4}}
           ]}

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -41,20 +41,14 @@
       "nodeSubType": "junction"
     }
   ],
-  "obstacles": [
-    {
-      "id": "A",
-      "name": "Enter Shinecharged for Item Grab and Escape",
-      "obstacleType": "abstract"
-    }
-  ],
   "enemies": [],
   "links": [
     {
       "from": 1,
       "to": [
         {"id": 1},
-        {"id": 2}
+        {"id": 2},
+        {"id": 3}
       ]
     },
     {
@@ -69,6 +63,7 @@
     {
       "from": 3,
       "to": [
+        {"id": 1},
         {"id": 2}
       ]
     },
@@ -108,22 +103,6 @@
       "requires": []
     },
     {
-      "id": 4,
-      "link": [1, 2],
-      "name": "Come In Shinecharging for Item Grab and Escape",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 0,
-          "openEnd": 1
-        }
-      },
-      "requires": [
-        "canShinechargeMovementTricky"
-      ],
-      "clearsObstacles": ["A"],
-      "flashSuitChecked": true
-    },
-    {
       "id": 27,
       "link": [1, 2],
       "name": "Come In Shinecharging, Leave Shinecharged",
@@ -147,6 +126,23 @@
         },
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
+    },
+    {
+      "id": 4,
+      "link": [1, 3],
+      "name": "Come In Shinecharging, End Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 135}
+      ],
+      "endsWithShineCharge": true,
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -185,15 +181,6 @@
         {"shinespark": {"frames": 40}}
       ],
       "flashSuitChecked": true
-    },
-    {
-      "id": 8,
-      "link": [2, 1],
-      "name": "Shinespark Escape",
-      "requires": [
-        {"obstaclesCleared": ["A"]},
-        {"shinespark": {"frames": 40}}
-      ]
     },
     {
       "id": 28,
@@ -375,29 +362,34 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
         "h_canCrystalFlash"
       ],
       "flashSuitChecked": true
     },
     {
       "id": 15,
-      "link": [2, 2],
-      "name": "Come In Shinecharged for Item Grab and Escape",
+      "link": [2, 3],
+      "name": "Come In Shinecharged, End Shinecharged",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 70},
+        {"shineChargeFrames": 40},
         "canShinechargeMovementComplex"
       ],
-      "clearsObstacles": ["A"],
+      "endsWithShineCharge": true,
       "flashSuitChecked": true
     },
     {
+      "id": 18,
+      "link": [2, 3],
+      "name": "Base",
+      "requires": []
+    },
+    {
       "id": 16,
-      "link": [2, 2],
-      "name": "Come In Shinecharging for Item Grab and Escape",
+      "link": [2, 3],
+      "name": "Come In Shinecharging, End Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 9,
@@ -405,27 +397,10 @@
         }
       },
       "requires": [
+        {"shineChargeFrames": 5},
         "canShinechargeMovementComplex"
       ],
-      "clearsObstacles": ["A"]
-    },
-    {
-      "id": 17,
-      "link": [2, 2],
-      "name": "Shinespark Escape",
-      "requires": [
-        {"obstaclesCleared": ["A"]},
-        {"shinespark": {"frames": 6}}
-      ],
-      "exitCondition": {
-        "leaveWithSpark": {}
-      }
-    },
-    {
-      "id": 18,
-      "link": [2, 3],
-      "name": "Base",
-      "requires": []
+      "endsWithShineCharge": true
     },
     {
       "id": 19,
@@ -457,10 +432,37 @@
       ]
     },
     {
+      "id": 8,
+      "link": [3, 1],
+      "name": "Start Shinecharged, Shinespark",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"shineChargeFrames": 35},
+        {"shinespark": {"frames": 40}}
+      ]
+    },
+    {
       "id": 21,
       "link": [3, 2],
       "name": "Base",
       "requires": []
+    },
+    {
+      "id": 17,
+      "link": [3, 2],
+      "name": "Start Shinecharged, Leave With Spark",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"shineChargeFrames": 25},
+        {"shinespark": {"frames": 6}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
     },
     {
       "id": 22,

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -694,7 +694,10 @@
           "canXRayCancelShinecharge",
           {"heatFrames": 160}
         ]}
-      ]
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      }
     },
     {
       "id": 26,

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -220,6 +220,7 @@
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
+        "h_getBlueSpeedMaxRunway",
         "canTemporaryBlue",
         "canMoondance",
         "canSpeedball"
@@ -247,6 +248,7 @@
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
+        "h_getBlueSpeedMaxRunway",
         "canTemporaryBlue",
         "canExtendedMoondance",
         "canSpeedball"
@@ -355,6 +357,7 @@
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
+        "h_getBlueSpeedMaxRunway",
         "canTemporaryBlue",
         "canMoondance",
         "canSpeedball"
@@ -383,6 +386,7 @@
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
+        "h_getBlueSpeedMaxRunway",
         "canTemporaryBlue",
         "canExtendedMoondance",
         "canSpeedball"

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -2857,8 +2857,7 @@
         }
       },
       "requires": [
-        "canShinechargeMovementTricky",
-        "canTemporaryBlue",
+        "h_shinechargeSlideTemporaryBlue",
         {"shineChargeFrames": 150}
       ],
       "exitCondition": {

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -394,6 +394,7 @@
           ]}
         ]},
         {"heatFrames": 675},
+        "h_getBlueSpeedMaxRunway",
         {"or": [
           "canSpeedball",
           {"heatFrames": 15}
@@ -424,6 +425,7 @@
         "canControlShinesparkEnd",
         "canPauseAbuse",
         {"resourceAvailable": [{"type": "RegularEnergy", "count": 93}]},
+        {"shinespark": {"frames": 0, "excessFrames": 0}},
         {"resourceConsumed": [{"type": "ReserveEnergy", "count": 61}]},
         {"or": [
           "canPreciseReserveRefill",
@@ -442,6 +444,9 @@
         "in any case, arm pumping should not be used until beginning to run through the Speed blocks, otherwise Samus will not obtain blue speed in time and will bonk into them."
       ],
       "devNote": [
+        "The zero shinespark requirement is to satisfy the tests, by marking that the shinecharge is used;",
+        "the actual shinespark energy usage is accounted for in the resourceConsumed.",
+        "This could possibly be rewritten to express the energy usage in the normal way.",
         "We don't include a `h_ShinesparksCostEnergy` requirement here, because even if shinesparks don't cost energy, it is still possible to use heat damage to make the shinespark stop in the correct place.",
         "FIXME: the regular energy required could be reduced in that case."
       ]
@@ -578,6 +583,7 @@
           ]}
         ]},
         {"heatFrames": 715},
+        "h_getBlueSpeedMaxRunway",
         {"or": [
           "canSpeedball",
           {"heatFrames": 15}
@@ -636,6 +642,7 @@
         "canControlShinesparkEnd",
         "canPauseAbuse",
         {"resourceAvailable": [{"type": "RegularEnergy", "count": 94}]},
+        {"shinespark": {"frames": 0, "excessFrames": 0}},
         {"resourceConsumed": [{"type": "ReserveEnergy", "count": 61}]},
         {"or": [
           "canPreciseReserveRefill",
@@ -654,6 +661,9 @@
         "in any case, arm pumping should not be used until beginning to run through the Speed blocks, otherwise Samus will not obtain blue speed in time and will bonk into them."
       ],
       "devNote": [
+        "The zero shinespark requirement is to satisfy the tests, by marking that the shinecharge is used;",
+        "the actual shinespark energy usage is accounted for in the resourceConsumed.",
+        "This could possibly be rewritten to express the energy usage in the normal way.",
         "We don't include a `h_ShinesparksCostEnergy` requirement here, because even if shinesparks don't cost energy, it is still possible to use heat damage to make the shinespark stop in the correct place.",
         "FIXME: the regular energy required could be reduced in that case."
       ]
@@ -1105,6 +1115,7 @@
           ]}
         ]},
         {"heatFrames": 825},
+        "h_getBlueSpeedMaxRunway",
         {"or": [
           "canSpeedball",
           {"heatFrames": 15}
@@ -1144,6 +1155,7 @@
         "canControlShinesparkEnd",
         "canPauseAbuse",
         {"resourceAvailable": [{"type": "RegularEnergy", "count": 99}]},
+        {"shinespark": {"frames": 0, "excessFrames": 0}},
         {"resourceConsumed": [{"type": "ReserveEnergy", "count": 80}]},
         {"or": [
           {"resourceConsumed": [{"type": "ReserveEnergy", "count": 20}]},
@@ -1180,6 +1192,9 @@
         "in any case, arm pumping should not be used until beginning to run through the Speed blocks, otherwise Samus will not obtain blue speed in time and will bonk into them."
       ],
       "devNote": [
+        "The zero shinespark requirement is to satisfy the tests, by marking that the shinecharge is used;",
+        "the actual shinespark energy usage is accounted for in the resourceConsumed.",
+        "This could possibly be rewritten to express the energy usage in the normal way.",
         "We don't include a `h_ShinesparksCostEnergy` requirement here, because even if shinesparks don't cost energy, it is still possible to use heat damage to make the shinespark stop in the correct place.",
         "FIXME: the regular energy required could be reduced in that case."
       ]

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -780,9 +780,9 @@
     {
       "id": 38,
       "link": [3, 7],
-      "name": "Come in Shinecharging",
+      "name": "Come in Getting Blue Speed",
       "entranceCondition": {
-        "comeInShinecharging": {
+        "comeInGettingBlueSpeed": {
           "length": 6,
           "openEnd": 0,
           "steepDownTiles": 2

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -180,6 +180,7 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
+        "h_getBlueSpeedMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -524,9 +524,9 @@
       "link": [2, 3],
       "name": "Speedball (Phantoon Dead)",
       "requires": [
+        "h_getBlueSpeedMaxRunway",
         "canSpeedball",
-        "f_DefeatedPhantoon",
-        "h_getBlueSpeedMaxRunway"
+        "f_DefeatedPhantoon"
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -539,8 +539,8 @@
       "link": [2, 3],
       "name": "Speedball (Phantoon Alive)",
       "requires": [
-        "canSpeedball",
-        {"getBlueSpeed": {"usedTiles": 22, "openEnd": 0}}
+        {"getBlueSpeed": {"usedTiles": 22, "openEnd": 0}},
+        "canSpeedball"
       ],
       "clearsObstacles": ["A"],
       "note": "This speedball is harder with Phantoon alive and has a shorter runway because of the robot standing in the way."
@@ -574,9 +574,9 @@
       "link": [2, 3],
       "name": "Leave With Temporary Blue",
       "requires": [
+        {"getBlueSpeed": {"usedTiles": 22, "openEnd": 0}},
         "canSpeedball",
-        "canChainTemporaryBlue",
-        {"getBlueSpeed": {"usedTiles": 22, "openEnd": 0}}
+        "canChainTemporaryBlue"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -283,10 +283,10 @@
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
+        {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
         "canTemporaryBlue",
         "canSpeedball",
-        "canMoondance",
-        {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}}
+        "canMoondance"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -311,11 +311,11 @@
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
+        {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
         "canTemporaryBlue",
         "canExtendedMoondance",
         "canSpeedball",
-        "Grapple",
-        {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}}
+        "Grapple"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -340,10 +340,10 @@
         "h_canCrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
+        {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
         "canTemporaryBlue",
         "canMoondance",
-        "canSpeedball",
-        {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}}
+        "canSpeedball"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
@@ -1032,7 +1032,8 @@
             {"or": [
               {"and": [
                 {"canShineCharge": {"usedTiles": 35, "openEnd": 1}},
-                "h_ShinesparksCostEnergy"
+                "h_ShinesparksCostEnergy",
+                {"shinespark": {"frames": 0, "excessFrames": 0}}
               ]},
               "f_DefeatedPhantoon"
             ]},
@@ -1162,7 +1163,8 @@
         "h_canJumpIntoCrystalFlashClip",
         "Grapple",
         "canOffScreenMovement",
-        {"canShineCharge": {"usedTiles": 25, "openEnd": 1}}
+        {"canShineCharge": {"usedTiles": 25, "openEnd": 1}},
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -710,8 +710,6 @@
       "link": [3, 6],
       "name": "Temporary Blue Bounce (In-Room)",
       "requires": [
-        "canTemporaryBlue",
-        "canSpringBallBounce",
         {"obstaclesNotCleared": ["B"]},
         {"or": [
           {"canShineCharge": {"usedTiles": 12, "openEnd": 1}},
@@ -719,7 +717,9 @@
             {"doorUnlockedAtNode": 3},
             {"canShineCharge": {"usedTiles": 13, "openEnd": 1}}
           ]}
-        ]}
+        ]},
+        "canTemporaryBlue",
+        "canSpringBallBounce"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -824,8 +824,6 @@
       "link": [3, 8],
       "name": "Temporary Blue (In-Room)",
       "requires": [
-        "canTemporaryBlue",
-        "canLateralMidAirMorph",
         {"or": [
           {"canShineCharge": {"usedTiles": 11, "openEnd": 2, "steepUpTiles": 3}},
           {"and": [
@@ -839,7 +837,9 @@
             ]},
             {"canShineCharge": {"usedTiles": 13, "openEnd": 1, "steepUpTiles": 3}}
           ]}
-        ]}
+        ]},
+        "canTemporaryBlue",
+        "canLateralMidAirMorph"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true,
@@ -854,12 +854,12 @@
       "link": [3, 8],
       "name": "Temporary Blue Chain (In-Room)",
       "requires": [
+        {"obstaclesNotCleared": ["B"]},
+        {"doorUnlockedAtNode": 3},
+        {"canShineCharge": {"usedTiles": 13, "openEnd": 1}},
         "canLongChainTemporaryBlue",
         "canXRayTurnaround",
-        "can4HighMidAirMorph",
-        {"doorUnlockedAtNode": 3},
-        {"obstaclesNotCleared": ["B"]},
-        {"canShineCharge": {"usedTiles": 13, "openEnd": 1}}
+        "can4HighMidAirMorph"
       ],
       "unlocksDoors": [
         {"nodeId": 3, "types": ["missiles", "super"], "requires": []},
@@ -1392,8 +1392,6 @@
       "link": [5, 8],
       "name": "Temporary Blue Chain (In-Room)",
       "requires": [
-        "canChainTemporaryBlue",
-        "canXRayTurnaround",
         {"or": [
           {"and": [
             "can4HighMidAirMorph",
@@ -1425,7 +1423,9 @@
             ]},
             {"canShineCharge": {"usedTiles": 12, "openEnd": 1, "steepUpTiles": 7}}
           ]}
-        ]}
+        ]},
+        "canChainTemporaryBlue",
+        "canXRayTurnaround"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true,
@@ -1829,13 +1829,14 @@
       "name": "Temporary Blue Bounce (Phantoon Dead)",
       "requires": [
         "f_DefeatedPhantoon",
+        {"canShineCharge": {"usedTiles": 20, "openEnd": 1, "steepDownTiles": 4}},
+        "canTemporaryBlue",
         "canXRayTurnaround",
         "canSpringBallBounce",
         {"or": [
           "HiJump",
           "canChainTemporaryBlue"
-        ]},
-        {"canShineCharge": {"usedTiles": 20, "openEnd": 1, "steepDownTiles": 4}}
+        ]}
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true,
@@ -1851,10 +1852,10 @@
       "name": "Chain Temporary Blue Bounce (Phantoon Alive)",
       "requires": [
         "Morph",
+        {"canShineCharge": {"usedTiles": 16, "openEnd": 1, "steepDownTiles": 4}},
         "canChainTemporaryBlue",
         "canXRayTurnaround",
-        "canSpringBallBounce",
-        {"canShineCharge": {"usedTiles": 16, "openEnd": 1, "steepDownTiles": 4}}
+        "canSpringBallBounce"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true,
@@ -1868,10 +1869,10 @@
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess",
+        {"canShineCharge": {"usedTiles": 16, "openEnd": 0, "steepUpTiles": 4}},
         "canTemporaryBlue",
         "can4HighMidAirMorph",
-        "canSpringBallBounce",
-        {"canShineCharge": {"usedTiles": 16, "openEnd": 0, "steepUpTiles": 4}}
+        "canSpringBallBounce"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true
@@ -1883,8 +1884,8 @@
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess",
-        "canSpeedball",
-        {"getBlueSpeed": {"usedTiles": 14, "openEnd": 0, "steepUpTiles": 3}}
+        {"getBlueSpeed": {"usedTiles": 14, "openEnd": 0, "steepUpTiles": 3}},
+        "canSpeedball"
       ],
       "clearsObstacles": ["C"]
     }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -725,7 +725,7 @@
             "properties": {
               "frames": {
                 "type": "integer",
-                "minimum": 1,
+                "minimum": 0,
                 "title": "Shinespark Frames",
                 "description": "The duration (in frames) of the shinespark that must be executed. This defines the energy cost of the shinespark assuming it is not interrupted by running down to 29 energy."
               },

--- a/tech.json
+++ b/tech.json
@@ -2052,13 +2052,15 @@
             {"noFlashSuit": {}}
           ],
           "note": [
-            "Maintaining the desctructive capabilities of speedbooster after running has stopped.",
-            "Used to fall on top of breakable bomb blocks or enemies.",
-            "Performed by storing a spark while falling off a ledge, holding angle and crouching after storing a spark, or unmorphing."
+            "The ability to maintain a temporary blue state through any of the following methods:",
+            "1. Gaining a shinecharge while holding an angle button, and continuing to hold angle,",
+            "2. Entering a speedball and unmorphing while holding an angle button,",
+            "3. Sliding off a ledge while gaining a shinecharge,",
+            "4. Running, gaining blue speed, jumping into a mid-air morph, and unmorphing."
           ],
           "devNote": [
-            "This is not a momentum continuing action like canBlueSpaceJump",
-            "FIXME: It is possible to maintain a flash suit with temporary blue, if there was no shinecharge, i.e. after a speed ball. Strats that do this need to be rechecked."
+            "This is not a momentum continuing action like canBlueSpaceJump.",
+            "A requirement (or entrance condition) for gaining blue speed or a shinecharge must be included prior to this tech requirement."
           ],
           "extensionTechs": [
             {
@@ -2112,7 +2114,8 @@
             "canSuitlessMaridia"
           ],
           "otherRequires": [
-            "SpeedBooster"
+            "SpeedBooster",
+            {"noFlashSuit": {}}
           ],
           "note": [
             "Starting from an air environment, run into water and charge a spark in the water. This is typically done while crossing a door transition from a room with air physics to a room with water.",


### PR DESCRIPTION
This introduces more comprehensive checks relating to shinecharges, temporary blue, and shinesparks, and fixes issues in strats that were failing the new checks. The new checks involve tracking Samus' current possible states (shinecharged, blue, shinesparking) in the strat from top to bottom, starting with the entrance condition if applicable (or "startsWithShineCharge"), then the `requires`, and finally the exit condition if applicable (or "endsWithShineCharge"), ensuring that each point Samus is in an appropriate state for the given requirement or condition.

The way this works, the tests can now be picky about the order of the requirements; for example, a `canShinecharge` requirement would need to come before a corresponding `shinespark` requirement, rather than the other way around. Many of the fixes simply involve reordering the requirements in order to satisfy the stricter checks. Others involve just adding missing "h_canShineChargeMaxRunway" or "h_getBlueSpeedMaxRunway" requirements.

Cases where the fixes have a logically significant effect to some degree:

- Crateria Super Room: Strat 22, "X-Mode BlueSuit", was missing a shinespark requirement for the superjump. I added one with 7 shinespark frames, based on the video.
- Aqueduct: Strat 25, "Temporary Blue Chain (Come in Running)", was missing a "canWaterShineCharge" requirement.
- Halfie Climb: Strat 83, "Suitless Stutter Water Shinecharge, Leave With Temporary Blue", had a `shinespark` requirement which didn't belong.
- Kassiuz Room: Strat 10, "Shinespark Deep Stuck X-Ray Climb", wrongly had entrance condition "comeInWithDoorStuckSetup" instead of "comeInShinecharged".
- Screw Attack Room: Strat 104, "Come In Shinecharged, End Shinecharged (Screw Attack)" had "canTemporaryBlue" requirement which didn't belong
- Double Chamber: Strat 84, "Leave With Temporary Blue", was missing "leaveWithTemporaryBlue" exit condition.
- Crocomire's Room: Strat 51, "Use Flash Suit", had a "or" where an "and" should have been.
- Ice Beam Gate Room: Strat 38, "Come in Shinecharging", should have been "Come in Getting Blue Speed" (with "comeInGettingBlueSpeed").
- Grapple Beam Room: the "Shinespark Escape" strats are reworked to use "startsWithShineCharge"/"endsWithShineCharge" similarly to Screw Attack Room, removing the obstacle "A". This will affect the difficulty placement of some combinations of strats. It also fixes a soundness issue where it could have expected coming in shinecharging from the top door, grabbing the item, then sparking through the bottom door without accounting for the time required to open its lock (if it requires Missiles or Power Bombs to open).

Helpers are added to help separate water shinecharge & water blue speed strats, to more accurately account for when a flash suit can be maintained. 

A helper "h_shinechargeSlideTemporaryBlue" is also added. For now this is to help the tests handle Screw Attack Room, where a shinecharge is maintained simultaneously with temporary blue (whereas "canTemporaryBlue" would normally be interpreted by the tests as waiting out any shinecharge frames). Having this shinecharge slide helper might also help in identifying these strats in case later we might want to add a separate tech for this or modify its requirements.