### PR TITLE
Add wallJumpAvoid to strat and notable schema

### DIFF
--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -658,6 +658,7 @@
           "requires": [{"acidFrames": 110}]
         }
       ],
+      "wallJumpAvoid": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "After reaching the top, fall down the right side to land on the platform below the door, taking a dip in acid before jumping into the door."
@@ -692,6 +693,7 @@
           "requires": [{"acidFrames": 110}]
         }
       ],
+      "wallJumpAvoid": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -728,6 +730,7 @@
         "leaveNormally": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "wallJumpAvoid": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -760,6 +763,7 @@
         "leaveNormally": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "wallJumpAvoid": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -812,6 +816,7 @@
         "leaveNormally": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "wallJumpAvoid": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -1006,6 +1011,7 @@
     {
       "id": 4,
       "name": "Bootless Walljumpless Space Jump",
+      "wallJumpAvoid": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "It is possible to climb faster by releasing jump early, rather than doing full-height jumps, in order to be able to Space Jump again more quickly."

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1499,6 +1499,12 @@
             }
           }
         },
+        "wallJumpAvoid": {
+          "type": "boolean",
+          "title": "Wall Jump Avoid",
+          "default": false,
+          "description": "If true, indicates that the strat is only useful if the wall jump ability were somehow not possible to use."
+        },
         "flashSuitChecked": {
           "type": "boolean",
           "title": "Flash Suit Checked",
@@ -2330,6 +2336,12 @@
               "Big Jump with Blue Speed"
             ],
             "pattern": "^(.*)$"
+          },
+          "wallJumpAvoid": {
+            "type": "boolean",
+            "title": "Wall Jump Avoid",
+            "default": false,
+            "description": "If true, indicates that the notable is only useful if the wall jump ability were somehow not possible to use."
           },
           "note": {
             "type": ["string", "array"],

--- a/strats.md
+++ b/strats.md
@@ -19,6 +19,7 @@ A `strat` can have the following properties:
   * _collectsItems_: An array listing items that are collected as part of this strat (e.g. for G-mode remote item acquire).
   * _setsFlags_: An array listing game flags that are set as part of this strat.
 These properties are described below in more detail.
+  * _wallJumpAvoid_: A boolean, which if true indicates that the strat is only useful if wall jump were somehow not possible to use.
   * _flashSuitChecked_: Indicates that the logical requirements of the strat have been verified to be logically sound with respect to whether a flash suit can be carried or not. Note that a `true` value does not necessarily mean that a flash suit can be carried with this strat, only that its logical requirements can be relied on to determine whether it can or not.
 ### Example
 
@@ -1728,6 +1729,14 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
   "setsFlags": ["f_MaridiaTubeBroken"]
 }
 ```
+
+## Wall Jump Avoid
+
+A `wallJumpAvoid` boolean can be used to indicate that a strat is only useful if wall jump is for some reason not possible to do, e.g. in case the wall jump ability is disabled due to a randomizer modification. By default, this property is `false`.
+
+This property should not be used in every case where a wall jump could be an alternative to the strat. Rather, it should only be used on strats that would be pointless if the player has the ability to wall jump. In other words, strats with `"wallJumpAvoid": true` should be ones where if the player has the ability to wall jump, then there would be no reason to ever do the strat. This property can then be used to filter out irrelevant strats in contexts where wall jump is available.
+
+Some strats may have components (as alternatives within an `or`) that are useful only in scenarios without the wall jump ability. However, the `"wallJumpAvoid": true` should only be used if the entire strat becomes useless in the presence of an ability to wall jump.
 
 ## Starts With Shinecharge
 


### PR DESCRIPTION
This addresses a long-standing issue (#1001) about marking strats that are only useful in walljumpless contexts. This PR just adds a new boolean property `wallJumpAvoid` to strats and notables, along with an example. Later PRs would go through and populate this throughout the logic.

Based on the discussion in the issue, one alternative that was considered was implementing a more general `tag` property. However, after thinking about this some more, it seems that a simple tag would not work well for the other examples mentioned in the issue. For example, to model a strat that softlocks you at an item location, we would want to model more information such as the specific item and/or tech that could get you out of the softlock. The existing "failures" schema is also relevant to modeling softlock risk, and we may want to refine/expand it someday, but a simple tag is again not going to be enough. And "patience" is already modeled through tech, so it seems unnecessary to model as a tag. A boolean property has the advantage of being a more structured format (compared to a bag of strings), making it more straightforward to consume.

The plan is to use these properties in Map Rando to help reduce the clutter on the Generate page as well as the logic pages. The notable property `wallJumpAvoid` would apply to filtering notables on the Generate page; initially we may simply filter out the walljumpless notables from showing there, though eventually we could add some control to toggle them on or off. The strat property `wallJumpAvoid` can be applied to filter strats on logic pages for rooms and tech, and we already have a place to add a toggle for that.