### PR TITLE
Add missing HiJump req to Bomb Boost Spring Ball Jump

### DIFF
--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -1372,6 +1372,7 @@
       "link": [4, 5],
       "name": "Bomb Boost Spring Ball Jump",
       "requires": [
+        "HiJump",
         "canSpringBallBombJump",
         {"tech": "canBombHorizontally"},
         "canTrickyJump"


### PR DESCRIPTION
Without HiJump, this is coming up almost 2 tiles short.

![image](https://github.com/user-attachments/assets/8fdeef7b-367c-444f-b474-3bd5d8c90ec9)
