### PR TITLE
Make auto-formatting sort object properties by schema order

### DIFF
--- a/schema/m3-note.schema.json
+++ b/schema/m3-note.schema.json
@@ -9,14 +9,20 @@
       "title": "Note field",
       "description": "Additional details or explanations, intended for users who want to understand an element in the model.",
       "default": "",
-      "pattern": "^(.*)$"
+      "pattern": "^(.*)$",
+      "items": {
+        "type": "string"
+      }
     },
     "devNote": {
       "type": ["string", "array"],
       "title": "Dev Note field",
       "description": "Additional details or explanations, intended for developers of the model.",
       "default": "",
-      "pattern": "^(.*)$"
+      "pattern": "^(.*)$",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1772,67 +1772,6 @@
         }
       }
     },
-    "links": {
-      "type": "array",
-      "title": "Links; pathways within the Room",
-      "items": {
-        "type": "object",
-        "title": "Link",
-        "required": [
-          "from",
-          "to"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "from": {
-            "type": "integer",
-            "title": "This Link originates at this Node ID within the Room",
-            "default": 0,
-            "examples": [
-              1
-            ]
-          },
-          "to": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "title": "This Link terminates at this Node ID within the Room",
-            "items": {
-              "type": "object",
-              "title": "The Items Schema",
-              "required": [
-                "id"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "id": {
-                  "type": "integer",
-                  "title": "Target Node ID within the Room",
-                  "examples": [
-                    2
-                  ]
-                },
-                "note": {
-                  "$ref" : "m3-note.schema.json#/definitions/note"
-                },
-                "devNote": {
-                  "$ref" : "m3-note.schema.json#/definitions/devNote"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "strats": {
-      "type": "array",
-      "title": "Room Strats",
-      "description": "An array of strats that can be used in this room.",
-      "items": {
-        "$ref": "#/definitions/strat"
-      }
-    },
     "obstacles": {
       "type": "array",
       "title": "Obstacles; Things that block your way and can be destroyed, not respawning until the room is reset",
@@ -1989,6 +1928,67 @@
             "$ref" : "m3-note.schema.json#/definitions/devNote"
           }
         }
+      }
+    },
+    "links": {
+      "type": "array",
+      "title": "Links; pathways within the Room",
+      "items": {
+        "type": "object",
+        "title": "Link",
+        "required": [
+          "from",
+          "to"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "from": {
+            "type": "integer",
+            "title": "This Link originates at this Node ID within the Room",
+            "default": 0,
+            "examples": [
+              1
+            ]
+          },
+          "to": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "title": "This Link terminates at this Node ID within the Room",
+            "items": {
+              "type": "object",
+              "title": "The Items Schema",
+              "required": [
+                "id"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "title": "Target Node ID within the Room",
+                  "examples": [
+                    2
+                  ]
+                },
+                "note": {
+                  "$ref" : "m3-note.schema.json#/definitions/note"
+                },
+                "devNote": {
+                  "$ref" : "m3-note.schema.json#/definitions/devNote"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "strats": {
+      "type": "array",
+      "title": "Room Strats",
+      "description": "An array of strats that can be used in this room.",
+      "items": {
+        "$ref": "#/definitions/strat"
       }
     },
     "notables": {

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -2023,7 +2023,10 @@
             "title": "Strat Description",
             "description": "A common description for all strats that use this notable",
             "default": "",
-            "pattern": "^(.*)$"
+            "pattern": "^(.*)$",
+            "items": {
+              "type": "string"
+            }
           },
           "devNote": {
             "$ref" : "m3-note.schema.json#/definitions/devNote"

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1657,15 +1657,15 @@
                     "$ref" : "#/definitions/strat"
                   }
                 },
+                "yields": {
+                  "$ref" : "#/definitions/yields",
+                  "description": "A list of flags that are activated by unlocking with this lock."
+                },
                 "note": {
                   "$ref" : "m3-note.schema.json#/definitions/note"
                 },
                 "devNote": {
                   "$ref" : "m3-note.schema.json#/definitions/devNote"
-                },
-                "yields": {
-                  "$ref" : "#/definitions/yields",
-                  "description": "A list of flags that are activated by unlocking with this lock."
                 }
               }
             }

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1379,12 +1379,6 @@
       ],
       "pattern": "^(.*)$"
     },
-    "note": {
-      "$ref" : "m3-note.schema.json#/definitions/note"
-    },
-    "devNote": {
-      "$ref" : "m3-note.schema.json#/definitions/devNote"
-    },
     "roomAddress": {
       "type": "string",
       "title": "Room Address",
@@ -2043,6 +2037,12 @@
       "type": "integer",
       "title": "Next Notable ID",
       "description": "Identifier for the next notable ID to be sequentially assigned within the room."
+    },
+    "note": {
+      "$ref" : "m3-note.schema.json#/definitions/note"
+    },
+    "devNote": {
+      "$ref" : "m3-note.schema.json#/definitions/devNote"
     }
   }
 }

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1625,6 +1625,10 @@
               "required": [ "lockType", "unlockStrats", "name" ],
               "additionalProperties": false,
               "properties": {
+                "name": {
+                  "title": "Lock Name",
+                  "description": "A name to describe the lock."
+                },
                 "lockType": {
                   "type": "string",
                   "title": "Lock Type",
@@ -1644,10 +1648,6 @@
                   "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
                   "title": "Lock Requirements",
                   "description": "Equipment, tech, and flag requirements for this node to be locked"
-                },
-                "name": {
-                  "title": "Lock Name",
-                  "description": "A name to describe the lock."
                 },
                 "unlockStrats": {
                   "type": "array",

--- a/scripts/autoformat.py
+++ b/scripts/autoformat.py
@@ -4,8 +4,22 @@
 
 import json
 from pathlib import Path
+from referencing import Registry, Resource
+import os
 
 import format_json
+import schema_order
+
+resource_list = []
+for path_str in sorted(Path("../schema/").glob("**/*.schema.json")):
+    path = Path(path_str)
+    schema = json.load(open(path, "r"))
+    resource = Resource.from_contents(schema)
+    resource_list.append((path.name, resource))
+
+registry = Registry().with_resources(resource_list).crawl()
+room_schema = registry.contents("m3-room.schema.json")
+room_resolver = registry.resolver("m3-room.schema.json")
 
 for path in sorted(Path("../region/").glob("**/*.json")):
     room_json = json.load(path.open("r"))
@@ -13,7 +27,8 @@ for path in sorted(Path("../region/").glob("**/*.json")):
         continue
 
     print("Processing", path)
-    new_room_json = format_json.format(room_json, indent=2)
+    new_room_json = schema_order.order_by_schema(room_json, room_schema, room_resolver)
+    new_room_json = format_json.format(new_room_json, indent=2)
 
     # Validate that the new JSON is equivalent to the old (i.e. the differences affect formatting only):
     assert json.loads(new_room_json) == room_json

--- a/scripts/schema_order.py
+++ b/scripts/schema_order.py
@@ -1,0 +1,21 @@
+def resolve_schema(schema, resolver):
+    if "$ref" in schema:
+        res = resolver.lookup(schema["$ref"])
+        ref_schema = res.contents
+        schema = {**ref_schema, **schema}
+        return schema, res.resolver
+    else:
+        return schema, resolver
+
+def order_by_schema(obj, schema, resolver):
+    schema, resolver = resolve_schema(schema, resolver)
+    if isinstance(obj, dict):
+        out = {}
+        for k, s in schema["properties"].items():
+            if k in obj:
+                out[k] = order_by_schema(obj[k], s, resolver)
+        return out
+    elif isinstance(obj, list):
+        return [order_by_schema(x, schema["items"], resolver) for x in obj]
+    else:
+        return obj


### PR DESCRIPTION
This adds a step in the auto-formatting script: it will now put object properties in the order dictated by the JSON schema. For example, in a strat with an `exitCondition`, the `exitCondition` will come after the `requires`. This helps iron out some little inconsistencies in the format of the data. It also moves the newly added room-level `mapTileMask` to near the top, instead of being near the bottom where it is now.

One thing is note is that while running this introduces a lot of changes in terms of amount of lines, it is low-risk because the auto-formatting script is still protected by a check that ensures the equivalence of the JSON input and output; specifically, the Python objects are tested for equality, which validates that any differences are only in formatting.

To make the new script run successfully, I had to add some missing `items` specifications to note/devNote object schemas. Where it made sense, I also reordered some things in the schema to be consistent with how things are already ordered (e.g. `obstacles` and `enemies` being positioned before `links` and `strats`).

Applying the changes by running the script is in a separate PR (#1855).