### PR TITLE
Wrecked Ship Main Shaft break bomb block with Ice and Screw

### DIFF
--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -861,11 +861,68 @@
         {"obstaclesNotCleared": ["B"]},
         {"canShineCharge": {"usedTiles": 13, "openEnd": 1}}
       ],
+      "clearsObstacles": ["C"],
       "unlocksDoors": [
         {"nodeId": 3, "types": ["missiles", "super"], "requires": []},
         {"nodeId": 3, "types": ["powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [3, 8],
+      "name": "Atomic Ice Moonfall Screw Clip",
+      "requires": [
+        {"notable": "Atomic Ice Moonfall Screw Clip"},
+        "f_DefeatedPhantoon",
+        {"enemyDamage": {"enemy": "Atomic", "type": "contact", "hits": 1}},
+        "canUseIFrames",
+        "canTrickyUseFrozenEnemies",
+        "canEnemyStuckMoonfall",
+        "ScrewAttack",
+        "Morph"
+      ],
+      "clearsObstacles": ["C"],
+      "note": [
+        "Freeze an Atomic near the bottom of the stairs above the bomb block, so that it is barely off-camera when Samus drops down.",
+        "Below, prepare a second Atomic to be frozen.",
+        "As it approaches, jump up to cause the upper Atomic to come on-camera and descend.",
+        "Take a hit from the lower Atomic, and freeze it about 1.5 tiles above the floor;",
+        "use the i-frames to jump on top of the lower Atomic and freeze the upper Atomic while it is inside Samus' head.",
+        "Immediately moonfall to the left.",
+        "If successful, Samus will clip two tiles into the floor.",
+        "Turn to the right, and perform a turnaround spin jump to the left to break the bomb block using Screw Attack.",
+        "If Samus clips through the Atomics but does not clip into the floor, it means the bottom Atomic was frozen too low.",
+        "If Samus clips only one tile into the floor, it means the bottom Atomic was frozen too high."
+      ]
+    },
+    {
+      "link": [3, 8],
+      "name": "Covern Wall Ice Screw Clip",
+      "requires": [
+        {"notable": "Covern Wall Ice Screw Clip"},
+        {"not": "f_DefeatedPhantoon"},
+        {"or": [
+          "canRiskPermanentLossOfAccess",
+          {"and": [
+            {"notable": "Atomic Ice Moonfall Screw Clip"},
+            {"enemyDamage": {"enemy": "Atomic", "type": "contact", "hits": 1}}
+          ]}
+        ]},
+        "canWallIceClip",
+        "ScrewAttack",
+        "Morph"
+      ],
+      "clearsObstacles": ["C"],
+      "note": [
+        "Damage a Covern to prepare it to be frozen.",
+        "Stand a few tiles away from the bomb block, and walk toward it as the Covern is about to reappear.",
+        "If successful, the Covern will spawn inside the wall but close enough that Samus can clip into it.",
+        "Freeze the Covern by pressing against the wall, then jumping and shooting down.",
+        "Run into the wall with as much speed as possible to clip into it.",
+        "Once Samus is clipped into the wall, perform a low turnaround spin jump to the right and immediately turn back to the left while still spinning,",
+        "using Screw Attack to break the bomb block.",
+        "If Phantoon is already dead, a moonfall with two frozen Atomics can instead be used to clip into the floor to be able to break the bomb block."
+      ]
     },
     {
       "id": 43,
@@ -1898,7 +1955,25 @@
         "Use the Covern to partial ceiling clip so your beam can reach the shot block of the ceiling at the end of the Morph tunnel to the left.",
         "It is possible to mid-air morph to get into the morph tunnel with nothing, from the Covern, the ground, or the stairs below."
       ]
+    },
+    {
+      "id": 2,
+      "name": "Atomic Ice Moonfall Screw Clip",
+      "note": [
+        "Use a stuck moonfall inside two frozen Atomics to clip two tiles into the floor.",
+        "Face right, then do a turn-around spin jump to the left to break the bomb block using Screw Attack."
+      ]
+    },
+    {
+      "id": 3,
+      "name": "Covern Wall Ice Screw Clip",
+      "note": [
+        "Walk toward the wall to cause a Covern to spawn inside it.",
+        "Jump and shoot down to freeze it.",
+        "Run against the wall to clip inside it.",
+        "Perform a turnaround spin jump to the right, then immediately turn back to the left, to break the bomb block with Screw Attack."
+      ]
     }
   ],
-  "nextNotableId": 2
+  "nextNotableId": 4
 }

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -908,6 +908,7 @@
             {"enemyDamage": {"enemy": "Atomic", "type": "contact", "hits": 1}}
           ]}
         ]},
+        "canMidairWiggle",
         "canWallIceClip",
         "ScrewAttack",
         "Morph"


### PR DESCRIPTION
Bobbob showed us these a while ago.

This also fixes the "Temporary Blue Chain (In-Room)" strat to clear the bomb block obstacle.

Videos:
- Atomic Ice Moonfall Screw Attack Clip: https://videos.maprando.com/video/2359
- Covern Wall Ice Screw Clip: https://videos.maprando.com/video/2365
