### PR TITLE
Add some of SamLittlehorns' new ice moonfall strats

### DIFF
--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -1065,6 +1065,30 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 2],
+      "name": "Ice Moonfall Door Lock Skip",
+      "requires": [
+        "Gravity",
+        {"or": [
+          "canWalljump",
+          "canGravityJump"
+        ]},
+        {"ammo": {"type": "Super", "count": 1}},
+        "canTrickyUseFrozenEnemies",
+        "canEnemyStuckMoonfall",
+        "canFreeFallClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Use a Super to position two frozen Scisers above the door, then moonfall between them to clip down past the door shell.",
+        "When a Sciser is about to thaw, hold backwards to move forward off the bottom Sciser while buffering a turnaround.",
+        "It is easy to accidentally go out-of-bounds if too much speed is gained or if not buffering a turnaround."
+      ],
+      "devNote": [
+        "FIXME: It may be possible to avoid the Super use, if Space Jump is available to follow a Sciser all the way around the ceiling."
+      ]
+    },    
+    {
       "id": 30,
       "link": [2, 2],
       "name": "Sciser Farm",
@@ -1810,6 +1834,26 @@
         "leaveNormally": {}
       }
     },
+    {
+      "link": [3, 3],
+      "name": "Ice Moonfall Door Lock Skip",
+      "requires": [
+        "Gravity",
+        {"or": [
+          "canWalljump",
+          "canGravityJump"
+        ]},
+        "canTrickyUseFrozenEnemies",
+        "canEnemyStuckMoonfall",
+        "canFreeFallClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Use two frozen Scisers to moonfall and clip down past the door shell.",
+        "When a Sciser is about to thaw, hold backwards to move forward off the bottom Sciser while buffering a turnaround.",
+        "It is easy to accidentally go out-of-bounds if too much speed is gained or if not buffering a turnaround."
+      ]
+    },    
     {
       "id": 67,
       "link": [3, 3],

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -69,6 +69,7 @@
       "from": 1,
       "to": [
         {"id": 1},
+        {"id": 2},
         {"id": 3}
       ]
     },
@@ -133,6 +134,21 @@
         "leaveWithGModeSetup": {}
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Ice Moonfall Door Lock Skip",
+      "requires": [
+        "Morph",
+        "canTrickyUseFrozenEnemies",
+        "canEnemyStuckMoonfall",
+        "canFreeFallClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Use two frozen Zebbos to moonfall and clip down past the door shell.",
+        "It can help to unequip Ice to synchronize the Zebbos, and freeze them while standing on the right ledge."
+      ]
     },
     {
       "id": 5,

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -2228,6 +2228,9 @@
         "One of the Sovas behind the bomb blocks will need to be released using a bomb or Power Bomb.",
         "In Norfair rooms, enemies thaw more quickly, so there is probably not enough time to clip down through the enemy;",
         "instead, before it thaws, slide off the edge or shoot it."
+      ],
+      "devNote": [
+        "FIXME: add strats for entering from the top, through the Power Bomb blocks or Bomb tunnel."
       ]
     },
     {

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -2407,6 +2407,23 @@
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
+      "link": [5, 5],
+      "name": "Ice Moonfall Door Lock Skip",
+      "requires": [
+        "h_canBombThings",
+        "canTrickyUseFrozenEnemies",
+        "canEnemyStuckMoonfall",
+        "canFreeFallClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Use two frozen Sovas to moonfall and clip down past the door shell.",
+        "One of the Sovas behind the bomb blocks will need to be released using a bomb or Power Bomb.",
+        "In Norfair rooms, enemies thaw more quickly, so there is probably not enough time to clip down through the enemy;",
+        "instead, before it thaws, slide off the edge or shoot it."
+      ]
+    },
+    {
       "id": 88,
       "link": [5, 5],
       "name": "G-Mode Indirect Morph Power Bomb the Blocks",

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -2211,6 +2211,26 @@
       "requires": []
     },
     {
+      "link": [4, 5],
+      "name": "Ice Moonfall Door Lock Skip",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_canBombThings",
+        "canTrickyUseFrozenEnemies",
+        "canEnemyStuckMoonfall",
+        "canFreeFallClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Use two frozen Sovas to moonfall and clip down past the door shell.",
+        "One of the Sovas behind the bomb blocks will need to be released using a bomb or Power Bomb.",
+        "In Norfair rooms, enemies thaw more quickly, so there is probably not enough time to clip down through the enemy;",
+        "instead, before it thaws, slide off the edge or shoot it."
+      ]
+    },
+    {
       "id": 80,
       "link": [4, 5],
       "name": "Carry Shinecharge",
@@ -2405,23 +2425,6 @@
         {"shinespark": {"frames": 12, "excessFrames": 12}}
       ],
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
-    },
-    {
-      "link": [5, 5],
-      "name": "Ice Moonfall Door Lock Skip",
-      "requires": [
-        "h_canBombThings",
-        "canTrickyUseFrozenEnemies",
-        "canEnemyStuckMoonfall",
-        "canFreeFallClip"
-      ],
-      "bypassesDoorShell": true,
-      "note": [
-        "Use two frozen Sovas to moonfall and clip down past the door shell.",
-        "One of the Sovas behind the bomb blocks will need to be released using a bomb or Power Bomb.",
-        "In Norfair rooms, enemies thaw more quickly, so there is probably not enough time to clip down through the enemy;",
-        "instead, before it thaws, slide off the edge or shoot it."
-      ]
     },
     {
       "id": 88,

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -547,13 +547,13 @@
       "name": "Ice Moonfall Door Lock Skip",
       "requires": [
         "canTrickyUseFrozenEnemies",
-        "canEnemyStuckMoonfall",
-        {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
+        "canEnemyStuckMoonfall"
       ],
       "bypassesDoorShell": true,
       "note": [
         "Use two frozen Rinkas to clip down past the door shell.",
-        "It is expected to take a Rinka hit during the transition."
+        "Time the Rinkas to be at correct heights by killing both, starting with the higher Rinka.",
+        "Freeze the lower Rinka where it is slightly inside the door shell for the moonfall to fall all the way through without any additional input."
       ]
     },
     {

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -543,6 +543,20 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Ice Moonfall Door Lock Skip",
+      "requires": [
+        "canTrickyUseFrozenEnemies",
+        "canEnemyStuckMoonfall",
+        {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+        "Use two frozen Rinkas to clip down past the door shell.",
+        "It is expected to take a Rinka hit during the transition."
+      ]
+    },
+    {
       "id": 28,
       "link": [2, 2],
       "name": "G-Mode Regain Mobility",


### PR DESCRIPTION
These are more strats for using an ice moonfall to clip down past a door lock.

Videos:
- Metroid Room 4: https://videos.maprando.com/video/2182
- Bubble Mountain:
    - Sam's original video (with Bombs): https://videos.maprando.com/video/2183
    - version with Power Bomb: https://videos.maprando.com/video/3084
- Red Fish Room: https://videos.maprando.com/video/2184 
- Mt. Everest bottom-left door:
    - Sam's original video: https://videos.maprando.com/video/2187
    - possibly improved version: https://videos.maprando.com/video/3090
- Mt. Everest bottom-right door:
    - Sam's original video: https://videos.maprando.com/video/2186
    - version not requiring Supers: https://videos.maprando.com/video/3086
