### PR TITLE
Refine Oasis jump-through-top-door strats, add detailNotes schema

### DIFF
--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -569,7 +569,7 @@
       ],
       "detailNote": [
         "The optimal amount of extra run speed is $3.4 or $3.5, by using 13 tiles of runway or about a half tile more;",
-        "this gives a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "this gives a 7-frame window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
         "Extra run speeds between $3.6 and $3.F can also work, but with shorter windows.",
         "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
         "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
@@ -610,7 +610,7 @@
       ],
       "detailNote": [
         "Lower run speeds are generally better, as long as the extra run speed is at least $3.4.",
-        "this gives up to a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "this gives up to a 7-frame window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
         "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
         "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
         "then switching from forward to backward, with at most 1 frame of neutral in between, while still holding jump and angle."
@@ -1217,7 +1217,7 @@
       ],
       "detailNote": [
         "The optimal amount of extra run speed is $3.4 or $3.5, by using 13 tiles of runway or about a half tile more;",
-        "this gives a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "this gives a 7-frame window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
         "Extra run speeds between $3.6 and $3.F can also work, but with shorter windows.",
         "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
         "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
@@ -1258,7 +1258,7 @@
       ],
       "detailNote": [
         "Lower run speeds are generally better, as long as the extra run speed is at least $3.4.",
-        "this gives up to a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "this gives up to a 7-frame window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
         "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
         "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
         "then switching from forward to backward, with at most 1 frame of neutral in between, while still holding jump and angle."

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -537,7 +537,7 @@
     {
       "id": 16,
       "link": [1, 3],
-      "name": "Cross Room Jump with Screw Attack and Speed through the Top Door (From the Left)",
+      "name": "Cross Room Jump Through Top Door (Screw Attack)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -545,7 +545,7 @@
         }
       },
       "requires": [
-        {"notable": "Cross Room Jump with Screw Attack and Speed through the Top Door"},
+        {"notable": "Cross Room Jump Through Top Door"},
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack",
@@ -560,12 +560,61 @@
       ],
       "note": [
         "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump, and make it all the way through the top door.",
-        "This uses exactly 14 tiles (with no open end) - more rises too fast to do the trick, less does not have the height needed to reach the door.",
-        "Use angle to break spin, then a momentumConservingTurnaround as early as possible, right as you pass the above tile horizontally. Using the background for positioning may help.",
-        "The second momentumConservingTurnaround is as late as possible, just before touching the above platform.",
-        "A third momentumConservingTurnaround is used on the door as it is opening."
+        "Ideally, gain speed using between 13 and 13.5 tiles of runway (with an open end).",
+        "Longer runway lengths can also work, up to 17 tiles, but will make the trick somewhat more precise.",
+        "Use angle to break spin, and do a momentum conserving turnaround either on the same frame or one frame later;",
+        "this first turnaround should be done early enough that the turnaround is complete by the time Samus clears the two-tile passage in the middle of the room.",
+        "Do a second momentum conserving turnaround must be done somewhat late, and by switching from holding left to holding right one frame later (a perfect 'boomerang').",
+        "Shoot open the door, and use a third momentum conserving turnaround on it as it opens."
       ],
-      "devNote": "This does not have collision oscillation. It is possible to do this without Screw Attack, but is extremely precise."
+      "detailNote": [
+        "The optimal amount of extra run speed is $3.4 or $3.5, by using 13 tiles of runway or about a half tile more;",
+        "this gives a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "Extra run speeds between $3.6 and $3.F can also work, but with shorter windows.",
+        "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
+        "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
+        "then switching from forward to backward, with at most 1 frame of neutral in between, while still holding jump and angle."
+      ],
+      "devNote": "This does not have collision oscillation."
+    },
+    {
+      "link": [1, 3],
+      "name": "Cross Room Jump Through Top Door (Blue Speed)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 0,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$3.4",
+          "maxExtraRunSpeed": "$3.F"
+        }
+      },
+      "requires": [
+        {"notable": "Cross Room Jump Through Top Door"},
+        "canInsaneJump",
+        "canCrossRoomJumpIntoWater",
+        "canMomentumConservingTurnaround"
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "Use a 2-tap shortcharge and jump into the room with a last-frame jump, breaking the bomb block with blue speed, and making it all the way through the top door.",
+        "Use angle to break spin, and do a momentum conserving turnaround either on the same frame or one frame later;",
+        "this first turnaround should be done early enough that the turnaround is complete by the time Samus clears the two-tile passage in the middle of the room.",
+        "Do a second momentum conserving turnaround must be done somewhat late, and by switching from holding left to holding right one frame later (a perfect 'boomerang').",
+        "Shoot open the door, and use a third momentum conserving turnaround on it as it opens."
+      ],
+      "detailNote": [
+        "Lower run speeds are generally better, as long as the extra run speed is at least $3.4.",
+        "this gives up to a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
+        "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
+        "then switching from forward to backward, with at most 1 frame of neutral in between, while still holding jump and angle."
+      ]
     },
     {
       "id": 66,
@@ -1136,7 +1185,7 @@
     {
       "id": 39,
       "link": [2, 3],
-      "name": "Cross Room Jump with Screw Attack and Speed through the Top Door (From the Right)",
+      "name": "Cross Room Jump Through Top Door (Screw Attack)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -1144,7 +1193,7 @@
         }
       },
       "requires": [
-        {"notable": "Cross Room Jump with Screw Attack and Speed through the Top Door"},
+        {"notable": "Cross Room Jump Through Top Door"},
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
         "ScrewAttack",
@@ -1159,12 +1208,61 @@
       ],
       "note": [
         "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump, and make it all the way through the top door.",
-        "This uses exactly 14 tiles (with no open end) - more rises too fast to do the trick, less does not have the height needed to reach the door.",
-        "Use angle to break spin, then a momentumConservingTurnaround as early as possible, right as you pass the above tile horizontally. Using the background for positioning may help.",
-        "The second momentumConservingTurnaround is as late as possible, just before touching the above platform.",
-        "A third momentumConservingTurnaround is used on the door as it is opening."
+        "Ideally, gain speed using between 13 and 13.5 tiles of runway (with an open end).",
+        "Longer runway lengths can also work, up to 17 tiles, but will make the trick somewhat more precise.",
+        "Use angle to break spin, and do a momentum conserving turnaround either on the same frame or one frame later;",
+        "this first turnaround should be done early enough that the turnaround is complete by the time Samus clears the two-tile passage in the middle of the room.",
+        "The second momentum conserving turnaround must be done somewhat late, and by switching from holding forward to holding backward one frame later (a perfect 'boomerang').",
+        "Shoot open the door, and use a third momentum conserving turnaround on it as it opens."
       ],
-      "devNote": "This does not have collision oscillation. It is possible to do this without Screw Attack, but is extremely precise."
+      "detailNote": [
+        "The optimal amount of extra run speed is $3.4 or $3.5, by using 13 tiles of runway or about a half tile more;",
+        "this gives a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "Extra run speeds between $3.6 and $3.F can also work, but with shorter windows.",
+        "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
+        "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
+        "then switching from forward to backward, with at most 1 frame of neutral in between, while still holding jump and angle."
+      ],
+      "devNote": "This does not have collision oscillation."
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room Jump Through Top Door (Blue Speed)",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 0,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$3.4",
+          "maxExtraRunSpeed": "$3.F"
+        }
+      },
+      "requires": [
+        {"notable": "Cross Room Jump Through Top Door"},
+        "canInsaneJump",
+        "canCrossRoomJumpIntoWater",
+        "canMomentumConservingTurnaround"
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "Use a 2-tap shortcharge and jump into the room with a last-frame jump, breaking the bomb block with blue speed, and making it all the way through the top door.",
+        "Use angle to break spin, and do a momentum conserving turnaround either on the same frame or one frame later;",
+        "this first turnaround should be done early enough that the turnaround is complete by the time Samus clears the two-tile passage in the middle of the room.",
+        "The second momentum conserving turnaround must be done somewhat late, and by switching from holding forward to holding backward one frame later (a perfect 'boomerang').",
+        "Shoot open the door, and use a third momentum conserving turnaround on it as it opens."
+      ],
+      "detailNote": [
+        "Lower run speeds are generally better, as long as the extra run speed is at least $3.4.",
+        "this gives up to a 7-window for the first turnaround, and typically a 4-frame window for the second turnaround if the first turnaround is done early enough.",
+        "A perfect boomerang is always required for the second turnaround, regardless of where in the window it is done.",
+        "It is recommended to buffer the spin break, by holding angle (up or down), jump, and forward through the transition,",
+        "then switching from forward to backward, with at most 1 frame of neutral in between, while still holding jump and angle."
+      ]
     },
     {
       "id": 67,
@@ -1673,14 +1771,14 @@
     },
     {
       "id": 2,
-      "name": "Cross Room Jump with Screw Attack and Speed through the Top Door",
+      "name": "Cross Room Jump Through Top Door",
       "note": [
-        "Use Screw Attack to break the bomb block by entering from a non-water room with a spin jump, and make it all the way through the top door.",
-        "This uses exactly 14 tiles (with no open end) - more rises too fast to do the trick, less does not have the height needed to reach the door.",
-        "Use angle to break spin, then a momentumConservingTurnaround as early as possible, right as you pass the above tile horizontally. Using the background for positioning may help.",
-        "The second momentumConservingTurnaround is as late as possible, just before touching the above platform.",
-        "A third momentumConservingTurnaround is used on the door as it is opening."
-      ]
+        "Use Screw Attack or blue speed to break the bomb block by entering from a non-water room with a spin jump, and make it all the way through the top door.",
+        "Use angle to break spin, and do a momentum conserving turnaround either on the same frame or one frame later;",
+        "this first turnaround should be done early enough that the turnaround is complete by the time Samus clears the two-tile passage in the middle of the room.",
+        "The second momentum conserving turnaround must be done somewhat late, and by switching from holding forward to holding backward one frame later (a perfect 'boomerang').",
+        "Shoot open the door, and use a third momentum conserving turnaround on it as it opens."
+     ]
     }
   ],
   "nextStratId": 70,

--- a/schema/m3-note.schema.json
+++ b/schema/m3-note.schema.json
@@ -7,7 +7,17 @@
     "note": {
       "type": ["string", "array"],
       "title": "Note field",
-      "description": "Additional details or explanations, intended for users who want to understand an element in the model.",
+      "description": "Explanations intended for users who want to understand an element in the model.",
+      "default": "",
+      "pattern": "^(.*)$",
+      "items": {
+        "type": "string"
+      }
+    },
+    "detailNote": {
+      "type": ["string", "array"],
+      "title": "Detail note field",
+      "description": "Additional details intended for users who want to understand an element in the model.",
       "default": "",
       "pattern": "^(.*)$",
       "items": {
@@ -16,8 +26,8 @@
     },
     "devNote": {
       "type": ["string", "array"],
-      "title": "Dev Note field",
-      "description": "Additional details or explanations, intended for developers of the model.",
+      "title": "Dev note field",
+      "description": "Details or explanations intended for developers of the model.",
       "default": "",
       "pattern": "^(.*)$",
       "items": {

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1540,6 +1540,9 @@
         "note": {
           "$ref" : "m3-note.schema.json#/definitions/note"
         },
+        "detailNote": {
+          "$ref" : "m3-note.schema.json#/definitions/detailNote"
+        },
         "devNote": {
           "$ref" : "m3-note.schema.json#/definitions/devNote"
         }

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -108,6 +108,7 @@ def process_keyvalue(k, v, metadata):
         "$schema",          # immaterial
         "description",      # immaterial
         "devNote",          # immaterial
+        "detailNote",       # immaterial
         "note",             # immaterial
         "name",             # !!could check for unique
         "id",               # !!could check for unique


### PR DESCRIPTION
- Update the notes of the strats that use Screw Attack to jump up through the top door of Oasis.
- Add blue speed variations that don't require Screw Attack.
- Add schema for `detailNotes`.

The existing notes here very much overstate how much precision is needed in the amount of runway to use. There's a wide range that works well, with only a slight benefit to using the minimal amount of 13 tiles. The blue speed version was also not so bad: with a 2-tap, I could consistently get run speed in a good range, and from there the trick is the same as the version with Screw Attack.

Videos for the blue speed version:
- left-to-right: https://videos.maprando.com/video/5482
- right-to-left: https://videos.maprando.com/video/5483 