### PR TITLE
Screw Attack Room left-to-right side platform jumps

### DIFF
--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -648,13 +648,10 @@
       },
       "devNote": [
         "Max extra run speed $7.0.",
-        "Avoid backing into the corner at the start of runway;",
-        "instead press against it and turn around, to put Samus into a better position.",
-        "It can help to advance 2 more pixels by performing an arm pump: press and release an angle button one time while running.",
-        "Alternatively, Samus can press against the overhang to the left of the leftmost ceiling spikes,",
-        "then advance between 4 and 8 pixels by performing between 2 and 4 arm pumps.",
-        "There is a 2-frame window for the jump,",
-        "then a 1-frame or 2-frame window for the morph depending on the jump (with a last-frame jump giving a 2-frame morph window)."
+        "Press against the overhang left of the ceiling spikes,",
+        "then perform 4 arm pumps to advance 8 pixels while running.",
+        "There is a 2-frame window for the jump and a 2-frame window for the morph.",
+        "These windows can be more narrow depending on what is required in the next room."
       ]
     },
     {

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -629,11 +629,11 @@
                   "openEnd": 1
                 }},
                 {"or": [
-                  "canMomentumConservingMorph",
                   {"and": [
-                    "canBeVeryPatient",
-                    "canInsaneJump"
-                  ]}
+                    "canLateralMidAirMorph",
+                    "canTrickyJump"
+                  ]},
+                  "canInsaneJump"
                 ]},
                 {"heatFrames": 80}
               ],
@@ -666,6 +666,7 @@
                   "openEnd": 1
                 }},
                 "canLateralMidAirMorph",
+                "canTrickyDashJump",
                 {"heatFrames": 70}
               ],
               "note": [
@@ -673,9 +674,9 @@
                 "Use a 2-tap in order to gain blue speed with high momentum."
               ],
               "detailNote": [
-                "The specific speed $3.2 does not work as Samus will not get high enough to break the blocks.",
-                "A lower speed of $3.1 can work, but it is recommended to instead do a double-stutter with an early second tap,",
-                "to more reliably gain a higher speed of $3.3 or higher."
+                "A lower speed of $3.1 can work, but it is recommended to instead do a double-stutter 2-tap with an early second tap,",
+                "to more reliably gain a speed of $3.3 or higher, in order to get a shorter jump.",
+                "The specific speed $3.2 does not work as Samus will not quite get high enough to break the blocks."
               ]
             },
             {
@@ -688,10 +689,7 @@
                 "canMomentumConservingMorph",
                 {"heatFrames": 70}
               ],
-              "note": [
-                "This applies to Flyway.",
-                "It is recommended to use a 2-tap to gain blue speed with less than full run speed."
-              ]
+              "note": ["This applies to Flyway."]
             },
             {
               "minHeight": 2,

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -612,6 +612,131 @@
       "endsWithShineCharge": true
     },
     {
+      "link": [1, 4],
+      "name": "Side Platform Jump with Blue Speed",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 17,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                {"getBlueSpeed": {
+                  "usedTiles": 15,
+                  "openEnd": 1
+                }},
+                {"or": [
+                  "canMomentumConservingMorph",
+                  {"and": [
+                    "canBeVeryPatient",
+                    "canInsaneJump"
+                  ]}
+                ]},
+                {"heatFrames": 80}
+              ],
+              "note": ["This applies to Warehouse Entrance."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 27.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                {"getBlueSpeed": {
+                  "usedTiles": 24,
+                  "openEnd": 1
+                }},
+                {"heatFrames": 60}
+              ],
+              "note": ["This applies to Dust Torizo Room."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 27.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                {"getBlueSpeed": {
+                  "usedTiles": 15,
+                  "openEnd": 1
+                }},
+                "canLateralMidAirMorph",
+                {"heatFrames": 70}
+              ],
+              "note": [
+                "This applies to Noob Bridge.",
+                "Use a 2-tap in order to gain blue speed with high momentum."
+              ],
+              "detailNote": [
+                "The specific speed $3.2 does not work as Samus will not get high enough to break the blocks.",
+                "A lower speed of $3.1 can work, but it is recommended to instead do a double-stutter with an early second tap,",
+                "to more reliably gain a higher speed of $3.3 or higher."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 37.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 0]],
+              "requires": [
+                "canMomentumConservingMorph",
+                {"heatFrames": 70}
+              ],
+              "note": [
+                "This applies to Flyway.",
+                "It is recommended to use a 2-tap to gain blue speed with less than full run speed."
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 45,
+              "speedBooster": true,
+              "obstructions": [[4, 0]],
+              "requires": [
+                "canMomentumConservingMorph",
+                "canInsaneMidAirMorph",
+                {"heatFrames": 150}
+              ],
+              "note": [
+                "This applies to Baby Kraid Room.",
+                "Perform a ceiling mockball through the transition,",
+                "and unmorph after the transition to avoid bonking on the overhang."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 39.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 2]],
+              "requires": [
+                {"heatFrames": 60}
+              ],
+              "note": ["This applies to Metal Pirates Room."]
+            }
+          ]
+        }
+      },
+      "requires": [
+        "canTrickyJump"
+      ],
+      "clearsObstacles": ["B"],
+      "note": [
+        "Jump into the room with blue speed, using it to break some of the bomb blocks above."
+      ],
+      "devNote": [
+        "FIXME: A similar strat from 1 to 2 would also be possible,",
+        "saving some heat frames by going directly to the middle door instead of stopping at the item."
+      ]
+    },
+    {
       "id": 78,
       "link": [1, 5],
       "name": "Direct jump with Screw Attack",


### PR DESCRIPTION
This is mainly useful as an alternative to shinesparking, in order to preserve a flash suit. It can also save some energy.

The test failure should be resolved after #2026 is merged (which can be done first).

Updated the Baby Kraid Room right-side setup note. Using the overhang makes the setup faster, and doing 4 arm pumps give you a 2nd possible frame for the morph, something I had missed before.