### PR TITLE
Grapple Tutorial Room 3 side platform jumps

### DIFF
--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -620,6 +620,87 @@
       "devNote": "This is likely never useful unless the Gamets are gone or Samus can't take a hit from them for some reason."
     },
     {
+      "link": [1, 4],
+      "name": "Side Platform Cross Room Jump",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 17,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "requires": [
+                {"or": [
+                  "SpeedBooster",
+                  "canLateralMidAirMorph"
+                ]}
+              ],
+              "note": ["This applies to Warehouse Entrance."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canTrickyJump"
+              ],
+              "note": ["This applies to Shaktool Room, Ridley Tank Room, Halfie Climb Room, and Dust Torizo Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 10.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "requires": [
+                {"or": [
+                  "SpeedBooster",
+                  "canPreciseWalljump"
+                ]}
+              ],
+              "note": ["This applies to Big Boy Room and Mickey Mouse Room."]
+            },
+            {
+              "minHeight": 4,
+              "maxHeight": 4,
+              "minTiles": 11.4375,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [
+                "canTrickyJump"
+              ],
+              "note": ["This applies to Aqueduct."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 45,
+              "speedBooster": true,
+              "obstructions": [[2, 0]],
+              "requires": [
+                "canTrickyJump"
+              ],
+              "note": ["This applies to Waterway Energy Tank Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 15.4375,
+              "speedBooster": true,
+              "obstructions": [[3, 2]],
+              "requires": [],
+              "note": ["This applies to Metal Pirates Room."]
+            }
+          ]
+        }
+      },
+      "requires": []
+    },
+    {
       "id": 25,
       "link": [2, 1],
       "name": "Grapple Teleport",


### PR DESCRIPTION
This is mainly useful if for some reason Gamet damage boost is not possible (e.g. if their damage value is increased). In any case, logically it can at least save a bit of energy.