### PR TITLE
Rename strats passing through Botwoon Quicksand tunnel

### DIFF
--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -194,7 +194,7 @@
     {
       "id": 6,
       "link": [1, 5],
-      "name": "Base",
+      "name": "Pass Through Hidden Tunnel",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "no"
@@ -310,7 +310,7 @@
     {
       "id": 14,
       "link": [3, 5],
-      "name": "Base",
+      "name": "Pass Through Hidden Tunnel",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "no"


### PR DESCRIPTION
It was an oversight that these strats were kept named "Base" when they're now an Extreme-level notable.