### PR TITLE
Aqueduct shinecharges

### DIFF
--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -309,7 +309,9 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
-      "note": ["Enter with a small spin jump."]
+      "note": [
+        "If coming from a water environment, this assumes entering with a small spin jump."
+      ]
     },
     {
       "id": 14,

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -303,12 +303,13 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 40},
+        {"shineChargeFrames": 20},
         "canHorizontalShinespark",
-        {"shinespark": {"frames": 155, "excessFrames": 10}}
+        {"shinespark": {"frames": 152, "excessFrames": 10}}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": ["Enter with a small spin jump."]
     },
     {
       "id": 14,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1028,6 +1028,7 @@
       "requires": [
         "canPreciseStutterWaterShineCharge",
         "canShinechargeMovementTricky",
+        "canInsaneJump",
         {"shineChargeFrames": 130}
       ],
       "exitCondition": {
@@ -1056,6 +1057,7 @@
       "requires": [
         "canPreciseStutterWaterShineCharge",
         "canShinechargeMovementTricky",
+        "canInsaneJump",
         {"shineChargeFrames": 140}
       ],
       "exitCondition": {
@@ -1085,7 +1087,12 @@
       "requires": [
         "canPreciseStutterWaterShineCharge",
         "canShinechargeMovementTricky",
-        {"shineChargeFrames": 150}
+        "canInsaneJump",
+        {"shineChargeFrames": 145},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 5}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -1099,7 +1106,11 @@
         "the ideal timing for the stutter is to release forward for 3 or 4 frames, and repress forward on the last possible frame before the transition.",
         "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
         "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
-        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge.",
+        "Alternatively, with greater difficulty but saving some shinecharge frames,",
+        "after performing the turnaround spin jump, briefly moonwalk back, then retain momentum by boomeranging forward",
+        "(switching from pressing backward to pressing forward on the next frame),",
+        "and arm pump to reach the door quickly."
       ],
       "devNote": [
         "The same shinecharge frames could be achieved with a closed end runway (effective length of 2.4375),",
@@ -1117,7 +1128,12 @@
       "requires": [
         "canPreciseStutterWaterShineCharge",
         "canShinechargeMovementTricky",
-        {"shineChargeFrames": 160}
+        "canInsaneJump",
+        {"shineChargeFrames": 150},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 10}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -1131,7 +1147,16 @@
         "the ideal timing for the stutter is to release forward for 3 frames, and repress forward on the last possible frame before the transition.",
         "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
         "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
-        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge.",
+        "Alternatively, with greater difficulty but saving some shinecharge frames,",
+        "after performing the turnaround spin jump, briefly moonwalk back, then retain momentum by boomeranging forward",
+        "(switching from pressing backward to pressing forward on the next frame),",
+        "and arm pump to reach the door quickly."
+      ],
+      "devNote": [
+        "FIXME: The canBeVeryPatient requirement is for difficulty placement of the boomerang method;",
+        "but the boomerang (or maybe specifically the moonwalk boomerang) should possibly be its own tech,",
+        "and the same with rapid arm pumping."
       ]
     },
     {
@@ -1147,7 +1172,7 @@
         "canInsaneJump",
         "canBeVeryPatient",
         "canShinechargeMovementTricky",
-        {"shineChargeFrames": 175}
+        {"shineChargeFrames": 160}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -1157,18 +1182,24 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "note": [
-        "With only 1 tile of runway in the other room, this requires subpixel-precise positioning and a double frame-perfect stutter:",
-        "At the start of the run, Samus must be on the last pixel of runway with X subpixels of $3FFF or less.",
+        "With only 1 tile of runway in the other room, Samus should ideally start on the last pixel of runway with X subpixels of $3FFF or less.",
         "Run toward the door, releasing forward for exactly 1 frame and pressing it again on the last possible frame before the transition.",
+        "Starting with X subpixels of $7FFF can also work (e.g., by simply backing against the door ledge, then jumping and turning around mid-air);",
+        "in this case, Samus must advance 1 or 2 pixels with an arm pump before the transition (e.g., firing a shot or pressing and/or releasing an angle button),",
+        "and the shinecharge will be gained slightly further away from the door.",
         "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
-        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge.",
+        "Alternatively, with greater difficulty but saving some shinecharge frames,",
+        "after performing the turnaround spin jump, briefly moonwalk back, then retain momentum by boomeranging forward",
+        "(switching from pressing backward to pressing forward on the next frame),",
+        "and arm pump to reach the door quickly."
       ],
       "detailNote": [
-        "Correct subpixels can be achieved using one of several methods:",
-        "1) press against the door ledge (or a wall aligned with it);",
+        "Ideal subpixels ($3FFF) can be achieved using one of several methods:",
+        "1) press forward against the door ledge (or a wall aligned with it);",
         "jump, and while mid-air, tap forward for exactly 1 frame to land with subpixels $BFFF,",
         "moonwalk back for exactly 1 frame to end with subpixels $3FFF.",
-        "2) press against the door ledge (from a platform below, assuming one exists)",
+        "2) press forward against the door ledge (from a platform below, assuming one exists)",
         "turn around (while on the ground), and moonwalk back two pixels,",
         "then jump and mid-air turnaround onto the ledge;",
         "if Samus jumped from the correct pixel but does not land on the ledge, then it was needed to moonwalk back 1 more frame;",

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1029,7 +1029,11 @@
         "canPreciseStutterWaterShineCharge",
         "canShinechargeMovementTricky",
         "canInsaneJump",
-        {"shineChargeFrames": 130}
+        {"shineChargeFrames": 130},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 15}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -1058,7 +1062,11 @@
         "canPreciseStutterWaterShineCharge",
         "canShinechargeMovementTricky",
         "canInsaneJump",
-        {"shineChargeFrames": 140}
+        {"shineChargeFrames": 140},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 10}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -1091,7 +1099,7 @@
         {"shineChargeFrames": 145},
         {"or": [
           "canBeVeryPatient",
-          {"shineChargeFrames": 5}
+          {"shineChargeFrames": 10}
         ]}
       ],
       "exitCondition": {
@@ -1132,7 +1140,7 @@
         {"shineChargeFrames": 150},
         {"or": [
           "canBeVeryPatient",
-          {"shineChargeFrames": 10}
+          {"shineChargeFrames": 15}
         ]}
       ],
       "exitCondition": {

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -743,7 +743,7 @@
       "requires": [
         "h_canUsePowerBombs",
         "canStutterWaterShineCharge",
-        "canShinechargeMovement",
+        "canShinechargeMovementComplex",
         "h_canShineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 25, "excessFrames": 11}},
@@ -767,7 +767,7 @@
         "h_canUsePowerBombs",
         "canPreciseStutterWaterShineCharge",
         "canInsaneJump",
-        "canShinechargeMovement",
+        "canShinechargeMovementTricky",
         "h_canShineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 25, "excessFrames": 11}},

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -734,11 +734,10 @@
     {
       "id": 21,
       "link": [2, 1],
-      "name": "Stutter Water ShineCharge",
+      "name": "Stutter Water Shinecharge",
       "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
-          "minTiles": 2.4375
+        "comeInStutterShinecharging": {
+          "minTiles": 2
         }
       },
       "requires": [
@@ -746,9 +745,42 @@
         "canStutterWaterShineCharge",
         "canShinechargeMovement",
         "h_canShineChargeMaxRunway",
-        {"shinespark": {"frames": 25, "excessFrames": 11}}
+        {"or": [
+          {"shinespark": {"frames": 25, "excessFrames": 11}},
+          {"and": [
+            "canMidairShinespark",
+            {"shinespark": {"frames": 22, "excessFrames": 11}}    
+          ]}
+        ]}
       ],
       "clearsObstacles": ["A"]
+    },
+    {
+      "link": [2, 1],
+      "name": "Very Precise Stutter Water Shinecharge",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "h_canUsePowerBombs",
+        "canPreciseStutterWaterShineCharge",
+        "canInsaneJump",
+        "canShinechargeMovement",
+        "h_canShineChargeMaxRunway",
+        {"or": [
+          {"shinespark": {"frames": 25, "excessFrames": 11}},
+          {"and": [
+            "canMidairShinespark",
+            {"shinespark": {"frames": 22, "excessFrames": 11}}    
+          ]}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "With only 1 tile of runway, this requires a single-frame stutter (release forward then repress on the next frame), on the last possible frame."
+      ]
     },
     {
       "id": 22,
@@ -902,16 +934,69 @@
     {
       "id": 27,
       "link": [2, 2],
-      "name": "Stutter Shinecharge, Shinespark Return",
+      "name": "Stutter Shinecharge, Leave With Spark",
       "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
+        "comeInStutterShinecharging": {
           "minTiles": 2
         }
       },
       "requires": [
-        "canShinechargeMovementComplex",
         "canStutterWaterShineCharge",
+        "canShinechargeMovementComplex",
+        {"or": [
+          {"shinespark": {"frames": 12}},
+          {"and": [
+            "canShinechargeMovementTricky",
+            {"shinespark": {"frames": 3}}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Water Shinecharge, Hero Shot Leave With Spark",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 0.4375,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canWaterShineCharge",
+        "canShinechargeMovementTricky",
+        "canHeroShot",
+        {"shinespark": {"frames": 29}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "Start with low run speed by positioning exactly 2 pixels from the door."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Very Precise Stutter Shinecharge, Leave With Spark",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "canShinechargeMovementComplex",
+        "canPreciseStutterWaterShineCharge",
+        "canInsaneJump",
         "h_canShineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 12}},
@@ -927,6 +1012,204 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only 1 tile of runway, this requires a single-frame stutter (release forward then repress on the next frame), on the last possible frame."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (5-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 5
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 130}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With a runway of 5 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 5 frames, and repress forward on the last possible frame before the transition.",
+        "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (4-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 4
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 140}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only a runway of 4 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 4 frames, and repress forward on the last possible frame before the transition.",
+        "It also works well to release forward for 3 frames and repress on the last possible frame.",
+        "Other timings can also work, but may gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (3-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 3
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only a runway of 3 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 3 or 4 frames, and repress forward on the last possible frame before the transition.",
+        "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+      ],
+      "devNote": [
+        "The same shinecharge frames could be achieved with a closed end runway (effective length of 2.4375),",
+        "with a 3-frame stutter, but there doesn't appear to be any application."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (2-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 160}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only a runway of 2 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 3 frames, and repress forward on the last possible frame before the transition.",
+        "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (1-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canInsaneJump",
+        "canBeVeryPatient",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 175}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only 1 tile of runway in the other room, this requires subpixel-precise positioning and a double frame-perfect stutter:",
+        "At the start of the run, Samus must be on the last pixel of runway with X subpixels of $3FFF or less.",
+        "Run toward the door, releasing forward for exactly 1 frame and pressing it again on the last possible frame before the transition.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+      ],
+      "detailNote": [
+        "Correct subpixels can be achieved using one of several methods:",
+        "1) press against the door ledge (or a wall aligned with it);",
+        "jump, and while mid-air, tap forward for exactly 1 frame to land with subpixels $BFFF,",
+        "moonwalk back for exactly 1 frame to end with subpixels $3FFF.",
+        "2) press against the door ledge (from a platform below, assuming one exists)",
+        "turn around (while on the ground), and moonwalk back two pixels,",
+        "then jump and mid-air turnaround onto the ledge;",
+        "if Samus jumped from the correct pixel but does not land on the ledge, then it was needed to moonwalk back 1 more frame;",
+        "in this case it is possible to retry by doing a mid-air turnaround back onto the platform, and moonwalking back for 1 frame.",
+        "3) if X-Ray is available, press against the door ledge (from a platform below, assuming one exists)",
+        "turn around (while on the ground), then jump and mid-air turnaround toward the door,",
+        "and use X-Ray to turnaround in place away from the door;",
+        "repeat this sequence 3 more times: jump, mid-air turnaround, X-Ray turnaround;",
+        "then do one more jump and mid-air turnaround, high enough to land on the door ledge,",
+        "and Samus should be in the correct position with subpixels $3FFF."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Water Shinecharge, Leave With Temporary Blue",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 0.4375,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canWaterShineCharge",
+        "canXRayCancelShinecharge",
+        "canXRayTurnaround",
+        "canLongChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "Start with low run speed by positioning exactly 2 pixels from the door.",
+        "Use X-Ray to cancel the shinecharge early, to avoid getting hit by the angry snail."
+      ],
+      "devNote": [
+        "This can also be done with a stutter shinecharge, which can shorten the temp blue chain,",
+        "but not by enough to remove the need for the canLongChainTemporaryBlue requirement."
       ]
     },
     {


### PR DESCRIPTION
This refines the water shinecharge strats entering from the bottom-left door of Aqueduct. This time I took a closer look at how the runway length affects the amount of frames remaining with "Leave Shinecharged" strats. It turned out to make a fairly big difference. Making 5 strats for the various runway lengths might seem like a bit of overkill, but there are applications for each case; maybe someday we'll be able to reference the runway length in the `requires` so that they wouldn't have to all be separate strats. Once this PR is merged, I plan to go back and apply the same refinement to `leaveShinecharged` variants in the other rooms (e.g. Precious Room, West Sand Hall Tunnel, Oasis).

Example applications:
1 tile, Screw Attack Room: https://videos.maprando.com/video/5923
2 tiles, Waterway: https://videos.maprando.com/video/5922
3 tiles, Colosseum: https://videos.maprando.com/video/5925
4 tiles, Below Spazer: https://videos.maprando.com/video/5924
5 tiles, Moat: https://videos.maprando.com/video/5927

