### PR TITLE
Blue Brin ETank low-energy fast walljump sparks

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -1011,15 +1011,15 @@
     {
       "id": 51,
       "link": [4, 2],
-      "name": "Walljump Up Shaft and Shinespark",
+      "name": "Wall Jump Spark",
       "requires": [
         {"or": [
           "h_canUsePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]},
-        "canShinechargeMovementComplex",
-        "canFastWalljumpClimb",
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
+        "canShinechargeMovementComplex",
+        "canConsecutiveWalljump",
         {"shinespark": {"frames": 17, "excessFrames": 3}}
       ],
       "clearsObstacles": ["A", "B", "C"],
@@ -1029,6 +1029,47 @@
         "Aligning the Power Bomb with the left side of the ceiling fixture that sticks down will position the explosion correctly for this."
       ],
       "devNote": "The runway here is 31 tiles before breaking the Power Bomb blocks, but becomes longer after."
+    },
+    {
+      "link": [4, 2],
+      "name": "Fast Wall Jump Spark With HiJump",
+      "requires": [
+        {"notable": "Fast Wall Jump Spark With HiJump"},
+        {"or": [
+          "h_canUsePowerBombs",
+          {"obstaclesCleared": ["C"]}
+        ]},
+        "canShinechargeMovementComplex",
+        "HiJump",
+        "canFastWalljumpClimb",
+        {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
+        {"shinespark": {"frames": 9, "excessFrames": 9}}
+      ],
+      "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
+      "note": [
+        "By wall jumping fast enough and sparking close to the block, it can be broken even on low energy (29 or less)."
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Bootless Fast Wall Jump Spark",
+      "requires": [
+        {"notable": "Bootless Fast Wall Jump Spark"},
+        {"or": [
+          "h_canUsePowerBombs",
+          {"obstaclesCleared": ["C"]}
+        ]},
+        "canShinechargeMovementComplex",
+        "canFastWalljumpClimb",
+        {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
+        {"shinespark": {"frames": 9, "excessFrames": 9}}
+      ],
+      "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
+      "note": [
+        "By wall jumping fast enough and sparking close to the block, it can be broken even on low energy (29 or less)."
+      ]
     },
     {
       "id": 52,
@@ -1255,8 +1296,22 @@
         "Gain a shinecharge using the runway at the bottom of the room.",
         "Perform a series of fast walljumps to reach the top of the room and spark out."
       ]
+    },
+    {
+      "id": 7,
+      "name": "Fast Wall Jump Spark With HiJump",
+      "note": [
+        "By wall jumping fast enough and sparking close to the block, it can be broken even on low energy (29 or less)."
+      ]
+    },
+    {
+      "id": 8,
+      "name": "Bootless Fast Wall Jump Spark",
+      "note": [
+        "By wall jumping fast enough and sparking close to the block, it can be broken even on low energy (29 or less)."
+      ]
     }
   ],
   "nextStratId": 64,
-  "nextNotableId": 7
+  "nextNotableId": 9
 }


### PR DESCRIPTION
This lowers the requirements on the existing strat "Walljump Up Shaft and Shinespark" from Expert to Very Hard, then adds two more variants (Expert and Extreme) for a low-energy spark, requiring HiJump or not, respectively.

Videos:
- HiJump: https://videos.maprando.com/video/2830
- Bootless: https://videos.maprando.com/video/2832