### PR TITLE
Colosseum side platform applications

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -299,7 +299,9 @@
         "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
         "2) With a momentum-conserving turnaround through the transition, or",
         "3) Jumping and aiming down through the transition.",
-        "Either back into the corner, or press against it and turn around; it doesn't matter which."
+        "To maximize the lenience for the jump, back into the Power Bomb block corner,",
+        "and while running perform a single-pixel arm pump (e.g. by firing a shot);",
+        "this only matters in certain situations, but in all cases it won't hurt."
       ],
       "devNote": [
         "Max extra run speed $5.4.",

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -175,7 +175,10 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "note": "The Owtch can be killed with a Power Bomb or blue speed, or while it is moving leftward with a Super, Charge, or Plasma."
+      "note": "The Owtch can be killed with a Power Bomb or blue speed, or while it is moving leftward with a Super, Charge, or Plasma.",
+      "devNote": [
+        "FIXME: Add alternatives that evade the Owtch rather than killing it (either here or on the strats that rely on obstacle 'A' cleared)."
+      ]
     },
     {
       "id": 22,
@@ -184,7 +187,7 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "Gravity",
-        "canInsaneJump",
+        "canTrickyDashJump",
         {"or": [
           "canMomentumConservingMorph",
           "canMomentumConservingTurnaround"
@@ -203,7 +206,11 @@
           "obstruction": [3, 0]
         }
       },
-      "devNote": ["Max extra run speed $4.B."]
+      "devNote": [
+        "Max extra run speed $4.B.",
+        "FIXME: The canTrickyDashJump is for difficulty placement but could probably be replaced by a more fitting tech,",
+        "since this isn't actually relying on a spike in jump height based on gaining a specific speed."
+      ]
     },
     {
       "id": 5,

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1195,6 +1195,283 @@
       "note": "Uses a runway of two tiles in the adjacent room."
     },
     {
+      "link": [2, 3],
+      "name": "Side Platform Cross Room Jump",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 27.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canMomentumConservingTurnaround"
+              ],
+              "note": ["This applies to Dust Torizo Room and Noob Bridge."],
+              "devNote": [
+                "The jump could also be done with a shorter runway, with a tricky dash jump using run speed $4.0 or $4.1.",
+                "But it wouldn't apply to any more rooms in the game."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 28.2472,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canMomentumConservingTurnaround"
+              ],
+              "note": ["This applies to Double Chamber."],
+              "devNote": [
+                "The jump could also be done with a shorter runway, with a tricky dash jump using run speed $4.0 or $4.1.",
+                "But it wouldn't apply to any more rooms in the game."
+              ]
+            },
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 23.8731,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "environment": "water",
+              "requires": [
+                "canInsaneJump",
+                "canGravityJump",
+                "canMomentumConservingTurnaround"
+              ],
+              "note": [
+                "This applies to Below Botwoon Energy Tank and Botwoon Energy Tank Room",
+                "gain run speed, and time a pause to unequip Gravity after Samus jumps;",
+                "hold down and back through the unpause to buffer a turnaround."
+              ],
+              "detailNote": [
+                "With a momentum conserving turnaround, this has a 3-frame window for the jump,",
+                "and between a 5-frame and 7-frame window for the pause, depending on the jump timing",
+                "(with later jumps corresponding to larger windows for the pause to hit).",
+                "A ceiling mockball is also possible but with greater difficulty."
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 45,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "requires": [
+                "canInsaneJump",
+                {"or": [
+                  "canMomentumConservingMorph",
+                  "canMomentumConservingTurnaround"
+                ]}
+              ],
+              "note": ["This applies to Statues Hallway and Baby Kraid Room."],
+              "devNote": [
+                "With a momentum conserving morph, this has a 2-frame window for the jump,",
+                "and a 1-frame or 2-frame window for the morph depending on the jump timing",
+                "(with a last-frame jump giving the larger window for the morph).",
+                "With a turnaround, this requires a last-frame jump, with a 2-frame window for the turnaround."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 21.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "environment": "water",
+              "requires": [
+                "canTrickyDashJump",
+                "canInsaneJump",
+                "canGravityJump",
+                "canMomentumConservingTurnaround"
+              ],
+              "note": [
+                "This applies to Draygon's Room.",
+                "Start about a tile away from the wall, gain run speed, and time a pause to unequip Gravity after Samus jumps;",
+                "hold down and back through the unpause to buffer a turnaround."
+              ],
+              "detailNote": [
+                "Gain extra run speed of $4.0 or $4.1.",
+                "A last-frame jump with a speed of $4.1 gives a 5-frame window for the pause/turnaround,",
+                "while a second-to-last-frame jump with a speed of $4.0 gives a 2-frame window."
+              ],
+              "devNote": [
+                "If Spring Ball is available, the frame window for the turnaround with $4.0 speed can be larger,",
+                "but it doesn't seem like a big enough difference to justify separate logical requirements."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 41.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "requires": [
+                "canInsaneJump",
+                "canMomentumConservingTurnaround"
+              ],
+              "note": [
+                "This applies to Blue Brinstar Energy Tank Room (Power Bomb blocks broken), Bowling Alley (middle), and Basement."
+              ],
+              "detailNote": [
+                "With ideal starting position, this has a 2-frame window for the jump,",
+                "and a 1-frame or 3-frame window for the turnaround based on the jump timing",
+                "(with a last-frame jump giving the larger window for the turnaround).",
+                "A ceiling mockball is also possible but more difficult, requiring a last-frame jump and a 2-frame window for the morph."
+              ],
+              "devNote": [
+                "The trick is more difficult if using the full runway in the long rooms Bowling Alley or Basement,",
+                "requiring a last-frame jump and a 2-frame window for the turnaround."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 39.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 2]],
+              "requires": [
+                "canMomentumConservingTurnaround"
+              ],
+              "note": ["This applies to Metal Pirates Room."]
+            },            
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 39.4375,
+              "speedBooster": true,
+              "obstructions": [[5, 2]],
+              "requires": [
+                "canInsaneJump",
+                {"or": [
+                  "canMomentumConservingTurnaround",
+                  "canMomentumConservingMorph"
+                ]}
+              ],
+              "note": ["This applies to Flyway"],
+              "devNote": [
+                "This requires a last-frame jump, with a 3-frame window for the turnaround.",
+                "A ceiling mockball is also possible, with somewhat greater difficulty:",
+                "it needs a last-frame jump, with a 2-frame window for the morph."
+              ]
+            }
+          ]
+        }
+      },
+      "requires": [
+        "canCrossRoomJumpIntoWater",
+        "canTrickyJump"
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Side Platform Cross Room Jump into Spring Ball Jump",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 4,
+              "speedBooster": false,
+              "obstructions": [[1, 0]],
+              "note": "Applies to Skree Boost Room, Screw Attack Room, and Lava Dive"
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 5.4375,
+              "speedBooster": false,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canTrickySpringBallJump",
+                "canTrickyJump"        
+              ],
+              "note": "Applies to Early Supers Room, Blue Hopper Room, Bowling Alley (bottom), Dust Torizo Room, and Noob Bridge"
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 9.4375,
+              "speedBooster": false,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canTrickySpringBallJump",
+                "canTrickyJump"
+              ],
+              "note": "Applies to Bomb Torizo Room, Pink Brinstar Hopper Room, Phantoon's Room, Big Boy Room, and Double Chamber."
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 9.4375,
+              "speedBooster": false,
+              "obstructions": [[3, 2]],
+              "requires": [
+                "canTrickySpringBallJump",
+                "canTrickyJump",
+                "canJumpIntoIBJ",
+                {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 1}}
+              ],
+              "note": "Applies to Metal Pirates Room."
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 31,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "requires": [
+                "canInsaneJump",
+                {"or": [
+                  "canMomentumConservingTurnaround",
+                  {"and": [
+                    "canMomentumConservingMorph",
+                    "canBeVeryPatient"
+                  ]}
+                ]}
+              ],
+              "note": ["This applies to Metroid Room 1."],
+              "devNote": [
+                "With ideal positioning, starting 5 or 6 pixels from the end of the runway,",
+                "this has a 2-frame window for the jump, and a 1-frame or 3-frame window for the turnaround based on the jump timing",
+                "(with a last-frame jump giving the larger window for the turnaround).",
+                "This can also be done with a momentum conserving morph, but with somewhat greater difficulty:",
+                "it has a 2-frame window for the jump, and a 1-frame or 2-frame window for the turnaround based on the jump timing."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 30.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "requires": [
+                "canInsaneJump",
+                "canMomentumConservingTurnaround"
+              ],
+              "note": [
+                "This applies to Blue Brinstar Energy Tank Room (Power Bomb blocks intact)."
+              ],
+              "detailNote": [
+                "With ideal starting position, this has a 2-frame window for the jump,",
+                "and a 1-frame or 3-frame window for the turnaround based on the jump timing",
+                "(with a last-frame jump giving the larger window for the turnaround)."
+              ]
+            }
+          ]
+        }
+      },
+      "requires": [
+        "canCrossRoomJumpIntoWater",
+        "canMomentumConservingTurnaround",
+        "canSpringBallJumpMidAir"
+      ]
+    },
+    {
       "id": 52,
       "link": [2, 3],
       "name": "X-Ray Climb",

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1238,7 +1238,7 @@
               "obstructions": [[3, 0]],
               "environment": "water",
               "requires": [
-                "canInsaneJump",
+                "canTrickyDashJump",
                 "canGravityJump",
                 "canMomentumConservingTurnaround"
               ],
@@ -1252,6 +1252,10 @@
                 "and between a 5-frame and 7-frame window for the pause, depending on the jump timing",
                 "(with later jumps corresponding to larger windows for the pause to hit).",
                 "A ceiling mockball is also possible but with greater difficulty."
+              ],
+              "devNote": [
+                "FIXME: The `canTrickyDashJump` is for difficulty placement but could probably be replaced by a more fitting tech,",
+                "since this isn't actually relying on a spike in jump height based on gaining a specific speed."
               ]
             },
             {
@@ -1336,7 +1340,8 @@
               "requires": [
                 "canMomentumConservingTurnaround"
               ],
-              "note": ["This applies to Metal Pirates Room."]
+              "note": ["This applies to Metal Pirates Room."],
+              "detailNote": ["Starting the turnaround before the transition helps make this easier."]
             },            
             {
               "minHeight": 3,
@@ -1345,7 +1350,6 @@
               "speedBooster": true,
               "obstructions": [[5, 2]],
               "requires": [
-                "canInsaneJump",
                 {"or": [
                   "canMomentumConservingTurnaround",
                   "canMomentumConservingMorph"
@@ -1428,18 +1432,15 @@
                 "canInsaneJump",
                 {"or": [
                   "canMomentumConservingTurnaround",
-                  {"and": [
-                    "canMomentumConservingMorph",
-                    "canBeVeryPatient"
-                  ]}
+                  "canMomentumConservingMorph"
                 ]}
               ],
               "note": ["This applies to Metroid Room 1."],
-              "devNote": [
+              "detailNote": [
                 "With ideal positioning, starting 5 or 6 pixels from the end of the runway,",
                 "this has a 2-frame window for the jump, and a 1-frame or 3-frame window for the turnaround based on the jump timing",
                 "(with a last-frame jump giving the larger window for the turnaround).",
-                "This can also be done with a momentum conserving morph, but with somewhat greater difficulty:",
+                "This can also be done with a momentum conserving morph:",
                 "it has a 2-frame window for the jump, and a 1-frame or 2-frame window for the turnaround based on the jump timing."
               ]
             },
@@ -1469,6 +1470,11 @@
         "canCrossRoomJumpIntoWater",
         "canMomentumConservingTurnaround",
         "canSpringBallJumpMidAir"
+      ],
+      "devNote": [
+        "This strat is included for completeness even though it's not really useful;",
+        "it would be easier to use the runway attached to the door, even if it is only 1 tile long,",
+        "i.e. with the 'Cross Room Jump with Spring Ball' strat (id: 51)."
       ]
     },
     {

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -1164,7 +1164,7 @@
               "minHeight": 2,
               "maxHeight": 2,
               "minTiles": 23,
-              "speedBooster": "any",
+              "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [
                 "canInsaneJump",

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -166,6 +166,10 @@
           "obstruction": [3, 0]
         }
       },
+      "note": [
+        "It is best to start 4 or 5 pixels from the end of the runway;",
+        "equivalently, start at the end of the runway and use arm pumps to advance 4 or 5 pixels while running."
+      ],
       "devNote": "Max extra run speed $5.7."
     },
     {

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -454,6 +454,7 @@
           "obstruction": [3, 0]
         }
       },
+      "note": "If using the full runway, back into the corner against the Chozo statue.",
       "devNote": ["Max extra run speed $7.0."]
     },
     {

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -716,12 +716,21 @@
                           }
                         }
                       },
+                      "environment": {
+                        "type": "string",
+                        "description": "Environment that Samus is in while exiting the previous room.",
+                        "enum": ["water", "air", "any"],
+                        "default": "any"
+                      },
                       "requires": {
                         "$ref" : "m3-requirements.schema.json#/definitions/logicalRequirements",
                         "description": "Logical requirements specific to using this platform geometry."
                       },
                       "note": {
                         "$ref" : "m3-note.schema.json#/definitions/note"
+                      },
+                      "detailNote": {
+                        "$ref" : "m3-note.schema.json#/definitions/detailNote"
                       },
                       "devNote": {
                         "$ref" : "m3-note.schema.json#/definitions/devNote"


### PR DESCRIPTION
- Adds side platform strats for going from the bottom right of Colosseum to the top right.
- Fixes a small bug in a Crab Hole side platform strat.
- Adds more notes to some setups. There are still more details that could added, especially for describing setups that only use part of the available runway (since this can sometimes be easier than using a full runway).
- Adds "environment" property to platforms in the entrance condition `comeInWithSidePlatform`, to be able to specify if it's required for the neighboring room to be water (with Gravity). Where applicable, doing a Gravity jump before the transition makes both momentum-conserving turnarounds and ceiling mockballs easier due to the slower underwater animations, in addition to its main effect of preserving greater vertical speed. In some cases it can make a strat possible that wouldn't be possible at all from an air room with the same geometry. I didn't add a corresponding property to the exit condition `leaveWithSidePlatform` because I think it can be reasonably inferred from the `doorEnvironments` on the door node.
