### PR TITLE
Remove collectsItems on strats with unhandled item spawn requirements

### DIFF
--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -1003,7 +1003,6 @@
         "canTemporaryBlue",
         "canSpringBallBounce"
       ],
-      "collectsItems": [4],
       "flashSuitChecked": true,
       "note": [
         "Use Temporary Blue to bounce into the Morph Tunnel with temp blue then continue to the bomb block using SpringBall.",
@@ -1012,7 +1011,8 @@
       ],
       "devNote": [
         "Killing phantoon only removes requirements for the strat.",
-        "The runway is a bit longer with Phantoon killed and the Power Bomb blocks broken, but it shouldn't matter at this difficulty."
+        "The runway is a bit longer with Phantoon killed and the Power Bomb blocks broken, but it shouldn't matter at this difficulty.",
+        "FIXME: This needs the item to be collected or unspawned, at least if using the long runway variant."
       ]
     },
     {
@@ -1042,11 +1042,11 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "collectsItems": [4],
       "flashSuitChecked": true,
       "note": [
         "Gain temporary blue, and bounce into the morph tunnel, using Spring Ball to reach the left side while retaining temporary blue.",
-        "After bouncing up out of the tunnel, unmorph, aim down, and use a pause buffer to remorph and land or bounce on the door frame, chaining temporary blue into the next room."
+        "After bouncing up out of the tunnel, unmorph, aim down, and use a pause buffer to remorph and land or bounce on the door frame, chaining temporary blue into the next room.",
+        "FIXME: This needs the item to be collected or unspawned, at least if using the long runway variant."
       ]
     },
     {

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -102,7 +102,9 @@
           "openEnd": 0
         }
       },
-      "collectsItems": [3]
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 2,
@@ -118,7 +120,9 @@
         }
       },
       "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
-      "collectsItems": [3]
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 3,
@@ -162,9 +166,10 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
-      "devNote": "FIXME: Requires the item to have been collected."
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 5,
@@ -183,9 +188,10 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
-      "devNote": "FIXME: Requires the item to have been collected."
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned (or using some more shinecharge frames)."
+      ]
     },
     {
       "id": 6,
@@ -205,9 +211,10 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
-      "devNote": "FIXME: Requires the item to have been collected."
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned (or only leaving in top position)."
+      ]
     },
     {
       "id": 7,
@@ -224,8 +231,10 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned (or using less runway)."
+      ]
     },
     {
       "id": 8,
@@ -246,8 +255,10 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 9,
@@ -268,8 +279,10 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 10,
@@ -343,9 +356,10 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
-      "devNote": "FIXME: Requires the item to have been collected."
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned (or using less runway)."
+      ]
     },
     {
       "id": 15,
@@ -364,9 +378,10 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
-      "devNote": "FIXME: Requires the item to have been collected."
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned (or using some more shinecharge frames)."
+      ]
     },
     {
       "id": 16,
@@ -386,9 +401,10 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
-      "devNote": "FIXME: Requires the item to have been collected."
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned (or only leaving in top position)."
+      ]
     },
     {
       "id": 17,
@@ -405,8 +421,10 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned (or using less runway)."
+      ]
     },
     {
       "id": 18,
@@ -427,8 +445,10 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 19,
@@ -449,8 +469,10 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 20,
@@ -509,7 +531,9 @@
           "openEnd": 0
         }
       },
-      "collectsItems": [3]
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 24,
@@ -525,7 +549,9 @@
         }
       },
       "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": []}],
-      "collectsItems": [3]
+      "devNote": [
+        "FIXME: This needs the item to be either collected or not spawned."
+      ]
     },
     {
       "id": 29,


### PR DESCRIPTION
This is a short-term fix to resolve some major logic unsoundness. Later we can come back and properly handle requirements for collecting the items in a way that takes into account their spawn conditions.