### PR TITLE
Adjust Main Street 'Suitless Frozen Fish, HiJump'

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -3382,7 +3382,7 @@
         "Alternatively, use one of several possible methods that do not require Supers:",
         "1) Freeze the crab on the corner of the ledge and the fish near the wall but with enough space for Samus to fit through and jump up.",
         "2) Freeze the crab on the ground and the fish low, then crouch jump and down grab onto the fish while pressing into it to gain extra height.",
-        "3) Freeze the fish near a wall and wall jump into it repeatedly."
+        "3) Freeze the fish near the left wall and wall jump into it repeatedly."
       ]
     },
     {

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -3371,12 +3371,18 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "canTrickyUseFrozenEnemies"
+        "canTrickyUseFrozenEnemies",
+        {"or": [
+          {"ammo": {"type": "Super", "count": 1}},
+          "canTrickyJump"
+        ]}
       ],
       "note": [
-        "Freeze the crab on the corner of the ledge and the fish near the wall but with enough space for Samus to fit through and jump up.",
-        "Alternatively, freeze the Sciser on the ground and the Skultera low, then crouch jump and down grab on the fish while rubbing into it to gain extra height.",
-        "With Supers, Samus can knock the Sciser off the wall and freeze it midair. Or freeze the Skultera near a wall and walljumping into it repeatedly."
+        "If Supers are available, Samus can knock the crab off the ceiling and freeze it mid-air, using it as a platform to jump onto the frozen fish above.",
+        "Alternatively, use one of several possible methods that do not require Supers:",
+        "1) Freeze the crab on the corner of the ledge and the fish near the wall but with enough space for Samus to fit through and jump up.",
+        "2) Freeze the crab on the ground and the fish low, then crouch jump and down grab onto the fish while pressing into it to gain extra height.",
+        "3) Freeze the fish near a wall and wall jump into it repeatedly."
       ]
     },
     {

--- a/tech.json
+++ b/tech.json
@@ -1643,8 +1643,8 @@
                       ],
                       "otherRequires": [],
                       "note": [
-                        "The ability to use Ice Beam to freeze enemies in especially precise positionings.",
-                        "If supers are available, they can be used to knock wall crawlers off walls and freeze them mid air."
+                        "The ability to use Ice Beam to freeze enemies in precise positions.",
+                        "If Supers are available, they can be used to knock wall crawlers off walls and freeze them mid air."
                       ],
                       "extensionTechs": [
                         {


### PR DESCRIPTION
This PR

- Adds a `canTrickyJump` requirement for the getting up the bottom of Main Street with Ice + HiJump without Supers. 
- Clarifies the `note`, prioritizing the Super version.
- Clarifies the `canTrickyUseFrozenEnemies` tech description.

In my testing, the version of this strat with Supers is noticeably easier than the other 3 methods. With Supers, there's a lot of lenience in where the crab and fish can be frozen, and there is time to deal with freezing or refreezing the fish after getting on top of the frozen crab. The other 3 methods all have something tricky about them that I think makes them fit better in Very Hard:

- The method that freeze the crab on the corner requires fairly precise positioning of both the crab and the fish simultaneously.
- The crouch-jump down-grab method requires pressing against the fish for almost the maximum possible time. Both the crab and the fish have to be simultaneously positioned well in order to do this.
- The wall jump method has a tricky jump to get into position to wall jump. Even if the fish is frozen in the correct place (which is fairly precise), it's easy to get caught on the sloped overhang and not be able to wall jump.

With practice, all 3 of these methods can be done reliably and more quickly than the Super method, but I think many players on Hard would struggle with them.

The tech description for `canTrickyUseFrozenEnemies` seemed to overstate what could be expected, with the phrase "especially precise positionings". I think that would fall more in the domain of higher tech like `canPreciseCeilingClip` and `canCrazyCrabClimb`.