### PR TITLE
Below Spazer left-side X-ray climb

### DIFF
--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -331,6 +331,19 @@
       ]
     },
     {
+      "link": [1, 3],
+      "name": "X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithDoorStuckSetup": {}
+      },
+      "requires": [
+        "canXRayClimb",
+        "h_canBombThings"
+      ],
+      "flashSuitChecked": true,
+      "note": "X-Ray climb up about 1 screen, then do a turn-around spin jump to reach the top ledge."
+    },
+    {
       "id": 12,
       "link": [1, 3],
       "name": "Grapple Teleport X-Ray Climb",


### PR DESCRIPTION
This is an X-ray climb up the left side of Below Spazer, only useful if walljump is unavailable:

Video: https://videos.maprando.com/video/5405