### PR TITLE
Ice Beam Gate Room anti-shortcharge

### DIFF
--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -220,7 +220,7 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Cross-Room Speed Jump (Left to Right)",
+      "name": "Cross-Room Speed Jump over Evirs",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -229,7 +229,7 @@
         }
       },
       "requires": [
-        {"notable": "Cross-Room Speed Jump"},
+        {"notable": "Cross-Room Speed Jump over Evirs"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canTrickyDashJump"
@@ -243,7 +243,7 @@
     {
       "id": 9,
       "link": [1, 2],
-      "name": "Cross-Room SpringBall Jump (Left to Right)",
+      "name": "Cross-Room Spring Ball Jump",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -251,7 +251,7 @@
         }
       },
       "requires": [
-        {"notable": "Cross-Room SpringBall Jump"},
+        {"notable": "Cross-Room Spring Ball Jump"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canLateralMidAirMorph",
@@ -259,8 +259,8 @@
         "canTrickyJump"
       ],
       "note": [
-        "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
-        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
+        "Enter with enough run speed to jump (after the transition) across the full room using one Spring Ball Jump.",
+        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Spring Ball jump."
       ]
     },
     {
@@ -655,7 +655,7 @@
     {
       "id": 26,
       "link": [2, 1],
-      "name": "Cross-Room Speed Jump",
+      "name": "Cross-Room Speed Jump over Evirs",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -664,7 +664,7 @@
         }
       },
       "requires": [
-        {"notable": "Cross-Room Speed Jump"},
+        {"notable": "Cross-Room Speed Jump over Evirs"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canTrickyDashJump"
@@ -681,7 +681,7 @@
     },
     {
       "link": [2, 1],
-      "name": "Cross-Room Blue Speed Jump",
+      "name": "Cross-Room Blue Speed Jump (Right to Left)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 1,
@@ -690,15 +690,17 @@
         }
       },
       "requires": [
+        {"notable": "Cross-Room Blue Speed Jump (Right to Left)"},
         "canPlayInSand",
-        "canCrossRoomJumpIntoWater",
-        "canInsaneJump"
+        "canCrossRoomJumpIntoWater"
       ],
       "note": [
-        "Perform a 1-tap to gain blue speed with a significant amount of momentum."
+        "Perform a 1-tap to gain blue speed with a significant amount of momentum.",
+        "Run through the door, and jump any time after the transition, crossing the room."
       ],
       "devNote": [
-        "This assumes an extra run speed of at least $4.4, though some lower speeds can also work."
+        "This assumes an extra run speed of at least $4.4, though some lower speeds can also work ($3.B through $3.F).",
+        "The window between $4.0 and $4.3 must be avoided because it would give too much jump height."
       ]
     },
     {
@@ -713,6 +715,7 @@
         }
       },
       "requires": [
+        {"notable": "Cross-Room Blue Speed Jump (Right to Left)"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canInsaneJump",
@@ -820,7 +823,7 @@
     {
       "id": 31,
       "link": [2, 1],
-      "name": "Cross-Room SpringBall Jump (Right to Left)",
+      "name": "Cross-Room Spring Ball Jump",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -828,7 +831,7 @@
         }
       },
       "requires": [
-        {"notable": "Cross-Room SpringBall Jump"},
+        {"notable": "Cross-Room Spring Ball Jump"},
         "canPlayInSand",
         "canCrossRoomJumpIntoWater",
         "canLateralMidAirMorph",
@@ -836,9 +839,9 @@
         "canTrickyJump"
       ],
       "note": [
-        "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
-        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump.",
-        "Alternatively, an immediate pause can be used to SpringBall jump during the first narrow gap between Sandfalls.",
+        "Enter with enough run speed to jump (after the transition) across the full room using one Spring Ball Jump.",
+        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Spring Ball jump.",
+        "Alternatively, an immediate pause can be used to Spring Ball jump during the first narrow gap between Sandfalls.",
         "Sometimes Samus will land above the sand on the far left end of the room, where it will be necessary to unmorph and jump out."
       ]
     },
@@ -1419,7 +1422,7 @@
       ],
       "note": [
         "On the left side of the raised platform, jump for max height.",
-        "Lateral Midair Morph for horizontal momentum, and perform the springball jump the moment before touching the sandfall.",
+        "Lateral Midair Morph for horizontal momentum, and perform the Spring Ball jump the moment before touching the sandfall.",
         "Pause again to disable springball as soon as possible."
       ]
     },
@@ -1463,7 +1466,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Cross-Room Speed Jump",
+      "name": "Cross-Room Speed Jump over Evirs",
       "note": [
         "Stand at an effective distance of approximately 20 tiles from the door.",
         "Run through the door, and jump any time after the transition, holding jump through the entire room to make it to the other side.",
@@ -1472,10 +1475,10 @@
     },
     {
       "id": 2,
-      "name": "Cross-Room SpringBall Jump",
+      "name": "Cross-Room Spring Ball Jump",
       "note": [
-        "Enter with enough run speed to jump (after the transition) across the full room using one SpringBall Jump.",
-        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Springball jump."
+        "Enter with enough run speed to jump (after the transition) across the full room using one Spring Ball Jump.",
+        "When exiting the first Sandfall, Samus will be rising still.  That is the time to Spring Ball jump."
       ]
     },
     {
@@ -1550,8 +1553,8 @@
       "name": "Spring Ball HiJump",
       "note": [
         "On the left side of the raised platform, jump for max height.",
-        "Lateral Midair Morph for horizontal momentum, and perform the springball jump the moment before touching the sandfall.",
-        "Pause again to disable springball as soon as possible."
+        "Use a stationary lateral mid-air morph for horizontal momentum, and perform the Spring Ball jump the moment before touching the sandfall.",
+        "Pause again to disable Spring Ball as soon as possible."
       ]
     },
     {
@@ -1563,8 +1566,16 @@
         "Perform a spring ball jump with a stationary lateral mid-air morph from the left side of the current platform to get onto the Evir. Use a running jump off of the Evir.",
         "As a backup, it may be possible to make the Evir rise again by hitting it with a PB - place the PB in the air to avoid double hitting and killing it."
       ]
+    },
+    {
+      "id": 12,
+      "name": "Cross-Room Blue Speed Jump (Right to Left)",
+      "note": [
+        "Perform a 1-tap to gain blue speed with a significant amount of momentum.",
+        "Run through the door, and jump any time after the transition, crossing the room."
+      ]
     }
   ],
   "nextStratId": 69,
-  "nextNotableId": 12
+  "nextNotableId": 13
 }

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -655,7 +655,7 @@
     {
       "id": 26,
       "link": [2, 1],
-      "name": "Cross-Room Speed Jump (Right to Left)",
+      "name": "Cross-Room Speed Jump",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -677,6 +677,28 @@
       "devNote": [
         "This needs an extra run speed of at least $4.4, and ideally not much more than that.",
         "A little higher run speed can also work but may require releasing jump near the peak to avoid getting caught on the overhang."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Cross-Room Blue Speed Jump",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 1,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$4.4"
+        }
+      },
+      "requires": [
+        "canPlayInSand",
+        "canCrossRoomJumpIntoWater",
+        "canInsaneJump"
+      ],
+      "note": [
+        "Perform a 1-tap to gain blue speed with a significant amount of momentum."
+      ],
+      "devNote": [
+        "This assumes an extra run speed of at least $4.4, though some lower speeds can also work."
       ]
     },
     {

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -919,6 +919,9 @@
       "id": 39,
       "link": [4, 2],
       "name": "Speed Through",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [
         "SpeedBooster"
       ]
@@ -927,6 +930,9 @@
       "id": 40,
       "link": [4, 2],
       "name": "Speed Through and Leave Shinecharged",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [
         "h_canShineChargeMaxRunway",
         {"shineChargeFrames": 50}
@@ -944,6 +950,9 @@
     {
       "link": [4, 2],
       "name": "Anti-Short Charge Hero Shot",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [
         {"notable": "Anti-Short Charge Hero Shot"},
         "SpeedBooster",
@@ -971,6 +980,9 @@
       "id": 41,
       "link": [4, 2],
       "name": "Ice Beam Mockball",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [
         "canMockball"
       ]
@@ -1405,5 +1417,5 @@
     }
   ],
   "nextStratId": 74,
-  "nextNotableId": 4
+  "nextNotableId": 5
 }

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -942,6 +942,32 @@
       "note": "Store the Shinespark after the second shutter to avoid breaking the Bomb Blocks in the floor."
     },
     {
+      "link": [4, 2],
+      "name": "Anti-Short Charge Hero Shot",
+      "requires": [
+        {"notable": "Anti-Short Charge Hero Shot"},
+        "SpeedBooster",
+        "canHeroShot"
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 45,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$5.9"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Avoid the first two magic frames by briefly releasing dash,",
+        "to avoid gaining blue speed until after Samus has run over the bomb blocks.",
+        "Fire a shot while running, to open the door and run through."
+      ]
+    },
+    {
       "id": 41,
       "link": [4, 2],
       "name": "Ice Beam Mockball",
@@ -1365,6 +1391,16 @@
       "note": [
         "Freeze a Mella inside the wall below the Power Bomb blocks.",
         "Use it to clip slightly inside the wall, then X-Ray climb up past the Power Bomb blocks."
+      ]
+    },
+    {
+      "id": 4,
+      "name": "Anti-Short Charge Hero Shot",
+      "note": [
+        "Run under the gates from right-to-left, carrying speed into the next room.",
+        "Avoid the first two magic frames by briefly releasing dash,",
+        "to avoid gaining blue speed until after Samus has run over the bomb blocks.",
+        "Fire a shot while running, to open the door and run through."
       ]
     }
   ],

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -975,6 +975,11 @@
                   "type": "integer",
                   "title": "Starting Down Tiles",
                   "description": "Number of tiles at the start of the runway (away from the door) that slope down, preventing a stutter"
+                },
+                "minExtraRunSpeed": {
+                  "type": "string",
+                  "pattern": "^\\$[0-9|A-F]\\.[0-9|A-F]+$",
+                  "description": "Minimum extra run speed (in hexadecimal) with which it is possible to leave with this condition."
                 }
               }
             },


### PR DESCRIPTION
- Adds a notable strat Ice Beam Gate Room: Anti-Short Charge Hero Shot.
- Adds a property `minExtraRunSpeed` to `leaveWithRunway`, to represent the new strat.
- Adds a "Cross-Room Blue Speed Jump" strat in East Sand Hall, which can match with the new strat in Ice Beam Gate Room. 
- Adds "comeInNormally" entrance conditions to Ice Beam Gate Hall strats that rely on the gates still being up (since we don't have an obstacle to represent their state).

There's already a "Cross-Room Blue Speed Jump, Leave With Temporary Blue" strat in East Sand Hall. The only reason the more simple "Cross-Room Blue Speed Jump" didn't already exist is because I was thinking it was covered by the "Cross-Room Speed Jump", which doesn't need as much runway. But that one has a specific run speed requirement which can't be met coming from Ice Beam Gate Room.

The "anti-short charge" feels fairly unintuitive, and the player may only get one attempt, so I was thinking the notable would be placed in either Extreme or Insane?