### PR TITLE
Notable sand bomb boost (left to right)

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1066,6 +1066,7 @@
       "link": [1, 5],
       "name": "Sand Bomb Boost",
       "requires": [
+        {"notable": "Sand Bomb Boost (Left to Right)"},
         "canDownGrab",
         "canSandBombBoost",
         "canInsaneJump"
@@ -2019,8 +2020,18 @@
         "If the timings don't work out just right, too much height is lost to the sand.",
         "Crouching in sand is also a high softlock risk."
       ]
+    },
+    {
+      "id": 3,
+      "name": "Sand Bomb Boost (Left to Right)",
+      "note": [
+        "Stand on the edge of the sand and place a Bomb and wait briefly before entering the sand.",
+        "Let the Bomb explosion push Samus up for a few frames before simultaneously jumping and aiming down.",
+        "There is about a 2 frame window before too much height is lost to reach the nearby ledge.",
+        "Jumping too early can lead to a softlock but jumping too late usually exits the sand safely."
+      ]
     }
   ],
   "nextStratId": 100,
-  "nextNotableId": 3
+  "nextNotableId": 4
 }


### PR DESCRIPTION
This will allow the left to right variant to be moved up in difficulty, or at least be a toggleable notable.