### PR TITLE
Add heat frames for leaveWithTemporaryBlue missile unlock

### DIFF
--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -156,7 +156,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "note": [
         "Use Space Jump, Spring Ball, to carry blue speed across the room;",
         "alternatively, use a long series of temporary blue chains."
@@ -196,7 +199,10 @@
           "direction": "right"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "note": [
         "Use Space Jump, Spring Ball, to carry blue speed across the room;",
         "alternatively, use a long series of temporary blue chains."
@@ -242,7 +248,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "note": [
         "Use Space Jump, Spring Ball, to carry blue speed across the room;",
         "alternatively, use a long series of temporary blue chains."
@@ -565,7 +574,10 @@
           "direction": "left"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "note": [
         "Gain the shinecharge below the right edge of the door above to avoid bringing the Dragon on-camera."
       ]
@@ -591,7 +603,10 @@
           "direction": "any"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 22,

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -287,7 +287,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 24,
@@ -435,7 +438,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 25,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -214,7 +214,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "devNote": [
         "Lower run speeds can also work but may be more difficult or require more heat damage."
       ]
@@ -341,7 +344,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "note": [
         "Carefully planned movement is needed to avoid damage from the Gerutas, and to avoid bonking on the overhangs."
       ]

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -226,7 +226,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 5,
@@ -595,7 +598,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 81,
@@ -617,7 +623,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 82,
@@ -641,7 +650,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 83,
@@ -665,7 +677,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 87,

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -163,7 +163,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "note": ["Use angle-down shots to kill the Geruta from the left of the morph tunnel."]
     },
     {
@@ -210,7 +213,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 6,

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -312,7 +312,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 51,
@@ -371,7 +374,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 10,
@@ -453,7 +459,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 14,
@@ -778,7 +787,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 28,

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -194,8 +194,7 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      }
     },
     {
       "id": 3,

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -220,7 +220,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 7,
@@ -474,7 +477,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 19,

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -288,7 +288,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 11,
@@ -458,7 +461,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "devNote": [
         "A run speed of $0.7 would be enough to make the first jump (and even less could work with an additional jump).",
         "The slightly higher speed of $0.A saves a few heat frames, making it reasonable enough to get through on 1 tank.",

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -444,7 +444,10 @@
           "direction": "any"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 18,
@@ -626,7 +629,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 48,
@@ -652,7 +658,10 @@
           "direction": "any"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 49,
@@ -678,7 +687,10 @@
           "direction": "any"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 27,
@@ -1068,7 +1080,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 51,
@@ -1092,7 +1107,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 44,

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -288,7 +288,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 29,
@@ -458,7 +461,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 20,

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -266,7 +266,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 66,
@@ -287,7 +290,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 4,
@@ -340,7 +346,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 5,
@@ -378,7 +387,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 6,
@@ -637,7 +649,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 70,
@@ -667,7 +682,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 71,
@@ -697,7 +715,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "devNote": [
         "FIXME: This could be done with lower run speed, at the cost of more heat frames."
       ]
@@ -884,7 +905,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 27,
@@ -1053,7 +1077,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "devNote": [
         "FIXME: This could be done with lower run speed, at the cost of more heat frames."
       ]
@@ -1116,7 +1143,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
       "devNote": [
         "FIXME: This could be done with lower run speed, at the cost of more heat frames."
       ]
@@ -1186,7 +1216,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 39,
@@ -1282,7 +1315,10 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 42,


### PR DESCRIPTION
When I added these strats, I forgot that heat frames aren't part of the implicit requirements when `unlocksDoors` is explicitly given. In all these cases, it doesn't cost any extra heat frames to open a Super door, and I think Power Bombs are also fine given that you're already morphing and not approaching the door too quickly. Missiles would generally be a problem though.

The 50 heat frames is the standard amount and may be more than needed. I don't think it's important to be too precise, given that it's unlikely to be important in logic and we don't have a convenient way of testing these yet anyway. The idea is just to be safe with it to avoid a possibility of unsoundness.