### PR TITLE
Test for unique strat names within a link

### DIFF
--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -754,16 +754,6 @@
       "note": "To save a hit, jump over the third Sidehopper as it lunges towards Samus."
     },
     {
-      "id": 21,
-      "link": [1, 1],
-      "name": "Free Passage",
-      "requires": [
-        "h_ZebesNotAwake"
-      ],
-      "clearsObstacles": ["C"],
-      "devNote": "The obstacle isn't really cleared, but should enable all strats that require it to be."
-    },
-    {
       "id": 24,
       "link": [1, 5],
       "name": "Blocks Already Broken",

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -823,7 +823,7 @@
     {
       "id": 34,
       "link": [1, 3],
-      "name": "Use Flash Suit",
+      "name": "Use Flash Suit (Cross Room Jump)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": false,
@@ -846,7 +846,7 @@
     {
       "id": 35,
       "link": [1, 3],
-      "name": "Use Flash Suit (Water Entrance)",
+      "name": "Use Flash Suit (Cross Room Jump From Water)",
       "entranceCondition": {
         "comeInNormally": {}
       },

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -708,7 +708,7 @@
     {
       "id": 35,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 19]]

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -2847,7 +2847,7 @@
     {
       "id": 134,
       "link": [10, 11],
-      "name": "Overload PLMs - Bomb the Speed Blocks",
+      "name": "G-Mode Morph, Overload PLMs - Bomb the Speed Blocks",
       "requires": [
         "canEnterGMode",
         "Gravity",
@@ -2862,7 +2862,7 @@
     {
       "id": 135,
       "link": [10, 11],
-      "name": "Overload PLMs - Bomb the Speed Blocks",
+      "name": "G-Mode, Overload PLMs - Bomb the Speed Blocks",
       "requires": [
         "canEnterGMode",
         "h_canUseMorphBombs",

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -862,7 +862,7 @@
     {
       "id": 39,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -119,7 +119,7 @@
     {
       "id": 41,
       "link": [1, 1],
-      "name": "Cacatac Farm",
+      "name": "Cacatac Farm (Gravity)",
       "requires": [
         {"resetRoom": {
           "nodes": [1, 2]

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -973,7 +973,7 @@
     {
       "id": 30,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -649,7 +649,7 @@
     {
       "id": 18,
       "link": [3, 1],
-      "name": "Shinespark",
+      "name": "Come In Shinecharging, Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 10,
@@ -664,7 +664,7 @@
     {
       "id": 19,
       "link": [3, 1],
-      "name": "Shinespark with Wave",
+      "name": "Come In Shinecharging, Shinespark with Wave",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 18,
@@ -1031,7 +1031,7 @@
     {
       "id": 29,
       "link": [3, 4],
-      "name": "Shinespark",
+      "name": "Come In Shinecharging, Shinespark",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 10,
@@ -1046,7 +1046,7 @@
     {
       "id": 30,
       "link": [3, 4],
-      "name": "Shinespark with Wave",
+      "name": "Come In Shinecharging, Shinespark with Wave",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 18,

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -903,14 +903,6 @@
       ]
     },
     {
-      "id": 38,
-      "link": [4, 3],
-      "name": "Base",
-      "requires": [
-        {"heatFrames": 210}
-      ]
-    },
-    {
       "id": 39,
       "link": [4, 3],
       "name": "Leave With Door Frame Below",

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -384,7 +384,7 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Shinespark Midair",
+      "name": "Come In With Spark",
       "entranceCondition": {
         "comeInWithSpark": {
           "position": "top"
@@ -1209,7 +1209,7 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Shinespark Midair",
+      "name": "Come In With Spark",
       "entranceCondition": {
         "comeInWithSpark": {
           "position": "top"

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -1018,6 +1018,7 @@ for r,d,f in os.walk(os.path.join(".","region")):
                     previous_link = (0, 0)
                     strat_id_set = set()
                     used_notable_name_set = set()
+                    link_strat_names = set()
                     for strat in room["strats"]:
                         if "link" not in strat or tuple(strat["link"]) not in link_set:
                             # Errors are already generated above in this case.
@@ -1055,6 +1056,12 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 msg = f"🔴ERROR: Strat ID {strat_id} is not less than nextStratId ({next_strat_id}):{stratRef}"
                                 messages["reds"].append(msg)
                                 messages["counts"]["reds"] += 1
+
+                        if (link[0], link[1], strat['name']) in link_strat_names:
+                                msg = f"🔴ERROR: Strat name not unique within link:{stratRef}"
+                                messages["reds"].append(msg)
+                                messages["counts"]["reds"] += 1
+                        link_strat_names.add((link[0], link[1], strat['name']))
 
                         def strat_err_fn(msg):
                             messages["reds"].append(f"🔴ERROR: {stratRef}:{msg}")


### PR DESCRIPTION
I'm pretty sure there used to be a test for this, but it apparently got lost during a migration at some point.

- Add test to check that there aren't two strats with the same name within the same link.
- Fix existing violations.