### PR TITLE
Separate Toilet version of Fish Tank Wall Jump Entry

### DIFF
--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -2105,7 +2105,7 @@
       "name": "Wall Jump Entry",
       "entranceCondition": {
         "comeInNormally": {},
-        "comesThroughToilet": "any"
+        "comesThroughToilet": "no"
       },
       "requires": [
         {"notable": "Wall Jump Entry"},
@@ -2116,12 +2116,46 @@
         "canCarefulJump"
       ],
       "note": [
-        "Wall jump in the room above, on the right wall of the doorway, immdiately before the door transition. Failure will likely result in a soft lock.",
+        "Wall jump in the room above, on the right wall of the doorway, immediately before the door transition.",
         "To get to the ledge: If the room above has normal physics, hold right in this room. If the room above has water physics, shoot to break spin while holding right in this room."
+      ],
+      "detailNote": [
+        "Wall jumping expands Samus' hitbox vertically, making it possible to trigger the door transition with upward momentum.",
+        "Failing this trick will likely result in a soft lock."
       ],
       "devNote": [
         "Strat starts before entering this transition.",
         "FIXME: The midair wiggle is only needed if the room above has water physics. That's not something in the logic for vertical doors currently. Also if the room above is heated, these may require some heat frames to set up."
+      ]
+    },
+    {
+      "link": [4, 5],
+      "name": "Wall Jump Entry (Through Toilet)",
+      "entranceCondition": {
+        "comeInNormally": {},
+        "comesThroughToilet": "yes"
+      },
+      "requires": [
+        {"notable": "Wall Jump Entry"},
+        "canSuitlessMaridia",
+        "canPreciseWalljump",
+        "canPrepareForNextRoom",
+        "canTrickyJump"
+      ],
+      "note": [
+        "Wall jump in the room above, on the left wall of the doorway, immediately before the door transition.",
+        "If entering from an air room above, simply hold right and jump to reach the ledge.",
+        "If entering from a water room above, release jump (while still holding right) when Samus is about to reach the ledge,",
+        "to reduce Samus' hitbox vertically by changing her pose from wall jumping to spin jumping."
+      ],
+      "detailNote": [
+        "Wall jumping expands Samus' hitbox vertically, making it possible to trigger the door transition with upward momentum.",
+        "Even though the wall jumping and spin jumping animations look the same, their hitbox is drastically different.",
+        "Passing through the Toilet centers Samus horizontally in the doorway.",
+        "Failing this trick will likely result in a soft lock."
+      ],
+      "devNote": [
+        "Strat starts before entering this transition."
       ]
     },
     {


### PR DESCRIPTION
The Fish Tank "Wall Jump Entry" works differently enough when passing through the Toilet that it makes sense to have a separate strat for it. This way we can tailor the note in that situation, to explain the key differences like wall jumping from the left side and releasing jump to shorten Samus' hitbox vertically. 