### PR TITLE
Refine Pink Brin Hoppers right-side speedy spring ball jump

### DIFF
--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -1114,6 +1114,19 @@
       "note": "Jump near the end of the runway in-room. Assumes there is a runway in the adjacent room of at least 37 tiles."
     },
     {
+      "link": [2, 3],
+      "name": "Speedy Spring Ball Jump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 14
+        }
+      },
+      "requires": [
+        "canTrickySpringBallJump"
+      ]
+    },
+    {
       "id": 50,
       "link": [2, 3],
       "name": "Speedy HiJump",
@@ -1163,18 +1176,18 @@
     {
       "id": 53,
       "link": [2, 3],
-      "name": "Tricky Speedy Spring Ball",
+      "name": "Tricky Speedy Spring Ball Jump",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
-          "minTiles": 7
+          "minTiles": 2
         }
       },
       "requires": [
         "canTrickySpringBallJump",
         "canTrickyDashJump"
       ],
-      "note": "Jump at the very end of the runway in-room. Requires a runway in the adjacent room of at least 7 tiles."
+      "note": "Using exactly 2 runway tiles (with open end) in the other room, jump at the very end of the runway in-room."
     },
     {
       "id": 54,


### PR DESCRIPTION
While reviewing a recent video by Sam (https://videos.maprando.com/video/4680), I noticed that the logic is requiring a longer runway for this strat than is required. This jump has two narrow windows of other-room runway length that work, one around 2 tiles and one around 7. And then anything above 14 tiles (including a little lenience) will work.

So this PR tightens the "Tricky Speedy Spring Ball Jump" strat, and also adds a less tricky version for when at least 14 tiles are available.