### PR TITLE
Refine Botwoon Quicksand Hidden Tunnel logic

### DIFF
--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -216,7 +216,8 @@
         "If Samus falls below the tunnel, even to the ledge just below, it will no longer be possible to reach."
       ],
       "devNote": [
-        "FIXME: Depending on the room above, the 'can4HighMidAirMorph' requirement might be unnecessary."
+        "FIXME: Depending on the room above, the 'can4HighMidAirMorph' requirement might be unnecessary.",
+        "FIXME: Entering through the Toilet can be possible with a lateral mid-air and enough run speed from an air room above."
       ]
     },
     {
@@ -331,7 +332,8 @@
         "If Samus falls below the tunnel, even to the ledge just below, it will no longer be possible to reach."
       ],
       "devNote": [
-        "FIXME: Depending on the room above, the 'can4HighMidAirMorph' requirement might be unnecessary."
+        "FIXME: Depending on the room above, the 'can4HighMidAirMorph' requirement might be unnecessary.",
+        "FIXME: Entering through the Toilet can be possible with a lateral mid-air and enough run speed from an air room above."
       ]
     },
     {

--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -200,28 +200,24 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        "Morph",
+        {"notable": "Pass Through Hidden Tunnel"},
+        "canPrepareForNextRoom",
+        "can4HighMidAirMorph",
         {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
         {"or": [
-          "canPrepareForNextRoom",
-          "canCarefulJump"
+          {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
+          "h_canUsePowerBombs"
         ]}
-      ]
-    },
-    {
-      "id": 7,
-      "link": [1, 5],
-      "name": "Pass Through Toilet",
-      "entranceCondition": {
-        "comeInNormally": {},
-        "comesThroughToilet": "any"
-      },
-      "requires": [
-        "canLateralMidAirMorph",
-        "canPrepareForNextRoom",
-        {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}}
       ],
-      "note": "Mid Air Morph before reaching the door transition, and without hitting a wall, in order to drift into the Morph tunnel quickly enough."
+      "note": [
+        "If the room above has a narrow sand exit, then spin jump through the transition pressing against the wall,",
+        "continue holding right to reach the wall above the tunnel,",
+        "then perform a tight mid-air morph and hold right to pass through the tunnel.",
+        "If Samus falls below the tunnel, even to the ledge just below, it will no longer be possible to reach."
+      ],
+      "devNote": [
+        "FIXME: Depending on the room above, the 'can4HighMidAirMorph' requirement might be unnecessary."
+      ]
     },
     {
       "id": 8,
@@ -319,28 +315,24 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        "Morph",
+        {"notable": "Pass Through Hidden Tunnel"},
+        "canPrepareForNextRoom",
+        "can4HighMidAirMorph",
         {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
         {"or": [
-          "canPrepareForNextRoom",
-          "canCarefulJump"
+          {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
+          "h_canUsePowerBombs"
         ]}
-      ]
-    },
-    {
-      "id": 15,
-      "link": [3, 5],
-      "name": "Pass Through Toilet",
-      "entranceCondition": {
-        "comeInNormally": {},
-        "comesThroughToilet": "any"
-      },
-      "requires": [
-        "canLateralMidAirMorph",
-        "canPrepareForNextRoom",
-        {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}}
       ],
-      "note": "Mid Air Morph before reaching the door transition, and without hitting a wall, in order to drift into the Morph tunnel quickly enough."
+      "note": [
+        "If the room above has a narrow sand exit, then spin jump through the transition pressing against the wall,",
+        "continue holding left to reach the wall above the tunnel,",
+        "then perform a tight mid-air morph and hold left to pass through the tunnel.",
+        "If Samus falls below the tunnel, even to the ledge just below, it will no longer be possible to reach."
+      ],
+      "devNote": [
+        "FIXME: Depending on the room above, the 'can4HighMidAirMorph' requirement might be unnecessary."
+      ]
     },
     {
       "id": 16,
@@ -377,7 +369,16 @@
       "flashSuitChecked": true
     }
   ],
-  "notables": [],
+  "notables": [
+    {
+      "id": 1,
+      "name": "Pass Through Hidden Tunnel",
+      "note": [
+        "Enter the room in a prepared way to pass through the hidden tunnel, which may require tricky movement to reach.",
+        "If Samus falls below the tunnel, even to the ledge just below, it will no longer be possible to reach."
+      ]
+    }
+  ],
   "nextStratId": 20,
-  "nextNotableId": 1
+  "nextNotableId": 2
 }


### PR DESCRIPTION
If entering from a 4-tile-wide sand transition above, it is surprisingly difficult to reach the tunnel. And I think 4-tile-wide entrance is consistently what happens in Map Rando whenever the tunnel would be logically useful. It feels like at least an Expert-level mid-air morph, but with only one attempt, so probably an Extreme notable.

I left a FIXME to handle different types of entrances. Even with the vanilla transition, it's not trivial and would probably be at least a Very Hard trick; a Bull can mess you up, or you can easily move too far off the top ledge and not have enough time to move back to the tunnel, since the acceleration is so slow in the sand. With the vanilla transition, though, there's no reason to ever use the tunnel because you could just enter from the opposite side above. In Map Rando, Aqueduct would not be a possible entrance above as the rooms won't fit together. That leaves Bug Sand Hole as the only possible wide entrance that could come into play, but I don't know if it can actually occur; I don't think I've seen it before.

I tested the entrance through Toilet, and confirmed it can work with a lateral mid-air morph from an air room above, but it requires a certain amount of run speed, so it would be situational whether you would be able to get that run speed or if the room above is an air room at all. Since we don't currently have a way to model that, for now I just removed the Toilet variations and left a FIXME for it.