### PR TITLE
Fix Crab Shaft cross room space jump strat, add notes

### DIFF
--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -514,7 +514,11 @@
         "canTrickyDashJump",
         "canDownGrab"
       ],
-      "note": "Requires running a very precise distance of 12 tiles in the adjacent room and down grabbing onto the platform (extra run speed exactly $3.1)."
+      "note": "Requires running a very precise distance of 12 tiles in the adjacent room and down grabbing onto the platform (extra run speed exactly $3.1).",
+      "devNote": [
+        "FIXME: With 6.4375 tiles, it is possible to reach the floor below the floating platform;",
+        "there's currently no node there, but with a flash suit it would be possible to spark up from there."
+      ]
     },
     {
       "id": 22,
@@ -608,14 +612,19 @@
       "entranceCondition": {
         "comeInSpaceJumping": {
           "speedBooster": true,
-          "minTiles": 12.4375
+          "minTiles": 18.4375
         }
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround"
       ],
-      "devNote": "This is on a spike in the speed graph, but higher tile counts work too."
+      "devNote": [
+        "This is on a spike in the speed graph, but higher tile counts work too.",
+        "FIXME: With 7 tiles (extra run speed $2.0 or $2.1) or 11 tiles (extra run speed between $2.C and $3.1),",
+        "it is possible to make it onto the floor below the floating platform;",
+        "there's currently no node there, but with a flash suit it would be possible to spark up from there."
+      ]
     },
     {
       "id": 64,


### PR DESCRIPTION
I checked this out thoroughly with TAStudio and am confident there's no way to make it onto the floating platform with a 12-tile runway Space Jump; the best candidate is extra run speed $3.1 (as the jump height drops off at $3.2), and it comes up about half a tile short still, even with last-frame Space Jump, lowest possible position in the doorway, and latest possible turnaround. Based on the note, the 18.4375 runway length is what was intended here; I must have just put in the wrong number.

I think it would be useful at some point to add a node below the floating platform, as there are many ways of getting there without necessarily being able to climb onto the floating platform; and with a flash suit, from there you could spark up either through the door or onto the floating platform.