### PR TITLE
Refine Precious Room shinecharge/shinespark strats

### DIFF
--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -53,6 +53,18 @@
         [1, 0],
         [1, 0]
       ]
+    },
+    {
+      "id": 4,
+      "name": "Bottom Right Shinecharged",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "note": "Gaining a shinecharge at the bottom-right of the room.",
+      "mapTileMask": [
+        [1, 1],
+        [1, 0],
+        [2, 0]
+      ]
     }
   ],
   "enemies": [],
@@ -72,13 +84,21 @@
       "from": 2,
       "to": [
         {"id": 1},
-        {"id": 2}
+        {"id": 2},
+        {"id": 4}
       ]
     },
     {
       "from": 3,
       "to": [
         {"id": 1}
+      ]
+    },
+    {
+      "from": 4,
+      "to": [
+        {"id": 1},
+        {"id": 2}
       ]
     }
   ],
@@ -184,48 +204,47 @@
       ]
     },
     {
-      "id": 9,
-      "link": [2, 1],
-      "name": "Shinespark",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 12,
-          "openEnd": 0
-        }
-      },
-      "requires": [
-        "Gravity",
-        {"shinespark": {"frames": 40, "excessFrames": 8}}
-      ]
-    },
-    {
       "id": 10,
       "link": [2, 1],
-      "name": "Shinespark, Come in Shinecharged",
+      "name": "Come in Shinecharged, Shinespark (Gravity)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 40},
         "Gravity",
-        {"shinespark": {"frames": 40, "excessFrames": 8}}
+        {"or": [
+          {"and": [
+            {"shineChargeFrames": 20},
+            {"shinespark": {"frames": 40, "excessFrames": 8}}
+          ]},
+          {"and": [
+            {"shineChargeFrames": 30},
+            "canMidairShinespark",
+            {"shinespark": {"frames": 33, "excessFrames": 8}}
+          ]}
+        ]}
       ],
       "flashSuitChecked": true
     },
     {
       "id": 11,
       "link": [2, 1],
-      "name": "Suitless Shinespark",
+      "name": "Come In Shinecharged, Shinespark (Suitless)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 60},
+        {"shineChargeFrames": 40},
         "canSuitlessMaridia",
-        {"shinespark": {"frames": 40, "excessFrames": 8}}
+        {"or": [
+          {"shinespark": {"frames": 40, "excessFrames": 8}},
+          {"and": [
+            "canMidairShinespark",
+            {"shinespark": {"frames": 37, "excessFrames": 8}}
+          ]}
+        ]}
       ],
-      "flashSuitChecked": true,
-      "note": "It takes a bit more time to set up the spark when suitless."
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -268,53 +287,6 @@
         "canSuitlessMaridia",
         "HiJump",
         "canSpringBallJumpMidAir"
-      ]
-    },
-    {
-      "id": 15,
-      "link": [2, 1],
-      "name": "Stutter Water Shinecharge",
-      "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
-          "minTiles": 2.4375
-        }
-      },
-      "requires": [
-        "canStutterWaterShineCharge",
-        "h_canShineChargeMaxRunway",
-        {"shinespark": {"frames": 40, "excessFrames": 8}}
-      ]
-    },
-    {
-      "id": 16,
-      "link": [2, 1],
-      "name": "Stutter Water Shinecharge, Leave With Temporary Blue",
-      "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
-          "minTiles": 2.4375
-        }
-      },
-      "requires": [
-        "canStutterWaterShineCharge",
-        "h_canShineChargeMaxRunway",
-        "canXRayTurnaround",
-        "canLongChainTemporaryBlue",
-        {"or": [
-          "canGravityJump",
-          {"and": [
-            "HiJump",
-            "canTrickySpringBallJump"
-          ]}
-        ]}
-      ],
-      "exitCondition": {
-        "leaveWithTemporaryBlue": {}
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "note": [
-        "To get out of the water at the top, do another gravity jump or spring ball jump, preferably while the water is high."
       ]
     },
     {
@@ -785,37 +757,6 @@
       }
     },
     {
-      "id": 30,
-      "link": [2, 2],
-      "name": "Stutter Water Shinecharge, Leave with Spark",
-      "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
-          "minTiles": 2.4375
-        }
-      },
-      "requires": [
-        "canStutterWaterShineCharge",
-        "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
-        {"or": [
-          {"shinespark": {"frames": 12}},
-          {"and": [
-            "canShinechargeMovementTricky",
-            {"shinespark": {"frames": 3}}
-          ]}
-        ]}
-      ],
-      "exitCondition": {
-        "leaveWithSpark": {}
-      },
-      "unlocksDoors": [
-        {"types": ["missiles", "super"], "requires": []},
-        {"types": ["powerbomb"], "requires": ["never"]}
-      ],
-      "note": "Enter the room with a careful amount of momentum where Samus must spend extra time slowing down during the stutter, but must not have much run speed."
-    },
-    {
       "id": 31,
       "link": [2, 2],
       "name": "Crystal Flash",
@@ -823,6 +764,95 @@
         "h_canCrystalFlash"
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 4],
+      "name": "Come In Shinecharging (Gravity)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"shineChargeFrames": 0}
+      ],
+      "endsWithShineCharge": true
+    },
+    {
+      "link": [2, 4],
+      "name": "Water Shinecharge",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 4,
+          "openEnd": 0
+        }
+      },
+      "requires": [
+        "canWaterShineCharge",
+        {"shineChargeFrames": 0}
+      ],
+      "endsWithShineCharge": true
+    },
+    {
+      "link": [2, 4],
+      "name": "Stutter Water Shinecharge",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 4
+        }
+      },
+      "requires": [
+        "canStutterWaterShineCharge",
+        {"shineChargeFrames": 0}
+      ],
+      "endsWithShineCharge": true,
+      "note": "Use between 4 and 5 tiles of runway, to make the stutter as lenient as possible.",
+      "detailNote": [
+        "With this length of runway, the following timings for the stutter are possible:",
+        "1. Release forward for 3, 4, or 5 frames, repress forward on the last possible frame;",
+        "2. Release forward for 2 or 3 frames, repress forward on the 2nd-to-last possible frame;",
+        "3. Release forward for 1 pr 2 frames, repress forward on the 3rd-to-last possible frame."
+      ]
+    },
+    {
+      "id": 15,
+      "link": [2, 4],
+      "name": "Precise Stutter Water Shinecharge",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 2.4375
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        {"shineChargeFrames": 0}
+      ],
+      "endsWithShineCharge": true,
+      "note": [
+        "With only a runway length of 3 tiles (closed end) in the other room, this requires a precise setup:",
+        "release forward for 3 or 4 frames, then repress forward on the last possible frame before the transition;",
+        "alternatively, release forward for 2 frames and repress forward on the second-to-last possible frame before the transition."
+      ]
+    },
+    {
+      "link": [2, 4],
+      "name": "Tricky Stutter Water Shinecharge",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "canTrickyStutterWaterShineCharge",
+        {"shineChargeFrames": 0}
+      ],
+      "endsWithShineCharge": true,
+      "note": [
+        "With only a runway of 2 tiles (open end) in the other room, this requires a double-frame-perfect setup:",
+        "release forward for exactly 3 frames, and repress forward on the last possible frame before the transition."
+      ]
     },
     {
       "id": 32,
@@ -835,7 +865,102 @@
           "SpaceJump"
         ]}
       ]
-    }
+    },
+    {
+      "link": [4, 1],
+      "name": "Start Shinecharged, Shinespark",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"shineChargeFrames": 60},
+        {"or": [
+          {"shinespark": {"frames": 40, "excessFrames": 8}},
+          {"and": [
+            "canMidairShinespark",
+            {"shinespark": {"frames": 37, "excessFrames": 8}}
+          ]},
+          {"and": [
+            "Gravity",
+            "canMidairShinespark",
+            {"shinespark": {"frames": 33, "excessFrames": 8}}
+          ]}
+        ]}
+      ]
+    },
+    {
+      "id": 16,
+      "link": [4, 1],
+      "name": "Start Shinecharged, Leave With Temporary Blue",
+      "startsWithShineCharge": true,
+      "requires": [
+        "h_canShineChargeMaxRunway",
+        {"shineChargeFrames": 0},
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue",
+        {"or": [
+          "canGravityJump",
+          {"and": [
+            "HiJump",
+            "canTrickySpringBallJump"
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "To get out of the water at the top, do another gravity jump or spring ball jump, preferably while the water is high."
+      ]
+    },
+    {
+      "id": 30,
+      "link": [4, 2],
+      "name": "Start Shinecharged, Leave with Spark",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"shineChargeFrames": 50},
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 12}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Start Shinecharged, Leave Shinecharged",
+      "startsWithShineCharge": true,
+      "requires": [
+        {"shineChargeFrames": 155},
+        "canShinechargeMovementTricky"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Start Shinecharged, Leave With Temporary Blue",
+      "startsWithShineCharge": true,
+      "requires": [
+        "h_canShineChargeMaxRunway",
+        {"shineChargeFrames": 0},
+        "canXRayTurnaround",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    }    
   ],
   "notables": [],
   "nextStratId": 39,

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -813,7 +813,7 @@
         "With this length of runway, the following timings for the stutter are possible:",
         "1. Release forward for 3, 4, or 5 frames, repress forward on the last possible frame;",
         "2. Release forward for 2 or 3 frames, repress forward on the 2nd-to-last possible frame;",
-        "3. Release forward for 1 pr 2 frames, repress forward on the 3rd-to-last possible frame."
+        "3. Release forward for 1 or 2 frames, repress forward on the 3rd-to-last possible frame."
       ]
     },
     {

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -796,27 +796,6 @@
       "endsWithShineCharge": true
     },
     {
-      "link": [2, 4],
-      "name": "Stutter Water Shinecharge",
-      "entranceCondition": {
-        "comeInStutterShinecharging": {
-          "minTiles": 4
-        }
-      },
-      "requires": [
-        "canStutterWaterShineCharge",
-        {"shineChargeFrames": 0}
-      ],
-      "endsWithShineCharge": true,
-      "note": "Use between 4 and 5 tiles of runway, to make the stutter as lenient as possible.",
-      "detailNote": [
-        "With this length of runway, the following timings for the stutter are possible:",
-        "1. Release forward for 3, 4, or 5 frames, repress forward on the last possible frame;",
-        "2. Release forward for 2 or 3 frames, repress forward on the 2nd-to-last possible frame;",
-        "3. Release forward for 1 or 2 frames, repress forward on the 3rd-to-last possible frame."
-      ]
-    },
-    {
       "id": 15,
       "link": [2, 4],
       "name": "Precise Stutter Water Shinecharge",
@@ -834,24 +813,34 @@
         "With only a runway length of 3 tiles (closed end) in the other room, this requires a precise setup:",
         "release forward for 3 or 4 frames, then repress forward on the last possible frame before the transition;",
         "alternatively, release forward for 2 frames and repress forward on the second-to-last possible frame before the transition."
+      ],
+      "detailNote": [
+        "If a longer runway is available (4 tiles), the timing windows are a bit more lenient:",
+        "1. Release forward for 3, 4, or 5 frames, repress forward on the last possible frame;",
+        "2. Release forward for 2 or 3 frames, repress forward on the 2nd-to-last possible frame;",
+        "3. Release forward for 1 or 2 frames, repress forward on the 3rd-to-last possible frame."
       ]
     },
     {
       "link": [2, 4],
-      "name": "Tricky Stutter Water Shinecharge",
+      "name": "Very Precise Stutter Water Shinecharge",
       "entranceCondition": {
         "comeInStutterShinecharging": {
           "minTiles": 2
         }
       },
       "requires": [
-        "canTrickyStutterWaterShineCharge",
+        "canPreciseStutterWaterShineCharge",
+        "canInsaneJump",
         {"shineChargeFrames": 0}
       ],
       "endsWithShineCharge": true,
       "note": [
         "With only a runway of 2 tiles (open end) in the other room, this requires a double-frame-perfect setup:",
         "release forward for exactly 3 frames, and repress forward on the last possible frame before the transition."
+      ],
+      "devNote": [
+        "FIXME: canInsaneJump is for difficulty placement; replace with a more appropriate tech since no jump is involved."
       ]
     },
     {

--- a/schema/m3-tech.schema.json
+++ b/schema/m3-tech.schema.json
@@ -78,6 +78,9 @@
                 "note": {
                   "$ref" : "m3-note.schema.json#/definitions/note"
                 },
+                "detailNote": {
+                  "$ref" : "m3-note.schema.json#/definitions/detailNote"
+                },
                 "devNote": {
                   "$ref" : "m3-note.schema.json#/definitions/devNote"
                 }

--- a/tech.json
+++ b/tech.json
@@ -2243,11 +2243,41 @@
               ],
               "otherRequires": [],
               "note": [
-                "Performing a canWaterShineCharge in a shorter runway by using a stutter that is greatly extended by the water slowdown.",
+                "Performing a water shinecharge in a shorter runway by using a stutter that is greatly extended by the water slowdown.",
                 "Perform a stutter shortly before entering water, typically through a door transition, by briefly releasing and then repressing forward before, but as close to, the transition as possible while continuing the dash.",
                 "This carries the stutter into the water where Samus will run in place while building the shinecharge, Allowing Samus to enter the water with little momentum.",
                 "After entering the water, dash should be held the entire time. With Gravity Suit it is possible to do this without leaving water, with or without a room transition, by removing the suit just after stuttering.",
                 "The same technique is applicable with acid."
+              ],
+              "detailNote": [
+                "To gain the shortcharge in the shortest distance and with the greatest amount of lenience,",
+                "it is best to use approximately 5 tiles of runway.",
+                "If fewer than 5 runway tiles are available, use the full runway length."
+              ],
+              "extensionTechs": [
+                {
+                  "name": "canPreciseStutterWaterShineCharge",
+                  "techRequires": [
+                    "canStutterWaterShineCharge"
+                  ],
+                  "otherRequires": [],
+                  "note": [
+                    "Performing a stutter water shinecharge in a situation requiring a precise stutter,",
+                    "for example if not much runway is available in one or both of the rooms."
+                  ],
+                  "extensionTechs": [
+                    {
+                      "name": "canTrickyStutterWaterShineCharge",
+                      "techRequires": [
+                        "canPreciseStutterWaterShineCharge"
+                      ],
+                      "otherRequires": [],
+                      "note": [
+                        "Performing a stutter water shinecharge requiring a very precise stutter."
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           ]

--- a/tech.json
+++ b/tech.json
@@ -2264,18 +2264,6 @@
                   "note": [
                     "Performing a stutter water shinecharge in a situation requiring a precise stutter,",
                     "for example if not much runway is available in one or both of the rooms."
-                  ],
-                  "extensionTechs": [
-                    {
-                      "name": "canTrickyStutterWaterShineCharge",
-                      "techRequires": [
-                        "canPreciseStutterWaterShineCharge"
-                      ],
-                      "otherRequires": [],
-                      "note": [
-                        "Performing a stutter water shinecharge requiring a very precise stutter."
-                      ]
-                    }
                   ]
                 }
               ]


### PR DESCRIPTION
I noticed that during the second seed of Nito's recent 24hr stream, he got Gravity early by sequence breaking the Precious Room stutter water shinecharge, doing it with 2 runway tiles when the logic required 2.4375.

I dug into it a little to see how the runway length affects the frame window, and concluded that we could probably use some more tech to help place strats into an appropriate difficulty level. We moved "canStutterWaterShinecharge" down to Very Hard a while ago, but in Precious Room with only 2.4375 tiles I think it's too tough for Very Hard, and would fit better in Expert. With only 2 tiles, I think it fits in Extreme, because this case needs a double-frame-perfect stutter: releasing for exactly 3 frames, and repressing on the last possible frame.

- New tech `canPreciseStutterWaterShinecharge` (for Expert) and `canTrickyStutterWaterShinecharge` (for Extreme).
- New node (4) representing being at the bottom-right of the room with a shinecharge. The new node is helpful since there are many ways to get the shinecharge there, and also many things to do with it once you have it.
- Split the existing stutter water shinecharge into 3 variants, requiring a different tech based on runway length.
- Switch to using the `comeInStutterShinecharging` rather than `comeInRunning`. The difference currently doesn't matter for the randomizer, but it's more accurate since it is in fact a different way of entering the room.
- Added a regular water shinecharge strat, which was missing.
- Tightened the shinecharge frames and shinespark frames.
- Added a `leaveShinecharged` variant that doubles back out the bottom-left door with frames remaining.
- Likewise, add a `leaveWithTemporaryBlue` variant that doubles back out the bottom-left door.
- Added `detailNote` to the schema for tech.
- Added more information on the `canStutterWaterShinecharge` tech, to recommend using 5 tiles of runway. Based on my testing, this is the optimal length to use, at least when applied to entering Precious Room. Going lower than 5 the stutter gradually gets more precise (narrower frame windows for the release and repress). Using 4 or 6 (or somewhere in between) is not too much worse, but 7 or higher seems to not work at all (for this room).

The new tech can of course be applied in more rooms, so the plan is to cover other rooms in follow-up PRs.