### PR TITLE
Fast Pillars Setup cross-room tricky dash jump

### DIFF
--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -574,6 +574,22 @@
       ]
     },
     {
+      "link": [1, 4],
+      "name": "Come in Running, Tricky Dash Jump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 1,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canTrickyDashJump",
+        "canInsaneJump",
+        "canMidairWiggle",
+        {"heatFrames": 140}
+      ]
+    },
+    {
       "id": 69,
       "link": [1, 4],
       "name": "Come in Shinecharging, Leave Shinecharged (Pirate Dodge Wall Climb)",

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -584,9 +584,48 @@
       },
       "requires": [
         "canTrickyDashJump",
+        "canTrickyDodgeEnemies",
         "canInsaneJump",
-        "canMidairWiggle",
         {"heatFrames": 140}
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Side Platform Cross Room Jump",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 27.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                {"heatFrames": 100}
+              ],
+              "note": ["This applies to Dust Torizo Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 39.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 2]],
+              "requires": [
+                {"heatFrames": 100}
+              ],
+              "note": ["This applies to Metal Pirates Room."]
+            }
+          ]
+        }
+      },
+      "requires": [
+        "canTrickyDodgeEnemies"
+      ],
+      "devNote": [
+        "More difficult side platform entrances are not considered,",
+        "because there is an alternative of doing a canTrickyDashJump with a 1-tile connected runway."
       ]
     },
     {


### PR DESCRIPTION
I created a bunch of videos a while ago for doing side platform jumps at this location. But then today when I came back to it, I realized that with 1 tile of air runway, you can do this tricky dash jump. It's dangerous (risk of hitting of the Space Pirate) but probably not any more than the side platform jumps, so with this I think there's not much reason to add strats for the side platform jumps.

Video: https://videos.maprando.com/video/6177