### PR TITLE
Sand Bomb Boost strat: add details and PB variant

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1073,10 +1073,32 @@
       ],
       "collectsItems": [5],
       "note": [
-        "Stand on the edge of the sand and place a Bomb and wait briefly before entering the sand.",
-        "Let the Bomb explosion push Samus up for a few frames before simultaneously jumping and aiming down.",
-        "There is about a 2 frame window before too much height is lost to reach the nearby ledge.",
-        "Jumping too early can lead to a softlock but jumping too late usually exits the sand safely."
+        "Stand on the edge of the sand and place a Bomb;",
+        "unmorph (leaving Samus crouched), then press forward to enter the sand when the bomb flashes yellow for the second time.",
+        "Once the Bomb puts Samus into a jumping pose where Samus is suspended mid-air slightly above the sand, press jump;",
+        "then aim down precisely when the bomb begins to propel Samus upward.",
+        "Move right to press against the wall before mid-air morphing (alternatively, a stationary lateral morph can work).",
+        "There is a 2-frame window for when to enter the sand:",
+        "if Samus enters the sand too early, she will sink slightly too far, resulting in not quite enough height to reach the tunnel;",
+        "if Samus enters the sand too late, she will not get properly boosted by the Bomb explosion and will end up stuck in the sand.",
+        "There is an 8-frame window for when to press jump, as it can be buffered during the period that the bomb begins interacting with Samus:",
+        "if Samus jumps too early or late, she will get stuck in the sand.",
+        "The timing for the aim-down press is frame-perfect: it must be pressed on the first frame that Samus begins being propelled upward by the bomb.",
+        "if Samus aims down too early, she will get stuck in the sand;",
+        "if Samus aims down too late, she will not get enough height to reach the tunnel.",
+        "The timing for the jump is between 6 frames before or 1 frame after the down press.",
+        "The amount of time that Samus holds forward after entering the sand is unimportant, as long as it is released before the aim-down."
+      ],
+      "devNote": [
+        "The timing window for when to press jump and when to aim-down is relative to the bomb explosion,",
+        "independent of each other and independent of when Samus enters the sand.",
+        "The timing for pressing forward (from a crouch) is 38 or 39 frames after laying the Bomb.",
+        "The timing for the jump is between 51 and 58 frames after laying the Bomb.",
+        "The timing for the aim-down press is 57 frames after laying the Bomb.",
+        "It is also possible to stand by pressing up before entering the sand (in which case forward would be pressed 37 or 38 frames after laying the Bomb);",
+        "this does not affect the size of the timing windows but introduces some more possibility for error,",
+        "e.g. by the up input being eaten if Samus is still in the unmorphing animation,",
+        "or by the forward input being not immediately processed if Samus is still in the standing animation."
       ]
     },
     {

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1945,15 +1945,16 @@
       "link": [4, 6],
       "name": "Sand Bomb Boost",
       "requires": [
-        "h_canCrouchJumpDownGrab",
-        "canSandBombBoost",
-        "canInsaneJump"
+        {"tech": "canSandBombBoost"},
+        "h_canBombThings",
+        "canInsaneJump",
+        "canDownGrab"
       ],
       "note": [
         "Kill all of the enemies and leave drops uncollected so that the Zoas will not be in the way.",
-        "Stand on the edge of the sand and place a Bomb and wait briefly before entering the sand.",
-        "Let the Bomb explosion push Samus up for a few frames before simultaneously jumping and aiming down.",
-        "Then move left to land on the Morph tunnel ledge.",
+        "Stand on the edge of the sand and place a Bomb or Power Bomb and wait briefly before entering the sand.",
+        "Let the explosion push Samus up for a few frames before simultaneously jumping and aiming down.",
+        "Then move left to down-grab onto the morph tunnel ledge.",
         "Jumping too early can lead to a softlock but jumping too late usually exits the sand safely."
       ]
     },

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1126,7 +1126,6 @@
         "There is a 13-frame window for when to enter the sand:",
         "if Samus enters the sand too early, she will sink slightly too far, resulting in not quite enough height to reach the tunnel;",
         "if Samus enters the sand too late, she will not get properly boosted by the Power Bomb explosion and will end up stuck in the sand.",
-        "There is an 8-frame window for when to press jump, as it can be buffered during the period that the bomb begins interacting with Samus:",
         "The timing for the aim-down press is frame-perfect: it must be pressed on the first frame that Samus begins being propelled upward by the Power Bomb.",
         "if Samus aims down too early, she will get stuck in the sand;",
         "if Samus aims down too late, she will not get enough height to reach the tunnel.",
@@ -1134,7 +1133,7 @@
         "The amount of time that Samus holds forward when entering the sand should be between 2 and 11 frames."
       ],
       "devNote": [
-        "The timing window for when to press jump and when to aim-down is relative to the bomb explosion,",
+        "The timing window for when to press jump and when to aim-down is relative to the Power Bomb explosion,",
         "independent of each other and independent of when Samus enters the sand.",
         "The timing for pressing forward (from a crouch) is between 27 and 39 frames after laying the Power Bomb.",
         "The timing for the jump is between 56 and 57 frames after laying the Power Bomb.",

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1064,12 +1064,15 @@
     {
       "id": 44,
       "link": [1, 5],
-      "name": "Sand Bomb Boost",
+      "name": "Sand Bomb Boost (Bomb)",
       "requires": [
         {"notable": "Sand Bomb Boost (Left to Right)"},
-        "canDownGrab",
         "canSandBombBoost",
-        "canInsaneJump"
+        "canInsaneJump",
+        {"or": [
+          "can4HighMidAirMorph",
+          "canStationaryLateralMidAirMorph"
+        ]}
       ],
       "collectsItems": [5],
       "note": [
@@ -1096,6 +1099,47 @@
         "The timing for the jump is between 51 and 58 frames after laying the Bomb.",
         "The timing for the aim-down press is 57 frames after laying the Bomb.",
         "It is also possible to stand by pressing up before entering the sand (in which case forward would be pressed 37 or 38 frames after laying the Bomb);",
+        "this does not affect the size of the timing windows but introduces some more possibility for error,",
+        "e.g. by the up input being eaten if Samus is still in the unmorphing animation,",
+        "or by the forward input being not immediately processed if Samus is still in the standing animation."
+      ]
+    },
+    {
+      "link": [1, 5],
+      "name": "Sand Bomb Boost (Power Bomb)",
+      "requires": [
+        {"notable": "Sand Bomb Boost (Left to Right)"},
+        {"tech": "canSandBombBoost"},
+        "h_canUsePowerBombs",
+        "canInsaneJump",
+        {"or": [
+          "can4HighMidAirMorph",
+          "canStationaryLateralMidAirMorph"
+        ]}
+      ],
+      "collectsItems": [5],
+      "note": [
+        "Stand on the edge of the sand and place a Power Bomb;",
+        "unmorph (leaving Samus crouched), then wait a moment before pressing forward to enter the sand.",
+        "On the exact frame when the Power Bomb begins to propel Samus upward, press down, and press jump on the same frame or one frame later.",
+        "Move right to press against the wall before mid-air morphing (alternatively, a stationary lateral morph can work).",
+        "There is a 13-frame window for when to enter the sand:",
+        "if Samus enters the sand too early, she will sink slightly too far, resulting in not quite enough height to reach the tunnel;",
+        "if Samus enters the sand too late, she will not get properly boosted by the Power Bomb explosion and will end up stuck in the sand.",
+        "There is an 8-frame window for when to press jump, as it can be buffered during the period that the bomb begins interacting with Samus:",
+        "The timing for the aim-down press is frame-perfect: it must be pressed on the first frame that Samus begins being propelled upward by the Power Bomb.",
+        "if Samus aims down too early, she will get stuck in the sand;",
+        "if Samus aims down too late, she will not get enough height to reach the tunnel.",
+        "if Samus jumps too early or late, she will get stuck in the sand.",
+        "The amount of time that Samus holds forward when entering the sand should be between 2 and 11 frames."
+      ],
+      "devNote": [
+        "The timing window for when to press jump and when to aim-down is relative to the bomb explosion,",
+        "independent of each other and independent of when Samus enters the sand.",
+        "The timing for pressing forward (from a crouch) is between 27 and 39 frames after laying the Power Bomb.",
+        "The timing for the jump is between 56 and 57 frames after laying the Power Bomb.",
+        "The timing for the aim-down press is 56 frames after laying the Power Bomb.",
+        "It is also possible to stand by pressing up before entering the sand (in which case forward would be pressed 28 or 40 frames after laying the Power Bomb);",
         "this does not affect the size of the timing windows but introduces some more possibility for error,",
         "e.g. by the up input being eaten if Samus is still in the unmorphing animation,",
         "or by the forward input being not immediately processed if Samus is still in the standing animation."
@@ -2047,10 +2091,12 @@
       "id": 3,
       "name": "Sand Bomb Boost (Left to Right)",
       "note": [
-        "Stand on the edge of the sand and place a Bomb and wait briefly before entering the sand.",
-        "Let the Bomb explosion push Samus up for a few frames before simultaneously jumping and aiming down.",
-        "There is about a 2 frame window before too much height is lost to reach the nearby ledge.",
-        "Jumping too early can lead to a softlock but jumping too late usually exits the sand safely."
+        "Stand on the edge of the sand and place a Bomb or Power Bomb and wait briefly before entering the sand.",
+        "Precisely as the explosion begins to propel Samus up, simultaneously press down and jump.",
+        "There are differences in the timing windows depending on whether a Bomb or Power Bomb is used:",
+        "For a Bomb, the timing to enter the sand is very precise, only 2 frames, while the timing to jump is lenient (8 frames).",
+        "For a Power Bomb, the timing to enter the sand lenient (13 frames), while the timing to jump is precise (2 frames).",
+        "In both cases, a frame-perfect aim-down input is required, and a failure likely results in Samus falling down through the sand."
       ]
     }
   ],


### PR DESCRIPTION
I played around with this in TAStudio to work out the details of the timing.

Interestingly, the timings for a Power Bomb turned out to be significantly different, and in a way that doesn't have anything to to do with lag. Overall the Power Bomb variant seems noticeably easier (though still Insane), so I added a variant for that. I think ammo lenience is not a significant concern, as this is already an Insane-level strat and softlock risk is the main challenge rather than running out of ammo.

The left-to-right strat had a `canDownGrab` requirement and right-to-left had a crouch-jump requirement, neither of which made sense, so I removed them. I added requirements for the mid-air morph in the left-to-right direction.