### PR TITLE
Add leaveWithGrappleJump in Everest

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -998,7 +998,7 @@
         "comeInWithGrappleJump": {
           "position": "left"
         },
-        "comesThroughToilet": "any"
+        "comesThroughToilet": "no"
       },
       "requires": [
         "HiJump",

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -4338,9 +4338,19 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "devNote": [
-        "Other Grapple blocks could be used on the left side, but there's no apparent reason to.",
-        "Variants with a `leaveWithGrappleJump` exit condition could also be added, but currently they wouldn't provide any new applications."
+        "Other Grapple blocks could be used on the left side, but there's no apparent reason to."
       ]
+    },
+    {
+      "link": [9, 5],
+      "name": "Leave With Grapple Jump",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGrappleJump": {
+          "position": "any"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
       "id": 186,


### PR DESCRIPTION
When I was thinking about this earlier, I forgot that the `comeInWithGrappleSwing` strat in Red Fish Room only gets you to the ledge, not all the way to the top of the room. So it makes sense to add a `leaveWithGrappleJump` strat to Mt. Everest after all.