### PR TITLE
Update Draygon cross-room requirements and notes

### DIFF
--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -758,13 +758,15 @@
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
-          "minTiles": 2.4375
+          "minTiles": 3
         }
       },
       "requires": [
         "canCrossRoomJumpIntoWater"
       ],
-      "note": "Requires a runway of at least 3 tiles (with no open end) in the adjacent room."
+      "note": [
+        "With a 3-tile runway in the other room, this has a 2-frame window to jump before the transition."
+      ]
     },
     {
       "id": 16,
@@ -781,8 +783,10 @@
         "canTrickyJump"
       ],
       "note": [
-        "Requires a runway of at least 2 tiles (with no open end) in the adjacent room.",
-        "Jump as late as possible to avoid the ledge hanging over the door."
+        "With a 2-tile runway in the other room, this requires a frame-perfect jump immediately before the transition."
+      ],
+      "devNote": [
+        "FIXME: Not sure if there is a reason for this strat to exist, if there isn't a 2-tile closed-end runway setup room."
       ]
     },
     {
@@ -800,10 +804,11 @@
         "canTrickyJump"
       ],
       "note": [
-        "Requires a runway of at least 2 tiles in the adjacent room.",
-        "Jump as late as possible to avoid the ledge hanging over the door."
+        "With a 2-tile runway in the other room, this requires a frame-perfect jump immediately before the transition."
       ],
-      "devNote": "This can be done with a slightly shorter runway (closed end), with a down grab, but that setup doesn't exist."
+      "devNote": [
+        "This can be done with a slightly shorter runway (closed end), with a down grab, but that setup doesn't exist."
+      ]
     },
     {
       "id": 18,
@@ -816,8 +821,10 @@
         }
       },
       "requires": [
-        "canCrossRoomJumpIntoWater",
-        "canTrickyDashJump"
+        "canCrossRoomJumpIntoWater"
+      ],
+      "note": [
+        "With a 1-tile runway in the other room, this has a 2-frame window to jump before the transition."
       ]
     },
     {
@@ -836,8 +843,12 @@
         "canTrickyJump"
       ],
       "note": [
-        "Requires an air ball and a runway of only 1 tile in the adjacent room.",
-        "Aim to morph on contact with the ceiling to slide accross it for extra distance."
+        "With a 1-tile runway in the other room, this requires a frame-perfect jump immediately before the transition.",
+        "Perform an air ball soon after entering the room."
+      ],
+      "devNote": [
+        "In water physics, an airball has higher base speed ($1.8) than spin jump ($1.6), which is why doing it early helps.",
+        "Doing a ceiling mockball can also work, but is more difficult."
       ]
     },
     {
@@ -851,7 +862,8 @@
         }
       },
       "requires": [
-        "canCrossRoomJumpIntoWater"
+        "canCrossRoomJumpIntoWater",
+        "canTrickyJump"
       ],
       "devNote": "FIXME: with this and several other cross-room strats, it would be possible to leave with temporary blue, if we had a way to encode the requirement to come in blue."
     },

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -850,7 +850,9 @@
           "minTiles": 2
         }
       },
-      "requires": [],
+      "requires": [
+        "canCrossRoomJumpIntoWater"
+      ],
       "devNote": "FIXME: with this and several other cross-room strats, it would be possible to leave with temporary blue, if we had a way to encode the requirement to come in blue."
     },
     {

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -840,15 +840,25 @@
       "requires": [
         "canCrossRoomJumpIntoWater",
         "canLateralMidAirMorph",
-        "canTrickyJump"
+        {"or": [
+          "canTrickyJump",
+          "canMomentumConservingMorph"
+        ]}
       ],
       "note": [
-        "With a 1-tile runway in the other room, this requires a frame-perfect jump immediately before the transition.",
-        "Perform an air ball soon after entering the room."
+        "Jump through the door in the previous room, and perform an air ball soon after entering.",
+        "With a last-frame jump through the door, there is a wide timing window to do the air ball.",
+        "With an earlier jump through the door, the airball must be done more precisely:",
+        "in this case buffer aim-down through the transition and morph immediately on entry,",
+        "in order to conserve momentum while contacting the overhang."
       ],
       "devNote": [
-        "In water physics, an airball has higher base speed ($1.8) than spin jump ($1.6), which is why doing it early helps.",
-        "Doing a ceiling mockball can also work, but is more difficult."
+        "There is a 4-frame window for the jump that can work;",
+        "jumping in the later part of that window is better as it gives a bigger window for the morph.",
+        "In water physics, an airball has higher base speed ($1.8) than spin jump ($1.6) or aim down ($1.4),",
+        "which is the other reason why doing it early helps, in addition to how it helps clear the overhang.",
+        "Doing a ceiling mockball at the top of the room can also work, but it is more difficult,",
+        "and the frame-perfect jump is required in that case."
       ]
     },
     {


### PR DESCRIPTION
- Added tech requirements to the Cross Room Space Jump, where previously there were none. Avoiding the overhang in Draygon's Room requires at least somewhat precise positioning and timing of the Space Jump. I'm not sure if it's quite `canPreciseSpaceJump` but it seems like at least a `canTrickyJump`. And of course it also needed `canCrossRoomJumpIntoWater`.
- Increased the `minTiles` for "Cross Room Jump (Lenient)" from 2.4375 to 3: I tested with Construction Zone (3-tile runway with closed end) and found it still required a frame-perfect jump. It needs 3-tile with open end in order to get a 2-frame window.
- Removed the `canTrickyDashJump` requirement from "Cross Room Jump with Speedbooster". Here all you have to do is use the full (1-tile) runway and it gives a 2-frame window for the jump, so really there's nothing tricky about executing it. It does rely on the fact that Speedbooster shortens your jump height, but that knowledge is something we expect more in Medium (with `canDisableEquipment`). It should be the same difficulty as the "Cross Room Jump (Lenient)" (though a bit less intuitive), so I think it should be ok in Hard?
- Updated The "Cross Room Jump with Air Ball" note, to recommend doing the air ball soon after entering the room. It's a lot easier this way compared to going for the ceiling mockball.
- Added information to the notes about the frame windows for each strat.