### PR TITLE
West Cac Alley underwater bomb into Spring Ball jump

### DIFF
--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -441,6 +441,14 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Underwater Bomb Into Spring Ball Jump",
+      "requires": [
+        "canDoubleSpringBallJumpMidAir",
+        "canUnderwaterBombIntoSpringBallJump"
+      ]
+    },
+    {
       "id": 39,
       "link": [1, 2],
       "name": "Use Flash Suit",


### PR DESCRIPTION
Video: https://videos.maprando.com/video/5308

The video demonstrates what seems to be a more reliable method of doing the tech:
- After pressing pause, delay the jump as much as possible, doing a very quick mid-air morph, and equip Spring Ball.
- Do the second pause close to as early as possible, and delay the first mid-air Spring Ball jump close to as much as possible. The mid-air Spring Ball jump should happen slightly after pressing pause. Unequip Spring Ball.
- Lay the Bomb slightly after coming out of the unpause, then pause again as soon as possible. Equip Spring Ball and buffer the second mid-air Spring Ball jump out of the unpause.

With this method, there is a 3-frame window for the amount of time between laying the Bomb and pressing pause again. The previous steps just need to be done well enough that Samus will be early enough in her jump to not fall too far and miss the Bomb explosion.