### PR TITLE
G-Mode: Spiky Acid Snakes, Lava Dive

### DIFF
--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -75,18 +75,6 @@
         [0, 1, 2, 0]
       ],
       "note": "Just below the center Namihe, almost at the bottom of the stairs."
-    },
-    {
-      "id": 6,
-      "name": "G-Mode Junction (By Center Namihe)",
-      "nodeType": "junction",
-      "nodeSubType": "g-mode",
-      "mapTileMask": [
-        [1, 1, 1, 1],
-        [0, 1, 2, 1],
-        [0, 1, 2, 0]
-      ],
-      "note": "Represents being just below the center Namihe, almost at the bottom of the stairs with G-Mode."
     }
   ],
   "enemies": [
@@ -136,8 +124,7 @@
         {"id": 2},
         {"id": 3},
         {"id": 4},
-        {"id": 5},
-        {"id": 6}
+        {"id": 5}
       ]
     },
     {
@@ -454,6 +441,83 @@
       "devNote": "FIXME: GT Max Suitless climb could be added, but is likely not reasonable."
     },
     {
+      "link": [2, 1],
+      "name": "G-Mode, Gravity Springwall",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "HiJump"},
+        "Gravity",
+        "canSpringwall",
+        "HiJump",
+        "canUseEnemies",
+        {"lavaFrames": 180},
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Wall jump off of the Upper-Left Namihe and then Spring Ball jump up and out of the Lava.",
+        "Pausing early in order to get more horizontal distance by equiping Spring Ball may help."
+      ],
+      "devNote": [
+        "This strat is not useful unless Samus has lava proof but not heat proof. Otherwise, the non-G-mode variant can be used.",
+        "FIXME: These lava frames are lenient, they are what it would take without Gravity (the non-G-mode variant also doesnt account for Gravity)."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "G-Mode, Gravity Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"disableEquipment": "SpeedBooster"},
+        {"lavaFrames": 190},
+        "canSuitlessLavaDive",
+        "canGravityJump",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"lavaFrames": 20},
+            {"gravitylessLavaFrames": 125}
+          ]},
+          {"and": [
+            "canStaggeredWalljump",
+            {"lavaFrames": 20},
+            {"gravitylessLavaFrames": 230}
+          ]}
+        ]},
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "devNote": "FIXME: Many strats without Gravity have been skipped for now."
+    },
+    {
+      "link": [2, 1],
+      "name": "G-Mode Morph, IBJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_lavaProof",
+        "Gravity",
+        "h_canArtificialMorphLongIBJ",
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "note": "The Namihe fireballs don't move while in G-mode, making it safe to IBJ straight up and out of the lava."
+    },
+    {
       "id": 45,
       "link": [2, 1],
       "name": "G-Mode Morph, Triple Spring Ball Jump (HiJump)",
@@ -465,7 +529,6 @@
       },
       "requires": [
         {"notable": "Artificial Morph, Triple Spring Ball Jump"},
-        "h_heatedGMode",
         "h_canArtificialMorphDoubleSpringBallJump",
         "canInsaneJump",
         {"gravitylessLavaFrames": 640},
@@ -488,7 +551,6 @@
       },
       "requires": [
         {"notable": "Artificial Morph, Triple Spring Ball Jump"},
-        "h_heatedGMode",
         {"tech": "canDoubleSpringBallJumpMidAir"},
         "h_canArtificialMorphSpringBall",
         "canInsaneJump",
@@ -589,7 +651,7 @@
         "canMidairWiggle",
         "canConsecutiveWalljump",
         "canInsaneWalljump",
-        {"lavaFrames": 392},
+        {"gravitylessLavaFrames": 392},
         {"heatFrames": 515}
       ],
       "note": [
@@ -727,42 +789,6 @@
       "devNote": "4 Tile jump entry is the Normalized Kronic Boost room setup."
     },
     {
-      "link": [2, 6],
-      "name": "G-Mode, Gravity",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        "Gravity",
-        {"disableEquipment": "SpeedBooster"},
-        {"lavaFrames": 190}
-      ],
-      "flashSuitChecked": true
-    },
-    {
-      "link": [2, 6],
-      "name": "G-Mode, Suitless",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": false
-        }
-      },
-      "requires": [
-        {"or": [
-          {"lavaFrames": 270},
-          {"and": [
-            "canBounceBall",
-            {"lavaFrames": 200}
-          ]}
-        ]}
-      ],
-      "flashSuitChecked": true
-    },
-    {
       "id": 22,
       "link": [3, 1],
       "name": "Base",
@@ -850,7 +876,7 @@
         "canPreciseWalljump",
         "canStaggeredWalljump",
         {"heatFrames": 270},
-        {"lavaFrames": 240}
+        {"gravitylessLavaFrames": 240}
       ],
       "note": [
         "Walljump off of the lower half of the Upper-Left Namihe to cross to the right side wall.",
@@ -895,7 +921,7 @@
         "canSpringwall",
         "canPreciseWalljump",
         {"heatFrames": 270},
-        {"lavaFrames": 240}
+        {"gravitylessLavaFrames": 240}
       ],
       "note": "Double springball jump out of a walljump starting from the top of the left wall Namihe."
     },
@@ -914,7 +940,7 @@
         "canUseEnemies",
         "canKago",
         {"heatFrames": 510},
-        {"lavaFrames": 480},
+        {"gravitylessLavaFrames": 480},
         {"enemyDamage": {"enemy": "Namihe", "type": "kago", "hits": 2}}
       ],
       "note": [
@@ -1144,11 +1170,11 @@
         "canUseEnemies",
         "canCameraManip",
         {"heatFrames": 600},
-        {"lavaFrames": 500},
+        {"gravitylessLavaFrames": 500},
         {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}}
       ],
       "note": [
-        "Use the bottommost right side namihe to generate a flame and walk with it to the bottommost left namihe head",
+        "Use the bottommost right side Namihe to generate a flame and walk with it to the bottommost left Namihe head",
         "Use a turnaround animation as Samus is hit by the flame to cancel out knockback frames.",
         "While invulnerability frames are active, walljump up the spikes either 2 or 3 times and jump accross to catch the middle wall and climb from there."
       ]
@@ -1161,7 +1187,7 @@
         "canSuitlessLavaDive",
         "h_canDoubleSpringBallJumpWithHiJump",
         {"heatFrames": 255},
-        {"lavaFrames": 225}
+        {"gravitylessLavaFrames": 225}
       ],
       "note": [
         "Double Spring Ball Jump from below the lowest-right Namihe.",
@@ -1241,57 +1267,6 @@
         "h_canHeatedLavaCrystalFlash"
       ],
       "flashSuitChecked": true
-    },
-    {
-      "link": [6, 1],
-      "name": "G-Mode, Gravity Jump",
-      "requires": [
-        "canSuitlessLavaDive",
-        "canGravityJump",
-        {"or": [
-          {"and": [
-            "HiJump",
-            {"lavaFrames": 20},
-            {"gravitylessLavaFrames": 125}
-          ]},
-          {"and": [
-            "canStaggeredWalljump",
-            {"lavaFrames": 20},
-            {"gravitylessLavaFrames": 230}
-          ]}
-        ]}
-      ]
-    },
-    {
-      "link": [6, 1],
-      "name": "G-Mode, Suitless",
-      "requires": [
-        "canSuitlessLavaDive",
-        "canGravityJump",
-        {"or": [
-          {"and": [
-            "HiJump",
-            {"lavaFrames": 20},
-            {"gravitylessLavaFrames": 125}
-          ]},
-          {"and": [
-            "canStaggeredWalljump",
-            {"lavaFrames": 20},
-            {"gravitylessLavaFrames": 230}
-          ]}
-        ]}
-
-
-        {"notable": "HiJumpless Dive"},
-        "canSuitlessLavaDive",
-        "canUseIFrames",
-        "canStaggeredWalljump",
-        "canFastWalljumpClimb",
-        "canUseEnemies",
-        "canCameraManip",
-        {"lavaFrames": 500},
-        {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}}
-      ]
     }
   ],
   "notables": [

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -75,6 +75,18 @@
         [0, 1, 2, 0]
       ],
       "note": "Just below the center Namihe, almost at the bottom of the stairs."
+    },
+    {
+      "id": 6,
+      "name": "G-Mode Junction (By Center Namihe)",
+      "nodeType": "junction",
+      "nodeSubType": "g-mode",
+      "mapTileMask": [
+        [1, 1, 1, 1],
+        [0, 1, 2, 1],
+        [0, 1, 2, 0]
+      ],
+      "note": "Represents being just below the center Namihe, almost at the bottom of the stairs with G-Mode."
     }
   ],
   "enemies": [
@@ -112,6 +124,7 @@
       "from": 1,
       "to": [
         {"id": 1},
+        {"id": 2},
         {"id": 3},
         {"id": 5}
       ]
@@ -123,7 +136,8 @@
         {"id": 2},
         {"id": 3},
         {"id": 4},
-        {"id": 5}
+        {"id": 5},
+        {"id": 6}
       ]
     },
     {
@@ -255,7 +269,10 @@
         "h_HeatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
-      "devNote": "Artificial morph jump into Crystal Flash clip doesn't seem to be possible. More testing could help."
+      "devNote": [
+        "Artificial morph jump into Crystal Flash clip doesn't seem to be possible. More testing could help.",
+        "FIXME: The thread the needle strats could be added to save a small amount of Energy, but may not be reasonable."
+      ]
     },
     {
       "link": [1, 2],
@@ -416,6 +433,25 @@
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
         "Then X-ray climb to get up to the door transition, without needing to open the door."
       ]
+    },
+    {
+      "link": [2, 1],
+      "name": "G-Mode, Gravity Space Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "Gravity",
+        "SpaceJump",
+        {"disableEquipment": "SpeedBooster"},
+        {"lavaFrames": 280},
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "devNote": "FIXME: GT Max Suitless climb could be added, but is likely not reasonable."
     },
     {
       "id": 45,
@@ -689,6 +725,42 @@
         "Morph before reaching the lava, Bounce, and Unmorph shortly after sink slightly before floating down to the stairs."
       ],
       "devNote": "4 Tile jump entry is the Normalized Kronic Boost room setup."
+    },
+    {
+      "link": [2, 6],
+      "name": "G-Mode, Gravity",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"disableEquipment": "SpeedBooster"},
+        {"lavaFrames": 190}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 6],
+      "name": "G-Mode, Suitless",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"or": [
+          {"lavaFrames": 270},
+          {"and": [
+            "canBounceBall",
+            {"lavaFrames": 200}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -1169,6 +1241,57 @@
         "h_canHeatedLavaCrystalFlash"
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [6, 1],
+      "name": "G-Mode, Gravity Jump",
+      "requires": [
+        "canSuitlessLavaDive",
+        "canGravityJump",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"lavaFrames": 20},
+            {"gravitylessLavaFrames": 125}
+          ]},
+          {"and": [
+            "canStaggeredWalljump",
+            {"lavaFrames": 20},
+            {"gravitylessLavaFrames": 230}
+          ]}
+        ]}
+      ]
+    },
+    {
+      "link": [6, 1],
+      "name": "G-Mode, Suitless",
+      "requires": [
+        "canSuitlessLavaDive",
+        "canGravityJump",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"lavaFrames": 20},
+            {"gravitylessLavaFrames": 125}
+          ]},
+          {"and": [
+            "canStaggeredWalljump",
+            {"lavaFrames": 20},
+            {"gravitylessLavaFrames": 230}
+          ]}
+        ]}
+
+
+        {"notable": "HiJumpless Dive"},
+        "canSuitlessLavaDive",
+        "canUseIFrames",
+        "canStaggeredWalljump",
+        "canFastWalljumpClimb",
+        "canUseEnemies",
+        "canCameraManip",
+        {"lavaFrames": 500},
+        {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}}
+      ]
     }
   ],
   "notables": [

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -224,6 +224,63 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "G-Mode, Suitless",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "canSuitlessLavaDive",
+        {"lavaFrames": 370},
+        {"or": [
+          "HiJump",
+          {"lavaFrames": 25}
+        ]},
+        {"or": [
+          "SpaceJump",
+          "canSpringBallJumpMidAir",
+          "canWalljump",
+          {"and": [
+            "HiJump",
+            {"lavaFrames": 10}
+          ]},
+          {"and": [
+            "canBombJumpWaterEscape",
+            {"lavaFrames": 30}
+          ]}
+        ]},
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "devNote": "Artificial morph jump into Crystal Flash clip doesn't seem to be possible. More testing could help."
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode, Gravity",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"disableEquipment": "SpeedBooster"},
+        {"or": [
+          {"lavaFrames": 300},
+          {"and": [
+            "SpaceJump",
+            {"lavaFrames": 260}
+          ]}
+        ]},
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 4,
       "link": [1, 3],
       "name": "Base",

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -444,7 +444,7 @@
         {"heatFrames": 340},
         {"lavaFrames": 280},
         {"or": [
-          "canDisableEquipment",
+          {"disableEquipment": "SpeedBooster"},
           {"and": [
             {"heatFrames": 120},
             {"lavaFrames": 120}
@@ -566,13 +566,14 @@
         {"heatFrames": 250},
         {"lavaFrames": 190},
         {"or": [
-          "canDisableEquipment",
+          {"disableEquipment": "SpeedBooster"},
           {"and": [
             {"heatFrames": 50},
             {"lavaFrames": 50}
           ]}
         ]}
-      ]
+      ],
+      "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
     },
     {
       "id": 19,
@@ -860,7 +861,7 @@
           ]},
           {"and": [
             "Gravity",
-            "canDisableEquipment",
+            {"disableEquipment": "SpeedBooster"},
             {"heatFrames": 140},
             {"lavaFrames": 140}
           ]},
@@ -869,7 +870,8 @@
             {"lavaFrames": 210}
           ]}
         ]}
-      ]
+      ],
+      "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
     },
     {
       "id": 34,
@@ -883,12 +885,12 @@
         ]},
         {"or": [
           {"and": [
-            "canDisableEquipment",
+            {"disableEquipment": "SpeedBooster"},
             {"heatFrames": 270},
             {"lavaFrames": 220}
           ]},
           {"and": [
-            "canDisableEquipment",
+            {"disableEquipment": "SpeedBooster"},
             "SpaceJump",
             "canCarefulJump",
             {"heatFrames": 225},
@@ -1090,7 +1092,7 @@
           ]},
           {"and": [
             "Gravity",
-            "canDisableEquipment",
+            {"disableEquipment": "SpeedBooster"},
             {"heatFrames": 150},
             {"lavaFrames": 150}
           ]},
@@ -1099,7 +1101,8 @@
             {"lavaFrames": 200}
           ]}
         ]}
-      ]
+      ],
+      "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
     },
     {
       "id": 42,

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -159,7 +159,7 @@
       "name": "Tank the Damage with Gravity",
       "requires": [
         "Gravity",
-        "canDisableEquipment",
+        {"disableEquipment": "SpeedBooster"},
         {"heatFrames": 350},
         {"lavaFrames": 100},
         {"spikeHits": 2},
@@ -187,7 +187,6 @@
       "requires": [
         "Gravity",
         "canCarefulJump",
-        "canDisableEquipment",
         "canSpringBallBounce",
         {"spikeHits": 2},
         {"heatFrames": 350},
@@ -206,7 +205,7 @@
       },
       "requires": [
         "Gravity",
-        "canDisableEquipment",
+        {"disableEquipment": "SpeedBooster"},
         "canSpringBallBounce",
         "canTrickyJump",
         {"spikeHits": 1},
@@ -231,7 +230,7 @@
       "requires": [
         "canCarefulJump",
         "HiJump",
-        "canDisableEquipment",
+        {"disableEquipment": "HiJump"},
         "canSpringBallBounce",
         {"spikeHits": 3},
         {"heatFrames": 350},
@@ -252,7 +251,8 @@
       "requires": [
         "canTrickyJump",
         "HiJump",
-        "canDisableEquipment",
+        {"disableEquipment": "HiJump"},
+        {"disableEquipment": "SpeedBooster"},
         "canSpringBallBounce",
         {"spikeHits": 2},
         {"heatFrames": 311},
@@ -276,7 +276,8 @@
       },
       "requires": [
         "HiJump",
-        "canDisableEquipment",
+        {"disableEquipment": "HiJump"},
+        {"disableEquipment": "SpeedBooster"},
         "canSpringBallBounce",
         "canTrickyJump",
         {"spikeHits": 1},
@@ -408,6 +409,89 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "G-Mode",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode, Tank the Spikes",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"or": [
+          {"and": [
+            {"lavaFrames": 150},
+            {"spikeHits": 7}
+          ]},
+          {"and": [
+            {"notable": "Suitless Damage Boosts"},
+            {"lavaFrames": 80},
+            {"spikeHits": 3},
+            "canUseIFrames",
+            "canHorizontalDamageBoost"
+          ]},
+          {"and": [
+            "Gravity",
+            {"disableEquipment": "SpeedBooster"},
+            {"lavaFrames": 100},
+            {"spikeHits": 2},
+            {"or": [
+              "canUseIFrames",
+              "canHorizontalDamageBoost"
+            ]}
+          ]},
+          {"and": [
+            {"notable": "Frozen Maw Platforms"},
+            "canResetFallSpeed",
+            "canTrickyUseFrozenEnemies",
+            "canTrickyJump",
+            "canHorizontalDamageBoost",
+            "canUseIFrames",
+            {"spikeHits": 2},
+            {"lavaFrames": 15}
+          ]}
+        ]},
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "devNote": "FIXME: Grapple could maybe be used to skip some damage by partially swinging across the room."
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode Morph, Long Ceiling Bomb Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphLongCeilingBombJump",
+        "h_canArtificialMorphResetFallSpeed",
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Samus can ceiling bomb jump up gentle slopes.",
+        "Going down gentle slopes is also possible but harder, instead an unmorph to reset fall speed is recommended here."
+      ]
+    },
+    {
       "id": 17,
       "link": [2, 1],
       "name": "Grapple",
@@ -470,7 +554,7 @@
       "name": "Tank the Damage with Gravity",
       "requires": [
         "Gravity",
-        "canDisableEquipment",
+        {"disableEquipment": "SpeedBooster"},
         {"heatFrames": 350},
         {"lavaFrames": 100},
         {"spikeHits": 2},
@@ -497,7 +581,6 @@
       },
       "requires": [
         "Gravity",
-        "canDisableEquipment",
         "canSpringBallBounce",
         {"spikeHits": 2},
         {"heatFrames": 350},
@@ -516,7 +599,7 @@
       },
       "requires": [
         "Gravity",
-        "canDisableEquipment",
+        {"disableEquipment": "SpeedBooster"},
         "canSpringBallBounce",
         "canTrickyJump",
         {"spikeHits": 1},
@@ -541,7 +624,7 @@
       "requires": [
         "canCarefulJump",
         "HiJump",
-        "canDisableEquipment",
+        {"disableEquipment": "HiJump"},
         "canSpringBallBounce",
         {"spikeHits": 3},
         {"heatFrames": 350},
@@ -562,7 +645,8 @@
       "requires": [
         "canTrickyJump",
         "HiJump",
-        "canDisableEquipment",
+        {"disableEquipment": "HiJump"},
+        {"disableEquipment": "SpeedBooster"},
         "canSpringBallBounce",
         {"spikeHits": 2},
         {"heatFrames": 311},
@@ -586,7 +670,8 @@
       },
       "requires": [
         "HiJump",
-        "canDisableEquipment",
+        {"disableEquipment": "HiJump"},
+        {"disableEquipment": "SpeedBooster"},
         "canSpringBallBounce",
         "canTrickyJump",
         {"spikeHits": 1},
@@ -771,6 +856,89 @@
         "canLongCeilingBombJump",
         "canResetFallSpeed"
       ],
+      "note": [
+        "Samus can ceiling bomb jump up gentle slopes.",
+        "Going down gentle slopes is also possible but harder, instead an unmorph to reset fall speed is recommended here."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode, Tank the Spikes",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"or": [
+          {"and": [
+            {"lavaFrames": 150},
+            {"spikeHits": 7}
+          ]},
+          {"and": [
+            {"notable": "Suitless Damage Boosts"},
+            {"lavaFrames": 80},
+            {"spikeHits": 3},
+            "canUseIFrames",
+            "canHorizontalDamageBoost"
+          ]},
+          {"and": [
+            "Gravity",
+            {"disableEquipment": "SpeedBooster"},
+            {"lavaFrames": 100},
+            {"spikeHits": 2},
+            {"or": [
+              "canUseIFrames",
+              "canHorizontalDamageBoost"
+            ]}
+          ]},
+          {"and": [
+            {"notable": "Frozen Maw Platforms"},
+            "canResetFallSpeed",
+            "canTrickyUseFrozenEnemies",
+            "canTrickyJump",
+            "canHorizontalDamageBoost",
+            "canUseIFrames",
+            {"spikeHits": 2},
+            {"lavaFrames": 15}
+          ]}
+        ]},
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
+      "devNote": "FIXME: Grapple could maybe be used to skip some damage by partially swinging across the room."
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode Morph, Long Ceiling Bomb Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_canArtificialMorphLongCeilingBombJump",
+        "h_canArtificialMorphResetFallSpeed",
+        "h_HeatedGModeOpenDifferentDoor"
+      ],
+      "flashSuitChecked": true,
       "note": [
         "Samus can ceiling bomb jump up gentle slopes.",
         "Going down gentle slopes is also possible but harder, instead an unmorph to reset fall speed is recommended here."

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -862,7 +862,7 @@
       ]
     },
     {
-      "link": [1, 2],
+      "link": [2, 1],
       "name": "G-Mode",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -877,7 +877,7 @@
       "flashSuitChecked": true
     },
     {
-      "link": [1, 2],
+      "link": [2, 1],
       "name": "G-Mode, Tank the Spikes",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -925,7 +925,7 @@
       "devNote": "FIXME: Grapple could maybe be used to skip some damage by partially swinging across the room."
     },
     {
-      "link": [1, 2],
+      "link": [2, 1],
       "name": "G-Mode Morph, Long Ceiling Bomb Jump",
       "entranceCondition": {
         "comeInWithGMode": {


### PR DESCRIPTION
This is the end of Upper Norfair! 

Most of these strats are just copies of the non-G-mode variants with removed heat frames. I skipped adding the G-mode strats in Lava Dive without Gravity - it felt too complex and very unlikely to ever be useful. 

Also cleaned up `disableEquipment` to describe what needs to be disabled in these two rooms, and used `gravitylessLavaFrames` for Lava Dive strats that could not be done with Gravity equipped.
