### PR TITLE
Add canHeatedGMode

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1067,8 +1067,18 @@
           ]
         },
         {
+          "name": "h_heatedGMode",
+          "requires": [
+            {"or": [
+              "h_heatProof",
+              "canHeatedGMode"
+            ]}
+          ]
+        },
+        {
           "name": "h_DirectHeatedGModeLeaveSameDoor",
           "requires": [
+            "h_heatedGMode",
             {"heatFrames": 1}
           ],
           "note": "Leaving the same door only adds one heat frame. This is likely only useful if remote acquiring an item or opening a yellow door."
@@ -1076,6 +1086,7 @@
         {
           "name": "h_IndirectHeatedGModeOpenSameDoor",
           "requires": [
+            "h_heatedGMode",
             {"heatFrames": 70}
           ],
           "note": "This requires extra frames, because the door needs to close fully before it can be shot open."
@@ -1083,6 +1094,7 @@
         {
           "name": "h_HeatedGModeOpenDifferentDoor",
           "requires": [
+            "h_heatedGMode",
             {"heatFrames": 35}
           ],
           "note": "There is a delay after using X-Ray before shooting. If PLMs are already overloaded, Samus can crouch next to the door, shoot up and very quickly use X-Ray."
@@ -1090,6 +1102,7 @@
         {
           "name": "h_HeatedGModeOffCameraDoor",
           "requires": [
+            "h_heatedGMode",
             {"or": [
               {"heatFrames": 70},
               {"and": [

--- a/helpers.json
+++ b/helpers.json
@@ -1069,10 +1069,18 @@
         {
           "name": "h_heatedGMode",
           "requires": [
+            "canEnterGMode",
             {"or": [
               "h_heatProof",
               "canHeatedGMode"
             ]}
+          ]
+        },
+        {
+          "name": "h_heatedGModePauseAbuse",
+          "requires": [
+            "h_heatedGMode",
+            "canPauseAbuse"
           ]
         },
         {

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -179,10 +179,9 @@
       },
       "requires": [
         {"or": [
-         "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": "It is possible to kill a Gamet by the door and pause abuse to grab its Energy drop on G-mode exit.",
@@ -244,6 +243,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 50}
       ],
       "flashSuitChecked": true
@@ -266,11 +266,11 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           {"heatFrames": 40}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": "Kill the Gamets where Samus can grab the drops. Exit G-mode, then pause abuse to pick them up without dying."
@@ -694,11 +694,11 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           {"heatFrames": 40}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": "Kill the Gamets where Samus can grab the drops. Exit G-mode, then pause abuse to pick them up without dying."
@@ -891,11 +891,11 @@
         "comesThroughToilet": "any"
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           {"heatFrames": 40}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": "Kill the Gamets where Samus can grab the drops. Exit G-mode, then pause abuse to pick them up without dying."

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -244,12 +244,11 @@
         ]},
         {"or": [
           {"and": [
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             "canBePatient"
           ]},
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -280,12 +279,11 @@
         ]},
         {"or": [
           {"and": [
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             "canBePatient"
           ]},
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -386,10 +384,9 @@
           ]}
         ]},
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -418,10 +415,9 @@
           "h_canArtificialMorphSpringBall"
         ]},
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -520,6 +516,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 0}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -238,10 +238,9 @@
       },
       "requires": [
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": "It is possible to kill a Sova on the door and pause abuse to grab its Energy drop on G-mode exit."
@@ -256,6 +255,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         "canLateralMidAirMorph",
         {"heatFrames": 60},
         {"lavaFrames": 20}
@@ -408,10 +408,9 @@
       },
       "requires": [
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -513,6 +512,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         "canLateralMidAirMorph",
         {"heatFrames": 60},
         {"lavaFrames": 20}

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -204,6 +204,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         "Morph",
         {"or": [
           {"heatFrames": 260},
@@ -258,6 +259,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         "Morph",
         {"or": [
           "Wave",
@@ -382,6 +384,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 0}
       ],
       "collectsItems": [3],

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -1399,11 +1399,10 @@
       "link": [6, 1],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode",
         {"or": [
           {"and": [
             {"ammo": {"type": "Super", "count": 1}},
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             {"heatFrames": 10}
           ]},
           "h_HeatedGModeOpenDifferentDoor"
@@ -1417,11 +1416,10 @@
       "link": [6, 3],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode",
         {"or": [
           {"and": [
             {"ammo": {"type": "Super", "count": 1}},
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             {"heatFrames": 10}
           ]},
           "h_HeatedGModeOpenDifferentDoor"
@@ -1435,11 +1433,10 @@
       "link": [6, 4],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode",
         {"or": [
           {"and": [
             {"ammo": {"type": "Super", "count": 1}},
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             {"heatFrames": 10}
           ]},
           "h_HeatedGModeOpenDifferentDoor"
@@ -1453,7 +1450,7 @@
       "link": [6, 5],
       "name": "Exit G-Mode",
       "requires": [
-        "canEnterGMode",
+        "h_heatedGMode",
         {"heatFrames": 0}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -332,7 +332,7 @@
         }
       },
       "requires": [
-        "canPauseAbuse",
+        "h_heatedGModePauseAbuse",
         {"or": [
           "canTrickyUseFrozenEnemies",
           {"ammo": {"type": "Super", "count": 1}},
@@ -340,8 +340,7 @@
             "canFarmWhileShooting",
             "canInsaneJump"
           ]}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -574,13 +573,12 @@
         }
       },
       "requires": [
-        "canPauseAbuse",
+        "h_heatedGModePauseAbuse",
         "canTrickyDodgeEnemies",
         {"or": [
           "canTrickyUseFrozenEnemies",
           {"ammo": {"type": "Super", "count": 3}}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -417,6 +417,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 19}
       ],
       "flashSuitChecked": true
@@ -471,6 +472,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 19}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -493,6 +493,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 40}
       ],
       "flashSuitChecked": true
@@ -773,6 +774,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 40}
       ],
       "flashSuitChecked": true

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -315,7 +315,7 @@
     },
     {
       "link": [1, 2],
-      "name": "G-Mode Sova Farm",
+      "name": "G-Mode",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -324,10 +324,9 @@
       },
       "requires": [
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           "h_HeatedGModeOpenDifferentDoor"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -616,8 +615,7 @@
             "canTrickyJump"
           ]}
         ]},
-        "canPauseAbuse",
-        {"heatFrames": 0}
+        "h_heatedGModePauseAbuse"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -291,12 +291,11 @@
         {"or": [
           "h_HeatedGModeOpenDifferentDoor",
           {"and": [
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
             "canTrickyDodgeEnemies"
           ]}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -557,12 +556,11 @@
         {"or": [
           "h_HeatedGModeOpenDifferentDoor",
           {"and": [
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
             "canTrickyDodgeEnemies"
           ]}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1069,12 +1067,11 @@
         {"or": [
           "h_HeatedGModeOpenDifferentDoor",
           {"and": [
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
             "canTrickyDodgeEnemies"
           ]}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1291,9 +1288,8 @@
       "requires": [
         {"or": [
           "h_HeatedGModeOpenDifferentDoor",
-          "canPauseAbuse"
-        ]},
-        {"heatFrames": 0}
+          "h_heatedGModePauseAbuse"
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1674,12 +1670,11 @@
         {"or": [
           "h_HeatedGModeOpenDifferentDoor",
           {"and": [
-            "canPauseAbuse",
+            "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
             "canTrickyDodgeEnemies"
           ]}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1779,9 +1774,8 @@
       "requires": [
         {"or": [
           "h_HeatedGModeOpenDifferentDoor",
-          "canPauseAbuse"
-        ]},
-        {"heatFrames": 0}
+          "h_heatedGModePauseAbuse"
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -382,6 +382,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 19}
       ],
       "clearsObstacles": ["A"],
@@ -772,6 +773,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 19}
       ],
       "flashSuitChecked": true

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -526,11 +526,11 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
-          "canPauseAbuse",
+          "h_heatedGModePauseAbuse",
           {"heatFrames": 40}
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": "Kill the Gamets where Samus can grab the drops. Exit G-mode, then pause abuse to pick them up without dying.",

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -313,6 +313,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         "canOffScreenMovement",
         {"or": [
           "h_canArtificialMorphMovement",

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -248,6 +248,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 90}
       ],
       "clearsObstacles": ["A"],
@@ -265,6 +266,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 0}
       ],
       "flashSuitChecked": true
@@ -1022,6 +1024,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         "canTrickyUseFrozenEnemies",
         {"or": [
           "HiJump",
@@ -1043,6 +1046,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
           "SpaceJump",
           {"and": [
@@ -1081,6 +1085,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
           "h_canArtificialMorphLongIBJ",
           "h_canArtificialMorphJumpIntoIBJ"
@@ -1100,6 +1105,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         "canTrickyUseFrozenEnemies",
         {"or": [
           "HiJump",
@@ -1125,6 +1131,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
           "SpaceJump",
           {"and": [
@@ -1167,6 +1174,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"or": [
           "h_canArtificialMorphLongIBJ",
           "h_canArtificialMorphJumpIntoIBJ"

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -2037,7 +2037,6 @@
       "link": [7, 1],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode",
         "h_HeatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
@@ -2048,7 +2047,6 @@
       "link": [7, 2],
       "name": "G-Mode, Simple Blind Movement",
       "requires": [
-        "canEnterGMode",
         {"or": [
           {"and": [
             "canTrickyJump",
@@ -2085,7 +2083,6 @@
       "link": [7, 3],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode",
         "h_HeatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
@@ -2095,7 +2092,6 @@
       "link": [7, 4],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode",
         "h_HeatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
@@ -2105,7 +2101,6 @@
       "link": [7, 5],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode",
         "h_HeatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
@@ -2116,7 +2111,6 @@
       "link": [8, 1],
       "name": "G-Mode, Blind Movement",
       "requires": [
-        "canEnterGMode",
         "canOffScreenMovement",
         {"or": [
           "canWalljump",
@@ -2155,7 +2149,7 @@
       "link": [8, 3],
       "name": "G-Mode, Simple Blind Movement",
       "requires": [
-        "canEnterGMode",
+        "h_heatedGMode",
         {"or": [
           {"heatFrames": 160},
           {"and": [
@@ -2199,7 +2193,6 @@
       "link": [8, 4],
       "name": "G-Mode, Simple Blind Movement",
       "requires": [
-        "canEnterGMode",
         "h_HeatedGModeOffCameraDoor"
       ],
       "exitCondition": {
@@ -2224,7 +2217,6 @@
       "link": [8, 5],
       "name": "G-Mode, Blind Movement",
       "requires": [
-        "canEnterGMode",
         "canOffScreenMovement",
         {"or": [
           "canWalljump",
@@ -2260,7 +2252,7 @@
       "link": [8, 6],
       "name": "Exit G-Mode, Fix Camera",
       "requires": [
-        "canEnterGMode",
+        "h_heatedGMode",
         {"heatFrames": 250}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -167,6 +167,7 @@
         }
       },
       "requires": [
+        "h_heatedGMode",
         {"heatFrames": 45}
       ],
       "flashSuitChecked": true

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -483,9 +483,8 @@
         }
       },
       "requires": [
-        "canPauseAbuse",
-        "canFarmWhileShooting",
-        {"heatFrames": 0}
+        "h_heatedGModePauseAbuse",
+        "canFarmWhileShooting"
       ],
       "flashSuitChecked": true,
       "note": "It is possible to kill the Sovas and pick up their drops during a pause abuse.",
@@ -906,15 +905,14 @@
       },
       "requires": [
         "canBePatient",
-        "canPauseAbuse",
+        "h_heatedGModePauseAbuse",
         "canFarmWhileShooting",
         {"or": [
           "canTrickyJump",
           "canTrickyUseFrozenEnemies",
           {"ammo": {"type": "Super", "count": 1}},
           "h_canUsePowerBombs"
-        ]},
-        {"heatFrames": 0}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": [

--- a/strats.md
+++ b/strats.md
@@ -1310,6 +1310,7 @@ A `comeInWithGMode` entrance condition must match with either a `leaveWithGModeS
 
 When matching with a `leaveWithGModeSetup`, a `comeInWithGMode` has implicit requirements:
 - The tech requirement `canEnterGMode`.
+- The requirement `h_heatedGMode` if either the previous room or current room is heated.
 - The `XRayScope` item requirement.
 - A requirement to have at least 1 reserve energy.
 - A requirement to damage down to 0 energy, triggering reserves (causing the reserve energy to become zero and the regular energy to become what the reserve energy was).

--- a/tech.json
+++ b/tech.json
@@ -2421,6 +2421,20 @@
               ],
               "extensionTechs": [
                 {
+                  "name": "canHeatedGMode",
+                  "techRequires": [
+                    "canEnterGMode"
+                  ],
+                  "otherRequires": [],
+                  "note": [
+                    "Setting up or using G-mode in a heated environment without heat protection.",
+                    "Positioning an enemy to set up G-mode from a heated room requires precise Energy management.",
+                    "With slightly too much Energy, Samus can take damage then use X-Ray until her i-frames expire to immediately be able to take damage again.",
+                    "While G-mode provides heat protection (sometimes referred to as 'artificial Varia'), entering G-mode in a heated room is risky, as a fail will likely result in death if Samus had only 4 Reserve Energy.",
+                    "Exiting G-mode while in a heated environment will remove Samus' artificial heat protection; luring and killing an enemy near the door to collect its drop with a pause abuse is possible."
+                  ]
+                },
+                {
                   "id": 163,
                   "name": "canEnterGModeImmobile",
                   "techRequires": [

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -332,7 +332,7 @@ def check_heat_req(req):
         if req in ["h_heatProof", "h_canHeatedCrystalFlash", "h_canHeatedLavaCrystalFlash", "h_LowerNorfairElevatorDownwardFrames",
                    "h_LowerNorfairElevatorUpwardFrames", "h_MainHallElevatorFrames", "h_canHeatedGreenGateGlitch",
                    "h_DirectHeatedGModeLeaveSameDoor", "h_IndirectHeatedGModeOpenSameDoor",
-                   "h_HeatedGModeOpenDifferentDoor", "h_HeatedGModeOffCameraDoor"]:
+                   "h_HeatedGModeOpenDifferentDoor", "h_HeatedGModeOffCameraDoor", "h_heatedGModePauseAbuse"]:
             return True
     if isinstance(req, dict):
         if "heatFrames" in req or "heatFramesWithEnergyDrops" in req:


### PR DESCRIPTION
Its uses should be able to be added implicitly. I'm not expected that entering and exiting a heated room while already in G-mode to require this, but might not matter much either way (i.e. enterring Caterpillar Room in direct, using the elevator into LN Elevator Room and returning to despawn the gate)