### PR TITLE
Croc Escape spring ball strats

### DIFF
--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -849,7 +849,7 @@
       "name": "Spring Ball Jump into Damage Boost",
       "requires": [
         {"notable": "Spring Ball Jump into Damage Boost"},
-        {"heatFrames": 1600},
+        {"heatFrames": 1920},
         "canTrickyDodgeEnemies",
         "canTrickySpringBallJump",
         "canNeutralDamageBoost",

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -845,6 +845,22 @@
       ]
     },
     {
+      "link": [2, 3],
+      "name": "Spring Ball Jump into Damage Boost",
+      "requires": [
+        {"notable": "Spring Ball Jump into Damage Boost"},
+        {"heatFrames": 1600},
+        "canTrickyDodgeEnemies",
+        "canTrickySpringBallJump",
+        "canNeutralDamageBoost",
+        {"enemyDamage": {"enemy": "Geruta", "type": "contact", "hits": 1}}
+      ],
+      "note": [
+        "Use mid-air Spring Ball jumps to manipulate the Geruta into position near the ledge.",
+        "Then do a Spring Ball jump into a neutral damage boost (while still morphed) to reach the ledge."
+      ]
+    },
+    {
       "id": 22,
       "link": [2, 3],
       "name": "SpringBall Freeze",
@@ -925,6 +941,28 @@
         "Stay on its left side when it touches the ceiling for the enemy to continue moving forward.",
         "It may not be possible to climb back up to the Geruta if Samus falls.",
         "When it moves towards the ceiling, reset Samus' fall speed using an unmorph or by taking knockback damage, in order to wait for the Geruta to fall low enough to refreeze."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Ceiling Mockball Spring Fling",
+      "requires": [
+        {"notable": "Ceiling Mockball Spring Fling"},
+        "SpeedBooster",
+        "canInsaneJump",
+        {"heatFrames": 500},
+        "canMomentumConservingMorph",
+        "canSpringFling",
+        {"or": [
+          "h_heatProof",
+          "canBeVeryPatient"
+        ]}
+      ],
+      "note": [
+        "Position at the end of the runway (or up to 4 pixels away) at the top-right of the room,",
+        "gain run speed, perform a last-frame jump and ceiling mockball,",
+        "then equip or unequip Spring Ball in order to reset Samus' vertical speed",
+        "and just barely make it onto the ledge with the item."
       ]
     },
     {
@@ -1088,12 +1126,19 @@
               "canInsaneJump",
               "h_additionalBomb"
             ]}
+          ]},
+          {"and": [
+            {"notable": "Ceiling Mockball Spring Fling"},
+            "SpeedBooster",
+            "canInsaneJump",
+            "canMomentumConservingMorph",
+            "canSpringFling"
           ]}
         ]},
         {"heatFrames": 0}
       ],
       "flashSuitChecked": true,
-      "devNote": "FIXME: A variant with shinesparking can be added. (Energy from immobile, CF, or energy free sparks)"
+      "devNote": "FIXME: Variants with shinesparking or Geruta damage boost can be added. (Energy from immobile, CF, or energy free sparks)"
     },
     {
       "id": 58,
@@ -1173,6 +1218,13 @@
               "canInsaneJump",
               "h_additionalBomb"
             ]}
+          ]},
+          {"and": [
+            {"notable": "Ceiling Mockball Spring Fling"},
+            "SpeedBooster",
+            "canInsaneJump",
+            "canMomentumConservingMorph",
+            "canSpringFling"
           ]}
         ]},
         {"heatFrames": 90}
@@ -1181,7 +1233,7 @@
       "flashSuitChecked": true,
       "devNote": [
         "Goes to 3 because opening the gate mostly only makes sense when going back to the right for a longer runway or obtaining the item.",
-        "FIXME: A variant with shinesparking can be added. (Energy from immobile, CF, or energy free sparks)"
+        "FIXME: Variants with shinesparking or Geruta damage boost can be added. (Energy from immobile, CF, or energy free sparks)"
       ]
     },
     {
@@ -1471,8 +1523,24 @@
         "It may not be possible to climb back up to the Geruta if Samus falls.",
         "When it moves towards the ceiling, reset Samus' fall speed using an unmorph or by taking knockback damage, in order to wait for the Geruta to fall low enough to refreeze."
       ]
+    },
+    {
+      "id": 6,
+      "name": "Ceiling Mockball Spring Fling",
+      "note": [
+        "Perform a last-frame jump and ceiling mockball,",
+        "then spring fling to just barely make it onto the ledge with the item."
+      ]
+    },
+    {
+      "id": 7,
+      "name": "Spring Ball Jump into Damage Boost",
+      "note": [
+        "Use mid-air Spring Ball jumps to manipulate the Geruta into position near the ledge.",
+        "Then do a Spring Ball jump into a neutral damage boost (while still morphed) to reach the ledge."
+      ]
     }
   ],
   "nextStratId": 63,
-  "nextNotableId": 6
+  "nextNotableId": 8
 }


### PR DESCRIPTION
This adds a couple notable strats based on videos that Sam recently shared:
- Ceiling Mockball Spring Fling:
  - original video by Sam: https://videos.maprando.com/video/6221
  - video from room entry, for measuring frames: https://videos.maprando.com/video/6228
- Spring Ball Jump into Damage Boost:
  - original video by Sam: https://videos.maprando.com/video/6061
  - video from room entry, for measuring frames: https://videos.maprando.com/video/6229

There's more work that can be done in the room. I didn't look into the frozen Geruta walljump variant, and Kyle also mentioned a G-mode setup with the Geruta.