### PR TITLE
Rest of East Upper Norfair temp blue

### DIFF
--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -329,6 +329,34 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come In Getting Blue, Leave With Temporary Blue (Space Jump)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$1.A"
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        "canChainTemporaryBlue",
+        {"heatFrames": 330}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 90}]},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 90}]}
+      ],
+      "devNote": [
+        "The minimum speed $1.A is arbitrary; lower speeds could work with larger heatFrames.",
+        "FIXME: set up a mechanism to automate heat frames required in cases like this."
+      ]
+    },
+    {
       "id": 16,
       "link": [1, 2],
       "name": "Frozen Maw Platforms (Left to Right)",
@@ -631,6 +659,34 @@
         "Ignore the second Yapping Maw.",
         "Freeze the Leftmost enemy as it extends.",
         "Delay the damage boost from the spikes slightly in order to rise above the lava before moving."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come In Getting Blue, Leave With Temporary Blue (Space Jump)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 3,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$1.A"
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        "canChainTemporaryBlue",
+        {"heatFrames": 330}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 90}]},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 90}]}
+      ],
+      "devNote": [
+        "The minimum speed $1.A is arbitrary; lower speeds could work with larger heatFrames.",
+        "FIXME: set up a mechanism to automate heat frames required in cases like this."
       ]
     },
     {

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -109,7 +109,9 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
+        {"id": 3},
         {"id": 5}
       ]
     },
@@ -176,7 +178,7 @@
       "requires": [
         "Wave",
         "canShinechargeMovementTricky",
-        {"heatFrames": 200},
+        {"heatFrames": 160},
         {"shineChargeFrames": 160}
       ],
       "exitCondition": {
@@ -217,6 +219,33 @@
         }
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Come In Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Wave",
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]},
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 560}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 5,
@@ -309,11 +338,68 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 3],
+      "name": "Come In Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 12,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        {"heatFrames": 140}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 50}]}
+      ]
+    },
+    {
       "id": 9,
       "link": [1, 4],
       "name": "Base",
       "requires": [
         {"heatFrames": 75}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come In Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 690}    
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            {"heatFrames": 745}    
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
       ]
     },
     {
@@ -344,6 +430,41 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 3],
+      "name": "Come In Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]},
+        "canLongChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 680}    
+          ]},
+          {"and": [
+            "canTrickySpringBallJump",
+            "canXRayTurnaround",
+            {"heatFrames": 775}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 12,
@@ -449,6 +570,28 @@
       "flashSuitChecked": true
     },
     {
+      "link": [3, 1],
+      "name": "Come In Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 12,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        {"heatFrames": 140}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 50}]}
+      ]
+    },
+    {
       "id": 17,
       "link": [3, 1],
       "name": "Grapple Teleport",
@@ -530,8 +673,8 @@
       "requires": [
         "Wave",
         "canShinechargeMovementTricky",
-        {"heatFrames": 205},
-        {"shineChargeFrames": 170}
+        {"heatFrames": 160},
+        {"shineChargeFrames": 160}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -557,7 +700,7 @@
         ]},
         "canShinechargeMovementTricky",
         {"heatFrames": 255},
-        {"shineChargeFrames": 170}
+        {"shineChargeFrames": 160}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -571,6 +714,32 @@
         }
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [3, 2],
+      "name": "Come In Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Wave",
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]},
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 460}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ]
     },
     {
       "id": 23,

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -241,6 +241,61 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Come In Getting Blue Speed, Leave With Temporary Blue (Big Jump)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 4,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$4.7"
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        {"heatFrames": 760}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
+      "note": [
+        "Move quickly (when X-Ray is not active) to climb the shaft before the Fune fireballs would reach Samus."
+      ],
+      "devNote": [
+        "The last runway tile is considered unusable, as Samus is likely to clip down through it."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come In Getting Blue Speed, Leave With Temporary Blue (Spring Ball Bounce)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 5,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canTrickySpringBallBounce",
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        {"heatFrames": 1020}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]}
+      ],
+      "note": [
+        "Move quickly (when X-Ray is not active) to climb the shaft before the Fune fireballs would reach Samus."
+      ]
+    },
+    {
       "id": 8,
       "link": [2, 2],
       "name": "Leave with Runway",

--- a/tech.json
+++ b/tech.json
@@ -2146,10 +2146,26 @@
               ],
               "otherRequires": [],
               "note": [
-                "The ability to move while maintaining Temporary Blue. This can be done by jumping, releasing angle, then doing a mid-air morph on the descent, using mockball inputs.",
+                "The ability to move while maintaining temporary blue. This can be done by jumping, releasing angle, then doing a mid-air morph using mockball inputs.",
                 "Afterwards, hold angle again while soft unmorphing and continue to hold angle after landing.",
-                "Hold forward the entire time while morphed after the mockball inputs to prevent losing Temporary Blue.",
-                "It is possible to use this alongside canXRayTurnaround to change directions during a Temporary Blue chain."
+                "Hold forward the entire time while morphed after the mockball inputs to prevent losing temporary blue.",
+                "In particular, forward must still be held when starting to unmorph",
+                "but must be released before the unmorph animation finishes (a 7-frame window, in air physics);",
+                "alternatively, if both angle-up and angle-down are held while landing, then there is no need to release forward before the unmorph animation finishes.",
+                "It is possible to use X-Ray to turn around during a temporary blue chain.",
+                "If enough fall speed can be gained to bounce when hitting the ground morphed,",
+                "then it is possible to unmorph after the bounce, providing a larger frame window compared to soft unmorphing directly;",
+                "this also allows Samus to travel a greater horizontal distance with each jump.",
+                "In air physics, a direct soft unmorph provides a 8-frame window in which to unmorph.",
+                "After that, there is a gap of 1 frame that does not work, as the game will not register an unmorph at the moment of bouncing.",
+                "Then there is a 20-frame window in which to unmorph after bouncing, before the second bounce.",
+                "Again there is a gap of 1 frame that does not work, at the moment of the second bounce.",
+                "Finally there are 2 frames that work after the second bounce.",
+                "In water physics, there is a 16-frame window for a direct soft unmorph.",
+                "All these frame windows can vary when landing on unlevel surfaces or slopes.",
+                "In air physics, a 4-tile-high space is enough to gain speed for a bounce;",
+                "in water physics, even a full-height jump with HiJump is not enough to get a bounce,",
+                "which means that bouncing is not possible except after falling a substantial distance."
               ],
               "extensionTechs": [
                 {


### PR DESCRIPTION
This should finish off a first pass at temp blue in East Upper Norfair. I also tightened/corrected some shinecharge frames and heat frames for shinecharge strats in Upper Norfair Farming Room. There's still stuff that can be done using a frozen Gamet to extend the runways at the bottom of this room, but those can be added later.

I also updated the tech description of `canChainTemporaryBlue` to give some more detail about the timings. Something that I think Kyle suggested a long time ago, which I think could be useful, would be to add a `detailNote` to the schema (between `note` and `devNote`), the idea being that `note` could describe what the tech covers, i.e. what you're expected to be able to do, while `detailNote` tells you more exactly how to do it. In the randomizer Generate page, for example, we might want to have detail notes be collapsed by default.