### PR TITLE
West Ocean respawning shot block moondance

### DIFF
--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -2271,6 +2271,29 @@
       "flashSuitChecked": true
     },
     {
+      "link": [12, 13],
+      "name": "Respawning Shot Block Moondance",
+      "requires": [
+        {"notable": "Respawning Shot Block Moondance"},
+        "canExtendedMoondance",
+        "canBeExtremelyPatient"
+      ],
+      "note": [
+        "Perform 176 moonfalls using the respawning shot block:",
+        "after each moonfall, destroy the shot block (aiming up with angle up + angle down) and press forward to stand up;",
+        "wait for the shot block to respawn before performing the next moonfall.",
+        "On the 176th moonfall, Samus will sink a tile into the floor.",
+        "Use Grapple to stand back up and perform 146 more moonfalls using the respawning shot block.",
+        "On the 146th moonfall, Samus will sink 2 tiles into the floor.",
+        "From here, continue using Grapple to stand up and perform another 145 moonfalls, but now without needing to use the shot block.",
+        "After clipping 2 tiles into the floor with the 145th moonfall, unequip Grapple and perform a final 146th moonfall from 2 tiles deep in the floor to clip past 3 more tiles and reach the bottom of the room.",
+        "Note that exact counting needed here: losing count and performing the 146th moonfall from the surface would cause Samus to clip 3 tiles into the floor and be stuck in a crouched state,",
+        "unable to stand back up with Grapple nor able to perform the final moonfall needed to clip the rest of the way down;",
+        "conversely, performing a moonfall early from 2 tiles deep, before gaining enough speed, will result in Samus only clipping down through a total of 4 tiles, again resulting in a softlock.",
+        "This strat takes approximately 45 minutes to execute."
+      ]
+    },
+    {
       "id": 110,
       "link": [12, 14],
       "name": "Base",
@@ -2840,7 +2863,16 @@
         "To overload the PLMs, place a PB precisely to the right of the bottom of the second overhang above the door to the Moat.",
         "This is at the max jump height without HiJump. Placing the PB higher or lower will not overload the PLMs without many PBs."
       ]
+    },
+    {
+      "id": 13,
+      "name": "Respawning Shot Block Moondance",
+      "note": [
+        "Use the respawning shot block and Grapple to perform a moondance gaining enough fall speed to clip through 3 tiles.",
+        "This requires a total of 468 moonfalls, taking approximately 45 minutes to execute.",
+        "Exact counting is required, to ensure that the final moonfall (clipping through 3 tiles) is performed from 2 tiles deep in the floor."
+      ]
     }
   ],
-  "nextNotableId": 13
+  "nextNotableId": 14
 }


### PR DESCRIPTION
This is what bobbob called the "World's Stupidest Moondance". In Map Rando I'm planning to make this an Ignored notable since it takes 45 minutes, exceeding even the patience threshold for Beyond (roughly 10-15 minutes).

- Video by Sam: https://videos.maprando.com/video/2311
- Original video by bobbob: https://vimeo.com/815466837