### PR TITLE
Ice Beam Gate Room: Mella Wall Ice Clip X-Ray Climb

### DIFF
--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -1220,6 +1220,26 @@
       ]
     },
     {
+      "link": [7, 3],
+      "name": "Mella Wall Ice Clip X-Ray Climb",
+      "requires": [
+        {"notable": "Mella Wall Ice Clip X-Ray Climb"},
+        "canManipulateMellas",
+        "canWallIceClip",
+        "canXRayClimb"
+      ],
+      "note": [
+        "Bring a Mella on-camera while moonwalking, to set it up to move upward at the maximum rate (about 4 pixels per swoop).",
+        "Guide it to a horizontal position inside the left wall below the Power Bomb blocks.",
+        "When it is high enough, freeze it as it retreats from a near-vertical swoop.",
+        "Get into position on the ledge below the Power Bomb blocks and wait for the Mella to thaw.",
+        "Freeze the it inside the wall as it continues its retreat upward, by jumping and firing a downward shot.",
+        "Run into the wall to clip into it.",
+        "Crouch and destroy the Mella by shooting up (by holding angle up and angle down)",
+        "Then X-Ray climb above the Power Bomb blocks."
+      ]
+    },
+    {
       "id": 59,
       "link": [7, 3],
       "name": "Enemies Already Killed",
@@ -1336,8 +1356,16 @@
         "Crouch jump, morph, and hold right against the wall, hitting the Sova from below while near the peak of Samus's jump.",
         "Continue holding right to pass through the Sova and onto the ledge above."
       ]
+    },
+    {
+      "id": 3,
+      "name": "Mella Wall Ice Clip X-Ray Climb",
+      "note": [
+        "Freeze a Mella inside the wall below the Power Bomb blocks.",
+        "Use it to clip slightly inside the wall, then X-Ray climb up past the Power Bomb blocks."
+      ]
     }
   ],
   "nextStratId": 73,
-  "nextNotableId": 3
+  "nextNotableId": 4
 }


### PR DESCRIPTION
Videos:
- SamLittlehorn's original video: https://videos.maprando.com/video/2513
- Possibly improved version, with no damage: https://videos.maprando.com/video/3091
- A version with Wave beam: https://videos.maprando.com/video/3091

The Wave version is what I was trying at first because it seemed easier, though after messing more with the Ice-only version it ended up seeming fine.

I'm thinking Extreme notable for this one; the `canWallIceClip` would already put it in Extreme, the notable is just because of the unintuitiveness/obscurity of the trick. If there end up being a lot more tricks like this, then maybe the notable would be not needed :shrug: 