### PR TITLE
Refine PCJR Mella ice clip

### DIFF
--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -1381,10 +1381,7 @@
       "requires": [
         {"notable": "Mella Ice Clip"},
         "Morph",
-        {"or": [
-          "h_canXRayMorphIceClip",
-          "h_canPreciseIceClip"
-        ]},
+        "h_canPreciseIceClip",
         {"or": [
           "canConsecutiveWalljump",
           {"and": [
@@ -1396,13 +1393,19 @@
       "flashSuitChecked": true,
       "note": [
         "Freeze the Mella at a precise location in order to jump through the crumble block, then wall jump up the long channel and mid air morph to get out.",
-        "The Mella pixel positioning window is larger and higher with Morph and an X-Ray Stand Up.",
-        "One normalization which requires moonwalk: Kill all but the middle Mella without letting the middle one move from its starting location by keeping it frozen if Samus passes through.",
-        "From the right, moonwalk backwards one pixel at a time until the Mella is no longer on screen. Shoot ice towards it, then move it on screen so that it is frozen immediately.",
-        "Move to the left and press against (but don't roll under) the speed blocks before the Mella thaws. Moonwalk backwards 5 pixels, then in very quick succession, press right and then jump to do a buffered spin jump.",
-        "The Mella should move horizontally and can then be used to clip through the crumble block."
+        "One normalized way to do this: Kill the first two Mellas, moonwalk to the right until the third Mella just barely goes off-camera,",
+        "fire a shot, and move left to scroll the Mella back on-camera just before the shot would despawn, in order to freeze it at a specific height.",
+        "While it is frozen, kill the remaining Mellas, press against the wall of Speed blocks.",
+        "Perform an action that changes Samus' pose (e.g., press an angle button, or jump or crouch) in order to be able to moonwalk from that position.",
+        "Moonwalk backwards 5 pixels, then jump straight up, and continue holding jump while pressing right, to perform a buffered turn-around spin jump to the right.",
+        "If executed correctly, the Mella will move horizontally left and will be at a good height to freeze and clip through the crumble block with a crouch jump.",
+        "Tip: if Samus moonwalks back further than 5 pixels, press against the Speed blocks again before trying to moonwalk back again, to avoid possibly getting bad subpixels."
       ],
-      "devNote": "While the high pixel position looks possible, it is fairly unreasonable, as it also requires very precise horizontal positioning and the Mellas are chaotic."
+      "devNote": [
+        "The manipulation can also work with moonwalking back 6, 7, 8, 9, or 10 pixels, but depending on the exact position the bug may move at a shallow angle rather than exactly horizontally;",
+        "in this case, the bug should be frozen a bit early (i.e. further right), to ensure it does not re-enter its idle animation where its height would become unpredictable.",
+        "FIXME: Investigate if there is a normalized setup for freezing in the high-pixel position."
+      ]
     },
     {
       "id": 77,

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -1381,6 +1381,8 @@
       "requires": [
         {"notable": "Mella Ice Clip"},
         "Morph",
+        "canMoonwalk",
+        "canManipulateMellas",
         "h_canPreciseIceClip",
         {"or": [
           "canConsecutiveWalljump",
@@ -1392,19 +1394,22 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Freeze the Mella at a precise location in order to jump through the crumble block, then wall jump up the long channel and mid air morph to get out.",
+        "Freeze the Mella at a precise location in order to jump through the crumble block, then wall jump up the long channel and mid-air morph to get out.",
         "One normalized way to do this: Kill the first two Mellas, moonwalk to the right until the third Mella just barely goes off-camera,",
         "fire a shot, and move left to scroll the Mella back on-camera just before the shot would despawn, in order to freeze it at a specific height.",
-        "While it is frozen, kill the remaining Mellas, press against the wall of Speed blocks.",
-        "Perform an action that changes Samus' pose (e.g., press an angle button, or jump or crouch) in order to be able to moonwalk from that position.",
+        "While it is frozen, kill the remaining Mellas, and press against the wall of Speed blocks.",
+        "Perform an action that changes Samus' pose (e.g., press an angle button, jump, or crouch/uncrouch) in order to be able to moonwalk from that position.",
         "Moonwalk backwards 5 pixels, then jump straight up, and continue holding jump while pressing right, to perform a buffered turn-around spin jump to the right.",
-        "If executed correctly, the Mella will move horizontally left and will be at a good height to freeze and clip through the crumble block with a crouch jump.",
+        "If executed correctly, the Mella will move horizontally left and will be at a good height to be able to freeze and clip through the crumble block with a crouch jump.",
+        "Get on top of the Mella with a mid-air morph, position under the crumble block, then unmorph for the crouch jump.",
+        "Quickly spin-jump to re-enter the shaft after breaking the crumble block.",
         "Tip: if Samus moonwalks back further than 5 pixels, press against the Speed blocks again before trying to moonwalk back again, to avoid possibly getting bad subpixels."
       ],
       "devNote": [
-        "The manipulation can also work with moonwalking back 6, 7, 8, 9, or 10 pixels, but depending on the exact position the bug may move at a shallow angle rather than exactly horizontally;",
+        "The manipulation can also work with moonwalking back between 6 and 10 pixels, but depending on the exact position the bug may move at a shallow angle rather than exactly horizontally;",
         "in this case, the bug should be frozen a bit early (i.e. further right), to ensure it does not re-enter its idle animation where its height would become unpredictable.",
-        "FIXME: Investigate if there is a normalized setup for freezing in the high-pixel position."
+        "FIXME: Investigate if there is a normalized setup for freezing in the high-pixel position.",
+        "FIXME: A freestyle version (or alternative normalized setup?) of the strat could be added, to avoid the canMoonwalk requirement, using X-Ray or a very precise freeze to get up."
       ]
     },
     {
@@ -1562,8 +1567,7 @@
       "id": 8,
       "name": "Mella Ice Clip",
       "note": [
-        "Freeze the Mella at a precise location in order to jump through the crumble block, then wall jump up the long channel and mid air morph to get out.",
-        "The Mella pixel positioning window is larger and higher with Morph and an X-Ray Stand Up."
+        "Freeze the Mella at a precise location in order to jump through the crumble block, then wall jump up the long channel and mid air morph to get out."
       ]
     },
     {


### PR DESCRIPTION
This PR removes the X-Ray variant of the Mella Ice Clip, making "h_canPreciseIceClip" (Expert) required. It also adds more detail to the notes/devNotes about how to do the trick using Eddie's normalized setup. If this is merged, we would also move the corresponding notable up from Very Hard to Expert difficulty.

HisBeardNis brought this up to me the other day in his stream: he mentioned he had been doing an Extreme seed but spent 3 hours to get this clip which is currently in Very Hard if X-Ray is available, as it was in his case.

I took a look and to me even with X-Ray it feels pretty bad to try to freestyle it; I don't think it's really ok in Very Hard. It's much better to use Eddie's normalization trick, and in that case X-Ray is irrelevant. The setup for the normalization is kind of complex and many things can go wrong: e.g., freezing the Mella at the wrong height, moonwalking back the wrong amount of pixels, missing the refreeze on the Mella, getting stuck on top of it with Samus in the wrong horizontal position, not being able to land on the Mella after breaking the crumble if it already thawed, getting a standing jump off of it instead of a spin-jump, or bonking the re-formed crumble by not spin jumping soon enough. With a full understanding of everything, it can be done reliably, but I think it's a bit too much for Very Hard.

To avoid the canMoonwalk requirement, technically a freestyle version (with or without X-Ray) or some alternative kind of normalized setup could be an option, but it would need additional requirements to place it at the right difficulty. I left it as a FIXME for now. 
