### PR TITLE
More Croc Speedway speedball strats

### DIFF
--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -487,6 +487,58 @@
       ]
     },
     {
+      "link": [3, 2],
+      "name": "Cross Room Jump Into Speedball (HiJump)",
+      "entranceCondition": {
+        "comeInWithPlatformBelow": {
+          "maxLeftPosition": 0,
+          "minRightPosition": 22,
+          "minHeight": 9,
+          "maxHeight": 10
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "HiJump",
+        {"canShineCharge": {"usedTiles": 18, "openEnd": 1}},
+        "canTrickyJump",
+        "canSpeedball",
+        {"heatFrames": 505}
+      ],
+      "devNote": [
+        "This strat is applicable only with Crocomire's Room and Post Crocomire Jump Room."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Cross Room Jump Into Speedball (Tricky Dash Jump)",
+      "entranceCondition": {
+        "comeInWithPlatformBelow": {
+          "maxLeftPosition": 0,
+          "minRightPosition": 41.5,
+          "minHeight": 10,
+          "maxHeight": 10
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "h_getBlueSpeedMaxRunway",
+        "canTrickyDashJump",
+        "canSpeedball",
+        {"heatFrames": 392}
+      ],
+      "note": [
+        "In the room below, gain a precise amount of speed (extra run speed $6.0 or $6.1) then jump and aim down.",
+        "After the transition, perform a speedball to cross the room.",
+        "With a precisely timed unmorph and a buffered shot to open the door, it is possible to just barely make it through with no tanks.",
+        "After unmorphing, walk instead of running, to avoid bonking the door.",
+        "Coming from Crocomire's Room below, it works to use the full available runway length."
+      ],
+      "devNote": [
+        "This strat is applicable only with Crocomire's Room."
+      ]
+    },
+    {
       "id": 12,
       "link": [3, 3],
       "name": "Shinespark",
@@ -577,7 +629,7 @@
     {
       "id": 16,
       "link": [4, 2],
-      "name": "Reverse Speedball",
+      "name": "Low Speed Reverse Speedball",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 1,
@@ -591,10 +643,55 @@
         {"heatFrames": 570}
       ],
       "clearsObstacles": ["A"],
-      "note": "Break the speed blocks by jumping over the gap with blue speed and continuing through the room with a speedball.",
+      "note": [
+        "Break the speed blocks by jumping over the gap with blue speed and continuing through the room with a speedball.",
+        "If entering with low speed, unmorph after killing the last Pirate at the bottom of the sloped section,",
+        "in order to run and gain more speed for the rest of the room."
+      ],
       "devNote": [
         "A run speed of $2.3 can also work but with greater difficulty.",
-        "FIXME: You can enter through 3 and speedball through the speedway."
+        "FIXME: add strats for cross-room spring ball bounce (with momentum or temp blue) and Space Jump"
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Full Speed Reverse Speedball",
+      "entranceCondition": {
+        "comeInBlueSpinning": {
+          "unusableTiles": 1,
+          "minExtraRunSpeed": "$7.0"
+        }
+      },
+      "requires": [
+        {"notable": "Reverse Speedball"},
+        "canTrickyJump",
+        "canSpeedball",
+        {"heatFrames": 370}
+      ],
+      "note": [
+        "Gain max run speed using a runway in the neighboring room, and jump through the door.",
+        "With this amount of speed, it is possible to make it across without any tanks."
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "High Speed Reverse Speedball",
+      "entranceCondition": {
+        "comeInBlueSpinning": {
+          "unusableTiles": 1,
+          "minExtraRunSpeed": "$6.5"
+        }
+      },
+      "requires": [
+        {"notable": "Reverse Speedball"},
+        "canInsaneJump",
+        "canSpeedball",
+        {"heatFrames": 392}
+      ],
+      "note": [
+        "Gain high run speed using a runway in the neighboring room, and jump through the door.",
+        "With a precisely timed unmorph and a buffered shot to open the door, it is possible to just barely make it through with no tanks.",
+        "After unmorphing, walk instead of running, to avoid bonking the door."
       ]
     },
     {


### PR DESCRIPTION
This was based on seeing [this video](https://videos.maprando.com/video/491) in the Incomplete queue. Worked on it a bit and was surprised to find that it can be done from Crocomire's Room without HiJump or any tanks.

- From the bottom door:
  - with HiJump: https://videos.maprando.com/video/3010
  - with tricky dash jump (speed $6.0): https://videos.maprando.com/video/3009
  - with tricky dash jump (speed $6.1): https://videos.maprando.com/video/3008
- From the bottom-right door:
  - with full run speed: https://videos.maprando.com/video/3011
  - with high run speed ($6.5, which is approximately the minimal amount needed to make it through tankless): https://videos.maprando.com/video/3012