### PR TITLE
Add missing spike hit req for red brin firefleas x-mode

### DIFF
--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -454,7 +454,7 @@
         {"obstaclesCleared": ["A"]},
         "canMidairShinespark",
         "canXMode",
-        {"spikeHits": 1},
+        {"spikeHits": 2},
         "h_canShineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 146}},


### PR DESCRIPTION
I don't believe this would be possible with only 1 spike hit. 