### PR TITLE
Script to import map tile data from room_geometry.json

### DIFF
--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1438,6 +1438,18 @@
         }
       }
     },
+    "mapTileMask": {
+      "type": "array",
+      "title": "Room map tile mask",
+      "description": "Map tiles which are accessible in normal ways (excluding X-ray climbing, etc.)",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "integer",
+          "enum": [0, 1]
+        }
+      }
+    },
     "nodes": {
       "type": "array",
       "title": "Nodes; Doors, Elevators, Item Locations, etc",

--- a/scripts/format_json.py
+++ b/scripts/format_json.py
@@ -3,7 +3,7 @@
 import json
 
 # Keys whose values should always be expanded to separate lines
-non_one_line_keys = {"requires", "techRequires", "otherRequires", "and", "or", "to", "id"}
+non_one_line_keys = {"requires", "techRequires", "otherRequires", "and", "or", "to", "id", "mapTileMask"}
 
 # Keys whose children are exceptions to the rule about `non_one_line_keys`
 one_line_parent_keys = {"unlocksDoors"}

--- a/scripts/migrations/import_map_tile_mask.py
+++ b/scripts/migrations/import_map_tile_mask.py
@@ -1,0 +1,32 @@
+import argparse
+import json
+from pathlib import Path
+
+import format_json
+
+parser = argparse.ArgumentParser(
+    'import_map_tile_mask',
+    'Import mapTileMask data from Map Rando room_geometry.json')
+parser.add_argument('room_geometry_path', type=str)
+args = parser.parse_args()
+
+room_geom_list = json.load(open(args.room_geometry_path, "r"))
+room_geom_by_addr = {room["rom_address"]: room for room in room_geom_list}
+
+for path in sorted(Path("../region/").glob("**/*.json")):
+    room_json = json.load(path.open("r"))
+    if room_json.get("$schema") != "../../../schema/m3-room.schema.json":
+        continue
+
+    addr = int(room_json["roomAddress"], 16)
+    if addr not in room_geom_by_addr:
+        print("Skipping", path)
+        continue
+    print("Processing", path)
+    room_geom = room_geom_by_addr[addr]
+    room_json["mapTileMask"] = room_geom["map"]
+
+    new_room_json = format_json.format(room_json, indent=2)
+
+    # Write the auto-formatted output:
+    path.write_text(new_room_json)


### PR DESCRIPTION
This is the starting point for a project to include map-tile data in `sm-json-data`. I'm using a script here to import the data from the Map Rando [room_geometry.json](https://github.com/blkerby/MapRandomizer/blob/6177311d46d36f1da6b2fc4702d240b2c8c7c145/room_geometry.json). I'll open a second PR committing the results of executing the script (#1849).

After this a few rooms will need to be manually added as they were not included in `room_geometry.json`: all Ceres rooms, Homing Geemer Room, and East Pants Room.

Next steps in the project then include:
- Importing node-level map-tile data. This data is used in the Map Rando spoiler map to determine which map tiles to highlight on each step. Currently this data often gets broken, whenever nodes are added, deleted, or redefined. It will be easier to maintain as part of the `sm-json-data` project, since then the node map-tile data can be updated at the same time as corresponding node logic changes, and tests can be used to ensure it is kept complete. This data can also have applications to other projects.
- Adding more data to describe features of each map tile, including walls, passages, doors, elevators, slopes, and items. The idea would be to include enough detail to make it possible to render the map tiles in either their vanilla form or their Map Rando form. Having this data in a structured format can help in removing Map Rando's dependence on the ROM during seed generation.