### PR TITLE
G-Mode: Refine Main Street Speed locked item

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -3300,7 +3300,6 @@
           ]},
           {"and": [
             "Morph",
-            "canBeVeryPatient",
             {"or": [
               "Gravity",
               "HiJump",
@@ -3346,7 +3345,6 @@
           ]},
           {"and": [
             "Morph",
-            "canBeVeryPatient",
             {"or": [
               "Gravity",
               "HiJump",
@@ -4177,13 +4175,15 @@
       "note": [
         "Freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
         "Exit G-Mode and rotate to obtain the item.",
-        "Samus will now be stuck on the crab, and if it thaws and hits her, she will be pushed up and stuck in the speed blocks."
+        "Samus will now be stuck on the crab, and if it thaws and hits her, she will be pushed up and stuck in the speed blocks.",
+        "Note that if the crab is arriving too early, it may be possible to slow the crab with Ice or lure the crab from above instead.",
+        "Alternatively, she may have to wait for the global crab to circle the room."
       ]
     },
     {
       "id": 185,
       "link": [11, 6],
-      "name": "G-Mode Overload Speed Blocks, PB Frozen Crab",
+      "name": "G-Mode Overload Speed Blocks, Bomb Frozen Crab",
       "requires": [
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
@@ -4196,42 +4196,22 @@
           "canCrouchJump",
           "canSpringBallJumpMidAir"
         ]},
-        {"disableEquipment": "Gravity"},
-        "h_canUsePowerBombs"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "Place a Power Bomb, then quickly stand and use X-Ray to exit G-Mode before it goes off. Rotate to touch the item before the crab dies.",
-        "It is important to turn Gravity off beforehand, or the Power Bomb will boost Samus and she will be stuck in the speed blocks."
-      ]
-    },
-    {
-      "id": 166,
-      "link": [11, 6],
-      "name": "G-Mode Overload Speed Blocks, Frozen Crab, Bomb Kago",
-      "requires": [
-        "canEnterGMode",
-        {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "canBePatient",
-        "h_canNavigateUnderwater",
-        "canTrickyUseFrozenEnemies",
         {"or": [
-          "Gravity",
-          "HiJump",
-          "canCrouchJump",
-          "canSpringBallJumpMidAir"
+          {"disableEquipment": "Gravity"},
+          "canKago"
         ]},
-        "h_canUseMorphBombs",
-        "canKago"
+        "h_canBombThings"
       ],
       "flashSuitChecked": true,
       "note": [
         "Freeze a crab on the edge of the speed blocks, such that Samus can jump inside and stand on the crab.",
-        "It is important to freeze the crab with all other beams turned off, so that the crab has 30 remaining Energy or less.",
-        "Place a Bomb, then quickly stand and use X-Ray to exit G-Mode before it goes off. Rotate to touch the item before the crab dies and to Kago the bomb blast.",
-        "It is important to Kago the bomb blast, because even suitless, the Bomb blast will boost Samus and she will be stuck in the speed blocks (unlike a Power Bomb blast)."
-      ]
+        "If using Bombs, it is important to freeze the crab with all other beams turned off, so that the crab has 30 remaining Energy or less.",
+        "Place a Bomb or Power Bomb, then quickly get into the crouch position and use X-Ray to exit G-Mode before it goes off.",
+        "It is important to be crouched, not standing, and have Gravity off, or the bomb will boost Samus and she will be stuck in the speed blocks.",
+        "Note that if the crab is arriving too early, it may be possible to slow the crab with Ice or lure the crab from above instead.",
+        "Alternatively, she may have to wait for the global crab to circle the room."
+      ],
+      "detailNote": "It is possible to kago the bomb boost in order to do this strat with Gravity still equipped."
     },
     {
       "id": 186,
@@ -4261,7 +4241,10 @@
         "but then she will not be able to use X-Ray to exit G-Mode, and will require a Reserve Trigger.",
         "The Crystal Flash needs to be done before unmorphing, while being careful not to kill the global crab.",
         "Samus then needs to jump into the speed-locked item and hit the crab to trigger Reserves and exit G-Mode.",
-        "This can be done with HiJump, Gravity, Spring Ball, or Ice. Turn around while inside the item to collect it."
+        "This can be done with HiJump, Gravity, Spring Ball, or Ice. Turn around while inside the item to collect it.",
+        "Wait for the global crab to get into position.",
+        "Note that if the crab is arriving too early, it may be possible to slow the crab with Ice or lure the crab from above instead.",
+        "Alternatively, she may have to wait for the global crab to circle the room."
       ],
       "devNote": [
         "Samus needs to use Bombs or Power Bombs to overload PLMs, so Morph or artificial Morph is already required.",
@@ -4352,10 +4335,6 @@
             "canWalljump"
           ]},
           {"and": [
-            "Gravity",
-            "canTrickyUseFrozenEnemies"
-          ]},
-          {"and": [
             "HiJump",
             {"or": [
               "canSpringBallJumpMidAir",
@@ -4366,13 +4345,12 @@
             ]}
           ]},
           {"and": [
-            "HiJump",
-            "canTrickyUseFrozenEnemies"
-          ]},
-          {"and": [
-            "h_canMaxHeightSpringBallJump",
             "canTrickyUseFrozenEnemies",
-            "canBeVeryPatient"
+            {"or": [
+              "HiJump",
+              "Gravity",
+              "h_canMaxHeightSpringBallJump"
+            ]}
           ]}
         ]},
         {"or": [
@@ -4396,8 +4374,7 @@
         "Place bombs against the speed blocks until they are overloaded.",
         "With a slow ascent, such as with Spring Ball and Ice, the crab will need to circle the entire room,",
         "it is possible to use a Super when it passes the speed blocks to speed this up significantly."
-      ],
-      "devNote": "FIXME: HiJump strats may need canBeVeryPatient if they can't be done before the crab is in position"
+      ]
     },
     {
       "id": 188,
@@ -4476,17 +4453,17 @@
     {
       "id": 82,
       "link": [13, 11],
-      "name": "G-Mode Morph IBJ Overload Speed Blocks",
+      "name": "G-Mode Morph, Overload Speed Blocks (Bombs)",
       "requires": [
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
         "h_canNavigateUnderwater",
-        "h_canArtificialMorphIBJ",
+        "h_canArtificialMorphBombs",
         {"or": [
           {"and": [
             "Gravity",
             {"or": [
-              "h_canArtificialMorphJumpIntoIBJ",
+              "h_canArtificialMorphIBJ",
               {"and": [
                 "h_canArtificialMorphSpringBall",
                 "HiJump"
@@ -4494,11 +4471,7 @@
               {"and": [
                 "h_canArtificialMorphSpringBall",
                 "canGravityJump"
-              ]},
-              "h_canArtificialMorphDoubleBombJump",
-              "h_canArtificialMorphStaggeredIBJ",
-              "canBeVeryPatient",
-              "h_canArtificialMorphPowerBomb"
+              ]}
             ]},
             {"or": [
               "h_canArtificialMorphSpringBall",
@@ -4513,8 +4486,7 @@
       "note": [
         "This is a long climb, and getting around the fish under the missiles can be tricky or slow.",
         "Place bombs against the speed blocks until they are overloaded."
-      ],
-      "devNote": "FIXME: Some IBJ strats may need canBeVeryPatient if they can't be done before the crab is in position"
+      ]
     }
   ],
   "notables": [


### PR DESCRIPTION
- Fixed a misunderstanding between Bomb/PB to kill the crab (thanks Eddie)
- Removed `canBeVeryPatient` from strats that can keep the top crab in position, instead of waiting for the global crab to cycle the room
- Removed `canBeVeryPatient` from strats that use crouch jump + bombs to overload the speed blocks (It's not that hard to get 2 bombs per jump, which gives plenty of time, otherwise Ice can help)