### PR TITLE
Side platforms schema, docs, tech, setups, and Oasis applications

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -635,6 +635,37 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform (Spike I-frames)",
+      "requires": [
+        "Gravity",
+        {"spikeHits": 1},
+        "canUseIFrames",
+        {"or": [
+          {"spikeHits": 2},
+          "canInsaneJump"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 16,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "note": [
+        "Run and jump to the left, turning around right before landing on the spikes.",
+        "Continue holding right, gaining speed to jump out through the door."
+      ],
+      "devNote": [
+        "Max extra run speed $3.3 with spin, or $3.4 with a quick aim-down.",
+        "This would not be logically valid for gaining blue speed, so we have to be sure it can't be used that way."
+      ]
+    },
+    {
       "id": 32,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -615,6 +615,26 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 5,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $1.2 with spin, or $1.3 with a quick aim-down."
+      ]
+    },
+    {
       "id": 32,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -268,10 +268,9 @@
       "name": "Leave With Side Platform (Power Bomb Blocks Intact)",
       "requires": [
         "SpeedBooster",
-        "canInsaneJump",
         {"or": [
           "canMomentumConservingMorph",
-          "canBeVeryPatient"
+          "canInsaneJump"
         ]}
       ],
       "exitCondition": {

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -240,10 +240,9 @@
       "requires": [
         {"obstaclesCleared": ["C"]},
         "SpeedBooster",
-        "canInsaneJump",
         {"or": [
           "canMomentumConservingMorph",
-          "canBeVeryPatient"
+          "canInsaneJump"
         ]}
       ],
       "exitCondition": {
@@ -256,11 +255,21 @@
           "obstruction": [3, 0]
         }
       },
+      "note": [
+        "Leaving with upward momentum is possible in three ways:",
+        "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
+        "2) With a momentum-conserving turnaround through the transition, or",
+        "3) Jumping specifically with a extra run speed between $5.2 and $5.4 and aiming down through the transition.",
+        "For the first two methods, avoid backing into the corner;",
+        "instead press against it and turn around, to put Samus into a better position.",
+        "For the third method, use only the part of the runway in front of the Power Bomb blocks, or about a tile less."
+      ],
       "devNote": [
         "Max extra run speed $6.8.",
-        "It is possible to leave without a momentum-conserving morph",
-        "by using only the part of the runway in front of the Power Bomb blocks, or about a tile less.",
-        "Depending on the exact position, it may be needed to aim down quickly after jumping, to avoid bonking the obstruction."
+        "Using the full runway, the momentum-conserving morph has a 4-frame window for the jump,",
+        "and between a 3-frame and 6-frame window for the morph depending on the jump timing (with later jumps giving a bigger window for the morph);",
+        "The momentum-conserving turnaround has a 2-frame window for the jump,",
+        "and either a 1-frame or 5-frame window for the turnaround depending on the jump (with the last-frame jump giving the larger window for the turnaround)."
       ]
     },
     {
@@ -283,11 +292,23 @@
           "obstruction": [3, 0]
         }
       },
+      "note": [
+        "Leaving with upward momentum is possible in three ways:",
+        "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
+        "2) With a momentum-conserving turnaround through the transition, or",
+        "3) Jumping and aiming down through the transition.",
+        "Either back into the corner, or press against it and turn around; it doesn't matter which."
+      ],
       "devNote": [
         "Max extra run speed $5.4.",
-        "It is possible to leave without a momentum-conserving morph",
-        "using the full runway length, or about a tile less.",
-        "If using the full runway, aim down quickly after jumping, to avoid bonking the obstruction."
+        "The momentum-conserving morph has a 3-frame window for the jump,",
+        "and between a 3-frame and 8-frame window for the morph depending on the jump timing (with later jumps giving a bigger window for the morph);",
+        "these windows can be more narrow depending on what is required in the next room.",
+        "The momentum-conserving turnaround has a 2-frame window for the jump:",
+        "if jumping on the second-to-last possible frame, then there is a 4-frame window for the turnaround,",
+        "while if jumping on the last frame, there is a 5-frame window for turning around before the transition",
+        "or it can be buffered through the transition",
+        "(or the turnaround could not be performed at all, to maintain forward and upward momentum by simply aiming down)."
       ]
     },
     {

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -235,6 +235,63 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Power Bomb Blocks Broken)",
+      "requires": [
+        {"obstaclesCleared": ["C"]},
+        "SpeedBooster",
+        "canInsaneJump",
+        {"or": [
+          "canMomentumConservingMorph",
+          "canBeVeryPatient"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 42,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $6.8.",
+        "It is possible to leave without a momentum-conserving morph",
+        "by using only the part of the runway in front of the Power Bomb blocks, or about a tile less.",
+        "Depending on the exact position, it may be needed to aim down quickly after jumping, to avoid bonking the obstruction."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Power Bomb Blocks Intact)",
+      "requires": [
+        "SpeedBooster",
+        "canInsaneJump",
+        {"or": [
+          "canMomentumConservingMorph",
+          "canBeVeryPatient"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 31,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $5.4.",
+        "It is possible to leave without a momentum-conserving morph",
+        "using the full runway length, or about a tile less.",
+        "If using the full runway, aim down quickly after jumping, to avoid bonking the obstruction."
+      ]
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged",

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -219,8 +219,7 @@
         {"obstaclesCleared": ["C"]},
         "SpeedBooster",
         "canInsaneJump",
-        "canMomentumConservingMorph",
-        "canInsaneMidAirMorph"
+        "canMomentumConservingMorph"
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {
@@ -232,7 +231,10 @@
           "obstruction": [4, 0]
         }
       },
-      "devNote": ["Max extra run speed $4.A."]
+      "devNote": [
+        "Max extra run speed $4.A.",
+        "Using the full runway, this requires a last-frame jump, followed by a 2-frame window for the morph."
+      ]
     },
     {
       "id": 57,

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -213,6 +213,28 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["C"]},
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 25,
+            "openEnd": 0
+          },
+          "obstruction": [4, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $4.A."]
+    },
+    {
       "id": 57,
       "link": [1, 1],
       "name": "Sidehopper Hit on Entry",

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -173,6 +173,22 @@
       "note": "Use a Frozen Zeb to extend the runway. The bug's height when standing next to the pipe is optimal."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 6,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.8."
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave With Mockball",
@@ -647,6 +663,24 @@
         }
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 10,
+            "openEnd": 0
+          },
+          "obstruction": [2, 0]
+        }
+      },
+      "devNote": "Max extra run speed $2.5."
     },
     {
       "id": 42,

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -668,7 +668,8 @@
       "link": [2, 2],
       "name": "Leave With Side Platform",
       "requires": [
-        "canMomentumConservingMorph"
+        "canTrickyJump",
+        "canLateralMidAirMorph"
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -669,7 +669,13 @@
       "name": "Leave With Side Platform",
       "requires": [
         "canTrickyJump",
-        "canLateralMidAirMorph"
+        {"or": [
+          "canLateralMidAirMorph",
+          {"and": [
+            "canMomentumConservingTurnaround",
+            "canInsaneJump"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -106,6 +106,22 @@
       "note": "Wait for the slow global Zeelas. They take almost 4 minutes to get there."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $7.0."
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged",
@@ -335,6 +351,25 @@
       },
       "flashSuitChecked": true,
       "note": "Wait for the slow global Zeelas. They take almost 2 minutes to get there."
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 20,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": "Max extra run speed $3.F."
     },
     {
       "id": 20,

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -125,7 +125,6 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "SpeedBooster",
-        "canInsaneJump",
         "canMomentumConservingMorph"
       ],
       "exitCondition": {
@@ -135,11 +134,14 @@
             "length": 45,
             "openEnd": 1
           },
-          "obstruction": [4, 0]
+          "obstruction": [3, 0]
         }
       },
       "devNote": [
-        "Max extra run speed $7.0."
+        "Max extra run speed $7.0.",
+        "Using the full runway, there is a 3-frame window for the jump,",
+        "then between a 2-frame and 4-frame window for the morph depending on the jump (with later jumps giving more frames for the morph).",
+        "If there is a solid tile on the ceiling in the next room past the door frame, then the windows for the jump and morph are tighter."
       ]
     },
     {
@@ -616,7 +618,8 @@
         {"obstaclesCleared": ["A"]},
         "SpeedBooster",
         "canInsaneJump",
-        "canMomentumConservingMorph"
+        "canMomentumConservingMorph",
+        "canInsaneMidAirMorph"
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {
@@ -629,7 +632,10 @@
         }
       },
       "devNote": [
-        "Max extra run speed $7.0."
+        "Max extra run speed $7.0.",
+        "Using the full runway, there is a 2-frame window for the jump,",
+        "then a 1-frame or 2-frame window for the morph depending on the jump (with a last-frame jump giving a 2-frame morph window).",
+        "If there is a solid tile on the ceiling in the next room past the door frame, then a the jump and morph are both frame-perfect."
       ]
     },
     {

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -125,7 +125,10 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "SpeedBooster",
-        "canMomentumConservingMorph"
+        {"or": [
+          "canMomentumConservingMorph",
+          "canInsaneJump"
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {
@@ -137,11 +140,22 @@
           "obstruction": [3, 0]
         }
       },
+      "note": [
+        "Leaving with upward momentum is possible in three ways:",
+        "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
+        "2) With a momentum-conserving turnaround through the transition, or",
+        "3) Jumping specifically with a extra run speed $5.2 or $5.3 and aiming down through the transition.",
+        "For the first two methods, avoid backing into the corner at the start of runway;",
+        "instead press against it and turn around, to put Samus into a better position."
+      ],
       "devNote": [
         "Max extra run speed $7.0.",
-        "Using the full runway, there is a 3-frame window for the jump,",
-        "then between a 2-frame and 4-frame window for the morph depending on the jump (with later jumps giving more frames for the morph).",
-        "If there is a solid tile on the ceiling in the next room past the door frame, then the windows for the jump and morph are tighter."
+        "Using the full runway, there is a 4-frame window for the jump,",
+        "then between a 1-frame and 4-frame window for the morph depending on the jump (with later jumps giving more frames for the morph).",
+        "If there is a solid tile on the ceiling in the next room past the door frame, then the windows for the jump and morph are tighter.",
+        "The momentum-conserving turnaround has a 3-frame window for the jump,",
+        "and between a 1-frame or 4-frame for the turnaround (with later jumps giving a larger window for the turnaround);",
+        "again the windows can be more narrow depending on what is required in the next room."
       ]
     },
     {

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -120,6 +120,29 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [4, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $7.0."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged",
@@ -585,6 +608,29 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [4, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $7.0."
+      ]
     },
     {
       "id": 28,

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -106,6 +106,30 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "f_DefeatedKraid",
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 24,
+            "openEnd": 0
+          },
+          "obstruction": [4, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $4.4."
+      ]
+    },
+    {
       "id": 29,
       "link": [1, 1],
       "name": "Charge",
@@ -467,6 +491,30 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "f_DefeatedKraid",
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 24,
+            "openEnd": 0
+          },
+          "obstruction": [4, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $4.4."
+      ]
     },
     {
       "id": 17,

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -112,8 +112,7 @@
         "f_DefeatedKraid",
         "SpeedBooster",
         "canInsaneJump",
-        "canMomentumConservingMorph",
-        "canInsaneMidAirMorph"
+        "canMomentumConservingMorph"
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {
@@ -126,7 +125,9 @@
         }
       },
       "devNote": [
-        "Max extra run speed $4.4."
+        "Max extra run speed $4.4.",
+        "Using the full runway, there is a 2-frame window for the jump,",
+        "then a 1-frame or 2-frame window for the morph depending on the jump (with a last-frame jump giving a 2-frame morph window)."
       ]
     },
     {
@@ -499,8 +500,7 @@
         "f_DefeatedKraid",
         "SpeedBooster",
         "canInsaneJump",
-        "canMomentumConservingMorph",
-        "canInsaneMidAirMorph"
+        "canMomentumConservingMorph"
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {
@@ -513,7 +513,9 @@
         }
       },
       "devNote": [
-        "Max extra run speed $4.4."
+        "Max extra run speed $4.4.",
+        "Using the full runway, there is a 2-frame window for the jump,",
+        "then a 1-frame or 2-frame window for the morph depending on the jump (with a last-frame jump giving a 2-frame morph window)."
       ]
     },
     {

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -173,6 +173,27 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"or": [
+          {"obstaclesCleared": ["A"]},
+          {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 6,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.A"
+    },
+    {
       "id": 5,
       "link": [1, 1],
       "name": "Leave Spinning",

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -531,6 +531,22 @@
       }
     },
     {
+      "link": [3, 3],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 17,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $3.B"
+    },
+    {
       "id": 26,
       "link": [3, 3],
       "name": "Leave Shinecharged",

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -193,6 +193,24 @@
       "devNote": "This is worst-case scenario. A strat that comes in and leaves with a single hit could be added."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 12,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $2.9."]
+    },
+    {
       "id": 79,
       "link": [1, 1],
       "name": "Base, Sidehopper Hit on Entry",

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -124,6 +124,25 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [2, 0]
+        }
+      },
+      "devNote": "Max extra run speed $7.0."
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged (Gravity)",

--- a/region/brinstar/red/Bat Room.json
+++ b/region/brinstar/red/Bat Room.json
@@ -74,6 +74,22 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.5"
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Spinning (Space Jump)",
@@ -385,6 +401,22 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.5"
     },
     {
       "id": 20,

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -108,6 +108,44 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Bomb Torizo Dead)",
+      "requires": [
+        "f_DefeatedBombTorizo"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 13,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $2.B with spin, or $2.C with a quick aim-down."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Bomb Torizo Alive)",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 10,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $2.2 with spin, or $2.3 with a quick aim-down."
+      ]
+    },
+    {
       "id": 18,
       "link": [1, 1],
       "name": "Fight Bomb Torizo",

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -113,11 +113,11 @@
             "length": 40,
             "openEnd": 0
           },
-          "obstruction": [3, 0]
+          "obstruction": [5, 2]
         }
       },
       "devNote": [
-        "Max extra run speed $6.8",
+        "Max extra run speed $6.5",
         "It is possible to leave without a momentum-conserving morph",
         "by gaining extra run speed $5.2 or $5.3 and doing a last-frame jump;",
         "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
@@ -369,7 +369,7 @@
         }
       },
       "devNote": [
-        "Max extra run speed $6.8",
+        "Max extra run speed $6.1",
         "It is possible to leave without a momentum-conserving morph",
         "by gaining extra run speed $5.2 or $5.3 and doing a last-frame jump;",
         "in this case specific positioning is required, to ensure Samus barely clears the obstruction."

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -97,13 +97,9 @@
       "name": "Leave With Side Platform",
       "requires": [
         "SpeedBooster",
-        "canInsaneJump",
         {"or": [
-          {"and": [
-            "canMomentumConservingMorph",
-            "canInsaneMidAirMorph"
-          ]},
-          "canBeVeryPatient"
+          "canMomentumConservingMorph",
+          "canInsaneJump"
         ]}
       ],
       "exitCondition": {
@@ -116,11 +112,22 @@
           "obstruction": [5, 2]
         }
       },
+      "note": [
+        "Leaving with upward momentum is possible in three ways:",
+        "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
+        "2) With a momentum-conserving turnaround through the transition, or",
+        "3) Jumping specifically with a extra run speed $5.2 or $5.3 and aiming down through the transition.",
+        "For the first two methods, back into the corner at the start of runway."
+      ],
       "devNote": [
-        "Max extra run speed $6.5",
-        "It is possible to leave without a momentum-conserving morph",
-        "by gaining extra run speed $5.2 or $5.3 and doing a last-frame jump;",
-        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+        "Max extra run speed $6.5.",
+        "Using the full runway, the momentum-conserving morph has a 4-frame window for the jump,",
+        "and between a 2-frame and 5-frame window for the morph depending on the jump timing (with later jumps giving a bigger window for the morph);",
+        "these windows can be more narrow depending on what is required in the next room.",
+        "The momentum-conserving turnaround has a 2-frame window for the jump,",
+        "and either a 3-frame or 5-frame for the turnaround (with the last-frame jump giving the larger window for the turnaround);",
+        "again the windows can be more narrow depending on what is required in the next room.",
+        "The aim-down method requires specific positioning to ensure Samus barely clears the door ledge with a frame-perfect jump."
       ]
     },
     {
@@ -349,13 +356,9 @@
       "name": "Leave With Side Platform",
       "requires": [
         "SpeedBooster",
-        "canInsaneJump",
         {"or": [
-          {"and": [
-            "canMomentumConservingMorph",
-            "canInsaneMidAirMorph"
-          ]},
-          "canBeVeryPatient"
+          "canMomentumConservingMorph",
+          "canInsaneJump"
         ]}
       ],
       "exitCondition": {
@@ -368,11 +371,21 @@
           "obstruction": [3, 0]
         }
       },
+      "note": [
+        "Leaving with upward momentum is possible in three ways:",
+        "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
+        "2) With a momentum-conserving turnaround through the transition, or",
+        "3) Jumping specifically with a extra run speed $5.2 or $5.3 and aiming down through the transition.",
+        "For the first two methods, avoid backing into the corner at the start of runway;",
+        "instead press against it and turn around, to put Samus into a better position."
+      ],
       "devNote": [
-        "Max extra run speed $6.1",
-        "It is possible to leave without a momentum-conserving morph",
-        "by gaining extra run speed $5.2 or $5.3 and doing a last-frame jump;",
-        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+        "Max extra run speed $6.1.",
+        "Using the full runway (either backing into the corner or turning around from it), the momentum-conserving morph has a 5-frame window for the jump,",
+        "and either a 2-frame window or 3-frame window for the morph depending on the jump timing;",
+        "these windows can be more narrow depending on what is required in the next room.",
+        "The momentum-conserving turnaround requires a frame-perfect (last-frame) jump and a frame-perfect turnaround.",
+        "The aim-down method requires specific positioning to ensure Samus barely clears the door ledge with a frame-perfect jump."
       ]
     },
     {

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -93,6 +93,37 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        "canInsaneJump",
+        {"or": [
+          {"and": [
+            "canMomentumConservingMorph",
+            "canInsaneMidAirMorph"
+          ]},
+          "canBeVeryPatient"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 40,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $6.8",
+        "It is possible to leave without a momentum-conserving morph",
+        "by gaining extra run speed $5.2 or $5.3 and doing a last-frame jump;",
+        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged",
@@ -312,6 +343,37 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        "canInsaneJump",
+        {"or": [
+          {"and": [
+            "canMomentumConservingMorph",
+            "canInsaneMidAirMorph"
+          ]},
+          "canBeVeryPatient"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 40,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $6.8",
+        "It is possible to leave without a momentum-conserving morph",
+        "by gaining extra run speed $5.2 or $5.3 and doing a last-frame jump;",
+        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+      ]
     },
     {
       "id": 17,

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -66,6 +66,33 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        {"or": [
+          "canMomentumConservingMorph",
+          "canInsaneJump"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $7.0.",
+        "It is possible to leave without a momentum-conserving morph",
+        "by gaining extra run speed $5.2 or $5.3, doing a last-frame jump, and aiming down before bonking the ceiling;",
+        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged",
@@ -236,6 +263,33 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        {"or": [
+          "canMomentumConservingMorph",
+          "canInsaneJump"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $7.0.",
+        "It is possible to leave without a momentum-conserving morph",
+        "by gaining extra run speed $5.2 or $5.3, doing a last-frame jump, and aiming down before bonking the ceiling;",
+        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+      ]
     },
     {
       "id": 15,

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -85,11 +85,21 @@
           "obstruction": [3, 0]
         }
       },
+      "note": [
+        "Leaving with upward momentum is possible in three ways:",
+        "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
+        "2) With a momentum-conserving turnaround through the transition, or",
+        "3) Jumping specifically with a extra run speed $5.2 or $5.3 and aiming down through the transition.",
+        "For the first two methods, back into the corner to use the full runway."
+      ],
       "devNote": [
         "Max extra run speed $7.0.",
-        "It is possible to leave without a momentum-conserving morph",
-        "by gaining extra run speed $5.2 or $5.3, doing a last-frame jump, and aiming down before bonking the ceiling;",
-        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+        "The momentum-conserving morph has a 4-frame window for the jump,",
+        "and between a 2-frame and 5-frame window for the morph depending on the jump timing (with later jumps giving a bigger window for the morph);",
+        "these windows will be more narrow if the ceiling in the next room extends past the door shell.",
+        "The momentum-conserving turnaround requires a frame-perfect jump, with a 4-frame window for the turnaround,",
+        "again possibly less depending on what is required in the next room.",
+        "The aim-down method requires specific positioning to ensure Samus barely clears the door ledge with a frame-perfect jump."
       ]
     },
     {
@@ -284,11 +294,21 @@
           "obstruction": [3, 0]
         }
       },
+      "note": [
+        "Leaving with upward momentum is possible in three ways:",
+        "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
+        "2) With a momentum-conserving turnaround through the transition, or",
+        "3) Jumping specifically with a extra run speed $5.2 or $5.3 and aiming down through the transition.",
+        "For the first two methods, back into the corner to use the full runway."
+      ],
       "devNote": [
         "Max extra run speed $7.0.",
-        "It is possible to leave without a momentum-conserving morph",
-        "by gaining extra run speed $5.2 or $5.3, doing a last-frame jump, and aiming down before bonking the ceiling;",
-        "in this case specific positioning is required, to ensure Samus barely clears the obstruction."
+        "The momentum-conserving morph has a 4-frame window for the jump,",
+        "and between a 2-frame and 5-frame window for the morph depending on the jump timing (with later jumps giving a bigger window for the morph);",
+        "these windows will be more narrow if the ceiling in the next room extends past the door shell.",
+        "The momentum-conserving turnaround requires a frame-perfect jump, with a 4-frame window for the turnaround,",
+        "again possibly less depending on what is required in the next room.",
+        "The aim-down method requires specific positioning to ensure Samus barely clears the door ledge with a frame-perfect jump."
       ]
     },
     {

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -1697,6 +1697,27 @@
       "flashSuitChecked": true
     },
     {
+      "link": [4, 4],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 270},
+        "canTrickyDodgeEnemies"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 6,
+          "runway": {
+            "length": 4,
+            "openEnd": 2
+          },
+          "obstruction": [5, 6]
+        }
+      },
+      "devNote": [
+        "FIXME: An option of killing the Pirate can also be possible."
+      ]
+    },
+    {
       "id": 51,
       "link": [4, 4],
       "name": "Crystal Flash",

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -146,6 +146,24 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 120}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 2,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $0.D."]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Crystal Flash",

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -117,6 +117,51 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Small Ledge)",
+      "requires": [
+        {"heatFrames": 130}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 2,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $0.B"
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Full Runway)",
+      "requires": [
+        {"heatFrames": 280},
+        {"or": [
+          {"obstaclesCleared": ["A"]},
+          {"and": [
+            "canHitbox",
+            "canTrickyDodgeEnemies"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 40,
+            "openEnd": 0
+          },
+          "obstruction": [3, 2]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $6.8."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -369,6 +414,51 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform (Small Ledge)",
+      "requires": [
+        {"heatFrames": 130}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 2,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $0.B"
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform (Full Runway)",
+      "requires": [
+        {"heatFrames": 280},
+        {"or": [
+          {"obstaclesCleared": ["A"]},
+          {"and": [
+            "canHitbox",
+            "canTrickyDodgeEnemies"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 40,
+            "openEnd": 0
+          },
+          "obstruction": [3, 2]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $6.8."
+      ]
     },
     {
       "id": 16,

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -729,6 +729,36 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        {"heatFrames": 180}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 12,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [{"heatFrames": 50}]},
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": [{"heatFrames": 110}]}
+      ],
+      "devNote": [
+        "Max extra run speed $2.9.",
+        "The `comeInNormally` condition is to ensure the shot blocks are intact;",
+        "waiting for them to respawn could also be an option but would require more heat frames."
+      ]
+    },
+    {
       "id": 23,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/lowernorfair/east/Ridley Tank Room.json
+++ b/region/lowernorfair/east/Ridley Tank Room.json
@@ -66,6 +66,24 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 12,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $2.B"
+    },
+    {
       "id": 2,
       "link": [1, 2],
       "name": "Base",

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -131,6 +131,29 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 210},
+        "canMomentumConservingMorph",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 9,
+            "openEnd": 2
+          },
+          "obstruction": [2, 1]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $2.9",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "G-Mode Regain Mobility",

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -361,6 +361,30 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        {"heatFrames": 240},
+        "canTrickyJump",
+        "canLateralMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 8,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $1.D.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 17,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -171,6 +171,24 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 120}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 9,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $2.4."
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -683,6 +701,24 @@
         "leaveWithRunway": {
           "length": 1,
           "openEnd": 1
+        }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 190},
+        "HiJump"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 8,
+          "runway": {
+            "length": 12,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
         }
       }
     },

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -261,6 +261,86 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Side Platform Cross Room Jump with Screw Attack",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 2,
+              "minTiles": 13.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canTrickyDashJump"
+              ],
+              "note": [
+                "Applies to Warehouse Entrance and Dust Torizo Room.",
+                "Gain extra run speed between $3.2 and $3.5, at a position where Samus just barely clears the obstruction."
+              ],
+              "devNote": [
+                "It is technically also possible from Ridley Tank Room, using exact run speed $1.8 and subpixels in a narrow range.",
+                "But without a normalized setup it doesn't seem reasonable."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 8.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": [
+                "Applies to Big Boy Room, Mickey Mouse Room, and Metal Pirates."
+              ]
+            },
+            {
+              "minHeight": 6,
+              "maxHeight": 6,
+              "minTiles": 2.5625,
+              "speedBooster": true,
+              "obstructions": [[5, 6]],
+              "requires": [
+                "canTrickyDashJump"
+              ],
+              "note": [
+                "Applies to Fast Pillars Setup Room.",
+                "Gain extra run speed exactly $1.1."
+              ]
+            },
+            {
+              "minHeight": 8,
+              "maxHeight": 8,
+              "minTiles": 6,
+              "speedBooster": false,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "HiJump"
+              ],
+              "note": [
+                "Applies to Screw Attack Room.",
+                "With extra run speed exactly $1.E, it works without collision oscillation.",
+                "Extra run speed $1.D also works, but with collision oscillation giving a 50% failure rate, as with most other setups."
+              ]
+            }
+          ]
+        }
+      },
+      "requires": [
+        {"notable": "Cross Room Jump with Screw Attack"},
+        "ScrewAttack",
+        "canCrossRoomJumpIntoWater",
+        "canTrickyJump"
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump.",
+        "It generally helps to enter as low as possible and with as much horizontal speed as possible,",
+        "and with HiJump turned off except if jumping from a very low platform.",
+        "Even if executed correctly, in most cases the trick can fail with 50% probability due to collision oscillation."
+      ]
+    },
+    {
       "id": 6,
       "link": [1, 1],
       "name": "Temporary Blue (Come In With Temporary Blue)",
@@ -855,7 +935,7 @@
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
-          "minTiles": 4
+          "minTiles": 4.4375
         }
       },
       "requires": [
@@ -891,6 +971,99 @@
       "note": [
         "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump.",
         "It helps to enter as low as possible and with as much horizontal speed as possible and with HiJump turned off.",
+        "Even if executed correctly, the trick can fail with 50% probability due to collision oscillation."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Side Platform Cross Room Jump with Screw Attack",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 13.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canTrickyDashJump"
+              ],
+              "note": [
+                "Applies to Lava Dive.",
+                "Gain extra run speed between $3.2 and $3.5, at a position where Samus just barely clears the obstruction."
+              ],
+              "devNote": [
+                "Other run speeds such as $3.8 can work but may require tighter positioning?"
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 5.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "note": ["Applies to Early Super Room, Bowling Alley (Bottom), Blue Hopper Room, Dust Torizo Room, and Noob Bridge."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 8.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canInsaneJump"
+              ],
+              "note": [
+                "Applies to Bowling Alley (Bottom), Blue Hopper Room, Dust Torizo Room, and Noob Bridge.",
+                "Without Speed Booster, this requires specific positioning to align Samus to just barely clear the door ledge."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 8.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": [
+                "Applies to Bomb Torizo Room, Pink Brinstar Hopper Room, Phantoon's Room, Big Boy Room, Double Chamber."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 5,
+              "speedBooster": true,
+              "obstructions": [[1, 0], [3, 2]],
+              "note": [
+                "Applies to Bomb Torizo Room, Pink Brinstar Hopper Room, Phantoon's Room, Big Boy Room, Double Chamber, and Metal Pirates Room.",
+                "With extra run speed exactly $1.2, this works without collision oscillation.",
+                "Extra run speed up through $1.8 also work but with collision oscillation giving a 50% failure rate, as with most other setups."
+              ]
+            },
+            {
+              "minHeight": 4,
+              "maxHeight": 4,
+              "minTiles": 4.5625,
+              "speedBooster": true,
+              "obstructions": [[5, 4]],
+              "note": [
+                "Applies to Tourian Escape Room 4."
+              ]
+            }
+          ]
+        }
+      },
+      "requires": [
+        {"notable": "Cross Room Jump with Screw Attack"},
+        "ScrewAttack",
+        "canCrossRoomJumpIntoWater",
+        "canTrickyJump"
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump.",
+        "It generally helps to enter as low as possible and with as much horizontal speed as possible, and with HiJump turned off.",
         "Even if executed correctly, the trick can fail with 50% probability due to collision oscillation."
       ]
     },

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -991,10 +991,13 @@
               ],
               "note": [
                 "Applies to Lava Dive.",
-                "Gain extra run speed between $3.2 and $3.5, at a position where Samus just barely clears the obstruction."
+                "Gain extra run speed of $3.5, at a position where Samus just barely clears the obstruction:",
+                "Starting at a horizontal position of $110 (272) or $111 (273) works at any subpixels;",
+                "parts of the neighboring pixels on either side also work."
               ],
               "devNote": [
-                "Other run speeds such as $3.8 can work but may require tighter positioning?"
+                "Run speed $3.2 works, at a pixel position of $F7 (247) with any subpixel, or on parts of the neighboring pixel on either side;",
+                "run speed $3.8 is possible but does not have an entire pixel that works."
               ]
             },
             {

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -289,7 +289,7 @@
               "maxHeight": 3,
               "minTiles": 8.4375,
               "speedBooster": "any",
-              "obstructions": [[1, 0]],
+              "obstructions": [[1, 0], [3, 2]],
               "note": [
                 "Applies to Big Boy Room, Mickey Mouse Room, and Metal Pirates."
               ]

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -108,6 +108,24 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 10,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $2.5"
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged (Suitless)",
@@ -493,6 +511,24 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 8,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.F"
     },
     {
       "id": 25,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1619,6 +1619,27 @@
       }
     },
     {
+      "link": [5, 5],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 4,
+          "runway": {
+            "length": 12,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $2.6.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 71,
       "link": [5, 5],
       "name": "Leave Shinecharged",

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -178,6 +178,32 @@
       "note": "The Owtch can be killed with a Power Bomb or blue speed, or while it is moving leftward with a Super, Charge, or Plasma."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity",
+        "canMomentumConservingMorph",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 23,
+            "openEnd": 1,
+            "gentleDownTiles": 2,
+            "gentleUpTiles": 2,
+            "steepUpTiles": 1
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $4.B."
+      ]
+    },
+    {
       "id": 5,
       "link": [1, 1],
       "name": "Leave Shinecharged",

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -183,8 +183,11 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "Gravity",
-        "canMomentumConservingMorph",
-        "canInsaneJump"
+        "canInsaneJump",
+        {"or": [
+          "canMomentumConservingMorph",
+          "canMomentumConservingTurnaround"
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -190,6 +190,31 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "Gravity",
+        "canInsaneJump",
+        "canMomentumConservingMorph",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 36,
+            "openEnd": 1,
+            "gentleUpTiles": 2
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $6.3."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Puyo Farm",

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -196,8 +196,13 @@
         {"obstaclesCleared": ["A"]},
         "Gravity",
         "canInsaneJump",
-        "canMomentumConservingMorph",
-        "canInsaneMidAirMorph"
+        {"or": [
+          {"and": [
+            "canMomentumConservingMorph",
+            "canInsaneMidAirMorph"    
+          ]},
+          "canMomentumConservingTurnaround"
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -195,6 +195,7 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "Gravity",
+        "SpeedBooster",
         "canInsaneJump",
         {"or": [
           {"and": [

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -114,6 +114,43 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Botwoon Dead)",
+      "requires": [
+        "Gravity",
+        "f_DefeatedBotwoon"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 16,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $3.2 with spin, or $3.3 with a quick aim-down."]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Botwoon Alive)",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 13,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $2.B with spin, or $2.C with a quick aim-down."]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged",

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -107,6 +107,26 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity",
+        "canInsaneJump",
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 22,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $4.2"]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Spinning",

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -2796,6 +2796,24 @@
       }
     },
     {
+      "link": [3, 3],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 13,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $2.D with spin, or $2.E with a quick aim-down."
+    },
+    {
       "id": 104,
       "link": [3, 3],
       "name": "Leave Shinecharged",

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -162,6 +162,30 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity",
+        {"or": [
+          {"ammo": {"type": "Super", "count": 1}},
+          "canTrickyDodgeEnemies"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 2,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $0.9."
+      ]
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Land on Door Frame",
@@ -1038,6 +1062,30 @@
         "Freeze the Yapping Maw on room entry, and continue to periodically refreeze it throughout.",
         "Jump and freeze the Zoa at the correct height, noting that it will rise one more pixel after it thaws.",
         "Maintain a half-tile runway between the frozen Zoa and the runway in order to extend it as much as possible."
+      ]
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity",
+        {"or": [
+          {"ammo": {"type": "Super", "count": 1}},
+          "canTrickyDodgeEnemies"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 2,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $0.9."
       ]
     },
     {

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -142,6 +142,24 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.2"
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Zoa Farm",
@@ -646,6 +664,24 @@
         "Dodge and freeze the other Zoas, or tank a hit then kill them and don't collect their drops.",
         "Maintain a half-tile runway between the frozen Zoa and the runway in order to extend it as much as possible."
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.2"
     },
     {
       "id": 30,

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -544,6 +544,22 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $0.8"
+    },
+    {
       "id": 15,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -241,6 +241,28 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 12,
+            "openEnd": 0,
+            "steepDownTiles": 1,
+            "gentleUpTiles": 1,
+            "gentleDownTiles": 1,
+            "startingDownTiles": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $2.A."]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Spinning",

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -1424,6 +1424,33 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity",
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 17,
+            "openEnd": 0,
+            "steepDownTiles": 2,
+            "startingDownTiles": 1
+          },
+          "obstruction": [4, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $3.9.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 35,
       "link": [2, 2],
       "name": "Leave Spinning",

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -113,6 +113,22 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $0.8"
+    },
+    {
       "id": 31,
       "link": [1, 1],
       "name": "Leave With Grapple Swing",

--- a/region/norfair/crocomire/Grapple Tutorial Room 2.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 2.json
@@ -376,6 +376,22 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $1.5"
+    },
+    {
       "id": 21,
       "link": [2, 2],
       "name": "Leave With Grapple Swing",

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -736,6 +736,26 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 320}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 28,
+            "openEnd": 0,
+            "gentleDownTiles": 3,
+            "gentleUpTiles": 3
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $5.0"]
+    },
+    {
       "id": 24,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -167,6 +167,24 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 250}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 16,
+            "openEnd": 1
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $3.9"
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged",

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -572,6 +572,25 @@
       "devNote": "There are more alternatives to the single canCrumbleJump, but it is basically assumed at this difficulty."
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 135},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 3,
+            "openEnd": 2
+          },
+          "obstruction": [3, 2]
+        }
+      },
+      "devNote": "Max extra run speed $1.5"
+    },
+    {
       "id": 29,
       "link": [2, 2],
       "name": "Sova Farm",

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -175,6 +175,25 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 3,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $0.B.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Crystal Flash",

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -182,6 +182,24 @@
       "devNote": "Because the Sovas are global, strats could be added that start from the other doors to tighten the total frame count, but it will typically require heatProof either way."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"heatFrames": 105}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 2,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $0.B"
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Crystal Flash",

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -103,6 +103,24 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 15,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $3.1"]
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged",
@@ -577,6 +595,24 @@
         }
       }
     },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 11,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $2.5 with spin, or $2.6 with a quick aim-down."
+      ]
+    },    
     {
       "id": 31,
       "link": [2, 2],

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -734,6 +734,58 @@
       "devNote": "FIXME: An alternative strat may be possible where the enemies are lured off-camera to the right instead of killed."
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform (Full Runway)",
+      "requires": [
+        {"or": [
+          {"obstaclesCleared": ["A"]},
+          {"and": [
+            {"enemyDamage": {"enemy": "Blue Sidehopper", "type": "contact", "hits": 2}},
+            "canUseIFrames"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 12,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": ["Max extra run speed $2.B."]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform (Partial Runway)",
+      "requires": [
+        {"enemyDamage": {"enemy": "Blue Sidehopper", "type": "contact", "hits": 1}},
+        "canUseIFrames",
+        "canTrickyDodgeEnemies"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 10,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": ["Max extra run speed $2.4."]
+    },
+    {
       "id": 12,
       "link": [2, 2],
       "name": "Sidehoppers Killed, Leave Spinning",

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -80,6 +80,22 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 28,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $5.0, or $5.1 with Hi-Jump."
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged",
@@ -247,6 +263,22 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 28,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $5.0, or $5.1 with Hi-Jump."
     },
     {
       "id": 15,

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -138,6 +138,30 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        {"or": [
+          "canMetroidAvoid",
+          "Ice",
+          "f_KilledMetroidRoom1"
+        ]},
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 31,
+            "openEnd": 1
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": "Max extra run speed $5.7."
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged",
@@ -1349,6 +1373,29 @@
         "Luring a Rinka is easiest with Morph - While morphed, barely move the bottom Rinka spawner on camera in order to have it shoot at a usable angle.",
         "Without Morph, use the top Rinka spawner and jump just before the Rinka starts moving to get a usable angle."
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        {"or": [
+          "canMetroidAvoid",
+          "f_KilledMetroidRoom1"
+        ]},
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 23,
+            "openEnd": 1
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": "Max extra run speed $4.7."
     },
     {
       "id": 37,

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -147,7 +147,13 @@
           "Ice",
           "f_KilledMetroidRoom1"
         ]},
-        "canMomentumConservingMorph"
+        {"or": [
+          "canMomentumConservingMorph",
+          {"and": [
+            "canMomentumConservingTurnaround",
+            "canInsaneJump"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {
@@ -1383,7 +1389,13 @@
           "canMetroidAvoid",
           "f_KilledMetroidRoom1"
         ]},
-        "canMomentumConservingMorph"
+        {"or": [
+          "canMomentumConservingMorph",
+          {"and": [
+            "canMomentumConservingTurnaround",
+            "canInsaneJump"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {
@@ -1395,7 +1407,11 @@
           "obstruction": [3, 0]
         }
       },
-      "devNote": "Max extra run speed $4.7."
+      "devNote": [
+        "Max extra run speed $4.7.",
+        "Using almost the full runway (between 3 and 6 pixels from the edge), the momentum conserving turnaround has a 2-frame window for the jump,",
+        "and a 1-frame or 3-frame window for the turnaround, depending on the jump (with a last-frame jump giving the larger window)."
+      ]
     },
     {
       "id": 37,

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -994,6 +994,33 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster",
+        {"or": [
+          "canMetroidAvoid",
+          "f_KilledMetroidRoom2"
+        ]},
+        "canInsaneJump",
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 11,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $2.6",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 46,
       "link": [2, 2],
       "name": "Leave Spinning",

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -252,6 +252,25 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 3,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $0.B.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Rinka",

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -104,6 +104,28 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "canMomentumConservingMorph",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 2,
+            "openEnd": 2
+          },
+          "obstruction": [2, 2]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $1.1.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Spinning",

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -850,6 +850,22 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 3,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": "Max extra run speed $0.F"
     }
   ],
   "notables": [

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -263,6 +263,24 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 4,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $0.F"
+      ]
+    },
+    {
       "id": 12,
       "link": [2, 2],
       "name": "Leave With Mockball",

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -170,6 +170,22 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 4,
+          "runway": {
+            "length": 4,
+            "openEnd": 2
+          },
+          "obstruction": [5, 4]
+        }
+      },
+      "devNote": ["Max extra run speed $1.8."]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Spinning",

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -201,6 +201,25 @@
       "devNote": "This should be possible with a frozen Covern, but it is annoying to set up."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 5,
+          "runway": {
+            "length": 14,
+            "openEnd": 0
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $2.C.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged, Second Closest Runway",

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -897,6 +897,27 @@
       ]
     },
     {
+      "link": [3, 3],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "SpeedBooster"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 5,
+            "openEnd": 0
+          },
+          "obstruction": [4, 2]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $1.3.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
+    },
+    {
       "id": 48,
       "link": [3, 3],
       "name": "Leave With Spark",

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -154,8 +154,13 @@
       "requires": [
         "f_DefeatedPhantoon",
         "SpeedBooster",
-        "canInsaneJump",
-        "canMomentumConservingMorph"
+        {"or": [
+          "canMomentumConservingMorph",
+          {"and": [
+            "canMomentumConservingTurnaround",
+            "canInsaneJump"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -149,6 +149,54 @@
       "devNote": "This does not require Phantoon to be killed, as the broken workrobot is there otherwise."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Power On)",
+      "requires": [
+        "f_DefeatedPhantoon",
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $7.0."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave With Side Platform (Power Off)",
+      "requires": [
+        {"not": "f_DefeatedPhantoon"},
+        "SpeedBooster",
+        "canInsaneJump",
+        "canMomentumConservingMorph",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [5, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $7.0.",
+        "The obstruction (from the Workrobot) actually extends between 4 and 5 tiles."
+      ]
+    },
+    {
       "id": 4,
       "link": [1, 1],
       "name": "Leave Shinecharged",

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -429,6 +429,26 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform (Power Off)",
+      "requires": [
+        {"not": "f_DefeatedPhantoon"},
+        "canRiskPermanentLossOfAccess",
+        "canMomentumConservingMorph"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [3, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $7.0."]
+    },
+    {
       "id": 57,
       "link": [2, 2],
       "name": "Leave With Grapple Swing",
@@ -837,6 +857,25 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesNotCleared": ["C"]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 10,
+            "openEnd": 0,
+            "steepDownTiles": 6
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $2.7."]
     },
     {
       "id": 37,

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -434,7 +434,13 @@
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess",
-        "canMomentumConservingMorph"
+        {"or": [
+          "canMomentumConservingMorph",
+          {"and": [
+            "canMomentumConservingTurnaround",
+            "canInsaneJump"
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -349,6 +349,34 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"or": [
+          "Gravity",
+          {"and": [
+            {"not": "f_DefeatedPhantoon"},
+            "canRiskPermanentLossOfAccess"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 5,
+          "runway": {
+            "length": 5,
+            "openEnd": 0,
+            "steepDownTiles": 3
+          },
+          "obstruction": [5, 5]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $1.7.",
+        "This strat is included for completeness, though it apparently doesn't have any applications."
+      ]
     }
   ],
   "notables": [],

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -69,6 +69,22 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 12,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": ["Max extra run speed $2.9."]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Spinning",

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -74,6 +74,35 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"or": [
+          {"and": [
+            "Gravity",
+            "canTrickyDodgeEnemies"
+          ]},
+          {"and": [
+            {"not": "f_DefeatedPhantoon"},
+            "canRiskPermanentLossOfAccess"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 4,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $0.F."
+      ]
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Leave Shinecharged, X-Mode",
@@ -759,6 +788,35 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"or": [
+          {"and": [
+            "Gravity",
+            "canTrickyDodgeEnemies"
+          ]},
+          {"and": [
+            {"not": "f_DefeatedPhantoon"},
+            "canRiskPermanentLossOfAccess"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 4,
+            "openEnd": 0
+          },
+          "obstruction": [1, 0]
+        }
+      },
+      "devNote": [
+        "Max extra run speed $0.F."
+      ]
     },
     {
       "id": 33,

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -646,7 +646,7 @@
             },
             "comeInWithPlatformBelow": {
               "type": "object",
-              "description": "Represents that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.",
+              "description": "Represents that Samus must come up through this vertical door with momentum by jumping from a platform below, possibly with run speed.",
               "required": [],
               "additionalProperties": false,
               "properties": {
@@ -665,6 +665,69 @@
                 "minRightPosition": {
                   "type": "number",
                   "description": "Minimum value of the platform rightPosition that will satisfy the condition."
+                }
+              }
+            },
+            "comeInWithSidePlatform": {
+              "type": "object",
+              "description": "Represents that Samus must jump through this horizontal door with upward momentum, by jumping from a platform to the side of the door in the other room.",
+              "required": ["platforms"],
+              "properties": {
+                "platforms": {
+                  "type": "array",
+                  "description": "Possible platform geometries in the other room that can satisfy the condition.",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": ["minTiles", "speedBooster", "minHeight", "maxHeight", "obstructions"],
+                    "properties": {
+                      "minHeight": {
+                        "type": "number",
+                        "description": "Minimum height of the platform in the other room that will satisfy this condition."
+                      },
+                      "maxHeight": {
+                        "type": "number",
+                        "description": "Maximum height of the platform in the other room that will satisfy this condition."
+                      },
+                      "minTiles": {
+                        "type": "number",
+                        "description": "Minimum length of platform runway in the other room, measured in tiles, including unusable parts near an obstruction."
+                      },
+                      "speedBooster": {
+                        "type": ["boolean", "string"],
+                        "description": "Whether or not this strat should be performed with Speed Booster.",
+                        "enum": [
+                          true,
+                          false,
+                          "any"
+                        ]
+                      },
+                      "obstructions": {
+                        "type": "array",
+                        "description": "Possible obstruction locations in the other room that can satisfy the condition.",
+                        "items": {
+                          "type": "array",
+                          "description": "X and Y coordinates of an obstruction location in the other room that can satisfy this condition.",
+                          "minItems": 2,
+                          "maxItems": 2,
+                          "items": {
+                            "type": "integer",
+                            "description": "X or Y coordinate measured as a tile count, with the X value representing the horizontal distance in front the door transition in the other room, and the Y value representing the distance below the doorway."
+                          }
+                        }
+                      },
+                      "requires": {
+                        "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
+                        "description": "Logical requirements specific to using this platform geometry."
+                      },
+                      "note": {
+                        "$ref" : "m3-note.schema.json#/definitions/note"
+                      },
+                      "devNote": {
+                        "$ref" : "m3-note.schema.json#/definitions/devNote"
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -832,6 +895,7 @@
             {"required": ["comeInWithWallJumpBelow"]},
             {"required": ["comeInWithSpaceJumpBelow"]},
             {"required": ["comeInWithPlatformBelow"]},
+            {"required": ["comeInWithSidePlatform"]},
             {"required": ["comeInWithGrappleSwing"]},
             {"required": ["comeInWithGrappleJump"]},
             {"required": ["comeInWithGrappleTeleport"]},
@@ -1153,6 +1217,31 @@
                 "rightPosition": {
                   "type": "number",
                   "description": "Position of the right end of the platform, measured as the number of tiles to the right of the center of the door. An open end should be represented as an extra half tile."
+                }
+              }
+            },
+            "leaveWithSidePlatform": {
+              "type": "object",
+              "description": "Represents that Samus can leave through this door by jumping from a platform to the side, carrying upward momentum into the next room.",
+              "required": ["runway", "height", "obstruction"],
+              "properties": {
+                "runway": {
+                  "$ref": "#/definitions/runway",
+                  "description": "Runway available to jump through the door, including unusable parts of the runway near an obstruction."
+                },
+                "height": {
+                  "type": "number",
+                  "description": "The vertical position of the runway, measured in number of tiles below the doorway, at the location where Samus would jump."
+                },
+                "obstruction": {
+                  "type": "array",
+                  "description": "Coordinates of the block that most restricts where Samus can jump, measured relative to the floor below the transition.",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": {
+                    "type": "integer",
+                    "description": "X or Y coordinate measured as a tile count, with the X value representing the horizontal distance in front the door transition, and the Y value representing the distance below the doorway."
+                  }
                 }
               }
             },

--- a/strats.md
+++ b/strats.md
@@ -82,8 +82,9 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveWithStoredFallSpeed_: This indicates that is is possible to walk through the door with the stored velocity to clip through floor tiles using a Moonfall.
 - _leaveWithGModeSetup_: This indicates that Samus can take enemy damage through the door transition, to set up R-mode or direct G-mode in the next room.
 - _leaveWithGMode_: This indicates that Samus can carry G-mode into the next room (where it will become indirect G-mode).
-- _leaveWithDoorFrameBelow_: This indicates that Samus can go up through this door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump.
-- _leaveWithPlatformBelow_: This indicates that Samus can go up through this door with momentum by jumping from a platform below, possibly with run speed.
+- _leaveWithDoorFrameBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump.
+- _leaveWithPlatformBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping from a platform below, possibly with run speed.
+- _leaveWithSidePlatform_: This indicates that Samus can go through this horizontal door with upward momentum by jumping from a platform near the doorway but not attached to it.
 - _leaveWithGrappleSwing_: This indicates that Samus can leave through this door by swinging using Grapple, carrying momentum and the ability to grapple jump in the next room.
 - _leaveWithGrappleJump_: This indicates that Samus can go up through this door by grapple jumping, with no horizontal momentum.
 - _leaveWithGrappleTeleport_: This indicates that Samus can leave through this door while grappling, which can enable a teleport in the next room.
@@ -471,6 +472,36 @@ In a heated room, heat frames must be explicitly included in the strat `requires
 }
 ```
 
+### Leave With Side Platform
+
+A `leaveWithSidePlatform` exit condition represents that that Samus can leave through this door by jumping from a platform to the side, carrying upward momentum into the next room. This applies to horizontal door transitions with a platform below the doorway, close enough to it that Samus can jump through the door without bonking on the ceiling. A `leaveWithSidePlatform` exit condition can satisfy a `comeInWithSidePlatform` entrance condition in the next room.
+
+A `leaveWithSidePlatform` object has the following properties:
+
+- _height_: The vertical distance between the doorway and the platform, at the point where Samus would jump.
+- _runway_: A [runway geometry](#runway-geometry) object describing the geometry of the runway that can be used to gain speed before jumping. Parts of the runway that are unusable due to being too close to an obstruction should still be included.
+- _obstruction_: This indicates the position of the tile that most restricts Samus' ability to jump low through the door. Typically this is the solid tile at the corner in front of the doorway. For an open-ended runway where falling off the runway is the limiting factor, it would be the coordinates of the air tile where Samus would fall off. The X coordinate is measured as the number of tiles in front of the transition tiles. The Y coordinate is the number of tiles below the floor of the doorway. The most broadly useful type of side platform is one below a doorway that drops off just past the door shell, in which case the `obstruction` would be [1, 0].
+
+In a heated room, heat frames must be explicitly included in the strat `requires`, based on a worst-case assumption of how the platform could need to be used. If a strat starts at the same (door) node that it ends at, then heat frames should include the time required to enter the door, shoot it open, position at the far end of the platform, run, and jump out.
+
+#### Example
+```json
+{
+  "name": "Leave With Side Platform",
+  "requires": [],
+  "exitCondition": {
+    "leaveWithSidePlatform": {
+      "height": 1,
+      "runway": {
+        "length": 4,
+        "openEnd": 0
+      },
+      "obstruction": [1, 0]
+    }
+  }
+}
+```
+
 ## Leave With Grapple Swing
 
 A `leaveWithGrappleSwing` exit condition represents that Samus can leave through this door by swinging using Grapple, allowing Samus to carry momentum and the ability to grapple jump in the next room. This can apply to horizontal doors or to vertical doors leading upward.
@@ -602,9 +633,10 @@ In all strats with an `entranceCondition`, the `from` node of the strat must be 
 - _comeInWithStoredFallSpeed_: This indicates that Samus must enter the room with fall speed stored, and is able to clip through a floor with a Moonfall.
 - _comeInWithRMode_: This indicates that Samus must have or obtain R-mode while coming through this door.
 - _comeInWithGMode_: This indicates that Samus must have or obtain G-mode (direct or indirect) while coming through this door. 
-- _comeInWithWallJumpBelow_: This indicates that Samus must come up through this door with momentum by wall-jumping in the door frame below.
-- _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this door with momentum by using Space Jump in the door frame below.
-- _comeInWithPlatformBelow_: This indicates that Samus must come up through this door with momentum by jumping from a platform below, possibly with run speed.
+- _comeInWithWallJumpBelow_: This indicates that Samus must come up through this vertical door with momentum by wall-jumping in the door frame below.
+- _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this vertical door with momentum by using Space Jump in the door frame below.
+- _comeInWithPlatformBelow_: This indicates that Samus must come up through this vertical door with momentum by jumping from a platform below, possibly with run speed.
+- _comeInWithSidePlatform_: This indicates that Samus must jump through this horizontal door with upward momentum, by jumping from a platform to the side of the doorway (but not attached to it) in the other room.
 - _comeInWithGrappleSwing_: This indicates that Samus swing into the room using Grapple, giving momentum and possibly the ability to grapple jump.
 - _comeInWithGrappleJump_: This indicates that Samus must come into the room by grapple jumping vertically through this door, with no horizontal momentum.
 - _comeInWithGrappleTeleport_: This indicates that Samus must come into the room while grappling, teleporting Samus to a position in this room corresponding to the location of the (grapple) block in the other room.
@@ -712,7 +744,7 @@ A `comeInJumping` entrance condition represents the need for Samus to be able to
 
 A `comeInSpaceJumping` entrance condition indicates that Samus must come in with a Space Jump through the bottom of the doorway, applicable to horizontal transitions. It has the following properties:
 
-* _speedBooster_: If true, then Speed Booster must be used while gaining run speed. If false, then Speed Booster must not be used. If "any", then Speed Booster may or may not be used.
+* _speedBooster_: If true, then Speed Booster must be used while gaining run speed or jumping. If false, then Speed Booster must not be used. If "any", then Speed Booster may or may not be used.
 * _minTiles_: The minimum horizontal speed that will satisfy the condition, measured in effective runway tiles with dash held on the remote runway.
 * _maxTiles_: The maximum horizontal speed that will satisfy the condition, measured in effective runway tiles with dash held on the remote runway.
 
@@ -1379,6 +1411,49 @@ __Example:__
       "maxHeight": 6,
       "maxLeftPosition": 1,
       "minRightPosition": 2
+    }
+  },
+  "requires": [
+    "canCrossRoomJumpIntoWater"
+  ]
+}
+```
+
+### Come In With Side Platform
+
+A `comeInWithSidePlatform` entrance condition indicates that Samus must jump through this horizontal door with upward momentum, by jumping from a platform to the side of the doorway (but not attached to it) in the other room. It has one property:
+
+* _platforms_: An array of objects, each describing a type of platform geometry that can satisfy this condition.
+  - _minTiles_: Minimum length of platform runway in the other room, measured in tiles (including unusable tiles).
+  - _speedBooster_: If true, then Speed Booster must be used while gaining run speed or jumping. If false, then Speed Booster must not be used. If "any", then Speed Booster may or may not be used.
+  - _minHeight:_ Minimum height of the platform that can satisfy this condition, measured in tiles. It expresses that the platform must be positioned at least a certain distance below the doorway.
+  - _maxHeight:_ Minimum height of the platform that can satisfy this condition, measured in tiles. It expresses that the platform must be positioned at most a certain distance below the doorway.
+  - _obstructions_: A list of possible `obstruction` positions that can satisfy this condition.
+  - _requires_: A list of logical requirements that are specific to this platform geometry object (optional).
+
+A `comeInWithSidePlatform` entrance condition must match with a `leaveWithSidePlatform` exit condition on the other side of the door. A match is valid provided that at least one of the `platforms` in the `comeInWithSidePlatform` condition matches the platform described in the `leaveWithSidePlatform` condition. A match consists of the following:
+
+- The effective runway length of the `runway` in `leaveWithSidePlatform` is at least `minTiles`.
+- `height` (in `leaveWithSidePlatform`) is between `minHeight` and `maxHeight`, inclusive.
+- The `obstruction` in `leaveWithSidePlatform` is contained in the list of `obstructions`.
+
+Any logical requirements of a matching platform object are treated as being prepended to the strat `requires`. If multiple platform objects match, then their `requires` are considered to be joined by an `or`.
+
+A `comeInWithSidePlatform` entrance condition has an implicit requirement of `canSidePlatformCrossRoomJump` tech.
+
+__Example:__
+```json
+{
+  "name": "Side Platform Cross Room Jump",
+  "entranceCondition": {
+    "comeInWithSidePlatform": {
+      "platforms": [{
+        "minTiles": 4,
+        "speedBooster": false,
+        "minHeight": 1,
+        "maxHeight": 2,
+        "obstructions": [[1, 0]]
+      }]
     }
   },
   "requires": [

--- a/tech.json
+++ b/tech.json
@@ -491,6 +491,16 @@
                     "A mid-air morph that has to be done in a 4-tile-high space, into a morph tunnel at the top of the space.",
                     "It's a lot more precise than with more room. Turn off HiJump before attempting this.",
                     "Most applications of this tech are in places where wall jump instant morphing is not possible."
+                  ],
+                  "extensionTechs": [
+                    {
+                      "name": "canInsaneMidAirMorph",
+                      "techRequires": ["can4HighMidAirMorph"],
+                      "otherRequires": [],
+                      "note": [
+                        "Performing a mid-air morph exceptionally quickly or precisely."
+                      ]
+                    }
                   ]
                 },
                 {
@@ -1258,6 +1268,15 @@
             "The ability to time a jump up into a respawning block so that Samus gets stuck in it and can jump up again.",
             "The bottom of Samus' hitbox must be completely in the respawning block or she will fall out.",
             "Because of this, it is typically required to aim down or morph to stay in the block."
+          ]
+        },
+        {
+          "name": "canSidePlatformCrossRoomJump",
+          "techRequires": [],
+          "otherRequires": [],
+          "note": [
+            "The ability to jump through a horizontal door transition from a nearby platform below the doorway,",
+            "jumping close and low enough through the door to be able to pass through while carrying upward momentum into the next room."
           ]
         }
       ]


### PR DESCRIPTION
This sets things up to model side platform cross room jumps, starting to address https://github.com/vg-json-data/sm-json-data/issues/1949:
- Adds schema and docs for new entrance/exit conditions `leaveWithSidePlatform` and `comeInWithSidePlatform`.
- Adds new tech `canSidePlatformCrossRoomJump`, implicitly required wherever those exit/entrance conditions are used.
- Adds `leaveWithSidePlatform` setups throughout the game.
- Adds `comeInWithSidePlatform` applications in Oasis.

These jumps are tricky to model because of how they depend on details of the "side platform" geometry. The proposed schema represents key features of the geometry, including the height and length of the runway and the position of the most restrictive "obstruction" block. More detail could be included, but these features seem sufficient to disambiguate all cases that occur in the game.

The schema was loosely inspired by the `leaveWithPlatformBelow`/`comeInWithPlatformBelow` exit/entrance conditions, which is a similar concept but for vertical doors. However, with side platforms, there is a wider range of types of platforms to consider, so the entrance condition `comeInWithSidePlatform` allows a list of platform specifications, avoiding the need to create a separate strat for each one. Each platform specification can have its own notes or additional logical requirements that may be specific to that type of platform.

Oasis is just an initial example. There are many applications throughout the game, which will go in follow-up PRs.

The other small change made in this PR is increasing the runway length for the "Cross Room Jump with Screw Attack (From the Right)", from 4 to 4.4375. This is the regular cross-room jump strat (not using a side platform). In my testing I couldn't get it to work with 4 tiles, so I believe it was an error, and the 4.4375 (5-tile closed-end) also matches what was already logically required when coming from the left.