### PR TITLE
West Ocean speedy HiJump to top item

### DIFF
--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -2253,6 +2253,15 @@
       ]
     },
     {
+      "link": [12, 9],
+      "name": "Speedy HiJump",
+      "requires": [
+        "SpeedBooster",
+        "HiJump",
+        "canCarefulJump"
+      ]
+    },
+    {
       "id": 108,
       "link": [12, 9],
       "name": "Slow Tripper Ride",


### PR DESCRIPTION
In Map Rando, with HiJump getting to the item is already in Basic logic by riding Trippers. Still, the speedy jump is much faster and commonly useful so it seems worth including; it also avoids the `canUseEnemies` requirement.

Video by SamLittlehorns: https://videos.maprando.com/video/2430
