### PR TITLE
Add missing Grapple Teleport strats, use 'Door Lock Skip' in names

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -560,7 +560,7 @@
     {
       "id": 27,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -285,7 +285,7 @@
     {
       "id": 9,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -426,7 +426,7 @@
     {
       "id": 16,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]
@@ -644,7 +644,7 @@
     {
       "id": 27,
       "link": [2, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -818,7 +818,7 @@
     {
       "id": 34,
       "link": [3, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -1023,7 +1023,7 @@
     {
       "id": 34,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -564,7 +564,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 28], [2, 29]]

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -395,7 +395,7 @@
     {
       "id": 10,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]
@@ -580,7 +580,7 @@
     {
       "id": 19,
       "link": [2, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -1124,7 +1124,7 @@
     {
       "id": 43,
       "link": [4, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -523,7 +523,7 @@
     {
       "id": 24,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -771,7 +771,7 @@
     {
       "id": 38,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -201,6 +201,18 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 1],
+      "name": "Grapple Teleport Door Lock Skip",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 28], [2, 29]]
+        }
+      },
+      "requires": [],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
+    },
+    {
       "id": 9,
       "link": [2, 1],
       "name": "Carry Grapple Teleport (Middle Position)",

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -725,7 +725,7 @@
     {
       "id": 35,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -277,7 +277,7 @@
     {
       "id": 15,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -541,7 +541,7 @@
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -499,7 +499,7 @@
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -752,10 +752,10 @@
     {
       "id": 36,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 18], [2, 28], [2, 29]]
+          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
         }
       },
       "requires": [],
@@ -779,9 +779,25 @@
       "bypassesDoorShell": true
     },
     {
+      "link": [3, 1],
+      "name": "Carry Grapple Teleport (Upper Middle Position)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 19]]
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithGrappleTeleport": {
+          "blockPositions": [[2, 19]]
+        }
+      },
+      "bypassesDoorShell": true
+    },
+    {
       "id": 38,
       "link": [3, 1],
-      "name": "Carry Grapple Teleport (Middle Position)",
+      "name": "Carry Grapple Teleport (Lower Middle Position)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 28]]

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -404,7 +404,7 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 28], [2, 29]]
@@ -416,7 +416,7 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "Grapple Teleport (Kraid Alive)",
+      "name": "Grapple Teleport Door Lock Skip (Kraid Alive)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18]]

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -968,7 +968,7 @@
     {
       "id": 40,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 29]]

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -237,7 +237,7 @@
     {
       "id": 13,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/red/Bat Room.json
+++ b/region/brinstar/red/Bat Room.json
@@ -348,7 +348,7 @@
     {
       "id": 16,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -453,7 +453,7 @@
     {
       "id": 17,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 19]]

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -359,7 +359,7 @@
     {
       "id": 16,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -1042,7 +1042,7 @@
     {
       "id": 31,
       "link": [1, 5],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -1263,7 +1263,7 @@
     {
       "id": 45,
       "link": [2, 5],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -1490,7 +1490,7 @@
     {
       "id": 57,
       "link": [3, 5],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -256,14 +256,17 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "devNote": [
+        "Though there is no door shell here, this strat is included for completeness in case a randomizer adds a door shell where bypassing it could be useful."
+      ]
     },
     {
       "id": 15,
@@ -443,14 +446,17 @@
     {
       "id": 26,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "devNote": [
+        "Though there is no door shell here, this strat is included for completeness in case a randomizer adds a door shell where bypassing it could be useful."
+      ]
     },
     {
       "id": 27,

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -297,7 +297,7 @@
     {
       "id": 13,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -920,7 +920,7 @@
     {
       "id": 34,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
@@ -1159,7 +1159,7 @@
     {
       "id": 48,
       "link": [4, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -374,7 +374,7 @@
     {
       "id": 15,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]
@@ -628,7 +628,7 @@
     {
       "id": 27,
       "link": [2, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -234,7 +234,7 @@
     {
       "id": 13,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -786,7 +786,7 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -145,7 +145,7 @@
     {
       "id": 6,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -614,7 +614,7 @@
     {
       "id": 29,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -598,7 +598,7 @@
     {
       "id": 20,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -225,7 +225,7 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -220,7 +220,7 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -260,7 +260,7 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -469,7 +469,7 @@
     {
       "id": 7,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19]]

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -1372,7 +1372,7 @@
     {
       "id": 36,
       "link": [3, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
@@ -1655,7 +1655,7 @@
     {
       "id": 48,
       "link": [4, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -600,7 +600,7 @@
     {
       "id": 22,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -219,7 +219,7 @@
     {
       "id": 9,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -360,7 +360,7 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -381,7 +381,7 @@
     {
       "id": 6,
       "link": [1, 4],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -993,7 +993,7 @@
     {
       "id": 39,
       "link": [4, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -451,7 +451,7 @@
     {
       "id": 6,
       "link": [1, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -667,7 +667,7 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
@@ -1391,7 +1391,7 @@
     {
       "id": 36,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -315,7 +315,7 @@
     {
       "id": 13,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -322,7 +322,7 @@
     {
       "id": 12,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -565,7 +565,7 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1580,7 +1580,7 @@
     {
       "id": 68,
       "link": [5, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/maridia/inner-pink/Draygon Save Room.json
+++ b/region/maridia/inner-pink/Draygon Save Room.json
@@ -181,7 +181,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -1019,7 +1019,7 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1116,7 +1116,7 @@
     {
       "id": 34,
       "link": [1, 4],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -2436,7 +2436,7 @@
     {
       "id": 85,
       "link": [2, 4],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -2782,7 +2782,7 @@
     {
       "id": 101,
       "link": [3, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
@@ -3429,7 +3429,7 @@
     {
       "id": 122,
       "link": [4, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -664,7 +664,7 @@
     {
       "id": 22,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -820,7 +820,7 @@
     {
       "id": 27,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -627,7 +627,7 @@
     {
       "id": 17,
       "link": [1, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -374,7 +374,7 @@
     {
       "id": 14,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -288,7 +288,7 @@
     {
       "id": 13,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -583,7 +583,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -824,7 +824,7 @@
     {
       "id": 36,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -688,7 +688,7 @@
     {
       "id": 17,
       "link": [1, 4],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -1802,7 +1802,7 @@
     {
       "id": 57,
       "link": [2, 4],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -2217,7 +2217,7 @@
     {
       "id": 70,
       "link": [3, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -3182,7 +3182,7 @@
     {
       "id": 104,
       "link": [4, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -1202,7 +1202,7 @@
     {
       "id": 19,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -1211,7 +1211,7 @@
       "requires": [],
       "bypassesDoorShell": true,
       "devNote": [
-        "Though there is no door shell here, this strat is included for completeness in case a randomizer adds a door shell where bypassing it could be useful."
+        "Though there is no door shell here, the bypassesDoorShell is included for completeness in case a randomizer adds a door shell where bypassing it could be useful."
       ]
     },
     {
@@ -2120,7 +2120,7 @@
     {
       "id": 44,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -2739,25 +2739,6 @@
       ]
     },
     {
-      "id": 105,
-      "link": [4, 6],
-      "name": "Grapple Teleport",
-      "entranceCondition": {
-        "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 34]]
-        }
-      },
-      "requires": [
-        "Morph"
-      ],
-      "bypassesDoorShell": true,
-      "note": ["After teleporting, morph and roll to the right to touch the transition."],
-      "devNote": [
-        "FIXME: put an exit condition (e.g. leaveNormally) here to express that there is no choice but to take the transition.",
-        "First we need matching entrance conditions (e.g. comeInNormally) to be defined everywhere."
-      ]
-    },
-    {
       "id": 106,
       "link": [4, 9],
       "name": "Grapple",
@@ -5133,5 +5114,8 @@
   ],
   "nextStratId": 253,
   "nextNotableId": 11,
-  "devNote": ["FIXME: This room could have strats for using Ice to bypass vertical doors."]
+  "devNote": [
+    "FIXME: This room could have strats for using Ice to bypass the top door.",
+    "FIXME: A 4->6 grapple teleport is possible, but the wrong-side transition will usually put Samus out-of-bounds. "
+  ]
 }

--- a/region/maridia/outer/West Glass Tube Tunnel.json
+++ b/region/maridia/outer/West Glass Tube Tunnel.json
@@ -159,7 +159,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/norfair/crocomire/Grapple Tutorial Room 1.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 1.json
@@ -324,7 +324,7 @@
     {
       "id": 7,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -738,7 +738,7 @@
     {
       "id": 22,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]
@@ -1278,7 +1278,7 @@
     {
       "id": 43,
       "link": [4, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -393,7 +393,7 @@
     {
       "id": 12,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -298,7 +298,7 @@
     {
       "id": 24,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -452,7 +452,7 @@
     {
       "id": 25,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19]]

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -2675,7 +2675,7 @@
     {
       "id": 95,
       "link": [6, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 28], [2, 29]]
@@ -2760,7 +2760,7 @@
     {
       "id": 99,
       "link": [6, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
@@ -3267,7 +3267,7 @@
     {
       "id": 120,
       "link": [7, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 28], [2, 29]]
@@ -3352,7 +3352,7 @@
     {
       "id": 124,
       "link": [7, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1796,7 +1796,7 @@
     {
       "id": 40,
       "link": [3, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 29]]

--- a/region/norfair/east/Frog Savestation.json
+++ b/region/norfair/east/Frog Savestation.json
@@ -181,7 +181,7 @@
     {
       "id": 6,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]
@@ -317,7 +317,7 @@
     {
       "id": 13,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -965,7 +965,7 @@
     {
       "id": 28,
       "link": [4, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -246,7 +246,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/norfair/east/Nutella Refill.json
+++ b/region/norfair/east/Nutella Refill.json
@@ -207,7 +207,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -679,7 +679,7 @@
     {
       "id": 17,
       "link": [3, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]
@@ -833,7 +833,7 @@
     {
       "id": 23,
       "link": [3, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -271,7 +271,7 @@
     {
       "id": 6,
       "link": [1, 3],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Precise X-Ray Climb",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 13]]

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -210,7 +210,7 @@
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -683,7 +683,7 @@
     {
       "id": 36,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -962,6 +962,6 @@
   "nextNotableId": 5,
   "devNote": [
     "FIXME: Maybe we can split MB into several events to properly indicate the ammo requirements?",
-    "FIXME: It is possible toGrapple teleport from Moat to the left of Mother Brain, through currently it has no known use."
+    "FIXME: It is possible to Grapple teleport from Moat to the left of Mother Brain, through currently it has no known use."
   ]
 }

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -207,7 +207,7 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 28], [2, 29]]
@@ -796,7 +796,7 @@
     {
       "id": 40,
       "link": [3, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 28], [2, 29]]

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -563,7 +563,7 @@
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 28], [2, 29]]

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -89,7 +89,7 @@
     {
       "id": 5,
       "link": [2, 1],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[3, 12], [3, 13]]

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -277,7 +277,7 @@
     {
       "id": 10,
       "link": [1, 2],
-      "name": "Grapple Teleport",
+      "name": "Grapple Teleport Door Lock Skip",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[12, 12], [12, 13]]


### PR DESCRIPTION
- Add a handful of missing Grapple Teleport strats.
- Use "Door Lock Skip" consistently in strat names involving grapple teleports that bypass a door shell.
- Remove an unsound grapple teleport strat in Mt. Everest. I think I was fooled by the Practice Hack's door portal behavior when testing this before. Approaching the morph tunnel transition from the back will usually put Samus OOB in the next room. There could possibly be some in-bounds applications, which we could add later if discovered.
- Clarifications to a few notes.