### PR TITLE
Fix/refine Draygon Microwave Fight strat

### DIFF
--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -303,7 +303,14 @@
       "requires": [
         "h_canNavigateUnderwater",
         {"or": [
-          "canTrickyDodgeEnemies",
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"or": [
+              "Gravity",
+              "canInsaneJump",
+              {"enemyDamage": {"enemy": "Draygon", "type": "turretProjectile", "hits": 1}}
+            ]}
+          ]},
           "h_canBreakThreeDraygonTurrets"
         ]},
         "canXRayWaitForIFrames",

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -302,10 +302,15 @@
       "name": "Microwave Fight",
       "requires": [
         "h_canNavigateUnderwater",
-        "h_canBreakThreeDraygonTurrets",
+        {"or": [
+          "canTrickyDodgeEnemies",
+          "h_canBreakThreeDraygonTurrets"
+        ]},
         "canXRayWaitForIFrames",
+        "Charge",
         "Plasma",
         {"or": [
+          "canTrickyDodgeEnemies",
           "Morph",
           {"and": [
             "Ice",
@@ -320,8 +325,7 @@
         "Fire a charged Plasma shot, then use X-Ray repeatedly while the shot is in contact with Draygon, to wait out Draygon's i-frames.",
         "It is possible to one-cycle, which is easiest with a full beam, alternatively, it is possible to Morph under the swoop and two-cycle it.",
         "Note that if Samus is crouched when Draygon dies, she will stand up; this can be used to see when the fight has ended."
-      ],
-      "devNote": "FIXME: Add strats that don't break the turrets."
+      ]
     },
     {
       "id": 7,


### PR DESCRIPTION
This adds a Charge requirement which appears to have been missing. Also adds `canTrickyDodgeEnemies` as an alternative to some of the other requirements.

This was prompted by Sam's video which does a 1-cycle with Charge+Plasma beam only and without breaking the turrets: https://videos.maprando.com/video/4356