### PR TITLE
Some tricky Bat Cave bottom-to-top strats

### DIFF
--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -186,14 +186,19 @@
           {"and": [
             "canWalljump",
             {"heatFrames": 180}
-          ]}          
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 195}
+          ]}
         ]}
       ],
       "note": [
         "Enter the room with a Missile selected on auto-cancel, holding angle-up.",
         "Fire a Missile shot to kill the first Skree, then run right and immediately fire a beam shot to destroy the shot block.",
         "Run off the edge and down-grab onto the next platform.",
-        "Run and jump directly up where the shot block used to be, moving quickly enough to dodge the Skree projectiles by going under them."
+        "Run and jump directly up where the shot block used to be, moving quickly enough to dodge the Skree projectiles by going under them.",
+        "Use a wall jump, HiJump, or a mid-air spring ball jump to make it up."
       ]
     },
     {

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -144,6 +144,34 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Tricky HiJump",
+      "requires": [
+        "HiJump",
+        "canTrickyJump",
+        {"heatFrames": 200}
+      ],
+      "note": [
+        "Shoot the Skree and shotblock from the door.",
+        "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be,",
+        "performing a mid-air spring ball jump to make it up to the ledge."  
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Tricky Spring Ball Jump",
+      "requires": [
+        "canTrickySpringBallJump",
+        "canTrickyJump",
+        {"heatFrames": 240}
+      ],
+      "note": [
+        "Shoot the Skree and shotblock from the door.",
+        "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be,",
+        "performing a mid-air spring ball jump to make it up to the ledge."  
+      ]
+    },
+    {
       "id": 5,
       "link": [1, 2],
       "name": "Jump into Respawning Block",

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -171,6 +171,32 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Auto Cancel Missile Tricky Dodge",
+      "requires": [
+        "canAutoCancelWeapon",
+        {"ammo": {"type": "Missile", "count": 1}},
+        "canTrickyDodgeEnemies",
+        "canInsaneJump",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 160}    
+          ]},
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 180}
+          ]}          
+        ]}
+      ],
+      "note": [
+        "Enter the room with a Missile selected on auto-cancel, holding angle-up.",
+        "Fire a Missile shot to kill the first Skree, then run right and immediately fire a beam shot to destroy the shot block.",
+        "Run off the edge and down-grab onto the next platform.",
+        "Run and jump directly up where the shot block used to be, moving quickly enough to dodge the Skree projectiles by going under them."
+      ]
+    },
+    {
       "id": 5,
       "link": [1, 2],
       "name": "Jump into Respawning Block",

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -153,7 +153,7 @@
       ],
       "note": [
         "Shoot the Skree and shotblock from the door.",
-        "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be.",
+        "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be."
       ]
     },
     {

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -113,10 +113,20 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "canTrickyUseFrozenEnemies",
           "canSpringBallJumpMidAir"
         ]},
         {"heatFrames": 350}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Frozen Skree",
+      "requires": [
+        "canTrickyUseFrozenEnemies",
+        {"heatFrames": 260}
+      ],
+      "note": [
+        "Freeze the middle Skree mid-air to use it as a platform."
       ]
     },
     {

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -153,8 +153,7 @@
       ],
       "note": [
         "Shoot the Skree and shotblock from the door.",
-        "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be,",
-        "performing a mid-air spring ball jump to make it up to the ledge."  
+        "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be.",
       ]
     },
     {


### PR DESCRIPTION
This splits off the "Frozen Skree" strat from the base strat, and tightens the heat frames on other variants of the Base strat by adding "tricky" versions. 

Videos:
- Frozen Skree - With Varia (by Sam): https://videos.maprando.com/video/2395
- Frozen Skree - Suitless: https://videos.maprando.com/video/2458
- Tricky HiJump: https://videos.maprando.com/video/2462
- Tricky Spring Ball Jump: https://videos.maprando.com/video/2461