### PR TITLE
Main Street G-Mode Cleanup

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -973,157 +973,6 @@
       "devNote": "FIXME: Add a midair version requiring 0 tanks"
     },
     {
-      "id": 22,
-      "link": [1, 6],
-      "name": "G-Mode Morph IBJ Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        },
-        "comesThroughToilet": "any"
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "h_canArtificialMorphIBJ",
-        "Gravity",
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "h_canArtificialMorphJumpIntoIBJ",
-          {"and": [
-            "h_canArtificialMorphSpringBall",
-            "HiJump"
-          ]},
-          {"and": [
-            "h_canArtificialMorphSpringBall",
-            "canGravityJump"
-          ]},
-          "h_canArtificialMorphDoubleBombJump",
-          "h_canArtificialMorphStaggeredIBJ",
-          "canBeVeryPatient",
-          "h_canArtificialMorphPowerBomb"
-        ]},
-        {"or": [
-          "h_canArtificialMorphSpringBall",
-          "h_canArtificialMorphCeilingBombJump",
-          "canBeVeryPatient"
-        ]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
-        "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 23,
-      "link": [1, 6],
-      "name": "G-Mode Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        },
-        "comesThroughToilet": "any"
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        "h_canUseMorphBombs",
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump"
-          ]}
-        ]},
-        {"or": [
-          "h_canUseSpringBall",
-          "canBeVeryPatient",
-          {"and": [
-            "Gravity",
-            "canCeilingBombJump"
-          ]}
-        ]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 24,
-      "link": [1, 6],
-      "name": "G-Mode Morph IBJ PB Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": true
-        },
-        "comesThroughToilet": "no"
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "h_canArtificialMorphIBJ",
-        "Gravity",
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "h_canArtificialMorphJumpIntoIBJ",
-          "h_canArtificialMorphDoubleBombJump",
-          "h_canArtificialMorphStaggeredIBJ",
-          "canBeVeryPatient",
-          "h_canArtificialMorphPowerBomb"
-        ]},
-        {"ammo": {"type": "PowerBomb", "count": 2}}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
-        "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
-        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
-        "Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 25,
-      "link": [1, 6],
-      "name": "G-Mode PB Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": false
-        },
-        "comesThroughToilet": "no"
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump"
-          ]}
-        ]},
-        "h_canUsePowerBombs",
-        "h_canUsePowerBombs"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
-        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
-        "Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
       "id": 26,
       "link": [1, 8],
       "name": "Base",
@@ -1192,6 +1041,190 @@
         {"shinespark": {"frames": 73, "excessFrames": 3}}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "id": 24,
+      "link": [1, 10],
+      "name": "Direct G-Mode Morph IBJ PB Overload Speed Blocks (Get Into Position)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        },
+        "comesThroughToilet": "no"
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canArtificialMorphIBJ",
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphJumpIntoIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
+          "canBeVeryPatient",
+          "h_canArtificialMorphPowerBomb"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": "This is a long climb, and getting around the fish under the speed blocks can be tricky or slow."
+    },
+    {
+      "id": 25,
+      "link": [1, 10],
+      "name": "Direct G-Mode PB Overload Speed Blocks (Get Into Position)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        },
+        "comesThroughToilet": "no"
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canNavigateUnderwater",
+        {"or": [
+          "canGravityJump",
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]},
+          {"and": [
+            "Gravity",
+            "canTrickyUseFrozenEnemies",
+            "h_canCrouchJumpDownGrab"
+          ]},
+          {"and": [
+            "HiJump",
+            {"or": [
+              "canUnderwaterWalljump",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "canTrickyUseFrozenEnemies",
+                "canCrouchJump"
+              ]}
+            ]}
+          ]},
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            "canTrickyUseFrozenEnemies",
+            "canBeVeryPatient",
+            {"ammo": {"type": "Super", "count": 1}}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Climb to the ledge left of the morph tunnel item. Carefully and quickly freeze the last crab high enough to use as a platform.",
+        "With a slow ascent, such as with Spring Ball and Ice, the crab will need to circle the entire room."
+      ]
+    },
+    {
+      "id": 22,
+      "link": [1, 11],
+      "name": "G-Mode Morph IBJ Overload Speed Blocks (Bombs)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canArtificialMorphIBJ",
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphJumpIntoIBJ",
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "HiJump"
+          ]},
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "canGravityJump"
+          ]},
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
+          "canBeVeryPatient",
+          "h_canArtificialMorphPowerBomb"
+        ]},
+        {"or": [
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphCeilingBombJump",
+          "canBeVeryPatient"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
+        "Place bombs against the speed blocks until they are overloaded."
+      ]
+    },
+    {
+      "id": 23,
+      "link": [1, 11],
+      "name": "G-Mode Overload Speed Blocks (From the Bottom)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canUseMorphBombs",
+        "h_canNavigateUnderwater",
+        {"or": [
+          "canGravityJump",
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]},
+          {"and": [
+            "Gravity",
+            "canTrickyUseFrozenEnemies",
+            "h_canCrouchJumpDownGrab"
+          ]},
+          {"and": [
+            "HiJump",
+            {"or": [
+              "canUnderwaterWalljump",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "canTrickyUseFrozenEnemies",
+                "canCrouchJump"
+              ]}
+            ]}
+          ]},
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            "canTrickyUseFrozenEnemies",
+            "canBeVeryPatient",
+            {"ammo": {"type": "Super", "count": 1}}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Gravity",
+            "h_canUseSpringBall"
+          ]},
+          {"and": [
+            "HiJump",
+            "h_canUseSpringBall"
+          ]},
+          "canBeVeryPatient",
+          {"and": [
+            "Gravity",
+            "canCeilingBombJump"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Place bombs against the speed blocks until they are overloaded.",
+        "With a slow ascent, such as with Spring Ball and Ice, the crab will need to circle the entire room."
+      ]
     },
     {
       "id": 157,
@@ -1764,154 +1797,6 @@
       "devNote": "FIXME: Add a midair version requiring 0 tanks"
     },
     {
-      "id": 56,
-      "link": [2, 6],
-      "name": "G-Mode Morph IBJ Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "h_canArtificialMorphIBJ",
-        "Gravity",
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "h_canArtificialMorphJumpIntoIBJ",
-          {"and": [
-            "h_canArtificialMorphSpringBall",
-            "HiJump"
-          ]},
-          {"and": [
-            "h_canArtificialMorphSpringBall",
-            "canGravityJump"
-          ]},
-          "h_canArtificialMorphDoubleBombJump",
-          "h_canArtificialMorphStaggeredIBJ",
-          "canBeVeryPatient",
-          "h_canArtificialMorphPowerBomb"
-        ]},
-        {"or": [
-          "h_canArtificialMorphSpringBall",
-          "h_canArtificialMorphCeilingBombJump",
-          "canBeVeryPatient"
-        ]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
-        "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 57,
-      "link": [2, 6],
-      "name": "G-Mode Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        "h_canUseMorphBombs",
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump"
-          ]}
-        ]},
-        {"or": [
-          "h_canUseSpringBall",
-          "canBeVeryPatient",
-          {"and": [
-            "Gravity",
-            "canCeilingBombJump"
-          ]}
-        ]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 58,
-      "link": [2, 6],
-      "name": "G-Mode Morph IBJ PB Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "h_canArtificialMorphIBJ",
-        "Gravity",
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "h_canArtificialMorphJumpIntoIBJ",
-          "h_canArtificialMorphDoubleBombJump",
-          "h_canArtificialMorphStaggeredIBJ",
-          "canBeVeryPatient",
-          "h_canArtificialMorphPowerBomb"
-        ]},
-        "h_canArtificialMorphPowerBomb",
-        "h_canArtificialMorphPowerBomb"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
-        "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
-        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
-        "Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 59,
-      "link": [2, 6],
-      "name": "G-Mode PB Overload Speed Blocks Frozen Crab (From the Bottom)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": false
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump"
-          ]}
-        ]},
-        "h_canUsePowerBombs",
-        "h_canUsePowerBombs"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
-        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
-        "Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
       "id": 60,
       "link": [2, 8],
       "name": "Base",
@@ -2003,6 +1888,186 @@
       ],
       "flashSuitChecked": true,
       "devNote": "This also requires coming in with a small amount of momentum. Even running less than the distance of a door frame is enough, but isn't able to be modeled currently."
+    },
+    {
+      "id": 58,
+      "link": [2, 10],
+      "name": "Direct G-Mode Morph IBJ PB Overload Speed Blocks (Get Into Position)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canArtificialMorphIBJ",
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphJumpIntoIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
+          "canBeVeryPatient",
+          "h_canArtificialMorphPowerBomb"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": "This is a long climb, and getting around the fish under the speed blocks can be tricky or slow."
+    },
+    {
+      "id": 59,
+      "link": [2, 10],
+      "name": "Direct G-Mode PB Overload Speed Blocks (Get Into Position)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canNavigateUnderwater",
+        {"or": [
+          "canGravityJump",
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]},
+          {"and": [
+            "Gravity",
+            "canTrickyUseFrozenEnemies",
+            "h_canCrouchJumpDownGrab"
+          ]},
+          {"and": [
+            "HiJump",
+            {"or": [
+              "canUnderwaterWalljump",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "canTrickyUseFrozenEnemies",
+                "canCrouchJump"
+              ]}
+            ]}
+          ]},
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            "canTrickyUseFrozenEnemies",
+            "canBeVeryPatient",
+            {"ammo": {"type": "Super", "count": 1}}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Climb to the ledge left of the morph tunnel item. Carefully and quickly freeze the last crab high enough to use as a platform.",
+        "With a slow ascent, such as with Spring Ball and Ice, the crab will need to circle the entire room."
+      ]
+    },
+    {
+      "id": 56,
+      "link": [2, 11],
+      "name": "G-Mode Morph IBJ Overload Speed Blocks (Bombs)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canArtificialMorphIBJ",
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphJumpIntoIBJ",
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "HiJump"
+          ]},
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "canGravityJump"
+          ]},
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
+          "canBeVeryPatient",
+          "h_canArtificialMorphPowerBomb"
+        ]},
+        {"or": [
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphCeilingBombJump",
+          "canBeVeryPatient"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
+        "Place bombs against the speed blocks until they are overloaded."
+      ]
+    },
+    {
+      "id": 57,
+      "link": [2, 11],
+      "name": "G-Mode Overload Speed Blocks (Bombs)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canUseMorphBombs",
+        "h_canNavigateUnderwater",
+        {"or": [
+          "canGravityJump",
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]},
+          {"and": [
+            "Gravity",
+            "canTrickyUseFrozenEnemies",
+            "h_canCrouchJumpDownGrab"
+          ]},
+          {"and": [
+            "HiJump",
+            {"or": [
+              "canUnderwaterWalljump",
+              "canSpringBallJumpMidAir",
+              {"and": [
+                "canTrickyUseFrozenEnemies",
+                "canCrouchJump"
+              ]}
+            ]}
+          ]},
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            "canTrickyUseFrozenEnemies",
+            "canBeVeryPatient",
+            {"ammo": {"type": "Super", "count": 1}}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Gravity",
+            "h_canUseSpringBall"
+          ]},
+          {"and": [
+            "HiJump",
+            "h_canUseSpringBall"
+          ]},
+          "canBeVeryPatient",
+          {"and": [
+            "Gravity",
+            "canCeilingBombJump"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Place bombs against the speed blocks until they are overloaded.",
+        "With a slow ascent, such as with Spring Ball and Ice, the crab will need to circle the entire room."
+      ]
     },
     {
       "id": 65,
@@ -2773,29 +2838,43 @@
       "requires": [
         {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canNavigateUnderwater",
-        "canTrickyUseFrozenEnemies",
         {"or": [
-          "Gravity",
+          "canGravityJump",
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]},
+          {"and": [
+            "Gravity",
+            "canTrickyUseFrozenEnemies"
+          ]},
           {"and": [
             "HiJump",
             {"or":[
+              "canSpringBallJumpMidAir",
+              "canUnderwaterWalljump"
+            ]}
+          ]},
+          {"and": [
+            "HiJump",
+            "canTrickyUseFrozenEnemies",
+            {"or":[
               "canCrouchJump",
-              "canDownGrab",
-              "canSpringBallJumpMidAir"
+              "canDownGrab"
             ]}
           ]},
           {"and": [
             "h_canMaxHeightSpringBallJump",
+            "canTrickyUseFrozenEnemies",
             "canBeVeryPatient"
           ]}
         ]}
       ],
       "flashSuitChecked": true,
       "note": [
-        "Climb to the ledge left of the morph tunnel item. Carefully and quickly freeze the last crab high enough to use as a platform.",
-        "With a slow ascent, such as with Spring Ball, the crab will need to circle the entire room."
-      ],
-      "devNote": "FIXME There are variants that don't require Ice which should be added, but it makes things a lot more complex."
+        "Climb to the ledge left of the morph tunnel item. With Ice, carefully and quickly freeze the last crab high enough to use as a platform.",
+        "With a slow ascent, such as with Spring Ball and Ice, the crab will need to circle the entire room."
+      ]
     },
     {
       "id": 82,
@@ -2852,12 +2931,30 @@
         {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
         "h_canUseMorphBombs",
         "h_canNavigateUnderwater",
-        "canTrickyUseFrozenEnemies",
         {"or": [
-          "Gravity",
-          "HiJump",
+          "canGravityJump",
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]},
+          {"and": [
+            "Gravity",
+            "canTrickyUseFrozenEnemies"
+          ]},
+          {"and": [
+            "HiJump",
+            {"or":[
+              "canSpringBallJumpMidAir",
+              "canUnderwaterWalljump"
+            ]}
+          ]},
+          {"and": [
+            "HiJump",
+            "canTrickyUseFrozenEnemies"
+          ]},
           {"and": [
             "h_canMaxHeightSpringBallJump",
+            "canTrickyUseFrozenEnemies",
             "canBeVeryPatient"
           ]}
         ]},
@@ -2880,9 +2977,8 @@
       "flashSuitChecked": true,
       "note": [
         "Place bombs against the speed blocks until they are overloaded.",
-        "With a slow ascent, such as with Spring Ball, the crab will need to circle the entire room."
-      ],
-      "devNote": "FIXME There are variants that don't require Ice which should be added, but it makes things a lot more complex."
+        "With a slow ascent, such as with Spring Ball and Ice, the crab will need to circle the entire room."
+      ]
     },
     {
       "id": 101,
@@ -3057,7 +3153,7 @@
               "Gravity",
               "HiJump"
             ]}
-          ]}
+          ]},
           {"and": [
             "Morph",
             "canBeVeryPatient",

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -180,6 +180,38 @@
         [1, 1, 1],
         [1, 1, 0]
       ]
+    },
+    {
+      "id": 10,
+      "name": "Direct G-Mode Morph On Ledge Left of Morph Tunnel Item",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "mapTileMask": [
+        [1, 1, 0],
+        [1, 1, 0],
+        [2, 1, 1],
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 1],
+        [1, 1, 0]
+      ]
+    },
+    {
+      "id": 11,
+      "name": "G-Mode Junction Below Speed Blocks (Overloaded PLMs)",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "mapTileMask": [
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 1],
+        [2, 2, 0],
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 1],
+        [1, 1, 0]
+      ]
     }
   ],
   "obstacles": [
@@ -254,7 +286,9 @@
         {"id": 3},
         {"id": 6},
         {"id": 8},
-        {"id": 9}
+        {"id": 9},
+        {"id": 10},
+        {"id": 11}
       ]
     },
     {
@@ -268,7 +302,9 @@
         },
         {"id": 6},
         {"id": 8},
-        {"id": 9}
+        {"id": 9},
+        {"id": 10},
+        {"id": 11}
       ]
     },
     {
@@ -280,7 +316,9 @@
         {"id": 4},
         {"id": 6},
         {"id": 8},
-        {"id": 9}
+        {"id": 9},
+        {"id": 10},
+        {"id": 11}
       ]
     },
     {
@@ -288,7 +326,9 @@
       "to": [
         {"id": 4},
         {"id": 6},
-        {"id": 9}
+        {"id": 9},
+        {"id": 10},
+        {"id": 11}
       ]
     },
     {
@@ -326,6 +366,18 @@
       "to": [
         {"id": 3},
         {"id": 4}
+      ]
+    },
+    {
+      "from": 10,
+      "to": [
+        {"id": 11}
+      ]
+    },
+    {
+      "from": 11,
+      "to": [
+        {"id": 6}
       ]
     }
   ],
@@ -993,8 +1045,7 @@
           "canBeVeryPatient",
           {"and": [
             "Gravity",
-            "canCeilingBombJump",
-            "canIBJ"
+            "canCeilingBombJump"
           ]}
         ]}
       ],
@@ -1783,8 +1834,7 @@
           "canBeVeryPatient",
           {"and": [
             "Gravity",
-            "canCeilingBombJump",
-            "canIBJ"
+            "canCeilingBombJump"
           ]}
         ]}
       ],
@@ -2408,155 +2458,6 @@
       "devNote": "The excess frames occur after the item is obtained, but it shouldn't matter, as Samus can farm a bit in room if needed."
     },
     {
-      "id": 82,
-      "link": [3, 6],
-      "name": "G-Mode Morph IBJ Overload Speed Blocks Frozen Crab (From the Middle)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "h_canArtificialMorphIBJ",
-        "Gravity",
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "h_canArtificialMorphJumpIntoIBJ",
-          {"and": [
-            "h_canArtificialMorphSpringBall",
-            "HiJump"
-          ]},
-          {"and": [
-            "h_canArtificialMorphSpringBall",
-            "canGravityJump"
-          ]},
-          "h_canArtificialMorphDoubleBombJump",
-          "h_canArtificialMorphStaggeredIBJ",
-          "canBeVeryPatient",
-          "h_canArtificialMorphPowerBomb"
-        ]},
-        {"or": [
-          "h_canArtificialMorphSpringBall",
-          "h_canArtificialMorphCeilingBombJump",
-          "canBeVeryPatient"
-        ]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
-        "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 83,
-      "link": [3, 6],
-      "name": "G-Mode Overload Speed Blocks Frozen Crab (From the Middle)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        "h_canUseMorphBombs",
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump"
-          ]}
-        ]},
-        {"or": [
-          "h_canUseSpringBall",
-          "canBeVeryPatient",
-          {"and": [
-            "Gravity",
-            "canCeilingBombJump",
-            "canIBJ"
-          ]}
-        ]}
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 84,
-      "link": [3, 6],
-      "name": "G-Mode Morph IBJ PB Overload Speed Blocks Frozen Crab (From the Middle)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "h_canArtificialMorphIBJ",
-        "Gravity",
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "h_canArtificialMorphJumpIntoIBJ",
-          "h_canArtificialMorphDoubleBombJump",
-          "h_canArtificialMorphStaggeredIBJ",
-          "canBeVeryPatient",
-          "h_canArtificialMorphPowerBomb"
-        ]},
-        "h_canArtificialMorphPowerBomb",
-        "h_canArtificialMorphPowerBomb"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
-        "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
-        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
-        "Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 85,
-      "link": [3, 6],
-      "name": "G-Mode PB Overload Speed Blocks Frozen Crab (From the Middle)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": false
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump"
-          ]}
-        ]},
-        "h_canUsePowerBombs",
-        "h_canUsePowerBombs"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
-        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
-        "Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
       "id": 86,
       "link": [3, 8],
       "name": "Base",
@@ -2835,6 +2736,155 @@
       ]
     },
     {
+      "id": 84,
+      "link": [3, 10],
+      "name": "Direct G-Mode Morph IBJ PB Overload Speed Blocks (Get Into Position)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canArtificialMorphIBJ",
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphJumpIntoIBJ",
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
+          "canBeVeryPatient",
+          "h_canArtificialMorphPowerBomb"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": "This is a long climb, and getting around the fish under the speed blocks can be tricky or slow."
+    },
+    {
+      "id": 85,
+      "link": [3, 10],
+      "name": "Direct G-Mode PB Overload Speed Blocks (Get Into Position)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canNavigateUnderwater",
+        "canTrickyUseFrozenEnemies",
+        {"or": [
+          "Gravity",
+          {"and": [
+            "HiJump",
+            {"or":[
+              "canCrouchJump",
+              "canDownGrab",
+              "canSpringBallJumpMidAir"
+            ]}
+          ]},
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            "canBeVeryPatient"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Climb to the ledge left of the morph tunnel item. Carefully and quickly freeze the last crab high enough to use as a platform.",
+        "With a slow ascent, such as with Spring Ball, the crab will need to circle the entire room."
+      ],
+      "devNote": "FIXME There are variants that don't require Ice which should be added, but it makes things a lot more complex."
+    },
+    {
+      "id": 82,
+      "link": [3, 11],
+      "name": "G-Mode Morph IBJ Overload Speed Blocks",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canArtificialMorphIBJ",
+        "Gravity",
+        {"or": [
+          "h_canArtificialMorphJumpIntoIBJ",
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "HiJump"
+          ]},
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            "canGravityJump"
+          ]},
+          "h_canArtificialMorphDoubleBombJump",
+          "h_canArtificialMorphStaggeredIBJ",
+          "canBeVeryPatient",
+          "h_canArtificialMorphPowerBomb"
+        ]},
+        {"or": [
+          "h_canArtificialMorphSpringBall",
+          "h_canArtificialMorphCeilingBombJump",
+          "canBeVeryPatient"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
+        "Place bombs against the speed blocks until they are overloaded."
+      ]
+    },
+    {
+      "id": 83,
+      "link": [3, 11],
+      "name": "G-Mode Overload Speed Blocks (Bombs)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canUseMorphBombs",
+        "h_canNavigateUnderwater",
+        "canTrickyUseFrozenEnemies",
+        {"or": [
+          "Gravity",
+          "HiJump",
+          {"and": [
+            "h_canMaxHeightSpringBallJump",
+            "canBeVeryPatient"
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Gravity",
+            "h_canUseSpringBall"
+          ]},
+          {"and": [
+            "HiJump",
+            "h_canUseSpringBall"
+          ]},
+          "canBeVeryPatient",
+          {"and": [
+            "Gravity",
+            "canCeilingBombJump"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Place bombs against the speed blocks until they are overloaded.",
+        "With a slow ascent, such as with Spring Ball, the crab will need to circle the entire room."
+      ],
+      "devNote": "FIXME There are variants that don't require Ice which should be added, but it makes things a lot more complex."
+    },
+    {
       "id": 101,
       "link": [4, 4],
       "name": "Leave with Runway",
@@ -2964,9 +3014,32 @@
       "devNote": "For other doors, a shinespark is more reasonable than a complex Temporary Blue Chain. And the enemies here are farmable for energy."
     },
     {
+      "id": 111,
+      "link": [4, 9],
+      "name": "Base",
+      "requires": []
+    },
+    {
+      "id": 110,
+      "link": [4, 10],
+      "name": "Direct G-Mode Morph PB Overload Speed Blocks (Get Into Position)",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canNavigateUnderwater"
+      ],
+      "flashSuitChecked": true,
+      "note": "Carefully descend to the ledge left of the morph tunnel item."
+    },
+    {
       "id": 109,
-      "link": [4, 6],
-      "name": "G-Mode Morph Overload Speed Blocks Frozen Crab (From the Top)",
+      "link": [4, 11],
+      "name": "G-Mode Morph Overload Speed Blocks (Bombs)",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -2975,25 +3048,27 @@
       },
       "requires": [
         {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "HiJump"
-          ]}
-        ]},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
+        "h_canNavigateUnderwater",
         "h_canArtificialMorphBombs",
         {"or": [
-          "h_canArtificialMorphSpringBall",
+          {"and": [
+            "h_canArtificialMorphSpringBall",
+            {"or": [
+              "Gravity",
+              "HiJump"
+            ]}
+          ]}
           {"and": [
             "Morph",
-            "canBeVeryPatient"
+            "canBeVeryPatient",
+            {"or": [
+              "Gravity",
+              "HiJump",
+              "canCrouchJump"
+            ]}
           ]},
           {"and": [
             "Gravity",
-            "h_canArtificialMorphIBJ",
             "h_canArtificialMorphCeilingBombJump"
           ]},
           {"and": [
@@ -3004,48 +3079,7 @@
         ]}
       ],
       "flashSuitChecked": true,
-      "note": [
-        "Place bombs against the speed blocks until they are overloaded. Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 110,
-      "link": [4, 6],
-      "name": "G-Mode Morph PB Overload Speed Blocks Frozen Crab (From the Top)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
-        {"or": [
-          "Gravity",
-          {"and": [
-            "canSuitlessMaridia",
-            "canCrouchJump"
-          ]}
-        ]},
-        "canTrickyUseFrozenEnemies",
-        "Wave",
-        "h_canArtificialMorphPowerBomb",
-        "h_canArtificialMorphPowerBomb"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Overloading the PLMs can be done with as few as 2 PBs if they are placed precisely.",
-        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right.",
-        "Afterwards, freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
-      ]
-    },
-    {
-      "id": 111,
-      "link": [4, 9],
-      "name": "Base",
-      "requires": []
+      "note": "Place bombs against the speed blocks until they are overloaded."
     },
     {
       "id": 112,
@@ -3534,7 +3568,7 @@
         "HiJump",
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "canDownGrab",
           {"obstaclesNotCleared": ["A"]}
         ]}
       ],
@@ -3671,6 +3705,44 @@
         "If the Speed blocks are broken, the global crab will not be able to reach this part of the room.",
         "If Morph is unavailable, then a down-grab must be done blind: buffer the down input through the reserve refill, then press forward immediately after taking damage."
       ]
+    },
+    {
+      "link": [10, 11],
+      "name": "G-Mode Morph PB Overload Speed Blocks",
+      "requires": [
+        "canEnterGMode",
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canNavigateUnderwater",
+        "h_canArtificialMorphPowerBomb",
+        "h_canArtificialMorphPowerBomb"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Overloading the PLMs can be done with as few as 2 Power Bombs if they are placed precisely.",
+        "Place them two ledges above the item - to the left of the morph tunnel item. It is important that they are placed on either of the flat tiles, not the sloped tile on the right."
+      ]
+    },
+    {
+      "link": [11, 6],
+      "name": "G-Mode Overload Speed Blocks, Frozen Crab",
+      "requires": [
+        "canEnterGMode",
+        {"notable": "G-Mode Overload Speed Blocks then use Frozen Crab"},
+        "h_canNavigateUnderwater",
+        "canTrickyUseFrozenEnemies",
+        {"or": [
+          "Gravity",
+          "HiJump",
+          "canCrouchJump"
+        ]},
+        "Wave"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
+        "Exit G-Mode and rotate to obtain the item, then kill the crab with Wave Beam to fall back down."
+      ],
+      "devNote": "FIXME works if the item is wave...  Spring Ball would also work, but one of these three is always required to get here."
     }
   ],
   "notables": [


### PR DESCRIPTION
This is mostly just a restructure of the current g-mode overload speed block strats. I added two new junctions and added more strats to get into position. It's also worth noting that there are no strats in this PR to grab the item without Ice, but there are strats added that get into position without it.

This lays the groundwork to (hopefully) be able to easily add the other ways to grab the item:
- wave+ice and wave is the item
- PB + ice
- Kago +ice (immobile, CF, E-Tank item)
- R-Mode standup (CF + no ice)