### PR TITLE
Add some tests for 'and' and 'or', fix a couple issues

### DIFF
--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -2519,14 +2519,12 @@
             }},
             "canXRayTurnaround"
           ]},
-          {"and": [
-            {"canShineCharge": {
-              "usedTiles": 15,
-              "gentleDownTiles": 2,
-              "steepDownTiles": 1,
-              "openEnd": 1
-            }}
-          ]}
+          {"canShineCharge": {
+            "usedTiles": 15,
+            "gentleDownTiles": 2,
+            "steepDownTiles": 1,
+            "openEnd": 1
+          }}
         ]},
         "canChainTemporaryBlue",
         "canGravityJump"

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -1202,7 +1202,7 @@
           ]},
           {"and": [
             "canTrickyUseFrozenEnemies",
-            {"and": [
+            {"or": [
               "HiJump",
               "canWalljump",
               "canSpringBallJumpMidAir"


### PR DESCRIPTION
This checks a couple things, to prevent some mistakes that we have seen in the past with `and`/`or`:
- That `and`/`or` requirements always have at least 2 elements inside.
- That `and` does not have another `and` directly inside of it, and similarly for `or`.

Logically or mathematically, there's nothing inherent wrong with having 0 or 1 elements in and `and`/`or` or having them directly nested inside each other. It's just that in practice it seems like it would usually indicate a mistake was made, and even if it's correct it could always be simplified to avoid violating those rules.

The new tests found only two issues, both of which are fixed here. The one in PCJR could use a closer look to make sure I understood the intent correctly. I imagine that with some patience, bringing the Mella up to the door could be possible with ice only (no walljump or other items), so that could maybe be added as an option, but I haven't tried so I don't know for sure.