### PR TITLE
Samus eater teleport

### DIFF
--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -3507,9 +3507,6 @@
       ],
       "note": [
         "Land in the right side of the third Samus Eater on the floor of Hellway."
-      ],
-      "devNote": [
-        "The last Samus Eater on the right can also work."
       ]
     },
     {

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -2911,6 +2911,22 @@
       "requires": []
     },
     {
+      "link": [5, 13],
+      "name": "Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[12, 13], [14, 13], [15, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "Morph"
+      ],
+      "note": [
+        "Land in the last Samus Eater of Alpha Power Bomb Room, or the second Samus Eater from the right of Hellway."
+      ]
+    },
+    {
       "id": 121,
       "link": [6, 2],
       "name": "Come in Shinecharging, Leave With Spark",
@@ -3476,6 +3492,25 @@
         }
       },
       "requires": []
+    },
+    {
+      "link": [6, 13],
+      "name": "Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[15, 13], [1, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "Morph"
+      ],
+      "note": [
+        "Land in the right side of the third Samus Eater on the floor of Hellway."
+      ],
+      "devNote": [
+        "The last Samus Eater on the right can also work."
+      ]
     },
     {
       "id": 152,

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -408,6 +408,7 @@
     {
       "from": 3,
       "to": [
+        {"id": 1},
         {"id": 3},
         {"id": 4},
         {"id": 10},
@@ -418,6 +419,7 @@
     {
       "from": 4,
       "to": [
+        {"id": 1},
         {"id": 4},
         {"id": 10},
         {"id": 13}
@@ -426,6 +428,7 @@
     {
       "from": 5,
       "to": [
+        {"id": 1},
         {"id": 4},
         {"id": 5},
         {"id": 13}
@@ -463,6 +466,7 @@
         {"id": 2},
         {"id": 4},
         {"id": 6},
+        {"id": 7},
         {"id": 8},
         {"id": 11},
         {"id": 12},
@@ -958,6 +962,27 @@
       "note": "Avoiding the hoppers can be tricky."
     },
     {
+      "link": [3, 1],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[1, 13], [2, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "note": [
+        "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the morph tunnel and bomb block.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "Other Samus Eaters can also probably work."
+      ]
+    },
+    {
       "id": 23,
       "link": [3, 3],
       "name": "Leave With Runway",
@@ -1037,6 +1062,28 @@
       },
       "requires": [],
       "flashSuitChecked": true
+    },
+    {
+      "link": [4, 1],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[1, 13], [2, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "canXRayClimb",
+        "canBePatient"
+      ],
+      "note": [
+        "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the morph tunnel and bomb block.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "Other Samus Eaters can also probably work."
+      ]
     },
     {
       "id": 136,
@@ -1271,6 +1318,28 @@
         "FIXME: This could be possible without a hit, but requires precise timing and some luck, it helps to have a way to one hit kill one of the hoppers on the descent.",
         "Bomb spread can work, but also requires some patience and knowledge how to preserve the charge partway through the tunnel.",
         "A Power Bomb also works, but will clear B, Samus can just go 4->10->13."
+      ]
+    },
+    {
+      "link": [5, 1],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[1, 13], [2, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "canXRayClimb",
+        "canBePatient"
+      ],
+      "note": [
+        "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the morph tunnel and bomb block.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "Other Samus Eaters can also probably work."
       ]
     },
     {
@@ -1833,6 +1902,29 @@
       ]
     },
     {
+      "link": [8, 7],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "canXRayClimb",
+        "canBePatient"
+      ],
+      "note": [
+        "Jump into the second Samus Eater in the ceiling of Hellway.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the right of the morph tunnel and Super block.",
+        "Samus will be off-camera, so it may be hard to tell when the climb is done;",
+        "moving left and right is a safe way to test, as it will cause the camera to scroll if Samus is at the top."
+      ],
+      "devNote": [
+        "Other Samus Eaters can also probably work."
+      ]
+    },
+    {
       "id": 72,
       "link": [8, 8],
       "name": "Leave With Runway",
@@ -1843,6 +1935,25 @@
           "openEnd": 0
         }
       }
+    },
+    {
+      "link": [8, 8],
+      "name": "G-Mode Setup - Get Hit By Reo",
+      "requires": [
+        "Morph"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "flashSuitChecked": true,
+      "note": [
+        "To manipulate the Reo into a suitable position, lure it to the left and crouch at the edge of the platform;",
+        "jump as needed to bring it back on camera when it goes off;",
+        "it should perform 4 big swoops down to the left, 2 small swoops (hitting the overhang above), then 5 more big swoops,",
+        "after which it will enter a slow hover moving directly towards Samus.",
+        "Then lure it down and to the right, making it pass through the morph tunnel.",
+        "Samus' vertical position must stay below that of the Reo, in order to keep the Reo in its hover state."
+      ]
     },
     {
       "id": 73,
@@ -2576,6 +2687,34 @@
         "Shoot then immediately jump so that the bug can be frozen at a pixel perfect height, which is higher than where it would typically be frozen (when not needing to preserve a flash suit).",
         "Once frozen, wait for the bug to thaw, then blindly follow it to the left without letting it go off camera, which would cause it to despawn.",
         "Refreeze it below the crumble blocks, perform a very precise ledge grab onto it, then jump through the crumble block to reach the door, all while carefully avoiding losing the flash suit."
+      ]
+    },
+    {
+      "link": [13, 5],
+      "name": "G-Mode Setup - Get Hit By Reo",
+      "requires": [
+        "h_canPreciseIceClip",
+        {"notable": "Reo Ice Clip Without Morph and X-Ray"}
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "note": [
+        "Lure the Reo (Bee) to the left to use it as a platform for ice clipping up through the crumbles.",
+        "Watch the Reo bounce against the left wall until it does a slow hover towards Samus.",
+        "There is a very small timing of when its right claw is above the small pale spore next to the big red spore, when Samus should jump to be above the Reo.",
+        "Crouching with Samus' front toe beneath this spore (facing left) will cause the bee to fly with the correct timing after Samus takes knockback damage, with a 3 pixel window.",
+        "This will cause it to fly left and into the two tile gap below the crumble blocks.",
+        "Freeze it once to get above it, and then again for the ice clip.",
+        "After clipping up, stand hanging slightly off the edge of the door frame to continue breaking the crumble blocks,",
+        "allowing the Reo to pass up through them when it thaws.",
+        "When the Reo is about to come up, after breaking the crumbles for the final time, move slightly left to the safety of the door frame,",
+        "and crouch for a moment before pressing left to enter the door transition."
+      ],
+      "devNote": [
+        "Morph could help with this trick, but we use the morphless notable for difficulty placement."
       ]
     },
     {

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1907,7 +1907,7 @@
       "entranceCondition": {
         "comeInWithSamusEaterTeleport": {
           "floorPositions": [],
-          "ceilingPositions": []
+          "ceilingPositions": [[10, 3]]
         }
       },
       "requires": [

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -310,7 +310,8 @@
           "floorPositions": [[12, 13], [2, 13], [8, 13]],
           "ceilingPositions": []
         }
-      }    
+      },
+      "bypassesDoorShell": true
     },
     {
       "id": 10,

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -296,6 +296,23 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 1],
+      "name": "Leave with Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSamusEaterTeleport": {
+          "floorPositions": [[12, 13], [2, 13], [8, 13]],
+          "ceilingPositions": []
+        }
+      }    
+    },
+    {
       "id": 10,
       "link": [1, 2],
       "name": "Avoid Boyon Damage",

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -416,6 +416,40 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[15, 13], [1, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        {"or": [
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            "h_canUseSpringBall",
+            {"thornHits": 4}
+          ]},
+          {"and": [
+            "h_canUseMorphBombs",
+            {"thornHits": 3},
+            {"samusEaterFrames": 320}
+          ]}
+        ]},
+        {"or": [
+          "canInsaneJump",
+          {"thornHits": 1}
+        ]}
+      ],
+      "note": [
+        "Land in the right side of the third Samus Eater on the floor of Hellway.",
+        "The Samus Eater teleport will result in Samus being placed below the Power Bombs blocks, below the door.",
+        "Use Spring Ball or Bombs to navigate past the thorns, Samus Eaters, and Yapping Maws.",
+        "It can be helpful to use a Super to kill the first Yapping Maw."
+      ]
+    },
+    {
       "id": 19,
       "link": [2, 1],
       "name": "Base",

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -300,7 +300,8 @@
           "floorPositions": [[7, 13], [11, 13], [15, 13], [10, 13], [14, 13], [1, 13]],
           "ceilingPositions": [[6, 3], [10, 3]]
         }
-      }    
+      },
+      "bypassesDoorShell": true
     },
     {
       "id": 12,
@@ -496,7 +497,8 @@
           "floorPositions": [[7, 13], [11, 13], [15, 13], [10, 13], [14, 13], [1, 13]],
           "ceilingPositions": [[6, 3], [10, 3]]
         }
-      }    
+      },
+      "bypassesDoorShell": true
     }
   ],
   "notables": [

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -286,6 +286,23 @@
       "note": "Shoot a Super towards the door while the Zeela is on the side of its platform to knock it off."
     },
     {
+      "link": [1, 1],
+      "name": "Leave with Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSamusEaterTeleport": {
+          "floorPositions": [[7, 13], [11, 13], [15, 13], [10, 13], [14, 13], [1, 13]],
+          "ceilingPositions": [[6, 3], [10, 3]]
+        }
+      }    
+    },
+    {
       "id": 12,
       "link": [1, 2],
       "name": "Base",
@@ -463,6 +480,23 @@
         "leaveWithGModeSetup": {}
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSamusEaterTeleport": {
+          "floorPositions": [[7, 13], [11, 13], [15, 13], [10, 13], [14, 13], [1, 13]],
+          "ceilingPositions": [[6, 3], [10, 3]]
+        }
+      }    
     }
   ],
   "notables": [

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -604,6 +604,27 @@
       "requires": []
     },
     {
+      "link": [2, 1],
+      "name": "Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[1, 13], [2, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "note": [
+        "Fall into the first Samus Eater in Hellway or Alpha Power Bomb Room.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space behind the bomb blocks at the top of the room.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "FIXME: In Hellway, a ceiling Samus Eater could probably also work, and shorten the X-Ray climb."
+      ]
+    },
+    {
       "id": 15,
       "link": [2, 2],
       "name": "Leave with Runway",
@@ -853,6 +874,29 @@
         "If entering the transition too deeply, Samus may end up stuck slightly inside the Bomb blocks and the floor.",
         "This can be avoided by tapping up to retract Grapple (pulling Samus left and down), holding left while releasing Grapple, then jumping to clip up through the floor.",
         "If Morph is available, rolling out to the left is also an option."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[1, 13], [8, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "canXRayClimb",
+        "canBePatient"
+      ],
+      "note": [
+        "Fall into the first Samus Eater in Hellway or Alpha Power Bomb Room.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space behind the bomb blocks at the top of the room.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "FIXME: Other Samus Eaters can also probably work.",
+        "In particular, in Hellway a ceiling Samus Eater could probably shorten the X-Ray climb."
       ]
     },
     {
@@ -1713,6 +1757,27 @@
         "Set reserves to auto, unpause, and hold left.",
         "While reserves are auto-refilling, Samus' i-frames will run out, allowing Samus to be hit by the Geemer again and be boosted high enough to reach the ledge.",
         "The screen will be black, which can be fixed by pausing and unpausing again."
+      ]
+    },
+    {
+      "link": [5, 8],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [],
+          "ceilingPositions": [[11, 13]]
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "note": [
+        "Jump into the second Samus Eater in the ceiling of Hellway.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the top of the room.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "Several other Samus Eaters could probably also work."
       ]
     },
     {

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1951,6 +1951,8 @@
       "name": "Samus Eater Teleport, Grapple Door Lock Skip",
       "entranceCondition": {
         "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[15, 13], [1, 13]],
+          "ceilingPositions": []
         }
       },
       "requires": [
@@ -1958,6 +1960,9 @@
       ],
       "bypassesDoorShell": true,
       "note": [
+        "Land in the right side of the third Samus Eater on the floor of Hellway.",
+        "This allows Samus to get inside the air pocket below door.",
+        "From there use Grapple to clip inside the wall and down into the transition, bypassing the door lock below."
       ]
     },
     {

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1947,6 +1947,20 @@
       ]
     },
     {
+      "link": [3, 2],
+      "name": "Samus Eater Teleport, Grapple Door Lock Skip",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+        }
+      },
+      "requires": [
+        "canGrappleClip"
+      ],
+      "bypassesDoorShell": true,
+      "note": [
+      ]
+    },
+    {
       "id": 77,
       "link": [3, 3],
       "name": "Leave with Runway",

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -3470,6 +3470,29 @@
       ]
     },
     {
+      "link": [6, 11],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [],
+          "ceilingPositions": [[10, 3]]
+        }
+      },
+      "requires": [
+        "canXRayClimb"
+      ],
+      "note": [
+        "Jump into the first Samus Eater in the ceiling of Hellway.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the ledge above.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "Other ceiling Samus Eaters can also probably work.",
+        "Floor Samus Eaters (e.g. in Alpha Power Bomb Room) won't work because it's not possible to climb above the Morph tunnel,",
+        "which extends along the entire screen behind the transition."
+      ]
+    },
+    {
       "id": 147,
       "link": [7, 2],
       "name": "Base",

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -500,6 +500,55 @@
       "flashSuitChecked": true
     },
     {
+      "link": [3, 2],
+      "name": "Samus Eater Teleport, X-Ray Climb (Lava Proof)",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[1, 13], [2, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "h_heatProof",
+        "h_lavaProof",
+        "canXRayClimb"
+      ],
+      "note": [
+        "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the blue gate.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
+      ],
+      "devNote": [
+        "Other Samus Eaters can also probably work.",
+        "When entering with a floor Samus Eater as in this strat, lava protection is necessary:",
+        "there is no way to enter with more than 4 energy, so even a tiny amount of lava damage would be fatal."
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Samus Eater Teleport, X-Ray Climb (Wave)",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [],
+          "ceilingPositions": [[6, 3]]
+        }
+      },
+      "requires": [
+        "h_heatProof",
+        "canXRayClimb",
+        "Wave"
+      ],
+      "note": [
+        "Jump into the first ceiling Samus Eater in Hellway.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the right of the blue gate.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done.",
+        "Off-camera the gate can be opened with Wave beam but not with a gate glitch."
+      ],
+      "devNote": [
+        "Other ceiling Samus Eaters can also probably work."
+      ]
+    },
+    {
       "id": 17,
       "link": [3, 3],
       "name": "Leave with Runway",

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -806,6 +806,29 @@
       ]
     },
     {
+      "link": [3, 2],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [],
+          "ceilingPositions": [[10, 3]]
+        }
+      },
+      "requires": [
+        "h_heatProof",
+        "canXRayClimb",
+        "canOffScreenMovement"
+      ],
+      "note": [
+        "Jump into the second ceiling Samus Eater in Hellway.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the right of the morph tunnel.",
+        "Samus will be off-camera, so it may not be easy to tell when the climb is done."
+      ],
+      "devNote": [
+        "Other Samus Eaters can also probably work."
+      ]
+    },
+    {
       "id": 21,
       "link": [3, 3],
       "name": "Leave with Runway - Fune Alive",

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -1065,6 +1065,36 @@
       ]
     },
     {
+      "link": [3, 8],
+      "name": "Samus Eater Teleport, X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithSamusEaterTeleport": {
+          "floorPositions": [[1, 13], [2, 13]],
+          "ceilingPositions": []
+        }
+      },
+      "requires": [
+        "canXRayClimb",
+        {"or": [
+          "Morph",
+          {"and": [
+            {"not": "f_DefeatedPhantoon"},
+            "canRiskPermanentLossOfAccess"
+          ]}
+        ]}
+      ],
+      "note": [
+        "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the bomb blocks.",
+        "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done.",
+        "Equip Morph Ball and touch the scroll PLMs in the morph tunnel, to fix the camera to be able to see the way to the item."
+      ],
+      "devNote": [
+        "Other Samus Eaters can also probably work.",
+        "Blind navigation to the item with power on is theoretically possible but seems unreasonable, as a spike hit will cause death."
+      ]
+    },
+    {
       "id": 45,
       "link": [4, 1],
       "name": "Base",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -690,6 +690,40 @@
                 }
               }              
             },
+            "comeInWithSamusEaterTeleport": {
+              "type": "object",
+              "description": "Represents that Samus must come into the room after teleporting to the location of a Samus Eater.",
+              "required": ["floorPositions", "ceilingPositions"],
+              "additionalProperties": false,
+              "properties": {
+                "floorPositions": {
+                  "type": "array",
+                  "description": "A list of screen-local tile coordinates of suitable floor Samus Eaters positions which will work for this strat, matching a position in a corresponding 'leaveWithSamusEaterTeleport' strat.",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "type": "integer",
+                      "description": "X or Y coordinate measured as a tile count, with 0 representing the top or left-most tile of the screen."
+                    }
+                  }
+                },
+                "ceilingPositions": {
+                  "type": "array",
+                  "description": "A list of screen-local tile coordinates of suitable ceiling Samus Eaters positions which will work for this strat, matching a position in a corresponding 'leaveWithSamusEaterTeleport' strat.",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "type": "integer",
+                      "description": "X or Y coordinate measured as a tile count, with 0 representing the top or left-most tile of the screen."
+                    }
+                  }
+                }
+              }              
+            },
             "comesThroughToilet": {
               "type": "string",
               "description": "For a strat having an entranceCondition through a vertical transition, indicates whether the strat is applicable if the Toilet comes between this room and the room with the exitCondition.",
@@ -730,7 +764,8 @@
             {"required": ["comeInWithWallJumpBelow"]},
             {"required": ["comeInWithSpaceJumpBelow"]},
             {"required": ["comeInWithPlatformBelow"]},
-            {"required": ["comeInWithGrappleTeleport"]}
+            {"required": ["comeInWithGrappleTeleport"]},
+            {"required": ["comeInWithSamusEaterTeleport"]}
           ]
         },
         "startsWithShineCharge": {
@@ -1068,6 +1103,42 @@
                     "items": {
                       "type": "integer",
                       "description": "X or Y coordinate measured as a tile count, with 0 representing the top or left-most tile of the room."
+                    }
+                  }
+                }
+              }              
+            },
+            "leaveWithSamusEaterTeleport": {
+              "type": "object",
+              "description": "Represents that Samus can leave through this door immediately after exiting G-mode, in such a way that Samus is teleported to the position of a Samus Eater at the start of the transition.",
+              "required": ["floorPositions", "ceilingPositions"],
+              "additionalProperties": false,
+              "properties": {
+                "floorPositions": {
+                  "type": "array",
+                  "description": "A list of screen-local tile coordinates of floor Samus Eaters, indicating the left-most tile of the Samus Eater that Samus can interact with.",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "type": "integer",
+                      "description": "X or Y coordinate measured as a tile count, with 0 representing the top or left-most tile of the screen.",
+                      "minimum": 0,
+                      "maximum": 15
+                    }
+                  }
+                },
+                "ceilingPositions": {
+                  "type": "array",
+                  "description": "A list of screen-local tile coordinates of ceiling Samus Eaters, indicating the left-most tile of the Samus Eater that Samus can interact with.",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "type": "integer",
+                      "description": "X or Y coordinate measured as a tile count, with 0 representing the top or left-most tile of the screen."
                     }
                   }
                 }

--- a/strats.md
+++ b/strats.md
@@ -85,6 +85,7 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveWithDoorFrameBelow_: This indicates that Samus can go up through this door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump.
 - _leaveWithPlatformBelow_: This indicates that Samus can go up through this door with momentum by jumping from a platform below, possibly with run speed.
 - _leaveWithGrappleTeleport_: This indicates that Samus can leave through this door while grappling, which can enable a teleport in the next room.
+- _leaveWithSamusEaterTeleport_: This indicates that Samus can leave through this door immediately after teleporting into a Samus Eater by exiting G-Mode.
 
 Each of these properties is described in more detail below.
 
@@ -504,23 +505,23 @@ A `leaveWithSamusEaterTeleport` comes with an implicit tech requirement `canSamu
 
 #### Example
 ```json
-    {
-      "link": [1, 1],
-      "name": "Leave with Samus Eater Teleport",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": false
-        }
-      },
-      "requires": [],
-      "exitCondition": {
-        "leaveWithSamusEaterTeleport": {
-          "floorPositions": [[12, 13], [2, 13], [8, 13]],
-          "ceilingPositions": []
-        }
-      }    
-    },
+{
+  "link": [1, 1],
+  "name": "Leave with Samus Eater Teleport",
+  "entranceCondition": {
+    "comeInWithGMode": {
+      "mode": "direct",
+      "morphed": false
+    }
+  },
+  "requires": [],
+  "exitCondition": {
+    "leaveWithSamusEaterTeleport": {
+      "floorPositions": [[12, 13], [2, 13], [8, 13]],
+      "ceilingPositions": []
+    }
+  }    
+}
 ```
 
 ## Entrance conditions
@@ -552,6 +553,7 @@ In all strats with an `entranceCondition`, the `from` node of the strat must be 
 - _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below.
 - _comeInWithPlatformBelow_: This indicates that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.
 - _comeInWithGrappleTeleport_: This indicates that Samus must come into the room while grappling, teleporting Samus to a position in this room corresponding to the location of the (grapple) block in the other room.
+- _comeInWithSamusEaterTeleport_: This indicates that Samus must come into the room immediately after initiating a teleport into a Samus Eater by exiting G-Mode in the other room.
 
 In addition it may contain the following property:
 
@@ -1351,6 +1353,34 @@ A `comeInWithGrappleTeleport` comes with an implicit tech requirement `canGrappl
       "blockPositions": [[5, 3]]
     }
   }
+}
+```
+
+## Come In  With Samus Eater Teleport
+
+A `comeInWithSamusEaterTeleport` entrance condition represents that Samus must come into the room immediately after teleporting Samus to a Samus Eater in the other room, causing Samus to be placed in a different position in the current room.
+
+A `comeInWithSamusEaterTeleport` object has the following properties:
+
+- _floorPositions_: A list of screen-local tile coordinates of floor Samus Eaters that can work for this strat, matching with an entry of the corresponding `floorPositions` in the `leaveWithSamusEaterTeleport` strat in the other room.
+- _ceilingPositions_: A list of screen-local tile coordinates of ceiling Samus Eaters that can work for this strat, matching with an entry of the corresponding `ceilingPositions` in the `leaveWithSamusEaterTeleport` strat in the other room.
+
+A `comeInWithSamusEaterTeleport` comes with an implicit tech requirement `canSamusEaterTeleport`.
+
+#### Example
+```json
+{
+  "link": [5, 13],
+  "name": "Samus Eater Teleport",
+  "entranceCondition": {
+    "comeInWithSamusEaterTeleport": {
+      "floorPositions": [[12, 13], [14, 13], [15, 13]],
+      "ceilingPositions": []
+    }
+  },
+  "requires": [
+    "Morph"
+  ]
 }
 ```
 

--- a/strats.md
+++ b/strats.md
@@ -491,6 +491,38 @@ A `leaveWithGrappleTeleport` comes with an implicit tech requirement `canGrapple
 }
 ```
 
+## Leave With Samus Eater Teleport
+
+A `leaveWithSamusEaterTeleport` exit condition represents that Samus can leave through this door immediately after initiating a teleport to the position of a Samus Eater in the room, by exiting G-mode. The position where Samus touched the Samus Eater determines where Samus will be placed in the next room. Most positions will result in Samus being placed behind the door after the transition, which will likely put Samus out of bounds. In some rooms, however, the space behind the door may be in-bounds; and there is a possibility of using specific Samus Eater locations to spawn Samus slightly in front of the door but lower than normal.
+
+A `leaveWithSamusEaterTeleport` object has the following properties:
+
+- _floorPositions_: A list of screen-local tile coordinates of floor Samus Eaters, indicating the left-most tile of the Samus Eater that Samus can interact with.
+- _ceilingPositions_: A list of screen-local tile coordinates of ceiling Samus Eaters, indicating the left-most tile of the Samus Eater that Samus can interact with.
+
+A `leaveWithSamusEaterTeleport` comes with an implicit tech requirement `canSamusEaterTeleport`.
+
+#### Example
+```json
+    {
+      "link": [1, 1],
+      "name": "Leave with Samus Eater Teleport",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSamusEaterTeleport": {
+          "floorPositions": [[12, 13], [2, 13], [8, 13]],
+          "ceilingPositions": []
+        }
+      }    
+    },
+```
+
 ## Entrance conditions
 
 In all strats with an `entranceCondition`, the `from` node of the strat must be a door node or entrance node. An `entranceCondition` object must contain exactly one of the following properties:

--- a/tech.json
+++ b/tech.json
@@ -2423,7 +2423,7 @@
                     "Exiting G-mode will teleport Samus to position where she touched the Samus Eater.",
                     "At the start of the door transition, Samus' X and Y pixel positions are reduced modulo 256 (the size of a screen),",
                     "so the relative position within the screen is all the matters (not the absolute position in the room).",
-                    "The transition must be touched 2 frames after control is regained control by releasing X-Ray.",
+                    "The transition must be touched 2 frames after control is regained after releasing X-Ray.",
                     "A normalized method to do this is to position Samus slightly more than 1 pixel from the door (but less than $1.3 pixels away),",
                     "then hold forward toward the door while X-Ray is released.",
                     "Correct subpixels for this method can be obtained in the following way: 1) jump and press against a wall above,",

--- a/tech.json
+++ b/tech.json
@@ -2410,6 +2410,30 @@
                     "For high-energy (immobile) setups, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
                     "This results in Samus entering a morph ball state without needing to have collected or equipped Morph."
                   ]
+                },
+                {
+                  "name": "canSamusEaterTeleport",
+                  "techRequires": [
+                    "canEnterGMode"
+                  ],
+                  "otherRequires": [],
+                  "note": [
+                    "Ability to use a Samus Eater to teleport when exiting G-mode, just before touching a door transition,",
+                    "modifying where Samus is placed in the next room.",
+                    "Exiting G-mode will teleport Samus to position where she touched the Samus Eater.",
+                    "At the start of the door transition, Samus' X and Y pixel positions are reduced modulo 256 (the size of a screen),",
+                    "so the relative position within the screen is all the matters (not the absolute position in the room).",
+                    "The transition must be touched 2 frames after control is regained control by releasing X-Ray.",
+                    "A normalized method to do this is to position Samus slightly more than 1 pixel from the door (but less than $1.3 pixels away),",
+                    "then hold forward toward the door while X-Ray is released.",
+                    "Correct subpixels for this method can be obtained in the following way: 1) jump and press against a wall above,",
+                    "2) jump and do a mid-air turnaround (making sure not to be in front of a wall when turning), which moves Samus back by half a pixel,",
+                    "3) moonwalking back toward the door until 2 pixels away;",
+                    "4) jump and do a turnaround mid-air toward the door.",
+                    "Moonwalking moves back Samus in half-pixel increments, so in the absence of frame-perfect timing there is a 50% chance of ending in the correct position.",
+                    "If Samus is 2 pixels away from the door after the final jump turnaround, then the position is correct;",
+                    "if Samus is 1 pixel away from the door, then the position is incorrect, and the setup should be repeated."
+                  ]
                 }
               ]
             },


### PR DESCRIPTION
This introduces
- a new tech `canSamusEaterTeleport`
- new entrance/exit conditions `leaveWithSamusEaterTeleport` and `comeInWithSamusEaterTeleport`
- setups in Hellway and Alpha Power Bomb Room
- applications in many rooms (covering all examples that I know of)

As usual, videos for all the new strats are on https://videos.maprando.com.
