### PR TITLE
Worst Room In The Game shinecharges

### DIFF
--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -245,6 +245,118 @@
       ]
     },
     {
+      "link": [1, 3],
+      "name": "Come In Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 125},
+        {"heatFrames": 125}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Come In Shinecharging, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"heatFrames": 170},
+        {"shinespark": {"frames": 10, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 130},
+        {"heatFrames": 130}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Come In Shinecharged, Leave With Spark (Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 95},
+        {"heatFrames": 125},
+        {"shinespark": {"frames": 10, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Come In Shinecharged, Leave With Spark (Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        {"shineChargeFrames": 105},
+        {"heatFrames": 140},
+        {"shinespark": {"frames": 9, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 4,
       "link": [1, 5],
       "name": "Base",
@@ -380,29 +492,69 @@
     {
       "id": 11,
       "link": [2, 4],
-      "name": "Shinespark",
+      "name": "Come In Shinecharged, Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
         {"shineChargeFrames": 60},
         "canShinechargeMovement",
+        "canMidairShinespark",
         {"or": [
           {"and": [
             "canShinechargeMovementTricky",
-            {"shinespark": {"frames": 26}}
+            {"shineChargeFrames": 10},
+            {"shinespark": {"frames": 23, "excessFrames": 2}}
           ]},
           {"and": [
             "canTrickyJump",
-            {"shinespark": {"frames": 40, "excessFrames": 3}}
+            {"shinespark": {"frames": 36, "excessFrames": 3}}
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}},
-            {"shinespark": {"frames": 26}},
+            {"shineChargeFrames": 10},
+            {"shinespark": {"frames": 22}},
             {"heatFrames": 25}
           ]}
         ]},
         {"heatFrames": 220}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "note": [
+        "Vertically Shinespark two tiles from the left on the floating platform.",
+        "Shinesparking farther right will make it very likely a fireball hits Samus during the crash animation.",
+        "There is a small position that crashes the shinespark early but does not take fireball damage."
+      ]
+    },
+    {
+      "link": [2, 4],
+      "name": "Come In Shinecharging, Shinespark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canShinechargeMovement",
+        "canMidairShinespark",
+        {"or": [
+          {"and": [
+            "canShinechargeMovementTricky",
+            {"shinespark": {"frames": 22, "excessFrames": 2}}
+          ]},
+          {"and": [
+            "canTrickyJump",
+            {"shinespark": {"frames": 33, "excessFrames": 3}}
+          ]},
+          {"and": [
+            {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}},
+            {"shinespark": {"frames": 22}},
+            {"heatFrames": 25}
+          ]}
+        ]},
+        {"heatFrames": 250}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -848,12 +1000,93 @@
             "canTrickyJump",
             {"heatFrames": 175}
           ]},
+          {"and": [
+            "HiJump",
+            "canTrickyDodgeEnemies",
+            {"heatFrames": 140}
+          ]},
           {"heatFrames": 225}
         ]}
       ],
       "note": [
         "Safely clear the shot blocks from the ground to avoid drawing fire from the space pirate.",
         "Diagonal shots from the door effectively clear a path through the shot blocks, or firing vertically from below can work too."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come In Shinecharging, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        {"or": [
+          "canWalljump",
+          "canInsaneJump"
+        ]},
+        {"heatFrames": 205},
+        {"shinespark": {"frames": 6, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Carry Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        "HiJump",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 140},
+        {"heatFrames": 140}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        "canShinechargeMovementTricky",
+        {"or": [
+          {"and": [
+            {"shineChargeFrames": 135},
+            {"heatFrames": 170},
+            {"shinespark": {"frames": 11, "excessFrames": 0}}
+          ]},
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 125},
+            {"heatFrames": 160},
+            {"shinespark": {"frames": 7, "excessFrames": 0}}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ]
     },
     {

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -255,8 +255,18 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
-        {"shineChargeFrames": 125},
-        {"heatFrames": 125}
+        {"or": [
+          {"and": [
+            "canDownBack",
+            "canInsaneJump",
+            {"shineChargeFrames": 125},
+            {"heatFrames": 125}
+          ]},
+          {"and": [
+            {"shineChargeFrames": 160},
+            {"heatFrames": 160}
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {}


### PR DESCRIPTION
The existing 2->4 shinespark strat seemed too difficult for Medium. Added a `canMidairShinespark` requirement to put it in Hard; even though it's technically possible to do this from the ground with no mid-air spark, I don't think that makes it significantly easier. One thing to keep in mind is that when sparking from from too far right (as a player on Medium would likely do), there's significant risk of not just taking the hit from the fireball but also getting knocked back down by it. Assuming a mid-air spark also allows us to tighten the shinespark frame requirements without having to double the amount of variants further. 

Videos on https://videos.maprando.com.