### PR TITLE
Some Crateria farms

### DIFF
--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -2130,21 +2130,44 @@
       "name": "Space Pirate Farm",
       "requires": [
         "h_ZebesIsAwake",
-        {"resetRoom": {
-          "nodes": [1, 5]
-        }},
-        {"refill": ["Energy", "Missile"]},
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",
           {"obstaclesNotCleared": ["B"]}
+        ]},
+        {"or": [
+          {"and": [
+            {"resetRoom": {"nodes": [1]}},
+            {"cycleFrames": 2350}
+          ]},
+          {"and": [
+            {"resetRoom": {"nodes": [2]}},
+            {"or": [
+              "h_canUseMorphBombs",
+              "ScrewAttack"
+            ]},
+            {"cycleFrames": 2270}
+          ]},
+          {"and": [
+            {"resetRoom": {"nodes": [3]}},
+            "h_canUseMorphBombs",
+            {"cycleFrames": 2695}
+          ]},
+          {"and": [
+            {"resetRoom": {"nodes": [4]}},
+            "h_canUseMorphBombs",
+            {"cycleFrames": 2480}
+          ]},
+          {"and": [
+            {"resetRoom": {"nodes": [5]}},
+            {"cycleFrames": 1905}
+          ]}
         ]}
       ],
-      "resetsObstacles": ["A", "B"],
-      "devNote": [
-        "The Space Pirates (wall) drop Supers and Power Bombs each at a 0.4% rate, too low to put into logic.",
-        "FIXME: Other nodes could be used to reset the room, with additional requirements."
-      ]
+      "farmCycleDrops": [
+        {"enemy": "Grey Space Pirate (wall)", "count": 11}
+      ],
+      "resetsObstacles": ["A", "B"]
     },
     {
       "id": 104,

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -2167,7 +2167,10 @@
       "farmCycleDrops": [
         {"enemy": "Grey Space Pirate (wall)", "count": 11}
       ],
-      "resetsObstacles": ["A", "B"]
+      "resetsObstacles": ["A", "B"],
+      "devNote": [
+        "FIXME: Shinesparking can also be a viable option, in case it is patched to not cost energy."
+      ]
     },
     {
       "id": 104,

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -86,24 +86,37 @@
       "link": [1, 1],
       "name": "Alcoon Farm",
       "requires": [
-        {"or": [
-          "canDodgeWhileShooting",
-          "ScrewAttack",
-          "Wave",
-          "Ice",
-          "Spazer",
-          "Plasma"
-        ]},
         {"resetRoom": {
           "nodes": [1]
         }},
-        {"refill": ["PowerBomb"]}
+        {"or": [
+          {"and": [
+            "ScrewAttack",
+            {"cycleFrames": 575}
+          ]},
+          {"and": [
+            "Plasma",
+            {"cycleFrames": 650}
+          ]},
+          {"and": [
+            {"or": [
+              "Wave",
+              "Spazer"
+            ]},
+            {"cycleFrames": 1000}
+          ]},
+          {"and": [
+            {"or": [
+              "canDodgeWhileShooting",
+              "Ice"
+            ]},
+            {"cycleFrames": 1210}
+          ]}
+        ]}
       ],
+      "farmCycleDrops": [{"enemy": "Alcoon", "count": 3}],
       "note": [
         "The Alcoons have a 99.5% Power Bomb drop rate, after which they only drop small energy."
-      ],
-      "devNote": [
-        "The energy dropped is too low even for a very patient strat, considering worst-case scenarios such as a neighboring heated room, no beams, and the possible need to refill several tanks worth of energy."
       ]
     },
     {

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -91,7 +91,10 @@
         }},
         {"or": [
           {"and": [
-            "ScrewAttack",
+            {"or": [
+              "ScrewAttack",
+              {"ammo": {"type": "Missile", "count": 3}}  
+            ]},
             {"cycleFrames": 575}
           ]},
           {"and": [

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -199,7 +199,18 @@
             ]},
             {"cycleFrames": 420}
           ]},
-          {"cycleFrames": 610}
+          {"and": [
+            {"or": [
+              "canDodgeWhileShooting",
+              "Spazer",
+              "Wave"
+            ]},
+            {"cycleFrames": 610}
+          ]},
+          {"and": [
+            {"cycleFrames": 800},
+            {"enemyDamage": {"enemy": "Mellow", "type": "contact", "hits": 2}}
+          ]}
         ]}
       ],
       "farmCycleDrops": [

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -180,10 +180,30 @@
       "link": [1, 1],
       "name": "Mellow Farm",
       "requires": [
-        {"resetRoom": {
-          "nodes": [1, 2]
-        }},
-        {"refill": ["Energy", "Missile"]}
+        {"or": [
+          {"resetRoom": {
+            "nodes": [1]
+          }},
+          {"and": [
+            {"resetRoom": {
+              "nodes": [2]
+            }},
+            {"cycleFrames": 50}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            {"or": [
+              "ScrewAttack",
+              "Plasma"
+            ]},
+            {"cycleFrames": 420}
+          ]},
+          {"cycleFrames": 610}
+        ]}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Mellow", "count": 12}
       ]
     },
     {

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -416,16 +416,38 @@
     {
       "id": 19,
       "link": [2, 2],
-      "name": "Space Pirate Farm",
+      "name": "Space Pirate Farm (Both Doors)",
       "requires": [
         "Morph",
         "Missile",
-        {"resetRoom": {
-          "nodes": [1, 2]
-        }},
-        {"refill": ["Energy", "Missile"]}
+        {"resetRoom": {"nodes": [1]}},
+        {"resetRoom": {"nodes": [2]}},
+        {"cycleFrames": 930}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Grey Space Pirate (standing)", "count": 8},
+        {"enemy": "Grey Space Pirate (wall)", "count": 2}
       ],
       "resetsObstacles": ["A"]
+    },
+    {
+      "link": [2, 2],
+      "name": "Space Pirate Farm (Single Door)",
+      "requires": [
+        "Morph",
+        "Missile",
+        {"or": [
+          {"resetRoom": {"nodes": [1]}},
+          {"resetRoom": {"nodes": [2]}}  
+        ]},
+        {"cycleFrames": 930}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Grey Space Pirate (standing)", "count": 4},
+        {"enemy": "Grey Space Pirate (wall)", "count": 1}
+      ],
+      "resetsObstacles": ["A"],
+      "note": "This strat is slower but only requires one of the two doors to be unlocked."
     },
     {
       "id": 20,

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -259,7 +259,7 @@
           {"and": [
             "canUseGrapple",
             {"cycleFrames": 740}
-          ]},
+          ]}
         ]}
       ],
       "farmCycleDrops": [
@@ -300,7 +300,7 @@
           {"and": [
             "canUseGrapple",
             {"cycleFrames": 370}
-          ]},
+          ]}
         ]}
       ],
       "farmCycleDrops": [

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -228,12 +228,81 @@
     {
       "id": 9,
       "link": [1, 1],
-      "name": "Waver and Choot Farm",
+      "name": "Waver and Choot Farm (Both Doors)",
       "requires": [
-        {"resetRoom": {
-          "nodes": [1, 2]
-        }},
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"resetRoom": {"nodes": [1]}},
+        {"resetRoom": {"nodes": [2]}},
+        {"or": [
+          {"and": [
+            "ScrewAttack",
+            {"cycleFrames": 990}
+          ]},
+          {"and": [
+            "Plasma",
+            {"cycleFrames": 620}
+          ]},
+          {"and": [
+            "Wave",
+            {"cycleFrames": 920}
+          ]},
+          {"and": [
+            "Spazer",
+            {"cycleFrames": 1010}
+          ]},
+          {"and": [
+            {"or": [
+              "canDodgeWhileShooting",
+              "Ice"
+            ]},
+            {"cycleFrames": 1740}
+          ]}
+        ]}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Waver", "count": 6},
+        {"enemy": "Choot", "count": 6}
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Waver and Choot Farm (Single Door)",
+      "requires": [
+        {"resetRoom": {"nodes": [1, 2]}},
+        {"cycleFrames": 100},
+        {"or": [
+          {"and": [
+            "ScrewAttack",
+            {"cycleFrames": 495}
+          ]},
+          {"and": [
+            "Plasma",
+            {"cycleFrames": 310}
+          ]},
+          {"and": [
+            "Wave",
+            {"cycleFrames": 460}
+          ]},
+          {"and": [
+            "Spazer",
+            {"cycleFrames": 505}
+          ]},
+          {"and": [
+            {"or": [
+              "canDodgeWhileShooting",
+              "Ice"
+            ]},
+            {"cycleFrames": 870}
+          ]}
+        ]}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Waver", "count": 3},
+        {"enemy": "Choot", "count": 3}
+      ],
+      "devNote": [
+        "The 100 extra cycleFrames is an average extra time needed to return back to the entry door rather than continuing to the opposite door.",
+        "For simplicity, the weapon-specific cycleFrames are exactly half those in the 'Both Doors' variant,",
+        "even though technically some weapons may be affected slightly more than others by having to use a specific door."
       ]
     },
     {

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -255,7 +255,11 @@
               "Ice"
             ]},
             {"cycleFrames": 1740}
-          ]}
+          ]},
+          {"and": [
+            "canUseGrapple",
+            {"cycleFrames": 740}
+          ]},
         ]}
       ],
       "farmCycleDrops": [
@@ -292,7 +296,11 @@
               "Ice"
             ]},
             {"cycleFrames": 870}
-          ]}
+          ]},
+          {"and": [
+            "canUseGrapple",
+            {"cycleFrames": 370}
+          ]},
         ]}
       ],
       "farmCycleDrops": [


### PR DESCRIPTION
I went ahead and put videos for these farm strats on https://videos.maprando.com, since I needed to do testing anyway to get `cycleFrames` values. They're not optimized as heavily as heat frames but I wanted them to be at least somewhat reasonable.

In cases where it seemed important, I included a "Both Doors" variant that resets the room twice, at opposite ends of the room. In this case the enemy drop counts are doubled, cycle frames are the total for traversing both directions, and it's understood that the randomizer will add extra `cycleFrames` for each `resetRoom` requirement to account for the time taken by the door transitions.