### PR TITLE
Green Maridia shinecharges

### DIFF
--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -288,6 +288,30 @@
       "note": "Cross the sand, then spark up left."
     },
     {
+      "link": [2, 1],
+      "name": "Come In Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 6.5,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canShinechargeMovementTricky",
+        "canDownBack",
+        {"shineChargeFrames": 130}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 13,
       "link": [2, 1],
       "name": "Grapple Teleport",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -151,7 +151,7 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "Suitless Shinespark",
+      "name": "Come In With Spark (Suitless)",
       "entranceCondition": {
         "comeInWithSpark": {
           "position": "top"
@@ -166,7 +166,7 @@
     {
       "id": 5,
       "link": [1, 2],
-      "name": "Shinespark Into Room",
+      "name": "Come In With Spark (Gravity)",
       "entranceCondition": {
         "comeInWithSpark": {
           "position": "top"
@@ -182,7 +182,7 @@
     {
       "id": 6,
       "link": [1, 2],
-      "name": "Shinespark",
+      "name": "Come In Shinecharging, Shinespark (Gravity)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -200,7 +200,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Suitless Shinespark, Careful Slow Shinecharge",
+      "name": "Come In Shinecharging, Shinespark (Suitless)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 1,
@@ -209,15 +209,12 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
-        "canSlowShortCharge",
+        "canPlayInSand",
         "canMidairShinespark",
-        {"canShineCharge": {"usedTiles": 14, "openEnd": 0}},
-        {"shinespark": {"frames": 69, "excessFrames": 7}}
+        {"shinespark": {"frames": 67, "excessFrames": 13}}
       ],
-      "note": "Gain an extra half-tile of runway by coming in very slowly to prevent falling off.",
-      "devNote": [
-        "If applicable, the heat frames in the adjacent room may be underrepresented, particularly on a longer runway,",
-        "but it shouldn't be too bad because with a longer runway, Samus can just come in fully shinecharged."
+      "note": [
+        "It helps to wait to enter the sandfall until after Samus is near the peak of her jump."
       ]
     },
     {
@@ -807,7 +804,7 @@
     {
       "id": 32,
       "link": [2, 1],
-      "name": "Suitless Shinespark",
+      "name": "Come In With Spark (Suitless)",
       "entranceCondition": {
         "comeInWithSpark": {
           "position": "top"
@@ -822,7 +819,7 @@
     {
       "id": 33,
       "link": [2, 1],
-      "name": "Shinespark Into Room",
+      "name": "Come In With Spark (Gravity)",
       "entranceCondition": {
         "comeInWithSpark": {
           "position": "top"
@@ -838,7 +835,7 @@
     {
       "id": 34,
       "link": [2, 1],
-      "name": "Shinespark",
+      "name": "Come In Shinecharging, Shinespark (Gravity)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -856,7 +853,7 @@
     {
       "id": 35,
       "link": [2, 1],
-      "name": "Suitless Shinespark, Careful Slow Shinecharge",
+      "name": "Come In Shinecharging, Shinespark (Suitless)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 1,
@@ -865,15 +862,12 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
-        "canSlowShortCharge",
+        "canPlayInSand",
         "canMidairShinespark",
-        {"canShineCharge": {"usedTiles": 14, "openEnd": 0}},
-        {"shinespark": {"frames": 69, "excessFrames": 7}}
+        {"shinespark": {"frames": 67, "excessFrames": 13}}
       ],
-      "note": "Gain an extra half-tile of runway by coming in very slowly to prevent falling off.",
-      "devNote": [
-        "If applicable, the heat frames in the adjacent room may be underrepresented, particularly on a longer runway,",
-        "but it shouldn't be too bad because with a longer runway, Samus can just come in fully shinecharged."
+      "note": [
+        "It helps to wait to enter the sandfall until after Samus is near the peak of her jump."
       ]
     },
     {

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -119,6 +119,8 @@
     {
       "from": 3,
       "to": [
+        {"id": 1},
+        {"id": 2},
         {"id": 3},
         {"id": 4},
         {"id": 5}
@@ -324,7 +326,7 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Leave Shinecharged",
+      "name": "Come In Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 13,
@@ -333,7 +335,7 @@
       },
       "requires": [
         "Gravity",
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -347,7 +349,7 @@
     {
       "id": 11,
       "link": [1, 2],
-      "name": "Suitless Water Shinecharge",
+      "name": "Suitless Water Shinecharge, Leave Shinecharged",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -357,7 +359,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "h_canShineChargeMaxRunway",
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -372,12 +374,12 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "Come In Shinecharged, Leave Sparking",
+      "name": "Come In Shinecharged, Leave With Sparkk",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 25},
+        {"shineChargeFrames": 20},
         {"shinespark": {"frames": 23}}
       ],
       "exitCondition": {
@@ -484,6 +486,39 @@
         "A third momentumConservingTurnaround is used on the door as it is opening."
       ],
       "devNote": "This does not have collision oscillation. It is possible to do this without Screw Attack, but is extremely precise."
+    },
+    {
+      "link": [1, 3],
+      "name": "Come In Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        "ScrewAttack",
+        "canShinechargeMovementTricky",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 130}
+          ]},
+          {"shineChargeFrames": 145}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: It can be possible to use a longer runway, or a stutter shinecharge with Gravity re-equip, with a cost of some shinecharge frames."
+      ]
     },
     {
       "id": 17,
@@ -626,7 +661,7 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Leave Shinecharged",
+      "name": "Come In Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 13,
@@ -635,7 +670,7 @@
       },
       "requires": [
         "Gravity",
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -649,7 +684,7 @@
     {
       "id": 25,
       "link": [2, 1],
-      "name": "Suitless Water Shinecharge",
+      "name": "Suitless Water Shinecharge, Leave Shinecharged",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -659,7 +694,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "h_canShineChargeMaxRunway",
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -674,7 +709,7 @@
     {
       "id": 26,
       "link": [2, 1],
-      "name": "Come In Shinecharged, Leave Sparking",
+      "name": "Come In Shinecharged, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -955,6 +990,39 @@
       "devNote": "This does not have collision oscillation. It is possible to do this without Screw Attack, but is extremely precise."
     },
     {
+      "link": [2, 3],
+      "name": "Come In Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        "ScrewAttack",
+        "canShinechargeMovementTricky",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 130}
+          ]},
+          {"shineChargeFrames": 145}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: It can be possible to use a longer runway, or a stutter shinecharge with Gravity re-equip, with a cost of some shinecharge frames."
+      ]
+    },
+    {
       "id": 40,
       "link": [2, 4],
       "name": "Diagonal Suitless Shinespark to the Top",
@@ -1107,6 +1175,52 @@
         "Note that it is possible to spark into the ceiling to break the blocks without energy loss, but it has collision oscillation.",
         "FIXME: Add temporary blue strats."
       ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {},
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "Gravity",
+        "ScrewAttack",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 160},
+        {"shinespark": {"frames": 6, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {},
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "Gravity",
+        "ScrewAttack",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 160},
+        {"shinespark": {"frames": 6, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 48,

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -249,7 +249,7 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 110},
+        {"shineChargeFrames": 100},
         {"notable": "Shinespark"},
         "h_canNavigateUnderwater",
         "canShinechargeMovementTricky",

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -110,13 +110,13 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "Leave Shinecharged",
+      "name": "Leave Shinecharged (Suitless)",
       "requires": [
         {"obstaclesCleared": ["A", "B"]},
         "canShinechargeMovement",
         "canWaterShineCharge",
         {"canShineCharge": {"usedTiles": 35, "openEnd": 2}},
-        {"shineChargeFrames": 100}
+        {"shineChargeFrames": 90}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -127,19 +127,18 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "Leave Shinecharged, Gravity",
+      "name": "Leave Shinecharged (Gravity)",
       "requires": [
         {"obstaclesCleared": ["A", "B"]},
         "canShinechargeMovement",
         "Gravity",
         {"canShineCharge": {"usedTiles": 42, "openEnd": 2}},
-        {"shineChargeFrames": 80}
+        {"shineChargeFrames": 55}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true,
-      "devNote": "FIXME: By falling off the runway with precise movement, 135 frames are possible."
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -504,7 +503,7 @@
         "canShinechargeMovement",
         "canWaterShineCharge",
         {"canShineCharge": {"usedTiles": 35, "openEnd": 2}},
-        {"shineChargeFrames": 100}
+        {"shineChargeFrames": 80}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -521,13 +520,12 @@
         "canShinechargeMovement",
         "Gravity",
         {"canShineCharge": {"usedTiles": 42, "openEnd": 2}},
-        {"shineChargeFrames": 80}
+        {"shineChargeFrames": 45}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true,
-      "devNote": "FIXME: By falling off the runway with precise movement, 135 frames are possible."
+      "flashSuitChecked": true
     },
     {
       "id": 27,

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -179,7 +179,7 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Leave Shinecharged",
+      "name": "Come In Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 13,
@@ -188,7 +188,7 @@
       },
       "requires": [
         "Gravity",
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -203,7 +203,7 @@
     {
       "id": 9,
       "link": [1, 2],
-      "name": "Suitless Water Shinecharge",
+      "name": "Suitless Water Shinecharge, Leave Shinecharged",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -220,7 +220,7 @@
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -233,14 +233,52 @@
       "note": "Get the shinecharge while killing the crab, then exit the right door."
     },
     {
-      "id": 10,
       "link": [1, 2],
-      "name": "Come In Shinecharged, Leave Sparking",
+      "name": "Carry Shinecharge",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 25},
+        "Gravity",
+        {"or": [
+          {"and": [
+            "Plasma",
+            {"shineChargeFrames": 55}
+          ]},
+          {"and": [
+            "canTrickyJump",
+            {"shineChargeFrames": 60}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "With the larger hitbox of Plasma, the door can be opened fast enough to safely run under the crab.",
+        "Otherwise, a small spin-jump may be required to reduce Samus' hitbox through the transition."
+      ],
+      "devNote": [
+        "FIXME: coming in with some run speed might be another way to avoid the crab?",
+        "Spin jumping through the transition technically does not conform to the exit condition,",
+        "but it is possible to land in a single frame in the next room by breaking spin,",
+        "and we include several frames of lenience which is hopefully enough account for any issue in the next room."
+      ]
+    },
+    {
+      "id": 10,
+      "link": [1, 2],
+      "name": "Come In Shinecharged, Leave With Spark",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 20},
         {"shinespark": {"frames": 23}}
       ],
       "exitCondition": {
@@ -395,7 +433,7 @@
     {
       "id": 18,
       "link": [2, 1],
-      "name": "Leave Shinecharged",
+      "name": "Come In Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 13,
@@ -404,7 +442,7 @@
       },
       "requires": [
         "Gravity",
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -418,7 +456,7 @@
     {
       "id": 19,
       "link": [2, 1],
-      "name": "Suitless Water Shinecharge",
+      "name": "Suitless Water Shinecharge, Leave Shinecharged",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -428,7 +466,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "h_canShineChargeMaxRunway",
-        {"shineChargeFrames": 1}
+        {"shineChargeFrames": 10}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -443,12 +481,12 @@
     {
       "id": 20,
       "link": [2, 1],
-      "name": "Come In Shinecharged, Leave Sparking",
+      "name": "Come In Shinecharged, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 25},
+        {"shineChargeFrames": 20},
         {"shinespark": {"frames": 23}}
       ],
       "exitCondition": {

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -155,7 +155,7 @@
     {
       "id": 3,
       "link": [1, 2],
-      "name": "Suitless Shinespark (Come In With Spark)",
+      "name": "Come In With Spark (Suitless)",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
@@ -166,7 +166,7 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "Shinespark (Come In With Spark)",
+      "name": "Come In With Spark (Gravity)",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
@@ -178,7 +178,7 @@
     {
       "id": 5,
       "link": [1, 2],
-      "name": "Shinespark (Come In Shinecharging)",
+      "name": "Come In Shinecharging, Shinespark (Gravity)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -194,7 +194,7 @@
     {
       "id": 6,
       "link": [1, 2],
-      "name": "Suitless Shinespark (Come In Shinecharging)",
+      "name": "Come In Shinecharging, Shinespark (Suitless)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 1,
@@ -493,7 +493,7 @@
     {
       "id": 21,
       "link": [2, 1],
-      "name": "Suitless Shinespark (Come In With Spark)",
+      "name": "Come In With Spark (Suitless)",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
@@ -504,7 +504,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Shinespark Into Room",
+      "name": "Come In With Spark (Gravity)",
       "entranceCondition": {
         "comeInWithSpark": {}
       },
@@ -516,7 +516,7 @@
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Shinespark",
+      "name": "Come In Shinecharging, Shinespark (Gravity)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -532,7 +532,7 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Suitless Shinespark (Come In Shinecharging)",
+      "name": "Come In Shinecharging, Shinespark (Suitless)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 1,


### PR DESCRIPTION
This completes a full pass over the regions to add/refine shinecharge strats, since "Carry Shinecharge" became possible in the schema. It's taken long enough that now the early regions could probably use another pass; not planning on that though, haha.