### PR TITLE
Fix to Double Chamber Hijumpless Spike Speedjump

### DIFF
--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1258,10 +1258,16 @@
       "name": "Hijumpless Spike Speedjump",
       "requires": [
         {"notable": "Hijumpless Spike Speedjump"},
+        {"or": [
+          {"spikeHits": 1},
+          {"and": [
+            {"enemyDamage": {"enemy": "Ripper 2 (green)", "type": "contact", "hits": 1}},
+            "canHorizontalDamageBoost"
+          ]}
+        ]},
         "canUseIFrames",
-        {"spikeHits": 1},
-        "SpeedBooster",
         "canTrickyDashJump",
+        "canPreciseWalljump",
         {"heatFrames": 300}
       ],
       "failures": [


### PR DESCRIPTION
The strat was missing a wall jump requirement, making the logic unsound. While fixing it, went ahead and also added the Ripper damage boost variant. Videos:
- Spike hit: https://videos.maprando.com/video/4447
- Ripper hit: https://videos.maprando.com/video/4446