### PR TITLE
Clean up some notable names

### DIFF
--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -623,9 +623,9 @@
     {
       "id": 31,
       "link": [2, 3],
-      "name": "Shinespark No Etanks No HiJump",
+      "name": "Tankless Bootless Shinespark",
       "requires": [
-        {"notable": "Shinespark No Etanks No HiJump"},
+        {"notable": "Tankless Bootless Shinespark"},
         "canFastWalljumpClimb",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
@@ -1113,7 +1113,7 @@
     },
     {
       "id": 2,
-      "name": "Shinespark No Etanks No HiJump",
+      "name": "Tankless Bootless Shinespark",
       "note": "Quickly wall jump up the right wall and shinespark up to barely get above the speed blocks without any tanks."
     },
     {

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -1265,7 +1265,7 @@
     {
       "id": 59,
       "link": [2, 3],
-      "name": "Shinespark into the Wall to Ride the Elevator, Come in Shinecharging",
+      "name": "Shinespark to Ride the Elevator (Come in Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 5,
@@ -1273,7 +1273,7 @@
         }
       },
       "requires": [
-        {"notable": "Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark to Ride the Elevator"},
         "canHorizontalShinespark",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
@@ -1283,13 +1283,13 @@
     {
       "id": 60,
       "link": [2, 3],
-      "name": "Shinespark into the Wall to Ride the Elevator, Come in Shinecharged",
+      "name": "Shinespark to Ride the Elevator (Come in Shinecharged)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
         {"shineChargeFrames": 45},
-        {"notable": "Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark to Ride the Elevator"},
         "canHorizontalShinespark",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
@@ -1300,12 +1300,12 @@
     {
       "id": 61,
       "link": [2, 3],
-      "name": "Shinespark into the Wall to Ride the Elevator, Come in Shinesparking",
+      "name": "Shinespark to Ride the Elevator (Come in With Spark)",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
       "requires": [
-        {"notable": "Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark to Ride the Elevator"},
         "canHorizontalShinespark",
         {"shinespark": {"frames": 15, "excessFrames": 6}}
       ],
@@ -1315,9 +1315,9 @@
     {
       "id": 62,
       "link": [2, 3],
-      "name": "Shinespark into the Wall to Ride the Elevator, Use Flash Suit",
+      "name": "Shinespark to Ride the Elevator (Use Flash Suit)",
       "requires": [
-        {"notable": "Shinespark into the Wall to Ride the Elevator"},
+        {"notable": "Shinespark to Ride the Elevator"},
         "canHorizontalShinespark",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 1, "excessFrames": 1}}
@@ -1560,7 +1560,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Shinespark into the Wall to Ride the Elevator",
+      "name": "Shinespark to Ride the Elevator",
       "note": "Shinesparking horizontally into the wall will trigger the elevator as Samus's echos hit it."
     },
     {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -916,9 +916,9 @@
     {
       "id": 36,
       "link": [3, 2],
-      "name": "Space Jump Water Escape with Ice and XRay Standup",
+      "name": "Space Jump Water Escape with Ice and X-Ray",
       "requires": [
-        {"notable": "Space Jump Water Escape with Ice and XRay Standup"},
+        {"notable": "Space Jump Water Escape with Ice and X-Ray"},
         {"enemyDamage": {"enemy": "Choot", "type": "contact", "hits": 1}},
         "canTrickyUseFrozenEnemies",
         "Morph",
@@ -941,9 +941,9 @@
     {
       "id": 37,
       "link": [3, 2],
-      "name": "Space Jump Water Escape with Ice (Left to Right)",
+      "name": "Space Jump Water Escape with Ice",
       "requires": [
-        {"notable": "Space Jump Water Escape with Ice (Left to Right)"},
+        {"notable": "Space Jump Water Escape with Ice"},
         "canSpaceJumpWaterBounce",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump"
@@ -956,10 +956,11 @@
     {
       "id": 38,
       "link": [3, 2],
-      "name": "Space Jump Water Escape (Left to Right)",
+      "name": "Precise Space Jump Water Escape",
       "requires": [
-        {"notable": "Space Jump Water Escape (Left to Right)"},
+        {"notable": "Precise Space Jump Water Escape"},
         "canSpaceJumpWaterBounce",
+        "canPreciseSpaceJump",
         "canPreciseWalljump",
         "canInsaneJump",
         "canMidairWiggle"
@@ -1441,7 +1442,7 @@
     },
     {
       "id": 6,
-      "name": "Space Jump Water Escape with Ice and XRay Standup",
+      "name": "Space Jump Water Escape with Ice and X-Ray",
       "note": [
         "Freeze the right-most ramp Choot in a way where Samus can climb on top of it and use Space Jump to escape the water.",
         "Use a turn around to avoid knockback when making contact with the Choot to better time the use of Ice.",
@@ -1454,7 +1455,7 @@
     },
     {
       "id": 7,
-      "name": "Space Jump Water Escape with Ice (Left to Right)",
+      "name": "Space Jump Water Escape with Ice",
       "note": [
         "Get to the right of the Choot on the rightmost platform. Spin jump up to the right, break spin while aligned with the wall, then freeze the Choot and stand on it while it is midair to the right of the stalagmite.",
         "Jump from the Choot to the water line and space jump at the water line to the Kamer platform."
@@ -1462,7 +1463,7 @@
     },
     {
       "id": 8,
-      "name": "Space Jump Water Escape (Left to Right)",
+      "name": "Precise Space Jump Water Escape",
       "note": [
         "Standing from the rightmost platform, jump to the right of the stalagmite. Perform a midair wiggle to get to the left to the stalagmite, then precisely wall jump off of it.",
         "Then perform a frame perfect space jump at the water line to bounce on the water over to the Kamer platform."

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -349,9 +349,9 @@
     {
       "id": 10,
       "link": [2, 5],
-      "name": "Reverse Crystal Flash Clip",
+      "name": "Crystal Flash Clip",
       "requires": [
-        {"notable": "Reverse Crystal Flash Clip"},
+        {"notable": "Crystal Flash Clip"},
         {"heatFrames": 100},
         "h_canHeatedCrystalFlash",
         "canCeilingClip",
@@ -1388,7 +1388,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Reverse Crystal Flash Clip",
+      "name": "Crystal Flash Clip",
       "note": "Perform the crystal flash all the way against the left wall of the accessible tunnel, then jump through the ceiling."
     },
     {

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -483,9 +483,9 @@
     {
       "id": 20,
       "link": [2, 1],
-      "name": "Shot Block Overload (Speedless Speedway)",
+      "name": "Shot Block Overload",
       "requires": [
-        {"notable": "Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload"},
         "Wave",
         {"or": [
           "Spazer",
@@ -532,7 +532,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "G-Mode Shot Block Overload (Speedless Speedway)",
+      "name": "G-Mode Shot Block Overload",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -540,7 +540,7 @@
         }
       },
       "requires": [
-        {"notable": "Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload"},
         "Wave",
         {"or": [
           {"and": [
@@ -666,14 +666,14 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "Transition with Stored Fall Speed (Speedless Speedway)",
+      "name": "Transition with Stored Fall Speed (Shot Block Overload)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
         }
       },
       "requires": [
-        {"notable": "Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload"},
         "Wave",
         {"or": [
           "Spazer",
@@ -706,14 +706,14 @@
     {
       "id": 30,
       "link": [2, 1],
-      "name": "Transition with Stored Fall Speed (more speed, Speedless Speedway)",
+      "name": "Transition with Stored Fall Speed (more speed, Shot Block Overload)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
         }
       },
       "requires": [
-        {"notable": "Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload"},
         "Wave",
         {"or": [
           "Spazer",
@@ -769,7 +769,7 @@
       "link": [2, 2],
       "name": "Shot Block Overload for Frozen Beetom Moondance",
       "requires": [
-        {"notable": "Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload"},
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
@@ -795,7 +795,7 @@
       "link": [2, 2],
       "name": "Shot Block Overload for Frozen Beetom Extended Moondance",
       "requires": [
-        {"notable": "Shot Block Overload (Speedless Speedway)"},
+        {"notable": "Shot Block Overload"},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
@@ -842,7 +842,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Shot Block Overload (Speedless Speedway)",
+      "name": "Shot Block Overload",
       "note": [
         "This strat is only usable right to left.",
         "This room has many offscreen shot blocks. Shooting enough of them with wave + spazer or wave + plasma allows you to pass through the speed blocks.",

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -483,9 +483,9 @@
     {
       "id": 20,
       "link": [2, 1],
-      "name": "Shot Block Overload",
+      "name": "Shot Block Overload (Speedless Speedway)",
       "requires": [
-        {"notable": "Shot Block Overload"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           "Spazer",
@@ -532,7 +532,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "G-Mode Shot Block Overload",
+      "name": "G-Mode Shot Block Overload (Speedless Speedway)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -540,7 +540,7 @@
         }
       },
       "requires": [
-        {"notable": "Shot Block Overload"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           {"and": [
@@ -666,14 +666,14 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "Transition with Stored Fall Speed (Shot Block Overload)",
+      "name": "Transition with Stored Fall Speed (Speedless Speedway)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
         }
       },
       "requires": [
-        {"notable": "Shot Block Overload"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           "Spazer",
@@ -706,14 +706,14 @@
     {
       "id": 30,
       "link": [2, 1],
-      "name": "Transition with Stored Fall Speed (more speed, Shot Block Overload)",
+      "name": "Transition with Stored Fall Speed (more speed, Speedless Speedway)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
         }
       },
       "requires": [
-        {"notable": "Shot Block Overload"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "Wave",
         {"or": [
           "Spazer",
@@ -769,7 +769,7 @@
       "link": [2, 2],
       "name": "Shot Block Overload for Frozen Beetom Moondance",
       "requires": [
-        {"notable": "Shot Block Overload"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
@@ -795,7 +795,7 @@
       "link": [2, 2],
       "name": "Shot Block Overload for Frozen Beetom Extended Moondance",
       "requires": [
-        {"notable": "Shot Block Overload"},
+        {"notable": "Shot Block Overload (Speedless Speedway)"},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
@@ -842,7 +842,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Shot Block Overload",
+      "name": "Shot Block Overload (Speedless Speedway)",
       "note": [
         "This strat is only usable right to left.",
         "This room has many offscreen shot blocks. Shooting enough of them with wave + spazer or wave + plasma allows you to pass through the speed blocks.",

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -580,9 +580,9 @@
     {
       "id": 19,
       "link": [3, 1],
-      "name": "Reverse Dodge While Climbing",
+      "name": "Dodge While Climbing",
       "requires": [
-        {"notable": "Reverse Dodge While Climbing"},
+        {"notable": "Dodge While Climbing"},
         "canCarefulJump",
         {"or": [
           "canConsecutiveWalljump",
@@ -602,9 +602,9 @@
     {
       "id": 30,
       "link": [3, 1],
-      "name": "Reverse Bootless Walljumpless Space Jump (Longer Acid Dip)",
+      "name": "Bootless Walljumpless Space Jump (Longer Acid Dip)",
       "requires": [
-        {"notable": "Reverse Bootless Walljumpless Space Jump"},
+        {"notable": "Bootless Walljumpless Space Jump"},
         "SpaceJump",
         "canTrickyJump",
         {"acidFrames": 90}
@@ -636,9 +636,9 @@
     {
       "id": 31,
       "link": [3, 1],
-      "name": "Reverse Bootless Walljumpless Space Jump (Short Acid Dip)",
+      "name": "Bootless Walljumpless Space Jump (Short Acid Dip)",
       "requires": [
-        {"notable": "Reverse Bootless Walljumpless Space Jump"},
+        {"notable": "Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         "canTrickyJump",
         {"acidFrames": 50}
@@ -671,9 +671,9 @@
     {
       "id": 32,
       "link": [3, 1],
-      "name": "Reverse Bootless Walljumpless Space Jump (Plasma)",
+      "name": "Bootless Walljumpless Space Jump (Plasma)",
       "requires": [
-        {"notable": "Reverse Bootless Walljumpless Space Jump"},
+        {"notable": "Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         "canTrickyJump",
         "Plasma",
@@ -712,9 +712,9 @@
     {
       "id": 33,
       "link": [3, 1],
-      "name": "Reverse Bootless Walljumpless Space Jump (Super)",
+      "name": "Bootless Walljumpless Space Jump (Super)",
       "requires": [
-        {"notable": "Reverse Bootless Walljumpless Space Jump"},
+        {"notable": "Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         {"enemyKill": {
           "enemies": [["Tourian Space Pirate (all)"]],
@@ -745,9 +745,9 @@
     {
       "id": 34,
       "link": [3, 1],
-      "name": "Reverse Bootless Walljumpless Space Jump (Left-Side Fall)",
+      "name": "Bootless Walljumpless Space Jump (Left-Side Fall)",
       "requires": [
-        {"notable": "Reverse Bootless Walljumpless Space Jump"},
+        {"notable": "Bootless Walljumpless Space Jump"},
         "canPreciseSpaceJump",
         {"or": [
           {"and": [
@@ -947,7 +947,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Reverse Dodge While Climbing",
+      "name": "Dodge While Climbing",
       "note": [
         "Navigate the room in reverse by killing or distracting the right side pirates and manipulating or dodging the left side pirates during the shaft climb.",
         "The acid starts rising when Samus is at the bottom of the long climb.",
@@ -970,7 +970,7 @@
     },
     {
       "id": 4,
-      "name": "Reverse Bootless Walljumpless Space Jump",
+      "name": "Bootless Walljumpless Space Jump",
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "It is possible to climb faster by releasing jump early, rather than doing full-height jumps, in order to be able to Space Jump again more quickly."

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -557,9 +557,9 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Crystal Flash Clip (Right to Left)",
+      "name": "Crystal Flash Clip",
       "requires": [
-        {"notable": "Crystal Flash Clip (Right to Left)"},
+        {"notable": "Crystal Flash Clip"},
         {"or": [
           "canTrivialMidAirMorph",
           "h_canUseSpringBall",
@@ -582,9 +582,9 @@
     {
       "id": 25,
       "link": [2, 1],
-      "name": "R-Mode Standup Clip (Right to Left)",
+      "name": "R-Mode Standup Clip",
       "requires": [
-        {"notable": "R-Mode Standup Clip (Right to Left)"},
+        {"notable": "R-Mode Standup Clip"},
         {"obstaclesCleared": ["A"]},
         "canCeilingClip",
         "canBePatient",
@@ -623,7 +623,7 @@
     },
     {
       "id": 2,
-      "name": "Crystal Flash Clip (Right to Left)",
+      "name": "Crystal Flash Clip",
       "note": [
         "Crystal flash to force a standup then spin jump up then morph to bypass the dead robot. Use Coverns to damage down if necessary.",
         "Note that if the Covern spawns on Samus while crystal flashing, it will deal large amounts of damage.",
@@ -632,7 +632,7 @@
     },
     {
       "id": 3,
-      "name": "R-Mode Standup Clip (Right to Left)",
+      "name": "R-Mode Standup Clip",
       "note": [
         "In R-Mode, kill the Coverns until there is Energy in Samus's Reserves. Get into the Morph tunnel and go to the far left.",
         "Wait for Coverns to damage Samus down until Reserves trigger, forcing a stand up and enabling her to escape.",


### PR DESCRIPTION
This simplifies a few notable names that seemed more verbose than necessary. I started with notables referenced in the v117 release notes, then did a few more. It's not a complete pass though.

I also added a `canPreciseSpaceJump` requirement on the East Ocean left-to-right strat with Space Jump only.

Also I notice we have a lot of notables for cross-room shinecharge/shinespark strats that probably don't need to be notable anymore, something that could be cleaned up later.