### PR TITLE
Most of rest of West Norfair temp blue

### DIFF
--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -657,6 +657,27 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        {"heatFrames": 1180},
+        {"canShineCharge": {
+          "usedTiles": 15,
+          "openEnd": 2
+        }},
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "note": ["Use the platform at the top-right of the room to gain temporary blue, then chain it through the door."]
+    },
+    {
       "id": 53,
       "link": [2, 2],
       "name": "G-Mode With Frozen Geruta, Remote Acquire Item",

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -157,6 +157,36 @@
       "note": "Fall into the room and land on the bottom right crumble platform to bring the Sova to the door."
     },
     {
+      "link": [1, 2],
+      "name": "Come in Shinecharging, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 1,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "canXRayTurnaround",
+        {"heatFrames": 375},
+        {"or": [
+          "canXRayCancelShinecharge",
+          {"heatFrames": 160}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["canInsaneJump"]},
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 50}]
+        }
+      ]      
+    },
+    {
       "id": 45,
       "link": [1, 2],
       "name": "G-Mode",

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -325,6 +325,19 @@
       ]
     },
     {
+      "link": [1, 4],
+      "name": "Temporary Blue Bounce",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canXRayTurnaround",
+        "canTrickySpringBallBounce"
+      ],
+      "clearsObstacles": ["C"]
+    },
+    {
       "id": 9,
       "link": [1, 4],
       "name": "G-Mode Morph",
@@ -553,17 +566,31 @@
     {
       "id": 20,
       "link": [2, 2],
-      "name": "Leave with Runway",
-      "requires": [],
+      "name": "Leave with Runway (Bomb Blocks Intact)",
+      "requires": [
+        {"obstaclesNotCleared": ["B"]}
+      ],
       "exitCondition": {
         "leaveWithRunway": {
           "length": 7,
           "openEnd": 0
         }
+      }
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Runway (Bomb Blocks Broken)",
+      "requires": [
+        {"obstaclesCleared": ["B"]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 3,
+          "openEnd": 1
+        }
       },
       "devNote": [
-        "The bomb blocks have to be intact, but it's always possible to get to this node without breaking them.",
-        "If the bomb blocks were broken, this runway could be extended with a frozen Sova."
+        "This runway could be extended with a frozen Sova."
       ]
     },
     {
@@ -596,6 +623,35 @@
       "link": [2, 3],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [2, 4],
+      "name": "Temporary Blue Bounce (Come In Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "can4HighMidAirMorph",
+        "canSpringBallBounce"
+      ],
+      "clearsObstacles": ["B", "C"]
+    },
+    {
+      "link": [2, 4],
+      "name": "Temporary Blue Bounce (Come In With Temporary Blue)",
+      "entranceCondition": {
+        "comeInWithTemporaryBlue": {}
+      },
+      "requires": [
+        "canChainTemporaryBlue",
+        "can4HighMidAirMorph",
+        "canSpringBallBounce"
+      ],
+      "clearsObstacles": ["C"]
     },
     {
       "id": 24,

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -257,8 +257,20 @@
         }
       },
       "requires": [
-        "canLongChainTemporaryBlue",
-        {"heatFrames": 370}
+        {"or": [
+          {"and": [
+            "canBlueSpaceJump",
+            {"heatFrames": 215}
+          ]},
+          {"and": [
+            "canTrickySpringBallBounce",
+            {"heatFrames": 215}
+          ]},
+          {"and": [
+            "canLongChainTemporaryBlue",
+            {"heatFrames": 370}
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
@@ -413,9 +425,22 @@
         }
       },
       "requires": [
-        "canLongChainTemporaryBlue",
-        "canInsaneJump",
-        {"heatFrames": 380}
+        "canChainTemporaryBlue",
+        {"or": [
+          {"and": [
+            "canBlueSpaceJump",
+            {"heatFrames": 215}
+          ]},
+          {"and": [
+            "canTrickySpringBallBounce",
+            {"heatFrames": 215}
+          ]},
+          {"and": [
+            "canLongChainTemporaryBlue",
+            "canInsaneJump",
+            {"heatFrames": 380}
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -253,7 +253,8 @@
         "comeInGettingBlueSpeed": {
           "length": 2,
           "openEnd": 1,
-          "minExtraRunSpeed": "$1.D"
+          "minExtraRunSpeed": "$1.D",
+          "maxExtraRunSpeed": "$2.F"
         }
       },
       "requires": [
@@ -421,7 +422,8 @@
         "comeInGettingBlueSpeed": {
           "length": 2,
           "openEnd": 1,
-          "minExtraRunSpeed": "$1.9"
+          "minExtraRunSpeed": "$1.9",
+          "maxExtraRunSpeed": "$2.F"
         }
       },
       "requires": [

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -247,6 +247,31 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 2,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$1.D"
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        {"heatFrames": 370}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 50}]
+        }
+      ]      
+    },
+    {
       "id": 24,
       "link": [1, 2],
       "name": "G-Mode",
@@ -376,6 +401,32 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 2,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$1.9"
+        }
+      },
+      "requires": [
+        "canLongChainTemporaryBlue",
+        "canInsaneJump",
+        {"heatFrames": 380}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super", "powerbomb"], "requires": []},
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 50}]
+        }
+      ]      
     },
     {
       "id": 13,

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -558,7 +558,45 @@
       "requires": [
         "canInsaneJump"
       ],
-      "devNote": "FIXME: This can be done with 8 tiles (technically even 7.4375 tiles) but would require higher movement tech."
+      "devNote": "Theoretically this can be done with 8 tiles (technically even 7.4375 tiles) but would require higher movement tech."
+    },
+    {
+      "link": [2, 4],
+      "name": "Insane Speedy Mockball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 5
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        "canMockball"
+      ],
+      "note": [
+        "Run into the room, and perform a very low short-hop mockball, delaying it so that Samus morphs right before the gate."
+      ],
+      "devNote": "Theoretically this can be done with 4 tiles (technically even 3.4375 tiles) but would require higher movement tech."
+    },
+    {
+      "link": [2, 4],
+      "name": "Come In Getting Blue Speed, Speedball, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 5,
+          "openEnd": 1,
+          "minExtraRunSpeed": "$3.8"
+        }
+      },
+      "requires": [
+        "canSpeedball",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": ["Extra run speeds as low as $2.F can work, but with greater difficulty."]
     },
     {
       "id": 19,

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -599,6 +599,44 @@
       "devNote": ["Extra run speeds as low as $2.F can work, but with greater difficulty."]
     },
     {
+      "link": [2, 4],
+      "name": "Come In Blue Spinning, Speedball, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInBlueSpinning": {
+          "unusableTiles": 0,
+          "minExtraRunSpeed": "$3.8"
+        }
+      },
+      "requires": [
+        "canSpeedball",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "devNote": ["Extra run speeds as low as $3.6 can work."]
+    },
+    {
+      "link": [2, 4],
+      "name": "Come In With Blue Spring Ball Bounce, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled",
+          "minExtraRunSpeed": "$4.4"
+        }
+      },
+      "requires": [
+        "canTrickySpringBallBounce",
+        "canInsaneJump",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
       "id": 19,
       "link": [2, 4],
       "name": "G-Mode Setup - Get Hit By Sova",


### PR DESCRIPTION
This just leaves Crocomire Speedway for a separate PR. I'm also skipping Ice Beam Tutorial Room and Ice Beam Snake Room, which probably have some dumb things that could be done to carry temp blue through them.

This also includes a new mockball strat for Ice Beam Gate Room left-to-right, using Speedbooster to do it with a much shorter other-room runway, by delaying the mockball until right before the gate.