### PR TITLE
Single Chamber temp blue

### DIFF
--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -152,6 +152,8 @@
       "from": 1,
       "to": [
         {"id": 1},
+        {"id": 2},
+        {"id": 3},
         {"id": 4},
         {"id": 6}
       ]
@@ -161,7 +163,8 @@
       "to": [
         {"id": 1},
         {"id": 2},
-        {"id": 3}
+        {"id": 3},
+        {"id": 4}
       ]
     },
     {
@@ -177,6 +180,7 @@
       "from": 4,
       "to": [
         {"id": 1},
+        {"id": 2},
         {"id": 3},
         {"id": 4},
         {"id": 6}
@@ -244,6 +248,46 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 1380}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 830}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "id": 4,
       "link": [1, 4],
       "name": "Come in Shinecharging, Leave With Spark",
@@ -276,12 +320,61 @@
       ]
     },
     {
+      "link": [1, 4],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 7,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 505}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "id": 5,
       "link": [1, 6],
       "name": "Base",
       "requires": [
         {"heatFrames": 100}
       ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0,
+          "gentleUpTiles": 4
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 1220}
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 1440}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "id": 6,
@@ -513,6 +606,96 @@
       "note": "Kill the Alcoon, then freeze the Multiviola to use as a platform."
     },
     {
+      "link": [2, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0,
+          "gentleUpTiles": 4
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 365}
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 380}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [2, 4],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0,
+          "gentleUpTiles": 4
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 700}
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 840}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$2.0"
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 890}
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 1020}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": [
+        "FIXME: This could be done with lower run speed, at the cost of more heat frames."
+      ]
+    },
+    {
       "id": 19,
       "link": [3, 1],
       "name": "Grapple Teleport",
@@ -676,6 +859,26 @@
       "flashSuitChecked": true
     },
     {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 610}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "id": 27,
       "link": [3, 3],
       "name": "Leave with Runway",
@@ -815,6 +1018,38 @@
       ]
     },
     {
+      "link": [3, 4],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$2.0"
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 370}
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 380}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": [
+        "FIXME: This could be done with lower run speed, at the cost of more heat frames."
+      ]
+    },
+    {
       "id": 35,
       "link": [4, 1],
       "name": "Enter Shinecharging, Leave Sparking",
@@ -842,6 +1077,38 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$2.0"
+        }
+      },
+      "requires": [
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 490}
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 580}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": [
+        "FIXME: This could be done with lower run speed, at the cost of more heat frames."
       ]
     },
     {
@@ -889,6 +1156,26 @@
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
         "Then X-ray climb to get up to the door transition, without needing to open the door."
       ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 945}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "id": 39,
@@ -964,6 +1251,26 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
+    },
+    {
+      "link": [4, 3],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 500}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "id": 42,


### PR DESCRIPTION
This room is where I hit a wall when I was last going through and adding temp blue strats.

As usual, videos for all these strats on https://videos.maprando.com. 

For measuring heat frames, it definitely helped to be able to reference a video, because there are a few tricky things:
- While using X-Ray the in-game time continues to count up while no heat damage is happening. So for estimating heat frames we look at the change in Samus energy rather than in-game time.
- We want to exclude the time spent gaining the shinecharge or blue speed.
- Since we're looking at the change in Samus energy rather than in-game time, we need to be careful to account for any drops that happened to be collected.

The strats in these videos (especially the Spring Ball jump ones) are generally optimized a little less than other heated strats, but keeping temp blue over long distances is already difficult enough that I wasn't wanting to push it; when trying to go really fast it's much more likely to make a mistake and lose it.