### PR TITLE
Frozen Mochtroid morphless grapple teleport setups

### DIFF
--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -227,7 +227,7 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "Leave With Grapple Teleport (Bombless, Bottom Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Bottom Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -252,7 +252,7 @@
     {
       "id": 9,
       "link": [1, 1],
-      "name": "Leave With Grapple Teleport (Bombless, Top Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Top Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -279,6 +279,64 @@
         "If needed to transition further to the left, it can be done from position 28 by rolling from left to down (with a brief down-left input), to result in a transition at a position of 20 or less."
       ]
     },
+    {
+      "link": [1, 1],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Bottom Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[3, 13]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the fourth Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To minimize lag, when grapple is extended horizontally release all inputs other than shot/grapple; there will still be a bit of unavoidable lag while Grapple is initially extending.",
+        "Try to get a good first bounce; otherwise heavy lag may be difficult to avoid, and it may be better to retry from the beginning.",
+        "Pressing right while inside the transition tiles will trigger the transition.",
+        "Continue holding Grapple through the transition to initiate a teleport in the next room.",
+        "If it is needed to trigger the transition further to the right (at position 238), then wait to come to a stop before pressing right.",
+        "If it is needed to trigger the transition further to the left (positions 235 or 237), then hold right while approaching the door.",
+        "Either way, Samus should automatically be able to stand in the next room (e.g. for an X-Ray climb)."
+      ]
+    },    
+    {
+      "link": [1, 1],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Top Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[3, 12]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the third Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To avoid heavy lag, hold down during the bottom part of the swing, and hold angle up during the top part.",
+        "Press up while approaching the door to retract Grapple to avoid bonking the ceiling.",
+        "Samus will typically come to rest at horizontal position 41.",
+        "From here it is possible to roll from pressing left to pressing diagonally down-left to enter the transition, though this will create heavy lag and Samus will not be able to stand in the next room.",
+        "Alternatively, only briefly press diagonally down-left and then press up, bringing Samus to a stop further left, typically at one of three positions 25, 28, or 38.",
+        "If Samus stops at position 38, then the process can be repeated to move closer to the door again, with a possibility of reaching position 25.",
+        "If Samus then stops at positions 25 or 28, then rolling from left to down-left will bring Samus into the transition in a pose that will be able to stand, and at horizontal position 21 (as far right as possible).",
+        "If Samus stops at position 23 or closer, the setup will have to be started over.",
+        "If needed to transition further to the left, it can be done from position 28 by rolling from left to down (with a brief down-left input), to result in a transition at a position of 20 or less."
+      ]
+    },    
     {
       "id": 10,
       "link": [1, 2],
@@ -1700,7 +1758,7 @@
     {
       "id": 81,
       "link": [3, 3],
-      "name": "Leave With Grapple Teleport (Bombless, Bottom Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Bottom Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -1728,7 +1786,7 @@
     {
       "id": 82,
       "link": [3, 3],
-      "name": "Leave With Grapple Teleport (Bombless, Top Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Top Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -1753,6 +1811,62 @@
         "then roll from right to down-right to enter the transition (at horizontal positon 1771)."
       ]
     },
+    {
+      "link": [3, 3],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Bottom Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[108, 13]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the fourth Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To minimize lag, when grapple is extended horizontally release all inputs other than shot/grapple; there will still be a bit of unavoidable lag while Grapple is initially extending.",
+        "Try to get a good first bounce; otherwise heavy lag may be difficult to avoid, and it may be better to retry from the beginning.",
+        "Pressing right while inside the transition tiles will trigger the transition.",
+        "Continue holding Grapple through the transition to initiate a teleport in the next room.",
+        "If it is needed to trigger the transition further to the right (at position 1774), then wait to come to a stop before pressing right.",
+        "If it is needed to trigger the transition further to the left (positions 1771 or 1773), then hold right while approaching the door.",
+        "Either way, Samus should automatically be able to stand in the next room (e.g. for an X-Ray climb)."
+      ]
+    },    
+    {
+      "link": [3, 3],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Top Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[108, 12]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the third Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To minimize lag, when grapple is extended horizontally release all inputs other than shot/grapple; there will still be a bit of unavoidable lag while Grapple is initially extending.",
+        "Try to get a good first bounce; otherwise heavy lag may be difficult to avoid, and it may be better to retry from the beginning.",
+        "While swinging up, tap up to retract Grapple to avoid the ceiling (or tap up after after coming to rest against the ceiling if this happens).",
+        "Samus should usually come to a stop one tile in front of the door (at horizontal position 1751).",
+        "Roll from pressing right to pressing diagonally down-right to enter the transition.",
+        "If it is needed for Samus to be able to stand in the next room, then only briefly press diagonally down-right and then press up, bringing Samus to a stop at position 1761 or 1763;",
+        "then roll from right to down-right to enter the transition (at horizontal positon 1771)."
+      ]
+    },    
     {
       "id": 83,
       "link": [3, 3],

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1824,7 +1824,7 @@
         }
       },
       "note": [
-        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the fourth Grapple block below the door.",
+        "Freeze a Mochtroid at a specific position, aiming for its top to be slightly above the midpoint of the fourth Grapple block below the door.",
         "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
         "If successful, Samus should clip slightly into the wall.",
         "Crouch, and fire Grapple while angling up.",
@@ -1852,7 +1852,7 @@
         }
       },
       "note": [
-        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the third Grapple block below the door.",
+        "Freeze a Mochtroid at a specific position, aiming for its top to be slightly above the midpoint of the third Grapple block below the door.",
         "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
         "If successful, Samus should clip slightly into the wall.",
         "Crouch, and fire Grapple while angling up.",

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -3642,7 +3642,7 @@
         }
       },
       "note": [
-        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the fourth Grapple block below the door.",
+        "Freeze a Mochtroid at a specific position, aiming for its top to be slightly above the midpoint of the fourth Grapple block below the door.",
         "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
         "If successful, Samus should clip slightly into the wall.",
         "Crouch, and fire Grapple while angling up.",
@@ -3670,7 +3670,7 @@
         }
       },
       "note": [
-        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the third Grapple block below the door.",
+        "Freeze a Mochtroid at a specific position, aiming for its top to be slightly above the midpoint of the third Grapple block below the door.",
         "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
         "If successful, Samus should clip slightly into the wall.",
         "Crouch, and fire Grapple while angling up.",

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -292,9 +292,84 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Top Position)",
+      "requires": [
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[2, 18]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid near the bottom of the Grapple wall, stand on it, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Swing down, and hold left while approaching the door to trigger the transition.",
+        "Continue holding Grapple through the door transition to initiate a teleport in the next room.",
+        "If needing to stand up in the next room (e.g. for an X-Ray climb), then enter the transition while swinging slowly, e.g. after coming to a stop directly below the block (or without Gravity equipped).",
+        "If needing to transition at horiziontal position 21 (as far right as possible), then additionally roll from pressing left to pressing diagonally up-left just before the transition.",
+        "The game may lag heavily if Samus enters a retracted position; if this happens, hold down to extend Grapple again."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Bottom Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[2, 29]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the fourth Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To avoid heavy lag, hold down during the bottom part of the swing, and hold angle up during the top part.",
+        "Continue holding Grapple through the transition to initiate a teleport in the next room.",
+        "If needing to stand up in the next room (e.g. for an X-Ray climb), then press up while approaching the door to retract Grapple and come to a stop; then roll from pressing left to diagonally down-left to trigger the transition.",
+        "This method will also transition at horizontal position 21 (as far right as possible).",
+        "If it is needed to transition further left (e.g. position 19 or 20), it can be done by instead rolling from pressing left to pressing down (with a brief diagonal input in between) and then left again if necessary."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Middle Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[2, 28]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the third Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To avoid heavy lag, hold down during the bottom part of the swing, and hold angle up during the top part.",
+        "Press up while approaching the door to retract Grapple to avoid bonking the ceiling.",
+        "After Samus comes to a stop (at horiziontal position 25), roll from pressing left to diagonally down-left to trigger the transition.",
+        "This method will allow Samus to stand up in the next room (e.g. for an X-Ray climb) and will also transition at horizontal position 21 (as far right as possible).",
+        "If it is needed to transition further left (at position 20) while still being able to stand, it can be done with by rolling from pressing left to briefly pressing down (with a brief diagonal input in between), which should bring Samus to a stop at position 20; then press left to trigger the transition."
+      ]
+    },
+    {
       "id": 8,
       "link": [1, 1],
-      "name": "Leave With Grapple Teleport (Bombless, Top Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Top Position)",
       "requires": [
         "Gravity",
         "canCrouchJump",
@@ -321,7 +396,7 @@
     {
       "id": 9,
       "link": [1, 1],
-      "name": "Leave With Grapple Teleport (Bombless, Bottom Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Bottom Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -347,7 +422,7 @@
     {
       "id": 10,
       "link": [1, 1],
-      "name": "Leave With Grapple Teleport (Bombless, Middle Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Middle Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -373,9 +448,9 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "Top Left Suitless Bombless Leave With Grapple Teleport",
+      "name": "Top Left Suitless Unmorph Leave With Grapple Teleport",
       "requires": [
-        {"notable": "Top Left Suitless Bombless Leave With Grapple Teleport"},
+        {"notable": "Top Left Suitless Unmorph Leave With Grapple Teleport"},
         "canUnmorphGrappleHang"
       ],
       "exitCondition": {
@@ -1659,7 +1734,7 @@
     {
       "id": 56,
       "link": [2, 2],
-      "name": "Leave With Grapple Teleport",
+      "name": "Leave With Grapple Teleport (Bomb Hang)",
       "requires": [
         "canGrappleBombHang",
         "h_canBombThings"
@@ -1684,7 +1759,7 @@
     {
       "id": 57,
       "link": [2, 2],
-      "name": "Leave With Grapple Teleport (Bombless)",
+      "name": "Leave With Grapple Teleport (Unmorph)",
       "requires": [
         "Gravity",
         "canCrouchJump",
@@ -1709,9 +1784,33 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid)",
+      "requires": [
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid near the bottom of the Grapple wall.",
+        "Stand on it, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Swing down, and hold left while approaching the door to trigger the transition.",
+        "Continue holding Grapple through the door transition to initiate a teleport in the next room.",
+        "If needing to stand up in the next room (e.g. for an X-Ray climb), then enter the transition while swinging slowly, e.g. after coming to a stop directly below the block (or without Gravity equipped).",
+        "If needing to transition at horiziontal position 21 (as far right as possible), then additionally roll from pressing left to pressing diagonally up-left just before the transition.",
+        "The game may lag heavily if Samus enters a retracted position; if this happens, hold down to extend Grapple again."
+      ]
+    },
+    {
       "id": 58,
       "link": [2, 2],
-      "name": "Leave With Grapple Teleport (Suitless, Bombless)",
+      "name": "Leave With Grapple Teleport (Suitless, Unmorph)",
       "requires": [
         "canUnmorphGrappleHang"
       ],
@@ -3477,7 +3576,7 @@
     {
       "id": 131,
       "link": [4, 4],
-      "name": "Leave With Grapple Teleport (Bombless, Bottom Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Bottom Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -3505,7 +3604,7 @@
     {
       "id": 132,
       "link": [4, 4],
-      "name": "Leave With Grapple Teleport (Bombless, Top Position)",
+      "name": "Leave With Grapple Teleport (Unmorph, Top Position)",
       "requires": [
         "Gravity",
         "canUnmorphGrappleHang"
@@ -3519,6 +3618,62 @@
         "Grapple to the fifth Grapple block below the door (the third one fully above the water line), jump off from it, and morph.",
         "Unmorph slightly before the peak of the jump (a 3-frame window), then immediately use grapple (a 2-frame window) to get stuck standing a pixel inside the second Grapple block.",
         "Then jump (to force crouch), angle down, and grapple.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To minimize lag, when grapple is extended horizontally release all inputs other than shot/grapple; there will still be a bit of unavoidable lag while Grapple is initially extending.",
+        "Try to get a good first bounce; otherwise heavy lag may be difficult to avoid, and it may be better to retry from the beginning.",
+        "While swinging up, tap up to retract Grapple to avoid the ceiling (or tap up after after coming to rest against the ceiling if this happens).",
+        "Samus should usually come to a stop one tile in front of the door (at horizontal position 215).",
+        "Roll from pressing right to pressing diagonally down-right to enter the transition.",
+        "If it is needed for Samus to be able to stand in the next room, then only briefly press diagonally down-right and then press up, bringing Samus to a stop at position 225 or 227;",
+        "then roll from right to down-right to enter the transition (at horizontal positon 235)."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Bottom Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 13]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the fourth Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
+        "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
+        "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
+        "To minimize lag, when grapple is extended horizontally release all inputs other than shot/grapple; there will still be a bit of unavoidable lag while Grapple is initially extending.",
+        "Try to get a good first bounce; otherwise heavy lag may be difficult to avoid, and it may be better to retry from the beginning.",
+        "Pressing right while inside the transition tiles will trigger the transition.",
+        "Continue holding Grapple through the transition to initiate a teleport in the next room.",
+        "If it is needed to trigger the transition further to the right (at position 238), then wait to come to a stop before pressing right.",
+        "If it is needed to trigger the transition further to the left (positions 235 or 237), then hold right while approaching the door.",
+        "Either way, Samus should automatically be able to stand in the next room (e.g. for an X-Ray climb)."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Leave With Grapple Teleport (Frozen Mochtroid, Top Position)",
+      "requires": [
+        "Gravity",
+        "canFrozenEnemyGrappleHang"
+      ],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[12, 12]]
+        }
+      },
+      "note": [
+        "Freeze a Mochtroid at a specific position, where its top is about at the midpoint of the third Grapple block below the door.",
+        "Stand on the frozen Mochtroid, and fire Grapple horizontally while walking toward the wall.",
+        "If successful, Samus should clip slightly into the wall.",
+        "Crouch, and fire Grapple while angling up.",
         "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",
         "Press jump to get a good bounce off the wall at the bottom of the swing, making it possible to swing up to the door.",
         "To minimize lag, when grapple is extended horizontally release all inputs other than shot/grapple; there will still be a bit of unavoidable lag while Grapple is initially extending.",
@@ -3543,7 +3698,7 @@
     },
     {
       "id": 2,
-      "name": "Top Left Suitless Bombless Leave With Grapple Teleport",
+      "name": "Top Left Suitless Unmorph Leave With Grapple Teleport",
       "note": [
         "Grapple to the top Grapple in the top-left corner of the room.",
         "Hold left while waiting for the grapple wall jump check to expire, then quickly morph.",

--- a/tech.json
+++ b/tech.json
@@ -818,6 +818,45 @@
                 "In this case, Samus will remain standing after releasing Grapple;",
                 "jumping (to force crouch) and firing an angled grapple shot will then result in glitched grapple hanging."
               ]
+            },
+            {
+              "name": "canFrozenEnemyGrappleHang",
+              "techRequires": [
+                "canUseGrapple",
+                "canTrickyUseFrozenEnemies"
+              ],
+              "otherRequires": [],
+              "note": [
+                "Entering a 'glitched grapple hanging' by using a well-positioned frozen enemy:",
+                "Freeze an enemy at a specific height, stand on it, then fire Grapple horizontally while walking toward a Grapple wall.",
+                "The Grapple shot may either contact the Grapple block directly, or it may kill a second enemy.",
+                "Either way, if successful, Samus will get clipped slightly inside the wall.",
+                "From there, crouch or jump (to force crouch), then fire an angled grapple shot to obtain glitched grapple hanging.",
+                "Jumping to force crouch will put Samus in a higher position, which in some positions can allow Samus to grapple to a higher block.",
+                "For grappling to the left, Samus' vertical pixel position in hexadecimal must end in 0, 1, 2, 3, 4, 5, 6, 7, or F;",
+                "this corresponds to the bottom of Samus' hitbox being between 4 and 12 pixels above the bottom of the tile;",
+                "in this case, aim to freeze the enemy so that its top aligns with the mid-point of the tile.",
+                "For grappling to the right, Samus' vertical pixel position in hexadecimal must end in 2, 3, 4, 5, 6, or 7;",
+                "this corresponds to the bottom of Samus' hitbox being between 7 and 12 pixels above the bottom of the tile;",
+                "in this case, aim to freeze the enemy so that its top is slightly above the mid-point of the tile."
+              ],
+              "devNote": [
+                "For grappling to the left, depending on the vertical position, it is possible to get stuck between 1 and 4 pixels deep;",
+                "on the right, it is possible to get stuck between 1 and 3 pixels deep.",
+                "Specifically, on the right, positions 2, 3, 4 only allow getting stuck 1 pixel deep;",
+                "position 5 allows getting stuck 1 or 2 pixels deep;",
+                "and positions 6 and 7 allow getting stuck 1, 2, or 3 pixels deep.",
+                "On the left, positions F, 0, and 1 allow getting stuck only 1 pixel deep;",
+                "positions 2, 3, and 4 allow getting stuck 1 or 2 pixels deep;",
+                "position 5 allows getting stuck 1, 2, or 3 pixels deep;",
+                "and positions 6 and 7 allow getting stuck 1, 2, 3, or 4 pixels deep.",
+                "Generally pressing Grapple closer to the wall will get Samus stuck deeper.",
+                "However, getting stuck deeper doesn't have a known application;",
+                "in many cases it removes the possibility of grappling to the higher Grapple block above.",
+                "For grappling to the left, in positions F, 0, 1, 2, and 3 it is possible to get stuck by simply grappling while pressed against the Grapple block;",
+                "for grappling to the right, this can be done in positions 2 and 3.",
+                "These positions also work if Samus is moving toward the block; and all other positions require Samus to be moving toward the block."
+              ]
             }
           ]
         },


### PR DESCRIPTION
This adds a new tech `canFrozenEnemyGrappleHang`, with applications in Halfie Climb and Colosseum. With this technique, it is possible to perform grapple teleports from these locations without Morph.

For the `canUnmorphGrappleHang` strats, the "Bombless" descriptor used in many of the strat names now became ambiguous, so I renamed these to use the word "Unmorph" instead.

somerando(cauuyjdp) showed us this technique here: https://discord.com/channels/1053421401354285129/1053436236628496454/1328638519047880729

As usual, I added videos for all of the new strats on https://videos.maprando.com.

G-mode artificial morph is another possible way that grapple teleports could be set up from these locations without Morph. Strats for that can be added in a later PR.