### PR TITLE
Maridia Elevator Room L->R side platform jumps

### DIFF
--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -634,8 +634,7 @@
         {"obstaclesCleared": ["A"]},
         "SpeedBooster",
         "canInsaneJump",
-        "canMomentumConservingMorph",
-        "canInsaneMidAirMorph"
+        "canMomentumConservingMorph"
       ],
       "exitCondition": {
         "leaveWithSidePlatform": {

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -107,7 +107,7 @@
         "leaveWithSidePlatform": {
           "height": 3,
           "runway": {
-            "length": 40,
+            "length": 38,
             "openEnd": 0
           },
           "obstruction": [5, 2]
@@ -367,7 +367,7 @@
         "leaveWithSidePlatform": {
           "height": 3,
           "runway": {
-            "length": 40,
+            "length": 38,
             "openEnd": 0
           },
           "obstruction": [3, 0]

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1346,7 +1346,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[5, 2]],
               "requires": [

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -731,7 +731,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1050,7 +1050,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [
@@ -2413,7 +2413,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [
@@ -2482,7 +2482,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -543,7 +543,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -278,6 +278,121 @@
       "devNote": "This is mainly useful as an alternative to crouch-jump down-grab in order to preserve a flash suit."
     },
     {
+      "link": [1, 2],
+      "name": "Side Platform Cross Room Jump",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 7.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [],
+              "note": ["This applies to Warehouse Entrance."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 8.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [],
+              "note": ["This applies to Ridley Tank Room, Halfie Climb Room, and Dust Torizo Room."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 8.4375,
+              "speedBooster": true,
+              "obstructions": [[2, 0]],
+              "requires": [
+                "canMomentumConservingMorph"
+              ],
+              "note": ["This applies to Early Supers Room and Waterway Energy Tank Room."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 20.4375,
+              "speedBooster": true,
+              "obstructions": [[2, 0]],
+              "requires": [
+                "canMomentumConservingTurnaround"
+              ],
+              "note": ["This applies to Waterway Energy Tank Room."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 19.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "requires": [
+                "canMomentumConservingMorph"
+              ],
+              "note": ["This applies to Noob Bridge, Metroid Room 1, and Statues Hallway."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 39.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "requires": [
+                {"or": [
+                  "canMomentumConservingMorph",
+                  "canInsaneJump"
+                ]}
+              ],
+              "note": ["This applies to Flyway."],
+              "detailNote": [
+                "This can be done most easily with a momentum-conserving morph:",
+                "to reduce Samus' horizontal momentum, avoid holding either forward or backward through the transition.",
+                "Otherwise, position the start of the run to gain an extra run speed of $5.2 and $5.3 with a last-frame jump and aim down,",
+                "and buffer a turnaround through the transition.",
+                "Using the full runway and doing a momentum-conserving turnaround before the transition is also possible but not recommended,",
+                "as it requires a last-frame jump and frame-perfect turnaround."
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 23.4375,
+              "speedBooster": true,
+              "obstructions": [[4, 0]],
+              "requires": [
+                "canMomentumConservingMorph",
+                "canInsaneJump"
+              ],
+              "note": ["This applies to Kraid Room and Baby Kraid Room."],
+              "detailNote": [
+                "To reduce Samus' horizontal momentum, avoid holding either forward or backward through the transition.",
+                "If coming from Baby Kraid Room, it is easiest to use only a small part of the available runway."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 39.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 2]],
+              "requires": [
+                "canTrickyJump"
+              ],
+              "note": ["This applies to Metal Pirates Room."],
+              "detailNote": ["Fire a shot to break spin soon after the transition, to stop Samus' rightward momentum."]
+            }
+          ]
+        }
+      },
+      "requires": [],
+      "wallJumpAvoid": true,
+      "flashSuitChecked": true,
+      "devNote": "This is mainly useful as an alternative to crouch-jump down-grab in order to preserve a flash suit."
+    },
+    {
       "id": 9,
       "link": [1, 2],
       "name": "Shinespark",

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -337,7 +337,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 29.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [
@@ -350,7 +350,8 @@
               "detailNote": [
                 "This can be done most easily with a momentum-conserving morph:",
                 "to reduce Samus' horizontal momentum, avoid holding either forward or backward through the transition.",
-                "Otherwise, position the start of the run to gain an extra run speed of $5.2 and $5.3 with a last-frame jump and aim down,",
+                "Otherwise, position the start of the run about 30 tiles from the runway end (8 tiles from the runway start),",
+                "to gain an extra run speed of $5.2 and $5.3 with a last-frame jump and aim down,",
                 "and buffer a turnaround through the transition.",
                 "Using the full runway and doing a momentum-conserving turnaround before the transition is also possible but not recommended,",
                 "as it requires a last-frame jump and frame-perfect turnaround."

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -1223,7 +1223,7 @@
                 "in order to avoid damage from the crab on the right.",
                 "To make the strat more lenient, less than the full available runway should be used:",
                 "Ideally, position Samus to gain an extra run speed of $5.2 or slightly more,",
-                "which corresponds to starting 30 tiles from the end of the runway (or 10 tiles from the start)."
+                "which corresponds to starting 30 tiles from the end of the runway (or 8 tiles from the start)."
               ],
               "devNote": [
                 "There is a dropoff in Samus' jump height at an extra run speed of $5.2, which is good here.",

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -510,7 +510,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [
@@ -939,7 +939,7 @@
             {
               "minHeight": 3,
               "maxHeight": 3,
-              "minTiles": 39.4375,
+              "minTiles": 37.4375,
               "speedBooster": true,
               "obstructions": [[3, 0]],
               "requires": [


### PR DESCRIPTION
This strat is only useful in a situation where wall-jump is unavailable and you want to preserve a flash suit (and so can't crouch-jump down-grab).

Removing the "canInsaneMidAirMorph" requirement from the Baby Kraid Room side platform setup, since depending on the runway length used, it is not necessarily that difficult. The "canInsaneMidAirMorph" can still be applied to individual applications as needed.