### PR TITLE
Construction Zone ice moonfall leave with stored fall speed

### DIFF
--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -217,6 +217,27 @@
       "note": "Shoot a Super at the wall, while the Geemer is moving vertically. If it is on the bottom of the shot blocks, it will not fall."
     },
     {
+      "link": [1, 1],
+      "name": "Ice Moonfall Leave with Stored Fall Speed",
+      "requires": [
+        {"notable": "Ice Moonfall Leave with Stored Fall Speed"},
+        "h_ZebesIsAwake",
+        {"ammo": {"type": "Super", "count": 1}},
+        "canEnemyStuckMoonfall",
+        "canTrickyUseFrozenEnemies"
+      ],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "note": [
+        "Use a Super to knock a Geemer off the ceiling, and freeze it mid-air over the Koma (face statue) on the left.",
+        "Perform a moonfall between the Geemer and the Koma to leave with stored fall speed."
+      ],
+      "devNote": ["The fall speed stored is between 1 and 2 tiles."]
+    },
+    {
       "id": 13,
       "link": [1, 2],
       "name": "Base",
@@ -558,6 +579,27 @@
       "note": "Shoot a Super at the wall, while the Geemer is moving vertically. If it is on the bottom of the shot blocks, it will not fall."
     },
     {
+      "link": [2, 2],
+      "name": "Ice Moonfall Leave with Stored Fall Speed",
+      "requires": [
+        {"notable": "Ice Moonfall Leave with Stored Fall Speed"},
+        "h_ZebesIsAwake",
+        {"ammo": {"type": "Super", "count": 1}},
+        "canEnemyStuckMoonfall",
+        "canTrickyUseFrozenEnemies"
+      ],
+      "exitCondition": {
+        "leaveWithStoredFallSpeed": {
+          "fallSpeedInTiles": 1
+        }
+      },
+      "note": [
+        "Use a Super to knock a Geemer off the ceiling, and freeze it mid-air over the Koma (face statue) on the right.",
+        "Perform a moonfall between the Geemer and the Koma to leave with stored fall speed."
+      ],
+      "devNote": ["The fall speed stored is between 1 and 2 tiles."]
+    },
+    {
       "id": 26,
       "link": [2, 3],
       "name": "Carry Shinecharge",
@@ -844,7 +886,16 @@
       "note": "Carefully shoot the shoot blocks at the right time to knock off a Geemer without killing it."
     }
   ],
-  "notables": [],
+  "notables": [
+    {
+      "id": 1,
+      "name": "Ice Moonfall Leave with Stored Fall Speed",
+      "note": [
+        "Use a Super to knock a Geemer off the ceiling, and freeze it mid-air over the Koma (face statue).",
+        "Perform a moonfall between the Geemer and the Koma to leave with stored fall speed."
+      ]
+    }
+  ],
   "nextStratId": 51,
-  "nextNotableId": 1
+  "nextNotableId": 2
 }


### PR DESCRIPTION
This is one of the easier ice moonfalls to set up. The only idea behind making it notable is that there's a big knowledge check in understanding that the Komas are enemies and that it's possible to get stuck using them.

Videos by SamLittlehorns:
- right side: https://videos.maprando.com/video/2637
- left side: https://videos.maprando.com/video/2638
