### PR TITLE
Fix Main Street Gmode Requirements

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -4389,9 +4389,9 @@
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
         "h_canNavigateUnderwater",
+        "h_canArtificialMorphIBJ",
         {"or": [
           {"and": [
-            "h_canArtificialMorphIBJ",
             "Gravity",
             {"or": [
               "h_canArtificialMorphJumpIntoIBJ",


### PR DESCRIPTION
We played a bugged seed that expected `G-Mode Morph IBJ Overload Speed Blocks` Without Morph Bombs.