### PR TITLE
Upper Norfair Farming Room simple strats

### DIFF
--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -863,6 +863,27 @@
       ]
     },
     {
+      "link": [5, 4],
+      "name": "Damage Boost",
+      "requires": [
+        "canNeutralDamageBoost",
+        {"enemyDamage": {"enemy": "Gamet", "type": "contact", "hits": 1}},
+        {"heatFrames": 350}
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "A damage boost allows getting up without a crouch jump, e.g. to preserve a flash suit."
+      ]
+    },
+    {
+      "link": [5, 4],
+      "name": "Spring Ball Jump",
+      "requires": [
+        "canSpringBallJumpMidAir",
+        {"heatFrames": 120}
+      ]
+    },
+    {
       "id": 42,
       "link": [5, 5],
       "name": "Wave Beam the Gate",


### PR DESCRIPTION
This adds a couple simple strats which were missing in Upper Norfair Farming Room for getting up to the top of the room from the bottom:

Videos:
- Damage Boost: https://videos.maprando.com/video/2456
- Spring Ball Jump: https://videos.maprando.com/video/2457

This was prompted by Sam's video for the spring ball jump (https://videos.maprando.com/video/2397).