### PR TITLE
Add tests for exit/entrance conditions based on strat name phrases

### DIFF
--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -224,7 +224,7 @@
     {
       "id": 9,
       "link": [2, 1],
-      "name": "Speedball (Come In Shinecharging)",
+      "name": "Come In Getting Blue Speed, Speedball",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 11,

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -3138,12 +3138,13 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 130},
+        {"shineChargeFrames": 120},
         "canTrickyDashJump",
-        "canShinechargeMovementComplex"
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 4, "excessFrames": 0}}
       ],
       "exitCondition": {
-        "leaveShinecharged": {}
+        "leaveWithSpark": {}
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -312,7 +312,7 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Speedball (Come in Spinning)",
+      "name": "Come in Blue Spinning, Speedball",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "unusableTiles": 0

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -234,7 +234,7 @@
     {
       "id": 8,
       "link": [2, 1],
-      "name": "Temporary Blue Bounce (Come in With Spring Ball Bounce)",
+      "name": "Temporary Blue Bounce (Come in With Blue Spring Ball Bounce)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "movementType": "controlled"

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -120,7 +120,7 @@
       "name": "Leave With Spring Ball Bounce",
       "requires": [],
       "exitCondition": {
-        "leaveWithMockball": {
+        "leaveWithSpringBallBounce": {
           "remoteRunway": {
             "length": 5,
             "openEnd": 1
@@ -128,7 +128,8 @@
           "landingRunway": {
             "length": 2,
             "openEnd": 1
-          }
+          },
+          "movementType": "uncontrolled"
         }
       },
       "devNote": [

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -496,7 +496,7 @@
     {
       "id": 23,
       "link": [1, 3],
-      "name": "Carry Shinecharge to Item",
+      "name": "Come In Shinecharged, End Shinecharged",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -573,7 +573,7 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Come in Shinecharging, Leave With Temporary Blue (Speedy Jump)",
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue (Speedy Jump)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 4,
@@ -764,7 +764,7 @@
     {
       "id": 40,
       "link": [2, 3],
-      "name": "Carry Shinecharge to Item (Come in Shinecharging)",
+      "name": "Come In Shinecharging, End Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 4,
@@ -784,7 +784,7 @@
     {
       "id": 41,
       "link": [2, 3],
-      "name": "Carry Shinecharge to Item (Come in Shinecharged)",
+      "name": "Come in Shinecharged, End Shinecharged",
       "entranceCondition": {
         "comeInShinecharged": {}
       },

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -226,7 +226,7 @@
     {
       "id": 72,
       "link": [1, 5],
-      "name": "Blue Spacejump Through Morph Tunnel (Come in Jumping)",
+      "name": "Come In Blue Spinning, Space Jump Through Morph Tunnel",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "minExtraRunSpeed": "$6.E",
@@ -254,7 +254,7 @@
     {
       "id": 73,
       "link": [1, 5],
-      "name": "Blue Spacejump Through Morph Tunnel (Come in Running)",
+      "name": "Come In Getting Blue Speed, Space Jump Through Morph Tunnel",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 5,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1842,7 +1842,7 @@
     {
       "id": 84,
       "link": [5, 7],
-      "name": "Suitless Blue Bomber (HiJump, Come in Spinning)",
+      "name": "Suitless Blue Bomber (HiJump, Come in Blue Spinning)",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "minExtraRunSpeed": "$3.4",
@@ -1871,7 +1871,7 @@
     {
       "id": 85,
       "link": [5, 7],
-      "name": "Suitless Blue Bomber (HiJump, Come in With Spring Ball Bounce)",
+      "name": "Suitless Blue Bomber (HiJump, Come in With Blue Spring Ball Bounce)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "movementType": "controlled",
@@ -1900,7 +1900,7 @@
     {
       "id": 86,
       "link": [5, 7],
-      "name": "Suitless Blue Bomber (Tricky Dash Jump, Come in Spinning)",
+      "name": "Suitless Blue Bomber (Tricky Dash Jump, Come in Blue Spinning)",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "minExtraRunSpeed": "$4.0",
@@ -1929,7 +1929,7 @@
     {
       "id": 87,
       "link": [5, 7],
-      "name": "Suitless Blue Bomber (Tricky Dash Jump, Come in With Spring Ball Bounce)",
+      "name": "Suitless Blue Bomber (Tricky Dash Jump, Come in With Blue Spring Ball Bounce)",
       "entranceCondition": {
         "comeInWithBlueSpringBallBounce": {
           "movementType": "controlled",

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -939,7 +939,7 @@
         "Gravity"
       ],
       "exitCondition": {
-        "leaveWithMockball": {
+        "leaveWithSpringBallBounce": {
           "remoteRunway": {
             "length": 17,
             "openEnd": 1
@@ -947,7 +947,8 @@
           "landingRunway": {
             "length": 3,
             "openEnd": 1
-          }
+          },
+          "movementType": "uncontrolled"
         }
       }
     },

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -151,7 +151,7 @@
         "Gravity"
       ],
       "exitCondition": {
-        "leaveWithMockball": {
+        "leaveWithSpringBallBounce": {
           "remoteRunway": {
             "length": 17,
             "openEnd": 1
@@ -159,7 +159,8 @@
           "landingRunway": {
             "length": 1,
             "openEnd": 1
-          }
+          },
+          "movementType": "uncontrolled"
         }
       }
     },

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -203,7 +203,7 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "X-Mode, Leave Shinecharged",
+      "name": "X-Mode, Leave With Spark",
       "requires": [
         "canXMode",
         "h_XModeSpikeHit",
@@ -224,7 +224,10 @@
         "leaveWithSpark": {}
       },
       "flashSuitChecked": true,
-      "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
+      "devNote": [
+        "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount).",
+        "FIXME: This should be doable with fewer items."
+      ]
     },
     {
       "id": 4,

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -2067,6 +2067,10 @@
         "canPauseRemorphTemporaryBlue",
         "canDoubleSpringBallJumpMidAir"
       ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Gaining blue speed with a precise amount of run speed (extra run speed of $2.0 or $2.1), and bounce through the transition.",
         "After the transition, press pause, unmorph, aim down, and unequip Spring Ball.",
@@ -2346,7 +2350,7 @@
     {
       "id": 88,
       "link": [3, 1],
-      "name": "Carry Shinecharge through Morph Tunnel to the Middle",
+      "name": "Shinecharge through Morph Tunnel",
       "requires": [
         "Morph",
         "Gravity",
@@ -2823,7 +2827,7 @@
     {
       "id": 111,
       "link": [3, 4],
-      "name": "Carry Shinecharge through Morph Tunnel to the Top",
+      "name": "Shinecharge through Morph Tunnel",
       "requires": [
         "Morph",
         "Gravity",

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -764,6 +764,10 @@
         "canXRayTurnaround",
         "canLongChainTemporaryBlue"
       ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Run into the room to gain temporary blue with a water shinecharge.",
         "Use X-ray along with HiJump and/or Spring Ball to chain it through the room."
@@ -858,6 +862,12 @@
         "canXRayTurnaround",
         "canLongChainTemporaryBlue"
       ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {
+          "direction": "any"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "Run into the room to gain temporary blue with a water shinecharge.",
         "Use X-ray along with HiJump to chain it through the room."

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -436,7 +436,7 @@
       "link": [1, 2],
       "name": "Come in Shinecharging, Leave With Temporary Blue",
       "entranceCondition": {
-        "comeInGettingBlueSpeed": {
+        "comeInShinecharging": {
           "length": 3,
           "openEnd": 1
         }
@@ -485,7 +485,7 @@
       "link": [1, 3],
       "name": "Come in Shinecharging, Leave With Temporary Blue",
       "entranceCondition": {
-        "comeInGettingBlueSpeed": {
+        "comeInShinecharging": {
           "length": 3,
           "openEnd": 1
         }
@@ -510,7 +510,7 @@
       "link": [1, 4],
       "name": "Come in Shinecharging, Leave With Temporary Blue",
       "entranceCondition": {
-        "comeInGettingBlueSpeed": {
+        "comeInShinecharging": {
           "length": 3,
           "openEnd": 1
         }
@@ -538,7 +538,7 @@
       "link": [1, 5],
       "name": "Come in Shinecharging, Leave With Temporary Blue",
       "entranceCondition": {
-        "comeInGettingBlueSpeed": {
+        "comeInShinecharging": {
           "length": 3,
           "openEnd": 1
         }
@@ -3069,7 +3069,7 @@
     {
       "id": 194,
       "link": [7, 1],
-      "name": "Come in Shinecharging, Leave With Temporary Blue (Spring Ball Bounce)",
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue (Spring Ball Bounce)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 2.5,
@@ -3092,7 +3092,7 @@
     {
       "id": 195,
       "link": [7, 1],
-      "name": "Come in Shinecharging, Leave With Temporary Blue (Space Jump)",
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue (Space Jump)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 2.5,
@@ -3362,7 +3362,7 @@
     {
       "id": 129,
       "link": [7, 6],
-      "name": "Come in Running, Leave Shinecharged",
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 2.5,

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -292,7 +292,7 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Come In Running and Shinespark",
+      "name": "Come In Shinecharging, Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -567,7 +567,7 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "Come In Running and Shinespark",
+      "name": "Come In Shinecharging, Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -1575,6 +1575,13 @@
         {"shinespark": {"frames": 10, "excessFrames": 0}},
         {"heatFrames": 210}
       ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
       "devNote": [
         "The canBePatient represents retrying until RNG works out to be able to jump over one of the Cacatacs without taking a hit."
       ]
@@ -1731,7 +1738,7 @@
     {
       "id": 49,
       "link": [6, 5],
-      "name": "Quick Platforming Leave Shinecharged",
+      "name": "Leave With Spark",
       "requires": [
         "h_heatProof",
         {"obstaclesCleared": ["A"]},

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -150,7 +150,7 @@
       "name": "Leave Space Jumping",
       "requires": [],
       "exitCondition": {
-        "leaveSpinning": {
+        "leaveSpaceJumping": {
           "remoteRunway": {
             "length": 17,
             "openEnd": 1
@@ -319,7 +319,7 @@
       "name": "Leave Space Jumping",
       "requires": [],
       "exitCondition": {
-        "leaveSpinning": {
+        "leaveSpaceJumping": {
           "remoteRunway": {
             "length": 17,
             "openEnd": 1

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -894,7 +894,7 @@
         "SpaceJump"
       ],
       "exitCondition": {
-        "leaveSpinning": {
+        "leaveSpaceJumping": {
           "remoteRunway": {
             "length": 29,
             "openEnd": 1

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -198,7 +198,7 @@
     {
       "id": 9,
       "link": [2, 1],
-      "name": "Carry Shinecharge (HiJump, Screw, Wall Jump)",
+      "name": "Come In Shinecharged, Leave With Spark (HiJump, Screw, Wall Jump)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -733,7 +733,7 @@
         {"obstaclesCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveWithMockball": {
+        "leaveWithSpringBallBounce": {
           "remoteRunway": {
             "length": 19,
             "openEnd": 1
@@ -741,7 +741,8 @@
           "landingRunway": {
             "length": 1,
             "openEnd": 1
-          }
+          },
+          "movementType": "uncontrolled"
         }
       }
     },

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -208,7 +208,7 @@
       "name": "Leave With Spring Ball Bounce",
       "requires": [],
       "exitCondition": {
-        "leaveWithMockball": {
+        "leaveWithSpringBallBounce": {
           "remoteRunway": {
             "length": 3,
             "openEnd": 1
@@ -216,7 +216,8 @@
           "landingRunway": {
             "length": 1,
             "openEnd": 1
-          }
+          },
+          "movementType": "uncontrolled"
         }
       }
     },

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -230,7 +230,7 @@
         "canPreciseSpaceJump"
       ],
       "exitCondition": {
-        "leaveSpinning": {
+        "leaveSpaceJumping": {
           "remoteRunway": {
             "length": 9,
             "openEnd": 0

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -105,7 +105,7 @@
         "SpaceJump"
       ],
       "exitCondition": {
-        "leaveSpaceJumping": {
+        "leaveSpinning": {
           "remoteRunway": {
             "length": 4,
             "openEnd": 2
@@ -729,7 +729,7 @@
         "SpaceJump"
       ],
       "exitCondition": {
-        "leaveSpaceJumping": {
+        "leaveSpinning": {
           "remoteRunway": {
             "length": 4,
             "openEnd": 2

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -788,6 +788,9 @@
         "canTrickySpringBallJump",
         "canChainTemporaryBlue"
       ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "note": [
         "If possible (and applicable), kill the Bull ahead of time, and do a shinecharge to gain temporary blue.",

--- a/strats.md
+++ b/strats.md
@@ -78,7 +78,7 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveSpinning_: This indicates that it is possible to jump through this door with a spin jump from a runway not connected to the door, possibly with blue speed.
 - _leaveWithMockball_: This indicates that it is possible to mockball through the door with a certain amount of momentum, and possibly with blue speed, from a runway not connected to the door.
 - _leaveWithSpringBallBounce_: This indicates that it is possible to leave through this door with a spring ball bounce with a certain amount of momentum.
-- _leaveSpaceJumping: This indicates that it is possible to Space Jump through the bottom of the doorway (through a horizontal transition) with a certain amount of momentum, and possibly with blue speed.
+- _leaveSpaceJumping_: This indicates that it is possible to Space Jump through the bottom of the doorway (through a horizontal transition) with a certain amount of momentum, and possibly with blue speed.
 - _leaveWithStoredFallSpeed_: This indicates that is is possible to walk through the door with the stored velocity to clip through floor tiles using a Moonfall.
 - _leaveWithGModeSetup_: This indicates that Samus can take enemy damage through the door transition, to set up R-mode or direct G-mode in the next room.
 - _leaveWithGMode_: This indicates that Samus can carry G-mode into the next room (where it will become indirect G-mode).


### PR DESCRIPTION
When certain phrases occur in strat names (e.g. "Leave With Temporary Blue") without a corresponding exit/entrance condition (e.g. "leaveWithTemporaryBlue"), it likely indicates a mistake. It's a common enough problem that it seemed worthwhile to add tests for this, including fixes for the failing cases. A few cases were relatively benign, where it seemed fine to just rename them to work around the tests. It's maybe an awkward sort of test but it does catch a lot.

I had to try out the case in Green Brinstar Main Shaft that had the wrong exit condition, to figure out what the shinespark frames were supposed to be; went ahead and adjusted the shinecharge frames too because I noticed they were loose.