### PR TITLE
Farm cycle schema and examples

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -204,6 +204,14 @@ __Example:__
 {"autoReserveTrigger": {}}
 ```
 
+#### cycleFrames object
+A `cycleFrames` object represents the need for Samus to spend time (measured as an amount of in-game frames) in a room as part of a farming cycle. Including a `cycleFrames` requirement is mandatory in farming strats with a [`farmCycleDrops`](strats.md#farm-cycle-drops) property. The `cycleFrames` can be used to determine how many cycles of a farm a player can reasonably be expected to perform, based on an assumed amount of "patience".
+
+__Example:__
+```json
+{"cycleFrames": 100}
+```
+
 #### heatFrames object
 A `heatFrames` object represents the need for Samus to spend time (measured in frames) in a heated room. This is meant to be converted to a flat health value based on item loadout. The vanilla damage for heated rooms is 1 damage every 4 frames, negated by Varia or Gravity Suit. The effect of Gravity suit on heat damage may be modified by randomizers. A `heatFrames` object implicitly includes a requirement `{"or": ["h_heatProof", "canHeatRun"]}`.
 
@@ -243,7 +251,7 @@ __Example:__
 
 #### shineChargeFrames object
 
-A `shineChargeFrames` object represents the need for Samus to have at least the given amount of shinecharge frames remaining. After this requirement, the new amount of shinecharge frames remaining is updated by subtracting away the given amount of frames.
+A `shineChargeFrames` object represents the need for Samus to have at least the given amount of shinecharge frames remaining. After this requirement, the new amount of shinecharge frames remaining is updated by subtracting away the given amount of frames. Including a `shineChargeFrames` requirement is mandatory for strats that begin with an already obtained shinecharge (e.g. with `comeInShinecharged`) or which end with an active shinecharge (e.g. with `leaveShinecharged`). For strats that both gain a shinecharge and consume it within the same strat, including `shineChargeFrames` requirements is optional.
 
 The underlying idea is that shinecharge frames can be modeled as a resource, similar to energy or ammo. The level of this resource can be considered to be part of Samus' state at any given point in time. However, unlike energy or ammo, this resource is not treated as persisting across arbitrary sequences of strats. Samus' shinecharge frames are considered to be set to 180 at the point of a `canShinecharge` requirement; but in order to persist across strats, the strat must either be marked with `"endsWithShineCharge": true` or have a `leavesShinecharged` exit condition, and the following strat must be marked with `"startsWithShineCharge": true` or have a `comeInShinecharged` entrance condition. These restrictions are necessary because strats in general do not model the amount of frames consumed, so it would be invalid to assume that Samus' shinecharge frames can remain unchanged across strats that are not designed to model shinecharge frames.
 

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -90,11 +90,26 @@
       "name": "Geemer Farm",
       "requires": [
         "h_ZebesIsAwake",
-        {"resetRoom": {
-          "nodes": [1, 2]
-        }},
-        {"partialRefill": {"type": "Missile", "limit": 10}},
-        {"partialRefill": {"type": "Energy", "limit": 100}}
+        {"or": [
+          {"and": [
+            {"resetRoom": {"nodes": [1, 2]}},
+            {"frames": 150}
+          ]},
+          {"and": [
+            "Morph",
+            {"resetRoom": {"nodes": [3]}},
+            {"or": [
+              {"frames": 510},
+              {"and": [
+                "Wave",
+                {"frames": 340}
+              ]}
+            ]}
+          ]}
+        ]}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Geemer (blue)", "count": 2}
       ]
     },
     {

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -93,16 +93,16 @@
         {"or": [
           {"and": [
             {"resetRoom": {"nodes": [1, 2]}},
-            {"frames": 150}
+            {"cycleFrames": 150}
           ]},
           {"and": [
             "Morph",
             {"resetRoom": {"nodes": [3]}},
             {"or": [
-              {"frames": 510},
+              {"cycleFrames": 510},
               {"and": [
                 "Wave",
-                {"frames": 340}
+                {"cycleFrames": 340}
               ]}
             ]}
           ]}

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2537,9 +2537,11 @@
       "link": [13, 13],
       "name": "Zeb Farm",
       "requires": [
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"frames": 105}
       ],
-      "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
+      "farmCycleDrops": [
+        {"enemy": "Zeb", "count": 1}
+      ]
     },
     {
       "id": 119,

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2537,7 +2537,7 @@
       "link": [13, 13],
       "name": "Zeb Farm",
       "requires": [
-        {"frames": 105}
+        {"cycleFrames": 105}
       ],
       "farmCycleDrops": [
         {"enemy": "Zeb", "count": 1}

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -94,6 +94,14 @@ The `viewableNodes` property is an array of objects, each of which describing ho
 #### yields
 The `yields` property is an array of game flags that are activated when interacting with a node. Just like interacting with any other node type, this requires having no active lock on the node and fulfilling any interaction requirements.
 
+#### farmCycleDrops
+A `farmCycleDrops` is an array of objects describing a set of enemies that can be farmed as part of executing this strat. Each object has the following properties:
+
+* _enemy_: The name of an enemy from which drops can be collected.
+* _count_: The amount of drops which can be collected from the given enemy, during one cycle.
+
+A strat with this property should begin and end at the same node, representing one cycle of a farm. The strat should include `cycleFrames` requirements to specify the amount of time required to execute the farm cycle. If the farm involves resetting the room in order to respawn the enemies after collecting their drops, then this should be indicated by including a `resetRoom` requirement, in which case any requirements needed for reaching the door and returning to the starting/ending node should be included. Only in-room time should be included; i.e. time spent in the door transition or in the other room on the other side of the door should not be included. Only frames that are part of the farming cycle need to be included in `cycleFrames`; i.e., in a case where the starting/ending node may not precisely coincide with the farm location, frames would not need to be included for reaching the farm from the starting node on the first cycle, nor for returning to the ending node after the last cycle.
+
 #### twinDoorAddresses
 A door node is considered to have a twin when the game has two sections that are visually identical, but are separate in the game's memory. The player will not know during gameplay that the two twin doors aren't actually the same. Both twins lead to the same destination door, but that destination door only ever leads to one of the twins, with the other only being reachable from within its room. An example (and the only known one currently) is East Pants Room, which has a another version of itself within Pants Room.
 

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -242,6 +242,12 @@
               }
             }
           },
+          "cycleFrames": {
+            "type": "integer",
+            "minimum": 0,
+            "title": "Cycle Frames",
+            "description": "Fulfilled by spending an amount of time in a room, measured in in-game frames, as part of a farming cycle."
+          },
           "heatFrames": {
             "type": "integer",
             "minimum": 0,

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1181,6 +1181,26 @@
           "title": "Keeps Shinecharge",
           "description": "If true, indicates that this strat ends with shinecharge frames remaining, which can be used in a subsequent strat."
         },
+        "farmCycleDrops": {
+          "type": "array",
+          "description": "A list of enemy drops which may be collected as part of executing this strat.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enemy": {
+                "type": "string",
+                "title": "Enemy Name",
+                "description": "The name of an enemy that drops can be collected from, as found in the enemies file."
+              },
+              "count": {
+                "type": "integer",
+                "title": "Count",
+                "description": "The number of drops that can be collected from this enemy by executing this strat."
+              }
+            }
+          }
+        },
         "flashSuitChecked": {
           "type": "boolean",
           "title": "Flash Suit Checked",


### PR DESCRIPTION
This is a proposed schema for a new way of representing farming strats, along with a couple examples.

I tried to be relatively accurate in these examples, but in general I think that for `cycleFrames` it is not so important to have the frame counts be tight compared to `heatFrames`. In the end, all these numbers are going to have a "patience" factor applied, which is somewhat arbitrary anyway.

Unrelated to the main change in the PR, I also added a little clarification to the `shineChargeFrames` doc.