### PR TITLE
Rename helpers to not use "can"

### DIFF
--- a/enemies/bosses/scenarios.json
+++ b/enemies/bosses/scenarios.json
@@ -336,7 +336,7 @@
           "name": "Turrets",
           "attack": "turretProjectile",
           "frequencyFrames": 1080,
-          "avoidingRequires": ["h_canBreakThreeDraygonTurrets"]
+          "avoidingRequires": ["h_breakThreeDraygonTurrets"]
         }
       ],
       "note": [

--- a/helpers.json
+++ b/helpers.json
@@ -67,7 +67,7 @@
           ]
         },
         {
-          "name": "h_canActivateBombTorizo",
+          "name": "h_activateBombTorizo",
           "requires": [ "Bombs" ],
           "devNote": [
             "In the vanilla game, Bomb Torizo is activated by having collected Bombs.",
@@ -76,7 +76,7 @@
           ]
         },
         {
-          "name": "h_canActivateAcidChozo",
+          "name": "h_activateAcidChozo",
           "requires": [ "SpaceJump" ],
           "devNote": "In Vanilla, the Acid Chozo Statue requires Space Jump to activate. This may be unintuitive in a randomizer, as many players will have never been there without Space Jump."
         },
@@ -149,10 +149,10 @@
           "name": "h_useMissileRefillAllAmmoCrystalFlash",
           "requires": [
             "h_MissileRefillStationAllAmmo",
-            "h_can10PowerBombCrystalFlash",
+            "h_10PowerBombCrystalFlash",
             {"refill": ["Missile", "Super", "PowerBomb"]}
           ],
-          "devNote": "A partial refill of 1500 Energy is also included in h_can10PowerBombCrystalFlash."
+          "devNote": "A partial refill of 1500 Energy is also included in h_10PowerBombCrystalFlash."
         },
         {
           "name": "h_useEnergyRefillStation",
@@ -466,7 +466,7 @@
       "description": "Standard helpers used to simplify the game logic.",
       "helpers": [
         {
-          "name": "h_canNavigateHeatRooms",
+          "name": "h_navigateHeatRooms",
           "requires": [
             {"or":[
               "h_heatProof",
@@ -478,7 +478,7 @@
           ]
         },
         {
-          "name": "h_canNavigateUnderwater",
+          "name": "h_navigateUnderwater",
           "requires": [
             {"or":[
               "Gravity",
@@ -487,21 +487,21 @@
           ]
         },
         {
-          "name": "h_canUseMorphBombs",
+          "name": "h_useMorphBombs",
           "requires": [
             "Morph",
             "Bombs"
           ]
         },
         {
-          "name": "h_canUsePowerBombs",
+          "name": "h_usePowerBombs",
           "requires": [
             "Morph",
             {"ammo": {"type": "PowerBomb", "count": 1}}
           ]
         },
         {
-          "name": "h_canBombThings",
+          "name": "h_bombThings",
           "requires": [
             "Morph",
             {"or": [
@@ -511,10 +511,10 @@
           ]
         },
         {
-          "name": "h_canDestroyBombWalls",
+          "name": "h_destroyBombWalls",
           "requires": [
             {"or": [
-              "h_canBombThings",
+              "h_bombThings",
               "ScrewAttack"
             ]}
           ]
@@ -529,7 +529,7 @@
           ]
         },
         {
-          "name": "h_canUseSpringBall",
+          "name": "h_useSpringBall",
           "requires": [
             "SpringBall",
             "Morph"
@@ -548,7 +548,7 @@
           ]
         },
         {
-          "name": "h_canShineChargeMaxRunway",
+          "name": "h_shineChargeMaxRunway",
           "requires": [ 
             {"canShineCharge": {
               "usedTiles": 45,
@@ -602,12 +602,12 @@
           ]
         },
         {
-          "name": "h_canGateGlitch",
+          "name": "h_gateGlitch",
           "requires": [
             "canGateGlitch",
             {"or": [
               {"noFlashSuit": {}},
-              "h_canUseSpringBall",
+              "h_useSpringBall",
               {"and": [
                 "Morph",
                 "canInsaneJump",
@@ -617,9 +617,9 @@
           ]
         },
         {
-          "name": "h_canBlueGateGlitch",
+          "name": "h_blueGateGlitch",
           "requires": [
-            "h_canGateGlitch",
+            "h_gateGlitch",
             {"or": [
               {"ammo": {"type": "Missile", "count": 1}},
               {"ammo": {"type": "Super", "count": 1}}
@@ -628,19 +628,19 @@
           ]
         },
         {
-          "name": "h_canGreenGateGlitch",
+          "name": "h_greenGateGlitch",
           "requires": [
-            "h_canGateGlitch",
+            "h_gateGlitch",
             {"ammo": {"type": "Super", "count": 1}},
             "h_GreenGateGlitchLeniency"
           ]
         },
         {
-          "name": "h_canHeatedBlueGateGlitch",
+          "name": "h_heatedBlueGateGlitch",
           "requires": [ 
-            "h_canNavigateHeatRooms",
+            "h_navigateHeatRooms",
             {"heatFrames": 100},
-            "h_canGateGlitch",
+            "h_gateGlitch",
             {"or": [
               {"ammo": {"type": "Missile", "count": 1}},
               {"ammo": {"type": "Super", "count": 1}}
@@ -649,17 +649,17 @@
           ]
         },
         {
-          "name": "h_canHeatedGreenGateGlitch",
+          "name": "h_heatedGreenGateGlitch",
           "requires": [ 
-            "h_canNavigateHeatRooms",
+            "h_navigateHeatRooms",
             {"heatFrames": 100},
-            "h_canGateGlitch",
+            "h_gateGlitch",
             {"ammo": {"type": "Super", "count": 1}},
             "h_HeatedGreenGateGlitchLeniency"
           ]
         },
         {
-          "name": "h_canCrouchJumpDownGrab",
+          "name": "h_crouchJumpDownGrab",
           "requires": [ 
             "canCrouchJump",
             "canDownGrab"
@@ -684,14 +684,14 @@
           ]
         },
         {
-          "name": "h_canPlasmaHitbox",
+          "name": "h_plasmaHitbox",
           "requires": [
             "Plasma",
             "canHitbox"
           ]
         },
         {
-          "name": "h_canThreeTileJumpMorph",
+          "name": "h_threeTileJumpMorph",
           "requires": [
             {"or": [
               "can3HighWallMidAirMorph",
@@ -700,16 +700,16 @@
           ]
         },
         {
-          "name": "h_canFourTileJumpMorph",
+          "name": "h_fourTileJumpMorph",
           "requires": [
             {"or": [
-              "h_canThreeTileJumpMorph",
+              "h_threeTileJumpMorph",
               "can4HighMidAirMorph"
             ]}
           ]
         },
         {
-          "name": "h_canOpenZebetites",
+          "name": "h_openZebetites",
           "requires": [
             {"or": [
               {"ammo": {"type": "Missile", "count": 12}},
@@ -732,7 +732,7 @@
           "devNote": "Technically all of the strats that use missiles can be done with 1 fewer missile. It requires fairly precise timing and dodging to open it fast enough."
         },
         {
-          "name": "h_canPartiallyBreakMotherBrainGlass",
+          "name": "h_partiallyBreakMotherBrainGlass",
           "requires": [
             {"or": [
               {"ammo": {"type": "Missile", "count": 1}},
@@ -746,7 +746,7 @@
           "devNote": "It requires 6 shots of either ammo type to partially open the glass and 18 to fully break it."
         },
         {
-          "name": "h_canBreakOneDraygonTurret",
+          "name": "h_breakOneDraygonTurret",
           "requires" : [
             {"or":[
               {"ammo": {"type": "Missile", "count": 3}},
@@ -755,29 +755,29 @@
           ]
         },
         {
-          "name": "h_canBreakThreeDraygonTurrets",
+          "name": "h_breakThreeDraygonTurrets",
           "requires" : [
-            "h_canBreakOneDraygonTurret",
-            "h_canBreakOneDraygonTurret",
-            "h_canBreakOneDraygonTurret"
+            "h_breakOneDraygonTurret",
+            "h_breakOneDraygonTurret",
+            "h_breakOneDraygonTurret"
           ]
         },
         {
-          "name": "h_canDoubleSpringBallJumpWithHiJump",
+          "name": "h_doubleSpringBallJumpWithHiJump",
           "requires": [
             "HiJump",
             "canDoubleSpringBallJumpMidAir"
           ]
         },
         {
-          "name": "h_canCrystalFlash",
+          "name": "h_crystalFlash",
           "requires": [
             "canCrystalFlash",
             {"partialRefill": {"type": "Energy", "limit": 1500}}
           ]
         },
         {
-          "name": "h_canAcidCrystalFlash",
+          "name": "h_acidCrystalFlash",
           "requires": [
             {"acidFrames": 185},
             "canHeatedCrystalFlash",
@@ -793,7 +793,7 @@
           ]
         },
         {
-          "name": "h_canHeatedCrystalFlash",
+          "name": "h_heatedCrystalFlash",
           "requires": [
             {"heatFrames": 185},
             {"or": [
@@ -811,7 +811,7 @@
           ]
         },
         {
-          "name": "h_canHeatedLavaCrystalFlash",
+          "name": "h_heatedLavaCrystalFlash",
           "requires": [
             {"heatFrames": 185},
             {"lavaFrames": 185},
@@ -839,7 +839,7 @@
           ]
         },
         {
-          "name": "h_canHeatedAcidCrystalFlash",
+          "name": "h_heatedAcidCrystalFlash",
           "requires": [
             {"heatFrames": 185},
             {"acidFrames": 185},
@@ -860,39 +860,39 @@
           ]
         },
         {
-          "name": "h_canBombIntoCrystalFlashClip",
+          "name": "h_bombIntoCrystalFlashClip",
           "requires": [
             {"tech": "canBombIntoCrystalFlashClip"},
             "Bombs",
-            "h_canCrystalFlash",
+            "h_crystalFlash",
             "h_BombIntoCrystalFlashClipLeniency"
           ]
         },
         {
-          "name": "h_canJumpIntoCrystalFlashClip",
+          "name": "h_jumpIntoCrystalFlashClip",
           "requires": [
             {"tech": "canJumpIntoCrystalFlashClip"},
             {"or": [
               "SpringBall",
               "canMidAirMorph"
             ]},
-            "h_canCrystalFlash",
+            "h_crystalFlash",
             "h_JumpIntoCrystalFlashClipLeniency"
           ]
         },
         {
-          "name": "h_can10PowerBombCrystalFlash",
+          "name": "h_10PowerBombCrystalFlash",
           "requires": [
             "can10PowerBombCrystalFlash",
             {"partialRefill": {"type": "Energy", "limit": 1500}}
           ]
         },
         {
-          "name": "h_canElevatorCrystalFlash",
+          "name": "h_elevatorCrystalFlash",
           "requires": [
             "canElevatorCrystalFlash",
             "h_ElevatorCrystalFlashLeniency",
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"resourceAtMost": [
               {"type": "RegularEnergy", "count": 50},
               {"type": "ReserveEnergy", "count": 0}
@@ -905,7 +905,7 @@
           ]
         },
         {
-          "name": "h_canHeated10PowerBombCrystalFlash",
+          "name": "h_heated10PowerBombCrystalFlash",
           "requires": [
             "can10PowerBombCrystalFlash",
             {"or": [
@@ -939,38 +939,38 @@
           ]
         },
         {
-          "name": "h_canXRayMorphIceClip",
+          "name": "h_XRayMorphIceClip",
           "requires": [
             "canXRayCeilingClip",
             "canTrickyUseFrozenEnemies"
           ]
         },
         {
-          "name": "h_canPreciseIceClip",
+          "name": "h_preciseIceClip",
           "requires": [
             "canTrickyUseFrozenEnemies",
             "canPreciseCeilingClip"
           ]
         },
         {
-          "name": "h_canHighPixelIceClip",
+          "name": "h_highPixelIceClip",
           "requires": [
             "canTrickyUseFrozenEnemies",
             "canHighPixelCeilingClip"
           ]
         },
         {
-          "name": "h_canIceClip",
+          "name": "h_iceClip",
           "requires": [
             {"or":[
-              "h_canXRayMorphIceClip",
-              "h_canPreciseIceClip",
-              "h_canHighPixelIceClip"
+              "h_XRayMorphIceClip",
+              "h_preciseIceClip",
+              "h_highPixelIceClip"
             ]}
           ]
         },
         {
-          "name": "h_canMaxHeightSpringBallJump",
+          "name": "h_maxHeightSpringBallJump",
           "requires": [
             "canCrouchJump",
             "canTrickySpringBallJump",
@@ -978,7 +978,7 @@
           ]
         },
         {
-          "name": "h_canTrickySpringwall",
+          "name": "h_trickySpringwall",
           "requires": [
             "canTrickySpringBallJump",
             "canSpringwall",
@@ -987,7 +987,7 @@
           ]
         },
         {
-          "name": "h_canBackIntoCorner",
+          "name": "h_backIntoCorner",
           "requires": [
             {"or": [
               "canMorphTurnaround",
@@ -1017,21 +1017,21 @@
           ]
         },
         {
-          "name": "h_canFrozenEnemyRunway",
+          "name": "h_frozenEnemyRunway",
           "requires": [
             "canEnemyExtendRunway",
             "canTrickyUseFrozenEnemies"
           ]
         },
         {
-          "name": "h_canTrickyFrozenEnemyRunway",
+          "name": "h_trickyFrozenEnemyRunway",
           "requires": [
             "canTrickyEnemyExtendRunway",
             "canTrickyUseFrozenEnemies"
           ]
         },
         {
-          "name": "h_canMidAirShootUp",
+          "name": "h_midAirShootUp",
           "requires": [
             {"or": [
               {"noFlashSuit": {}},
@@ -1071,7 +1071,7 @@
       "description": "Ammo requirements needed to unlock different door types.",
       "helpers": [
         {
-          "name": "h_canOpenRedDoors",
+          "name": "h_openRedDoors",
           "requires": [
             {"or": [
               {"ammo": {"type": "Missile", "count": 5}},
@@ -1080,15 +1080,15 @@
           ]
         },
         {
-          "name": "h_canOpenGreenDoors",
+          "name": "h_openGreenDoors",
           "requires": [ {"ammo": {"type": "Super", "count": 1}} ]
         },
         {
-          "name": "h_canOpenYellowDoors",
-          "requires": [ "h_canUsePowerBombs" ]
+          "name": "h_openYellowDoors",
+          "requires": [ "h_usePowerBombs" ]
         },
         {
-          "name": "h_canOpenEyeDoors",
+          "name": "h_openEyeDoors",
           "requires": [
             {"or": [
               {"ammo": {"type": "Missile", "count": 3}},   

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -620,7 +620,7 @@ A `gainFlashSuit` object has no properties.
 
 With certain exceptions explained below, a flash suit can generally be carried around by any sequence of strats until it is used. A flash suit use is indicated by a `useFlashSuit` logical requirement. 
 
-The need to perform actions that cannot preserve a flash suit are indicated by a `noFlashSuit` logical requirement; typically this is expressed indirectly through tech or helpers, such as `canCrouchJump`, `canXRayStandup`, `canCrystalFlash`, or `h_canMidAirShootUp`. A `canShineCharge` logical requirement also cannot preserve a flash suit.
+The need to perform actions that cannot preserve a flash suit are indicated by a `noFlashSuit` logical requirement; typically this is expressed indirectly through tech or helpers, such as `canCrouchJump`, `canXRayStandup`, `canCrystalFlash`, or `h_midAirShootUp`. A `canShineCharge` logical requirement also cannot preserve a flash suit.
 
 The process of verifying which strats allow preserving a flash suit is not yet complete. Strats which have been checked are indicated by a property `"flashSuitChecked": true`. Any strat without this property should be assumed to be logically unusable for carrying a flash suit. Note that a strat with `"flashSuitChecked": true` may or may not be able to preserve a flash suit, depending on its logical requirements.
 

--- a/region/brinstar/blue/Billy Mays Room.json
+++ b/region/brinstar/blue/Billy Mays Room.json
@@ -86,7 +86,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -145,7 +145,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -442,7 +442,7 @@
         "canTrickyJump",
         {"or": [
           {"spikeHits": 1},
-          "h_canBackIntoCorner"
+          "h_backIntoCorner"
         ]}
       ],
       "note": "It's not necessary to jump through the door, the in-room doorsill gives enough running room to make it up."
@@ -752,7 +752,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -216,7 +216,7 @@
       "name": "Leave With Runway - Frozen Reo",
       "requires": [
         "h_ZebesIsAwake",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"enemyDamage": {"enemy": "Reo", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -536,7 +536,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true
@@ -800,7 +800,7 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]},
         {"or": [
@@ -822,10 +822,10 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
         {"shinespark": {"frames": 43}}
       ],
@@ -854,7 +854,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -866,7 +866,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -910,7 +910,7 @@
       "name": "Broken Power Bomb Blocks",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]}
       ],
@@ -950,7 +950,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]},
         {"or": [
@@ -960,7 +960,7 @@
         ]},
         {"or": [
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             "canTrivialMidAirMorph"
           ]},
           "ScrewAttack"
@@ -976,10 +976,10 @@
       "name": "Power Bomb and Bombs",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "SpaceJump",
           "canLongIBJ",
@@ -999,7 +999,7 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"and": [
             {"obstaclesCleared": ["B"]},
             "Morph"
@@ -1010,7 +1010,7 @@
           {"obstaclesCleared": ["A"]},
           "ScrewAttack",
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             "canMidAirMorph"
           ]}
         ]},
@@ -1031,14 +1031,14 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"and": [
             {"obstaclesCleared": ["B"]},
             "Morph"
           ]},
           {"obstaclesCleared": ["C"]}
         ]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canTrivialMidAirMorph",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
@@ -1059,7 +1059,7 @@
       "name": "Shinespark",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
@@ -1075,7 +1075,7 @@
       "name": "Wall Jump Spark",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
@@ -1098,7 +1098,7 @@
       "requires": [
         {"notable": "Fast Wall Jump Spark"},
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
@@ -1120,7 +1120,7 @@
       "requires": [
         {"notable": "Fast Wall Jump Spark"},
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -135,7 +135,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/blue/First Missile Room.json
+++ b/region/brinstar/blue/First Missile Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -369,7 +369,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["C"]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -456,7 +456,7 @@
         {"or": [
           "Plasma",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
               "canTrickyDodgeEnemies",
               {"enemyKill": {
@@ -609,7 +609,7 @@
           "Plasma",
           "ScrewAttack",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"enemyKill": {
               "enemies": [["Sidehopper"]],
               "explicitWeapons": ["Missile", "Super", "PowerBomb"]
@@ -792,7 +792,7 @@
       "link": [1, 5],
       "name": "Bomb the Blocks",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         {"obstaclesCleared": ["C"]}
       ],
       "clearsObstacles": ["A"]
@@ -810,7 +810,7 @@
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Sidehopper", "type": "contact", "hits": 1}}
         ]},
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -858,7 +858,7 @@
         "canPrepareForNextRoom",
         "canTrickyDodgeEnemies",
         "canCameraManip",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -882,7 +882,7 @@
         "canPrepareForNextRoom",
         "canTrickyDodgeEnemies",
         "canCameraManip",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "clearsObstacles": ["A"],
       "note": [
@@ -1221,7 +1221,7 @@
       "link": [4, 2],
       "name": "Crouch Jump Down Grab",
       "requires": [
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ]
     },
     {
@@ -1229,7 +1229,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -1240,7 +1240,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -1281,7 +1281,7 @@
         {"or": [
           "Wave",
           "canDodgeWhileShooting",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "ScrewAttack"
         ]},
         {"obstaclesCleared": ["A"]}
@@ -1296,7 +1296,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -1307,7 +1307,7 @@
       "link": [5, 5],
       "name": "Bomb the Blocks",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "clearsObstacles": ["A"]
     },

--- a/region/brinstar/green/Brinstar Map Room.json
+++ b/region/brinstar/green/Brinstar Map Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -40,7 +40,7 @@
               "requires": [
                 "Morph",
                 {"or": [
-                  "h_canBombThings",
+                  "h_bombThings",
                   {"obstaclesCleared": ["A"]},
                   {"and": [
                     "canSlowShortCharge",
@@ -132,7 +132,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -164,7 +164,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -214,7 +214,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -254,7 +254,7 @@
       "link": [2, 1],
       "name": "Speedball (In-Room) Extended Runway With Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "canSlowShortCharge",
         {"getBlueSpeed": {"usedTiles": 15, "openEnd": 1}},
         "canSpeedball"
@@ -445,7 +445,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -114,7 +114,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -183,7 +183,7 @@
         "canTrickyJump",
         {"or": [
           "canTemporaryBlue",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ],
       "collectsItems": [3],
@@ -208,7 +208,7 @@
         "canTrickyJump",
         {"or": [
           "canTemporaryBlue",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ],
       "collectsItems": [3],
@@ -341,7 +341,7 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -156,7 +156,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zeb",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "Morph",
           "canTwoTileSqueeze",
@@ -246,7 +246,7 @@
       "name": "Leave With Spark To The Left",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"canShineCharge": {"usedTiles": 17, "openEnd": 0}},
         "canShinechargeMovementTricky",
         "canQuickDrop",
@@ -394,7 +394,7 @@
               "SpaceJump",
               "canIBJ",
               "canSpringBallJumpMidAir",
-              "h_canCrouchJumpDownGrab"
+              "h_crouchJumpDownGrab"
             ]},
             {"resetRoom": {
               "nodes": [1]
@@ -410,7 +410,7 @@
       "name": "Leave With Runway - Frozen Zeb",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "canMockball",
         "canTrickyJump"
       ],
@@ -431,7 +431,7 @@
               "SpaceJump",
               "canIBJ",
               "canSpringBallJumpMidAir",
-              "h_canCrouchJumpDownGrab"
+              "h_crouchJumpDownGrab"
             ]},
             {"resetRoom": {
               "nodes": [1]
@@ -716,7 +716,7 @@
           "SpaceJump",
           "canIBJ",
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"canShineCharge": {"usedTiles": 25, "openEnd": 1}},
         "canShinechargeMovement",
@@ -807,7 +807,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -831,7 +831,7 @@
       "link": [2, 4],
       "name": "Crouch Jump Down Grab",
       "requires": [
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -852,7 +852,7 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "flashSuitChecked": true
     },
@@ -881,7 +881,7 @@
       "name": "Ice Clip",
       "requires": [
         {"obstaclesCleared": ["B"]},
-        "h_canXRayMorphIceClip"
+        "h_XRayMorphIceClip"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -480,7 +480,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -509,7 +509,7 @@
           "types": ["powerbomb"],
           "requires": [
             {"or": [
-              "h_canUseSpringBall",
+              "h_useSpringBall",
               {"and": [
                 "canTrickyJump",
                 {"or": [
@@ -544,7 +544,7 @@
           "types": ["powerbomb"],
           "requires": [
             {"or": [
-              "h_canUseSpringBall",
+              "h_useSpringBall",
               {"and": [
                 "canTrickyJump",
                 {"or": [
@@ -759,13 +759,13 @@
       "requires": [
         {"notable": "Beetom Clip"},
         {"or": [
-          "h_canXRayMorphIceClip",
-          "h_canPreciseIceClip"
+          "h_XRayMorphIceClip",
+          "h_preciseIceClip"
         ]},
         "Morph",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
         {"or": [
-          "h_canPreciseIceClip",
+          "h_preciseIceClip",
           "canWalljump",
           "HiJump",
           "SpaceJump",
@@ -795,7 +795,7 @@
       "name": "Beetom Clip (High Pixel, Preserve Flash Suit)",
       "requires": [
         {"notable": "Beetom Clip (High Pixel, Preserve Flash Suit)"},
-        "h_canHighPixelIceClip",
+        "h_highPixelIceClip",
         "Morph",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
         {"or": [
@@ -846,7 +846,7 @@
       "name": "Leave With Runway - Frozen Beetom",
       "requires": [
         "Morph",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
       ],
       "exitCondition": {

--- a/region/brinstar/green/Etecoon Save Room.json
+++ b/region/brinstar/green/Etecoon Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Etecoon Super Room.json
+++ b/region/brinstar/green/Etecoon Super Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -103,7 +103,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Single Frozen Beetom",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -122,7 +122,7 @@
       "requires": [
         {"notable": "Frozen Beetom Bridge"},
         "canTrickyJump",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
       ],
       "exitCondition": {
@@ -185,7 +185,7 @@
           "ScrewAttack",
           {"and": [
             "Ice",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]}
         ]},
         {"refill": ["PowerBomb"]}
@@ -286,7 +286,7 @@
           {"obstaclesCleared": ["A"]},
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
         ]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -302,7 +302,7 @@
           {"obstaclesCleared": ["A"]},
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
         ]},
-        "h_can10PowerBombCrystalFlash"
+        "h_10PowerBombCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -852,7 +852,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Single Frozen Beetom",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -871,7 +871,7 @@
       "requires": [
         {"notable": "Frozen Beetom Bridge"},
         "canTrickyJump",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
       ],
       "exitCondition": {

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -86,7 +86,7 @@
         "h_XModeThornHit",
         "h_XModeThornHit",
         "h_XModeThornHit",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 130}
       ],
@@ -182,7 +182,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Green Brinstar Main Shaft Save Room.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -661,7 +661,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "canBePatient",
           {"ammo": {"type": "Super", "count": 1}}
@@ -1143,7 +1143,7 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -2008,7 +2008,7 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "canBePatient",
           {"ammo": {"type": "Super", "count": 1}}
@@ -2615,7 +2615,7 @@
       "link": [5, 5],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "canBeVeryPatient",
           {"ammo": {"type": "Super", "count": 1}}
@@ -3325,7 +3325,7 @@
       "link": [6, 6],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "canBePatient"
       ],
       "exitCondition": {
@@ -3667,7 +3667,7 @@
       "link": [7, 7],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -4051,7 +4051,7 @@
       "link": [8, 8],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "canBePatient"
       ],
       "exitCondition": {
@@ -4235,7 +4235,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4401,7 +4401,7 @@
       "requires": [
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "canTrivialMidAirMorph",
             {"or": [
@@ -4501,7 +4501,7 @@
       "link": [10, 10],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4554,7 +4554,7 @@
       },
       "requires": [
         "canXRayClimb",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -4852,7 +4852,7 @@
       "link": [12, 12],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4862,7 +4862,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -4934,7 +4934,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -4946,7 +4946,7 @@
       "link": [13, 12],
       "name": "Ice Clip",
       "requires": [
-        "h_canIceClip"
+        "h_iceClip"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -4959,7 +4959,7 @@
       "link": [13, 13],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -4970,20 +4970,20 @@
       "name": "Bottom Ice Clip",
       "requires": [
         {"notable": "Bottom Ice Clip"},
-        "h_canBombThings",
+        "h_bombThings",
         "h_additionalBomb",
         {"enemyDamage": {"enemy": "Zeela", "type": "contact", "hits": 1}},
         "canTrickyJump",
         {"or": [
-          "h_canXRayMorphIceClip",
+          "h_XRayMorphIceClip",
           {"and": [
-            "h_canHighPixelIceClip",
+            "h_highPixelIceClip",
             "canInsaneJump",
             "canBeVeryPatient"
           ]}
         ]},
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "can4HighMidAirMorph",
             "canInsaneJump"
@@ -5070,7 +5070,7 @@
       "link": [14, 13],
       "name": "Base",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         "h_additionalBomb"
       ],
       "flashSuitChecked": true

--- a/region/brinstar/green/Green Brinstar Missile Refill.json
+++ b/region/brinstar/green/Green Brinstar Missile Refill.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -978,7 +978,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1047,7 +1047,7 @@
       "link": [3, 1],
       "name": "Gate Glitch",
       "requires": [
-        "h_canBlueGateGlitch"
+        "h_blueGateGlitch"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -1352,7 +1352,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -93,7 +93,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "canBeVeryPatient"
       ],
       "exitCondition": {
@@ -127,7 +127,7 @@
       "link": [1, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 30}
       ],
@@ -207,7 +207,7 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -231,7 +231,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -341,7 +341,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "canBePatient"
       ],
       "exitCondition": {
@@ -378,7 +378,7 @@
       "link": [2, 2],
       "name": "Leave Shinecharged (Bridge Runway)",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 130}
       ],

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -213,7 +213,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -257,7 +257,7 @@
       "requires": [
         {"notable": "Ice Clip Door Lock Skip Without Morph and X-Ray"},
         "canTrickyGMode",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"or": [
           "Morph",
           "canInsaneJump",
@@ -290,7 +290,7 @@
       "link": [2, 2],
       "name": "Kihunter Ice Clip Door Lock Skip",
       "requires": [
-        "h_canXRayMorphIceClip"
+        "h_XRayMorphIceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -305,7 +305,7 @@
       "name": "Ice Clip Door Lock Skip Without Morph and X-Ray",
       "requires": [
         {"notable": "Ice Clip Door Lock Skip Without Morph and X-Ray"},
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -443,7 +443,7 @@
       "requires": [
         {"notable": "Ice Clip Door Lock Skip Without Morph and X-Ray"},
         "canTrickyGMode",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"or": [
           "Morph",
           "canInsaneJump",

--- a/region/brinstar/green/Spore Spawn Room.json
+++ b/region/brinstar/green/Spore Spawn Room.json
@@ -86,7 +86,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -201,7 +201,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -164,7 +164,7 @@
       "link": [1, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"obstaclesCleared": ["A"]},
         {"shineChargeFrames": 40}
@@ -254,7 +254,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -267,7 +267,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -659,7 +659,7 @@
       "link": [2, 2],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"obstaclesCleared": ["A"]},
         {"shineChargeFrames": 45}
@@ -749,7 +749,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -762,7 +762,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -772,7 +772,7 @@
       "name": "Gain Flash Suit (Spikesuit)",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"thornHits": 1},
         "canSpikeSuit",
         {"or": [

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -120,7 +120,7 @@
             {"thornHits": 2}
           ]}
         ]},
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -594,7 +594,7 @@
       "name": "Leave With Runway - Frozen Zeb",
       "requires": [
         "canTrickyJump",
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -884,7 +884,7 @@
             {"thornHits": 2}
           ]}
         ]},
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -152,7 +152,7 @@
             "canDodgeWhileShooting",
             {"or": [
               "canCarefulJump",
-              "h_canCrouchJumpDownGrab"
+              "h_crouchJumpDownGrab"
             ]}
           ]}
         ]}
@@ -175,7 +175,7 @@
             "canDodgeWhileShooting",
             {"or": [
               "canCarefulJump",
-              "h_canCrouchJumpDownGrab"
+              "h_crouchJumpDownGrab"
             ]}
           ]}
         ]}
@@ -217,7 +217,7 @@
             "canDodgeWhileShooting",
             {"or": [
               "canCarefulJump",
-              "h_canCrouchJumpDownGrab"
+              "h_crouchJumpDownGrab"
             ]}
           ]}
         ]}
@@ -336,7 +336,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -628,7 +628,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/brinstar/kraid/Kraid Save Room.json
+++ b/region/brinstar/kraid/Kraid Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Varia Suit Room.json
+++ b/region/brinstar/kraid/Varia Suit Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -99,7 +99,7 @@
               {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
             ]},
             {"or": [
-              "h_canUseMorphBombs",
+              "h_useMorphBombs",
               {"and": [
                 "Morph",
                 {"resourceAvailable": [{"type": "Energy", "count": 50}]},
@@ -139,7 +139,7 @@
       "name": "Leave With Runway - Single Frozen Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -158,7 +158,7 @@
         {"notable": "Frozen Beetom Runway"},
         {"obstaclesNotCleared": ["A"]},
         "canTrickyJump",
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 6}}
       ],
       "exitCondition": {
@@ -317,7 +317,7 @@
           "canPrepareForNextRoom",
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
         ]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -333,7 +333,7 @@
         {"resetRoom": {
           "nodes": [1]
         }},
-        "h_can10PowerBombCrystalFlash"
+        "h_10PowerBombCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -136,7 +136,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -146,7 +146,7 @@
       "name": "Super Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"ammo": {"type": "Super", "count": 3}},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canMoondance"
       ],
       "exitCondition": {
@@ -170,7 +170,7 @@
       "name": "Super Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"ammo": {"type": "Super", "count": 3}},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canExtendedMoondance"
       ],
       "exitCondition": {
@@ -390,7 +390,7 @@
       "link": [2, 2],
       "name": "Elevator Crystal Flash for Flash Suit",
       "requires": [
-        "h_canElevatorCrystalFlash"
+        "h_elevatorCrystalFlash"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -609,7 +609,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -716,7 +716,7 @@
           "canSpringBallJumpMidAir",
           {"and": [
             "canMockball",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]}
         ]}
       ],
@@ -740,7 +740,7 @@
       "name": "Arm Pump Jump",
       "requires": [
         {"notable": "Arm Pump Jump"},
-        "h_canBackIntoCorner",
+        "h_backIntoCorner",
         "canInsaneJump",
         "canDownGrab"
       ],

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -253,7 +253,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["C"]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -373,7 +373,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -397,7 +397,7 @@
       "link": [2, 5],
       "name": "Crouch Jump Down Grab",
       "requires": [
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ],
       "clearsObstacles": ["C", "D"],
       "note": [
@@ -481,7 +481,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -501,7 +501,7 @@
       "link": [3, 5],
       "name": "Bomb the Block",
       "requires": [
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "clearsObstacles": ["B", "C"],
       "note": "The Kihunters can be killed by retreating to the morph tunnel if needed."
@@ -511,7 +511,7 @@
       "link": [3, 5],
       "name": "Power Bomb the Block",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": [
@@ -741,7 +741,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -752,7 +752,7 @@
       "link": [5, 3],
       "name": "Power Bomb the Block",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": "Placing the Power Bomb against the right wall will not break the shot blocks going down."
@@ -833,7 +833,7 @@
       "requires": [
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canIBJ"
         ]},
         {"obstaclesCleared": ["A"]}
@@ -844,10 +844,10 @@
       "link": [5, 4],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canIBJ"
         ]}
       ],

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -143,7 +143,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -403,7 +403,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings"
+          "h_bombThings"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -516,7 +516,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings"
+          "h_bombThings"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -580,7 +580,7 @@
       "name": "Zeela Ice Clip Door Lock Skip",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canIceClip"
+        "h_iceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -595,7 +595,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Big Pink Save Room.json
+++ b/region/brinstar/pink/Big Pink Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -643,7 +643,7 @@
       "name": "G-Mode Setup - Get Hit By Zeb",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -687,7 +687,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1322,7 +1322,7 @@
           "canShinechargeMovementTricky",
           {"and": [
             "canShinechargeMovement",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]}
         ]},
         {"obstaclesCleared": ["C"]},
@@ -1358,7 +1358,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["B"]},
           {"and": [
             "Morph",
@@ -1431,7 +1431,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -1662,7 +1662,7 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": ["canInsaneJump"]},
         {"types": ["missiles"], "requires": ["never"]},
-        {"types": ["powerbomb"], "requires": ["h_canUseSpringBall"]}
+        {"types": ["powerbomb"], "requires": ["h_useSpringBall"]}
       ],
       "note": "Jump through the door and shoot it open as you enter, landing on the door frame to avoid falling through the crumbles."
     },
@@ -1696,7 +1696,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1760,7 +1760,7 @@
       "link": [6, 6],
       "name": "Leave With Runway - Frozen Zeb",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "Morph",
           "canTrickyEnemyExtendRunway"
@@ -2079,7 +2079,7 @@
         "Morph",
         {"or": [
           {"and": [
-            "h_canBombThings",
+            "h_bombThings",
             {"ammo": {"type": "Super", "count": 1}}
           ]},
           {"obstaclesCleared": ["F"]}
@@ -2291,8 +2291,8 @@
       "requires": [
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ]
     },
@@ -2550,7 +2550,7 @@
         }
       },
       "requires": [
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canMidAirMorph"
       ],
       "exitCondition": {
@@ -2633,7 +2633,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["E"]}
         ]}
       ],
@@ -2645,7 +2645,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -2664,8 +2664,8 @@
       "requires": [
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ]
     },
@@ -2676,7 +2676,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["D"]}
         ]}
       ],
@@ -2707,7 +2707,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["E"]}
         ]}
       ],
@@ -2720,7 +2720,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["D"]}
         ]}
       ],
@@ -2751,7 +2751,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -2955,10 +2955,10 @@
         "canWallIceClip",
         "Wave",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "canMidAirMorph",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]}
         ]}
       ],
@@ -2978,7 +2978,7 @@
         {"notable": "Wall Ice Clip X-Ray Climb"},
         "canWallIceClip",
         {"or": [
-          "h_canCrystalFlash",
+          "h_crystalFlash",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {"enemy": "Reo", "type": "contact", "hits": 1}}
@@ -3030,7 +3030,7 @@
         {"notable": "Wall Ice Clip X-Ray Climb"},
         "canWallIceClip",
         {"or": [
-          "h_canCrystalFlash",
+          "h_crystalFlash",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {"enemy": "Reo", "type": "contact", "hits": 1}}
@@ -3080,8 +3080,8 @@
       "name": "Reo Ice Clip With Morph and X-Ray",
       "requires": [
         {"notable": "Reo Ice Clip With Morph and X-Ray"},
-        "h_canPreciseIceClip",
-        "h_canXRayMorphIceClip"
+        "h_preciseIceClip",
+        "h_XRayMorphIceClip"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -3103,7 +3103,7 @@
       "name": "Reo Ice Clip Without Morph and X-Ray",
       "requires": [
         {"notable": "Reo Ice Clip Without Morph and X-Ray"},
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -3130,7 +3130,7 @@
           "Wave",
           "Spazer"
         ]},
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -3157,7 +3157,7 @@
           "Spazer"
         ]},
         "canInsaneJump",
-        "h_canHighPixelIceClip"
+        "h_highPixelIceClip"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -3174,7 +3174,7 @@
       "link": [13, 5],
       "name": "G-Mode Setup - Get Hit By Reo",
       "requires": [
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"notable": "Reo Ice Clip Without Morph and X-Ray"}
       ],
       "exitCondition": {
@@ -3211,7 +3211,7 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canIBJ",
           {"and": [
             "Morph",
@@ -3233,7 +3233,7 @@
       "requires": [
         {"notable": "Off Screen Super Block"},
         "canOffScreenSuperShot",
-        "h_canBombThings",
+        "h_bombThings",
         "canCameraManip"
       ],
       "clearsObstacles": ["F"],
@@ -3249,8 +3249,8 @@
       "link": [13, 7],
       "name": "Crystal Flash Standup - Super Block",
       "requires": [
-        "h_canBombThings",
-        "h_canCrystalFlash",
+        "h_bombThings",
+        "h_crystalFlash",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "clearsObstacles": ["F"],

--- a/region/brinstar/pink/Dachora Energy Refill.json
+++ b/region/brinstar/pink/Dachora Energy Refill.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -149,7 +149,7 @@
       "name": "Blockade Leave with Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "canMoondance"
       ],
       "exitCondition": {
@@ -169,7 +169,7 @@
       "requires": [
         {"notable": "Blockade Extended Moondance"},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "canExtendedMoondance"
       ],
       "exitCondition": {
@@ -201,7 +201,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -233,7 +233,7 @@
       "requires": [
         {"notable": "Blockade Extended Moondance"},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "ScrewAttack",
         "canExtendedMoondance",
         "canDisableEquipment"
@@ -286,7 +286,7 @@
       "requires": [
         {"or": [
           "h_getBlueSpeedMaxRunway",
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -308,7 +308,7 @@
       "name": "Blockade Leave with Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "canMoondance",
         "h_getBlueSpeedMaxRunway"
       ],
@@ -332,7 +332,7 @@
       "requires": [
         {"notable": "Blockade Extended Moondance"},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "h_getBlueSpeedMaxRunway",
           {"and": [
@@ -580,7 +580,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -589,7 +589,7 @@
       "link": [2, 3],
       "name": "Spark from Floor",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 110, "excessFrames": 3}}
       ],
       "note": "Diagonal spark left to save health."
@@ -602,7 +602,7 @@
         "canShinechargeMovement",
         "HiJump",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 85, "excessFrames": 3}}
       ],
       "note": "Diagonal spark left to save health."
@@ -616,7 +616,7 @@
         "canFastWalljumpClimb",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 67, "excessFrames": 3}}
       ]
     },
@@ -629,7 +629,7 @@
         "canFastWalljumpClimb",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 73, "excessFrames": 3}}
       ],
       "note": "Quickly wall jump up the right wall and shinespark up to barely get above the speed blocks without any tanks.",
@@ -758,7 +758,7 @@
             "h_getBlueSpeedMaxRunway",
             "canCarefulJump"
           ]},
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1076,7 +1076,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1088,7 +1088,7 @@
       "requires": [
         {"or": [
           "h_getBlueSpeedMaxRunway",
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],

--- a/region/brinstar/pink/Hopper Energy Tank Room.json
+++ b/region/brinstar/pink/Hopper Energy Tank Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -344,7 +344,7 @@
         "canPrepareForNextRoom",
         {"tech": "canJumpIntoIBJ"},
         "canResetFallSpeed",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canHitbox",
         {"or": [
           "canPseudoScrew",
@@ -385,7 +385,7 @@
         {"obstaclesCleared": ["A"]},
         {"or": [
           "canTrickyJump",
-          "h_canBackIntoCorner"
+          "h_backIntoCorner"
         ]},
         "HiJump",
         "canOffScreenSuperShot"
@@ -432,7 +432,7 @@
         {"obstaclesCleared": ["A"]},
         {"or": [
           "canTrickyJump",
-          "h_canBackIntoCorner"
+          "h_backIntoCorner"
         ]},
         "canStationarySpinJump",
         "SpaceJump",
@@ -526,7 +526,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1151,7 +1151,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1191,7 +1191,7 @@
       "link": [2, 3],
       "name": "Ride the Elevator",
       "requires": [
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "clearsObstacles": ["B"],
       "note": "The elevator can be raised by hitting below the shot block with a Bomb."
@@ -1202,7 +1202,7 @@
       "name": "Elevator with Power Bombs or Wave",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "Wave"
         ]}
       ],
@@ -1769,7 +1769,7 @@
         "canTrickyJump",
         "canOffScreenSuperShot",
         {"or": [
-          "h_canBackIntoCorner",
+          "h_backIntoCorner",
           {"and": [
             {"enemyDamage": {"enemy": "Sidehopper", "type": "contact", "hits": 1}},
             "canNeutralDamageBoost"

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -193,7 +193,7 @@
       "name": "Leave Shinecharged (X-Mode)",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -306,7 +306,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -631,7 +631,7 @@
       "name": "Crystal Flash Clip",
       "requires": [
         {"notable": "Crystal Flash Clip"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canCeilingClip"
       ],
       "flashSuitChecked": true,
@@ -694,7 +694,7 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -237,7 +237,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -114,7 +114,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Caterpillar",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -153,7 +153,7 @@
       "name": "Leave Shinecharged (Gravity)",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 35}
       ],
@@ -272,7 +272,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -451,7 +451,7 @@
         {"or": [
           "canBombJumpWaterEscape",
           {"and": [
-            "h_canUseSpringBall",
+            "h_useSpringBall",
             "canJumpIntoIBJ"
           ]}
         ]}

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -97,7 +97,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"thornHits": 1},
         "h_SpikeSuitSamusEaterLeniency",
         "h_SpikeSuitThornHitLeniency",
@@ -125,7 +125,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 80}
       ],
       "exitCondition": {
@@ -144,7 +144,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canXRayCancelShinecharge",
         "canChainTemporaryBlue"
       ],
@@ -307,7 +307,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -341,7 +341,7 @@
           {"obstaclesCleared": ["A"]},
           {"and": [
             "canCarefulJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           "can4HighMidAirMorph",
           {"and": [
@@ -385,7 +385,7 @@
           }},
           {"and": [
             "canBePatient",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Boyon", "type": "contact", "hits": 16}},
@@ -581,7 +581,7 @@
           {"obstaclesCleared": ["A"]},
           {"and": [
             "canCarefulJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           "can4HighMidAirMorph",
           {"and": [
@@ -611,7 +611,7 @@
           }},
           {"and": [
             "canBePatient",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Boyon", "type": "contact", "hits": 16}},
@@ -644,7 +644,7 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["B"]
     },
@@ -669,7 +669,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["B"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["B"]

--- a/region/brinstar/red/Bat Room.json
+++ b/region/brinstar/red/Bat Room.json
@@ -219,7 +219,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -247,7 +247,7 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         {"or": [
           "HiJump",
           "SpaceJump",
@@ -294,7 +294,7 @@
       "link": [1, 3],
       "name": "Use Flash Suit",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 16, "excessFrames": 3}}
       ],
@@ -313,7 +313,7 @@
         {"shineChargeFrames": 10},
         "canShinechargeMovement",
         {"shinespark": {"frames": 24, "excessFrames": 2}},
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -327,7 +327,7 @@
         {"shineChargeFrames": 40},
         "canShinechargeMovementComplex",
         {"shinespark": {"frames": 16, "excessFrames": 3}},
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -339,7 +339,7 @@
       },
       "requires": [
         "canXRayClimb",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "flashSuitChecked": true,
       "note": "X-Ray climb up about 1 screen, then do a turn-around spin jump to reach the top ledge."
@@ -575,7 +575,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -622,7 +622,7 @@
         }
       },
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -630,7 +630,7 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -842,7 +842,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -357,7 +357,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -390,7 +390,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -479,11 +479,11 @@
         {"or": [
           {"and": [
             {"ammo": {"type": "Super", "count": 1}},
-            "h_canUseSpringBall",
+            "h_useSpringBall",
             {"thornHits": 4}
           ]},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"thornHits": 3},
             {"samusEaterFrames": 320}
           ]}
@@ -596,7 +596,7 @@
       "link": [2, 2],
       "name": "Break the Power Bomb Blocks",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["B"]
     }

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -266,7 +266,7 @@
       "name": "Leave With Runway - Frozen Caterpillar",
       "requires": [
         "canBeVeryPatient",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Morph"
       ],
       "exitCondition": {
@@ -335,7 +335,7 @@
         "canMidAirMorph",
         "canNeutralDamageBoost",
         "canTrickyJump",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"enemyDamage": {"enemy": "Zero", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -709,7 +709,7 @@
       "name": "Leave With Runway (Shot Blocks Broken) - Frozen Caterpillar",
       "requires": [
         "canBeVeryPatient",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Morph"
       ],
       "exitCondition": {
@@ -730,7 +730,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -779,7 +779,7 @@
         "canMidAirMorph",
         "canNeutralDamageBoost",
         "canTrickyJump",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"enemyDamage": {"enemy": "Zero", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -1223,7 +1223,7 @@
           "canSpringBallJumpMidAir",
           {"and": [
             "canTrickyDashJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]}
         ]}
       ],
@@ -1285,7 +1285,7 @@
               "canSpringBallJumpMidAir",
               {"and": [
                 "canTrickyDashJump",
-                "h_canCrouchJumpDownGrab"
+                "h_crouchJumpDownGrab"
               ]}
             ]}
           ]}
@@ -1428,7 +1428,7 @@
       "link": [4, 1],
       "name": "Crouch Jump Down Grab",
       "requires": [
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ]
     },
     {
@@ -1703,7 +1703,7 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Caterpillar",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -1769,7 +1769,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1828,7 +1828,7 @@
           "SpaceJump",
           "canIBJ",
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]}
       ],
       "exitCondition": {
@@ -1864,7 +1864,7 @@
               "SpaceJump",
               "canIBJ",
               "canSpringBallJumpMidAir",
-              "h_canCrouchJumpDownGrab"
+              "h_crouchJumpDownGrab"
             ]}
           ]}
         ]}
@@ -1957,7 +1957,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2000,7 +2000,7 @@
         "canMidAirMorph",
         "canNeutralDamageBoost",
         "canTrickyJump",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"enemyDamage": {"enemy": "Zero", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {

--- a/region/brinstar/red/Caterpillar Save Room.json
+++ b/region/brinstar/red/Caterpillar Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -107,7 +107,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -125,7 +125,7 @@
       "requires": [
         {"notable": "Frozen Zeb Runway"},
         "canTrickyJump",
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         {"thornHits": 2}
       ],
       "exitCondition": {
@@ -151,7 +151,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 100}
       ],
       "exitCondition": {
@@ -170,7 +170,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canXRayCancelShinecharge",
         "canChainTemporaryBlue"
       ],
@@ -409,7 +409,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"thornHits": 1},
         "canSpikeSuit",
         {"shinespark": {"frames": 6, "excessFrames": 6}}
@@ -434,7 +434,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Zeela",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -452,7 +452,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 110}
       ],
       "exitCondition": {
@@ -471,7 +471,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canXRayCancelShinecharge",
         "canLongChainTemporaryBlue"
       ],

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -177,7 +177,7 @@
           "SpaceJump",
           "h_XModeSpikeHit"
         ]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 50}}
       ],
       "exitCondition": {
@@ -195,7 +195,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -472,7 +472,7 @@
         "canMidairShinespark",
         "canXMode",
         {"spikeHits": 2},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 146, "excessFrames": 6}}
       ],
       "flashSuitChecked": true,
@@ -492,7 +492,7 @@
         "canMidairShinespark",
         "canXMode",
         {"spikeHits": 2},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 146}},
           {"and": [
@@ -732,7 +732,7 @@
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 140}
       ],
@@ -831,7 +831,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -878,9 +878,9 @@
       "name": "Tricky Springball Jump",
       "requires": [
         {"or": [
-          "h_canTrickySpringwall",
+          "h_trickySpringwall",
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             "canNeutralDamageBoost"
           ]}
         ]},
@@ -1063,7 +1063,7 @@
           ]},
           {"and": [
             "canTrickyDashJump",
-            "h_canBackIntoCorner",
+            "h_backIntoCorner",
             "canInsaneJump"
           ]},
           {"and": [
@@ -1105,7 +1105,7 @@
           {"and": [
             "canInsaneWalljump",
             "canInsaneJump",
-            "h_canBackIntoCorner"
+            "h_backIntoCorner"
           ]},
           {"and": [
             {"spikeHits": 1},

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -346,7 +346,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           {"resourceCapacity": [{"type": "Missile", "count": 1}]},
           {"resourceCapacity": [{"type": "Super", "count": 1}]}
         ]},
@@ -379,7 +379,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Beetom",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -457,7 +457,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -469,7 +469,7 @@
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -552,7 +552,7 @@
       "name": "Leave with Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
@@ -578,7 +578,7 @@
       "name": "Leave with Extended Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
@@ -1162,7 +1162,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1242,7 +1242,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -2115,7 +2115,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2223,7 +2223,7 @@
       "name": "Frozen Beetom Lure",
       "requires": [
         "canTrickyUseFrozenEnemies",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"obstaclesNotCleared": ["A"]}
       ],
       "note": "Using a crouch jump, get the Beetom attach to Samus. Quickly freeze it before it deals damage, if Samus is at very low energy."
@@ -2397,7 +2397,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2551,7 +2551,7 @@
       "link": [9, 9],
       "name": "Kill the Rippers - Power Bomb Without Breaking the Ledges",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canCarefulJump",
         {"or": [
           "canWalljump",

--- a/region/brinstar/red/Sloaters Refill.json
+++ b/region/brinstar/red/Sloaters Refill.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Spazer Room.json
+++ b/region/brinstar/red/Spazer Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -25,7 +25,7 @@
             {
               "name": "Power Bomb",
               "requires": [
-                "h_canUsePowerBombs"
+                "h_usePowerBombs"
               ],
               "note": "Raise the shutter before checking the item to not become stuck."
             }
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -222,12 +222,12 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]},
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall"
+          "h_bombThings",
+          "h_useSpringBall"
         ]}
       ],
       "note": "If using Power Bombs, 1 is used to break the blocks and another is used to escape."
@@ -238,7 +238,7 @@
       "name": "Jump Morph",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canThreeTileJumpMorph"
+        "h_threeTileJumpMorph"
       ]
     },
     {
@@ -257,7 +257,7 @@
       "link": [2, 2],
       "name": "Power Bomb the Block",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A"]
     },

--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -92,7 +92,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/ceres/main/Ceres Ridley's Room.json
+++ b/region/ceres/main/Ceres Ridley's Room.json
@@ -73,7 +73,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Door",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "bypassesDoorShell": true
     },
@@ -82,7 +82,7 @@
       "link": [1, 1],
       "name": "Leave With Runway, Power Bomb the Door",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "exitCondition": {
         "leaveWithRunway": {

--- a/region/ceres/main/Dead Scientist Room.json
+++ b/region/ceres/main/Dead Scientist Room.json
@@ -95,7 +95,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/ceres/main/Falling Tile Room.json
+++ b/region/ceres/main/Falling Tile Room.json
@@ -99,7 +99,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/ceres/main/Magnet Stairs Room.json
+++ b/region/ceres/main/Magnet Stairs Room.json
@@ -100,7 +100,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/crateria/central/Blue Brinstar Elevator Room.json
+++ b/region/crateria/central/Blue Brinstar Elevator Room.json
@@ -80,7 +80,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -251,7 +251,7 @@
       "link": [2, 2],
       "name": "Elevator Crystal Flash for Flash Suit",
       "requires": [
-        "h_canElevatorCrystalFlash"
+        "h_elevatorCrystalFlash"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -148,7 +148,7 @@
       "link": [1, 1],
       "name": "Fight Bomb Torizo",
       "requires": [
-        "h_canActivateBombTorizo",
+        "h_activateBombTorizo",
         {"or": [
           "canDodgeWhileShooting",
           {"ammo": {"type": "Super", "count": 2}},
@@ -314,7 +314,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -637,7 +637,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",
@@ -928,7 +928,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1080,7 +1080,7 @@
           "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
-            "h_canFourTileJumpMorph"
+            "h_fourTileJumpMorph"
           ]}
         ]}
       ],
@@ -1108,7 +1108,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1128,7 +1128,7 @@
           "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
-            "h_canFourTileJumpMorph"
+            "h_fourTileJumpMorph"
           ]}
         ]}
       ],
@@ -1144,7 +1144,7 @@
       "link": [3, 6],
       "name": "Base",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",
@@ -1241,7 +1241,7 @@
           "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
-            "h_canFourTileJumpMorph"
+            "h_fourTileJumpMorph"
           ]}
         ]}
       ],
@@ -1265,7 +1265,7 @@
           "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
-            "h_canFourTileJumpMorph"
+            "h_fourTileJumpMorph"
           ]}
         ]}
       ],
@@ -1335,7 +1335,7 @@
             {"or": [
               "h_canArtificialMorphSpringBall",
               "h_canArtificialMorphBombs",
-              "h_canFourTileJumpMorph"
+              "h_fourTileJumpMorph"
             ]}
           ]},
           {"and": [
@@ -1421,7 +1421,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",
@@ -1435,7 +1435,7 @@
       "link": [4, 6],
       "name": "Base",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",
@@ -1533,7 +1533,7 @@
           "h_canArtificialMorphBombs",
           {"and": [
             "Morph",
-            "h_canFourTileJumpMorph"
+            "h_fourTileJumpMorph"
           ]}
         ]}
       ],
@@ -1999,7 +1999,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]},
         {"or": [
@@ -2037,7 +2037,7 @@
       "link": [6, 3],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -2106,7 +2106,7 @@
       "link": [6, 4],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -2257,7 +2257,7 @@
               "nodes": [2]
             }},
             {"or": [
-              "h_canUseMorphBombs",
+              "h_useMorphBombs",
               "ScrewAttack"
             ]},
             {"cycleFrames": 2270}
@@ -2266,14 +2266,14 @@
             {"resetRoom": {
               "nodes": [3]
             }},
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"cycleFrames": 2695}
           ]},
           {"and": [
             {"resetRoom": {
               "nodes": [4]
             }},
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"cycleFrames": 2480}
           ]},
           {"and": [
@@ -2295,7 +2295,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",

--- a/region/crateria/central/Crateria Map Room.json
+++ b/region/crateria/central/Crateria Map Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -76,7 +76,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Alcoon",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -136,7 +136,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Crateria Save Room.json
+++ b/region/crateria/central/Crateria Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -261,7 +261,7 @@
         "h_XModeSpikeHit",
         "canShinechargeMovement",
         "canUseIFrames",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 110}
       ],
       "exitCondition": {
@@ -275,7 +275,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -838,7 +838,7 @@
         {"notable": "In-Room X-Mode BlueSuit"},
         "canSuperJump",
         {"spikeHits": 3},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 5}},
         {"spikeHits": 2},
         {"or": [
@@ -1033,7 +1033,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1049,7 +1049,7 @@
           }},
           {"and": [
             "canBePatient",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Boyon", "type": "contact", "hits": 16}},
@@ -1075,7 +1075,7 @@
         {"or": [
           {"and": [
             "canTrivialUseFrozenEnemies",
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             "canMidairShinespark",
             {"shinespark": {"frames": 118, "excessFrames": 6}}
           ]},
@@ -1101,7 +1101,7 @@
       "name": "Frozen Boyon Runway",
       "requires": [
         "canTrivialUseFrozenEnemies",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 128, "excessFrames": 6}}
       ]
     },
@@ -1111,7 +1111,7 @@
       "name": "Frozen Boyon Runway (Mid-Air Spark)",
       "requires": [
         "canTrivialUseFrozenEnemies",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canMidairShinespark",
         {"or": [
           {"shinespark": {"frames": 118, "excessFrames": 6}},
@@ -1128,7 +1128,7 @@
       "name": "Frozen Boyon Runway (Speedy Jump Spark)",
       "requires": [
         "canTrivialUseFrozenEnemies",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovementComplex",
         {"or": [
           {"shinespark": {"frames": 111, "excessFrames": 6}},
@@ -1147,7 +1147,7 @@
         "canTrivialUseFrozenEnemies",
         "canShinechargeMovementComplex",
         "canFastWalljumpClimb",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 93, "excessFrames": 6}},
           {"and": [
@@ -1393,7 +1393,7 @@
         {"or": [
           {"and": [
             "canTrivialUseFrozenEnemies",
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             "canMidairShinespark",
             {"shinespark": {"frames": 118, "excessFrames": 6}}
           ]},
@@ -1501,7 +1501,7 @@
         "canLongCeilingBombJump",
         "canJumpIntoIBJ",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "canPreciseWalljump",
             "canWallJumpInstantMorph"
@@ -1522,7 +1522,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1591,7 +1591,7 @@
           }},
           {"and": [
             "canBePatient",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]}
         ]}
       ],

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -81,8 +81,8 @@
       "requires": [
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ]
     },
@@ -173,7 +173,7 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -377,7 +377,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -39,7 +39,7 @@
               "name": "Base",
               "requires": [
                 {"or": [
-                  "h_canOpenRedDoors",
+                  "h_openRedDoors",
                   "f_ZebesSetAblaze"
                 ]}
               ],
@@ -268,7 +268,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -466,7 +466,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -503,7 +503,7 @@
             ]}
           ]},
           {"and": [
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             "canMidairShinespark",
             {"or": [
               {"shinespark": {"frames": 29, "excessFrames": 1}},
@@ -577,7 +577,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -813,7 +813,7 @@
         "canTrickyJump",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings"
+          "h_bombThings"
         ]},
         {"getBlueSpeed": {"usedTiles": 30, "openEnd": 2}}
       ],
@@ -1007,7 +1007,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1378,7 +1378,7 @@
       "requires": [
         {"notable": "Crystal Flash X-Ray Climb"},
         "canXRayClimb",
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1470,10 +1470,10 @@
       "link": [5, 1],
       "name": "Shinespark",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 40}},
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1485,7 +1485,7 @@
       "link": [5, 1],
       "name": "Speedy Jump Diagonal Spark",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         "canMidairShinespark",
         {"or": [
@@ -1497,7 +1497,7 @@
         ]},
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "ScrewAttack"
         ]}
       ],
@@ -1516,7 +1516,7 @@
       "requires": [
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 31, "excessFrames": 2}},
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1532,7 +1532,7 @@
       "link": [5, 3],
       "name": "Shinespark",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 78, "excessFrames": 11}},
           {"and": [
@@ -1574,7 +1574,7 @@
       "requires": [
         {"or": [
           "h_getBlueSpeedMaxRunway",
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -1666,7 +1666,7 @@
           "canJumpIntoIBJ"
         ]},
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1680,7 +1680,7 @@
         "HiJump",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings",
+          "h_bombThings",
           {"and": [
             "ScrewAttack",
             {"or": [
@@ -1704,7 +1704,7 @@
       "requires": [
         "canSpringBallJumpMidAir",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1717,7 +1717,7 @@
       "requires": [
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 7, "excessFrames": 2}},
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -387,7 +387,7 @@
       "link": [1, 1],
       "name": "Leave with Runway, Broken Wall",
       "requires": [
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -426,7 +426,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -436,7 +436,7 @@
       "name": "G-Mode Setup - Bomb the Blocks and Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -502,7 +502,7 @@
       "link": [1, 8],
       "name": "Base",
       "requires": [
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ]
     },
     {
@@ -1007,7 +1007,7 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Geemer",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
@@ -1498,7 +1498,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1547,7 +1547,7 @@
       "link": [5, 8],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -1639,7 +1639,7 @@
           "canBeVeryPatient",
           {"ammo": {"type": "Super", "count": 1}}
         ]},
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         "canUseGrapple",
         "canXRayStandUp"
       ],
@@ -2087,7 +2087,7 @@
       "link": [6, 6],
       "name": "Leave With Runway - Frozen Geemer",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "h_ZebesIsAwake",
         {"or": [
           "canBePatient",
@@ -2448,7 +2448,7 @@
       "link": [8, 1],
       "name": "Base",
       "requires": [
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ]
     },
     {
@@ -2513,7 +2513,7 @@
       "link": [8, 1],
       "name": "Leave with Runway, Broken Wall",
       "requires": [
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -2554,7 +2554,7 @@
       "name": "G-Mode Setup - Power Bomb the Blocks from Below and Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -2871,7 +2871,7 @@
       "link": [8, 8],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -236,7 +236,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -644,7 +644,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canDestroyBombWalls"
+          "h_destroyBombWalls"
         ]}
       ]
     }

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -167,7 +167,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/The Final Missile.json
+++ b/region/crateria/central/The Final Missile.json
@@ -89,7 +89,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -101,7 +101,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Choot",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Gravity"
       ],
       "exitCondition": {
@@ -119,7 +119,7 @@
       "link": [1, 1],
       "name": "Leave With Runway, Suitless - Frozen Choot",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -138,7 +138,7 @@
       "name": "Double Frozen Choot Runway (Left)",
       "requires": [
         {"notable": "Double Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "Gravity"
       ],
       "exitCondition": {
@@ -161,7 +161,7 @@
       "name": "Double Frozen Choot Runway, Suitless (Left)",
       "requires": [
         {"notable": "Double Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -184,7 +184,7 @@
       "name": "Triple Frozen Choot Runway (Left)",
       "requires": [
         {"notable": "Triple Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "Gravity",
         "canInsaneJump",
         {"enemyDamage": {"enemy": "Choot", "type": "contact", "hits": 1}}
@@ -211,7 +211,7 @@
       "name": "Triple Frozen Choot Runway, Suitless (Left)",
       "requires": [
         {"notable": "Triple Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "canInsaneJump",
         {"enemyDamage": {"enemy": "Choot", "type": "contact", "hits": 1}}
       ],
@@ -334,7 +334,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -485,7 +485,7 @@
         }
       },
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -512,7 +512,7 @@
         }
       },
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -739,7 +739,7 @@
         }
       },
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -766,7 +766,7 @@
         }
       },
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -862,7 +862,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Choot",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Gravity"
       ],
       "exitCondition": {
@@ -880,7 +880,7 @@
       "link": [2, 2],
       "name": "Leave With Runway, Suitless - Frozen Choot",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -899,7 +899,7 @@
       "name": "Double Frozen Choot Runway (Right)",
       "requires": [
         {"notable": "Double Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "Gravity"
       ],
       "exitCondition": {
@@ -922,7 +922,7 @@
       "name": "Double Frozen Choot Runway, Suitless (Right)",
       "requires": [
         {"notable": "Double Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -945,7 +945,7 @@
       "name": "Triple Frozen Choot Runway (Right)",
       "requires": [
         {"notable": "Triple Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "Gravity",
         "canInsaneJump",
         {"enemyDamage": {"enemy": "Choot", "type": "contact", "hits": 1}}
@@ -972,7 +972,7 @@
       "name": "Triple Frozen Choot Runway, Suitless (Right)",
       "requires": [
         {"notable": "Triple Frozen Choot Runway"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "canInsaneJump",
         {"enemyDamage": {"enemy": "Choot", "type": "contact", "hits": 1}}
       ],

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -103,8 +103,8 @@
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"or": [
-          "h_canXRayMorphIceClip",
-          "h_canPreciseIceClip"
+          "h_XRayMorphIceClip",
+          "h_preciseIceClip"
         ]}
       ],
       "bypassesDoorShell": true,
@@ -121,7 +121,7 @@
       "name": "Sciser High Pixel Ice Clip Door Lock Skip",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
-        "h_canHighPixelIceClip"
+        "h_highPixelIceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -156,7 +156,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -191,7 +191,7 @@
       "requires": [
         "canUpwardGModeSetup",
         "canTrickyUseFrozenEnemies",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         "canBePatient"
       ],
       "exitCondition": {
@@ -272,7 +272,7 @@
       },
       "requires": [
         "canTrickyGMode",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -385,7 +385,7 @@
             "HiJump"
           ]}
         ]},
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -521,7 +521,7 @@
             {"or": [
               "HiJump",
               "canWalljump",
-              "h_canCrouchJumpDownGrab",
+              "h_crouchJumpDownGrab",
               "canIBJ",
               "canSpringBallJumpMidAir"
             ]}

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -393,7 +393,7 @@
       "requires": [
         {"or": [
           "canCameraManip",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"enemyDamage": {"enemy": "Sciser", "type": "contact", "hits": 1}}
         ]}
       ],
@@ -474,7 +474,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -360,7 +360,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -814,7 +814,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1002,7 +1002,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1081,7 +1081,7 @@
           "canSpaceJumpWaterBounce",
           {"and": [
             "SpaceJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]}
         ]}
       ],
@@ -1133,7 +1133,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canUseFrozenEnemies",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "SpaceJump"
       ],
       "note": [
@@ -1373,7 +1373,7 @@
         "canTrickyJump",
         "canNeutralDamageBoost",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           {"and": [
             "h_UnderwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
@@ -1396,7 +1396,7 @@
       "requires": [
         "canSuitlessMaridia",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           {"and": [
             "h_UnderwaterCrouchJumpWithFlashSuit",
             "canDownGrab"

--- a/region/crateria/east/Forgotten Highway Elbow.json
+++ b/region/crateria/east/Forgotten Highway Elbow.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -254,11 +254,11 @@
         {"or": [
           "canInsaneJump",
           {"and": [
-            "h_canFourTileJumpMorph",
+            "h_fourTileJumpMorph",
             "canStationarySpinJump"
           ]}
         ]},
-        "h_canElevatorCrystalFlash"
+        "h_elevatorCrystalFlash"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/crateria/east/Forgotten Highway Kago Room.json
+++ b/region/crateria/east/Forgotten Highway Kago Room.json
@@ -114,7 +114,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Homing Geemer Room.json
+++ b/region/crateria/east/Homing Geemer Room.json
@@ -85,7 +85,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -254,11 +254,11 @@
         {"or": [
           "canInsaneJump",
           {"and": [
-            "h_canFourTileJumpMorph",
+            "h_fourTileJumpMorph",
             "canStationarySpinJump"
           ]}
         ]},
-        "h_canElevatorCrystalFlash"
+        "h_elevatorCrystalFlash"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -112,7 +112,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -338,7 +338,7 @@
         "canDisableEquipment",
         {"or": [
           "canTrickyJump",
-          "h_canUseMorphBombs"
+          "h_useMorphBombs"
         ]}
       ],
       "collectsItems": [3],
@@ -354,7 +354,7 @@
         {"doorUnlockedAtNode": 1},
         {"or": [
           "canTrickyJump",
-          "h_canUseMorphBombs"
+          "h_useMorphBombs"
         ]}
       ],
       "collectsItems": [3],
@@ -657,7 +657,7 @@
       "link": [2, 1],
       "name": "Pass Below",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -804,7 +804,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -951,13 +951,13 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"obstaclesNotCleared": ["B", "C"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 19, "excessFrames": 19}}
       ],
       "resetsObstacles": ["A"],
       "devNote": [
         "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark.",
-        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },
@@ -968,7 +968,7 @@
       "requires": [
         {"obstaclesCleared": ["A", "C"]},
         {"obstaclesNotCleared": ["B"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 21, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -982,7 +982,7 @@
       ],
       "devNote": [
         "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark.",
-        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },
@@ -1101,7 +1101,7 @@
       "name": "Double Spring Ball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         {"obstaclesNotCleared": ["A", "B", "C"]}
       ]
     },
@@ -1121,12 +1121,12 @@
       "requires": [
         {"obstaclesCleared": ["B"]},
         {"obstaclesNotCleared": ["A", "C"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 23, "excessFrames": 7}}
       ],
       "resetsObstacles": ["B"],
       "devNote": [
-        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },
@@ -1137,7 +1137,7 @@
       "requires": [
         {"obstaclesCleared": ["B", "C"]},
         {"obstaclesNotCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 23, "excessFrames": 7}}
       ],
       "exitCondition": {
@@ -1150,7 +1150,7 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "devNote": [
-        "FIXME: The h_canShineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -772,7 +772,7 @@
       "link": [2, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canLongChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -1037,7 +1037,7 @@
         "HiJump",
         {"or": [
           {"and": [
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             "canXRayTurnaround"
           ]},
           {"canShineCharge": {
@@ -1166,7 +1166,7 @@
       "requires": [
         "canPrepareForNextRoom",
         {"doorUnlockedAtNode": 4},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "This is to represent the ability to Crystal Flash after coming in jumping, shooting open the door, and landing in the door frame."
@@ -1218,7 +1218,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]}
@@ -1353,7 +1353,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]},
@@ -1429,7 +1429,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]},
@@ -1490,7 +1490,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]},
@@ -1704,7 +1704,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 50, "excessFrames": 10}}
       ]
     },
@@ -1716,7 +1716,7 @@
         "Gravity",
         "canShinechargeMovement",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 35, "excessFrames": 10}}
       ],
       "note": "Jump to the submerged platform, then jump again."
@@ -1766,7 +1766,7 @@
         {"notable": "Grapple Clip Door Lock Skip"},
         "canUseEnemies",
         "canGrappleClip",
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
@@ -1797,7 +1797,7 @@
       "name": "Leave With Temporary Blue (Gravity)",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"and": [
             "canSpringBallJumpMidAir",
@@ -1980,9 +1980,9 @@
         {"notable": "G-Mode Setup Lure Zeb from Below"},
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall",
-          "h_canUsePowerBombs"
+          "h_bombThings",
+          "h_useSpringBall",
+          "h_usePowerBombs"
         ]},
         "canCameraManip"
       ],
@@ -2009,9 +2009,9 @@
         {"notable": "G-Mode Setup Lure Zeb from Below"},
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall",
-          "h_canUsePowerBombs"
+          "h_bombThings",
+          "h_useSpringBall",
+          "h_usePowerBombs"
         ]},
         "canCameraManip"
       ],
@@ -2045,7 +2045,7 @@
       "link": [6, 6],
       "name": "Leave With Runway - Frozen Zeb",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -2083,8 +2083,8 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall"
+          "h_bombThings",
+          "h_useSpringBall"
         ]}
       ],
       "note": "The shot blocks can be destroyed without using bombs"
@@ -2169,8 +2169,8 @@
       "requires": [
         {"notable": "Bug Ice Clip"},
         {"or": [
-          "h_canXRayMorphIceClip",
-          "h_canPreciseIceClip"
+          "h_XRayMorphIceClip",
+          "h_preciseIceClip"
         ]}
       ],
       "flashSuitChecked": true,
@@ -2317,7 +2317,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -2333,7 +2333,7 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canIBJ"
         ]},
         {"or": [
@@ -2347,7 +2347,7 @@
       "link": [11, 13],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -2381,8 +2381,8 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall"
+          "h_bombThings",
+          "h_useSpringBall"
         ]}
       ]
     },
@@ -2393,8 +2393,8 @@
       "requires": [
         {"notable": "Shinespark, Morph Tunnel Rush"},
         "canShinechargeMovementComplex",
-        "h_canUseSpringBall",
-        "h_canShineChargeMaxRunway",
+        "h_useSpringBall",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 25}}
       ],
       "exitCondition": {
@@ -2417,9 +2417,9 @@
         "canFreeFallClip",
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
-            "h_canBombThings",
+            "h_bombThings",
             "h_additionalBomb"
           ]}
         ]}
@@ -2477,7 +2477,7 @@
       "link": [12, 9],
       "name": "Shinespark",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 36}}
       ]
     },
@@ -2505,7 +2505,7 @@
       "link": [12, 12],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2557,9 +2557,9 @@
         "canFreeFallClip",
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
-            "h_canBombThings",
+            "h_bombThings",
             "h_additionalBomb"
           ]}
         ]}
@@ -2587,7 +2587,7 @@
       "requires": [
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 38}}
       ],
       "exitCondition": {
@@ -2605,7 +2605,7 @@
         "canFastWalljumpClimb",
         "HiJump",
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 162}
       ],
       "exitCondition": {
@@ -2625,7 +2625,7 @@
         "HiJump",
         "Gravity",
         "SpaceJump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 145}
       ],
       "exitCondition": {
@@ -2678,7 +2678,7 @@
       "name": "Gravity Suit and Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 17, "excessFrames": 5}}
       ]
     },
@@ -2693,7 +2693,7 @@
           "HiJump",
           "SpaceJump"
         ]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 140}
       ],
       "exitCondition": {
@@ -2710,7 +2710,7 @@
         "Gravity",
         "canShinechargeMovementComplex",
         "canPreciseWalljump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 15}}
       ],
       "exitCondition": {
@@ -2809,10 +2809,10 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "Gravity",
-            "h_canBombThings"
+            "h_bombThings"
           ]}
         ]}
       ],
@@ -2823,7 +2823,7 @@
       "link": [13, 13],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2893,7 +2893,7 @@
       "name": "G-mode Overload PLMs by Bombing Crumble Block with Space Jump",
       "requires": [
         "canEnterGMode",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "SpaceJump",
         "canBeVeryPatient"
       ],
@@ -2941,7 +2941,7 @@
       "requires": [
         {"notable": "G-mode Overload PLMs by Power Bombing Morph Maze Item"},
         "canEnterGMode",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           "SpaceJump",
           "canLongIBJ",

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -176,7 +176,7 @@
       "requires": [
         "h_runOverRespawningEnemies",
         {"or": [
-          "h_canDestroyBombWalls",
+          "h_destroyBombWalls",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -380,7 +380,7 @@
               "steepDownTiles": 1,
               "openEnd": 1
             }},
-            "h_canDestroyBombWalls"
+            "h_destroyBombWalls"
           ]},
           {"and": [
             {"canShineCharge": {
@@ -389,7 +389,7 @@
               "steepDownTiles": 1,
               "openEnd": 1
             }},
-            "h_canDestroyBombWalls",
+            "h_destroyBombWalls",
             {"doorUnlockedAtNode": 1}
           ]}
         ]},
@@ -626,7 +626,7 @@
           "canCarefulJump",
           {"acidFrames": 35}
         ]},
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "clearsObstacles": ["A", "B"],
       "note": "When taking too much acid damage, it is always possible to return to the left and farm."
@@ -648,7 +648,7 @@
           {"obstaclesCleared": ["A"]}
         ]},
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -700,7 +700,7 @@
       "link": [1, 4],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"useFlashSuit": {}},
         {"or": [
           {"and": [
@@ -786,7 +786,7 @@
         {"notable": "Spark Master"},
         "canSlowShortCharge",
         "canShinechargeMovementTricky",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "HiJump",
         "Gravity",
         {"acidFrames": 16},
@@ -874,7 +874,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1034,7 +1034,7 @@
       "requires": [
         {"notable": "R-Mode Blue Suit"},
         {"obstaclesCleared": ["D"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 0}
       ],
       "exitCondition": {
@@ -1049,7 +1049,7 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ]
     },
     {
@@ -1057,7 +1057,7 @@
       "link": [3, 4],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "canCarefulJump",
           {"acidFrames": 40}
@@ -1109,7 +1109,7 @@
           "canCarefulJump",
           {"acidFrames": 35}
         ]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "canTrickyJump",
           {"and": [
@@ -1167,7 +1167,7 @@
       "link": [4, 1],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canHorizontalShinespark",
         {"useFlashSuit": {}},
         {"or": [
@@ -1185,10 +1185,10 @@
       "link": [4, 3],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           "canCarefulJump",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"acidFrames": 5}
         ]}
       ],
@@ -1199,9 +1199,9 @@
       "link": [4, 3],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"acidFrames": 10}
         ]},
         {"or": [

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -175,7 +175,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -185,7 +185,7 @@
       "name": "G-Mode Setup - Get hit by Waver",
       "requires": [
         {"or": [
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           "ScrewAttack"
         ]}
       ],
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get hit by Waver, Using a Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -255,7 +255,7 @@
       "link": [1, 2],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "canTrickyJump",
           "Ice",
@@ -271,7 +271,7 @@
         {"or": [
           "canCarefulJump",
           {"and": [
-            "h_canUseSpringBall",
+            "h_useSpringBall",
             {"acidFrames": 20}
           ]},
           {"and": [
@@ -494,7 +494,7 @@
       "link": [1, 2],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"useFlashSuit": {}},
         {"or": [
           {"and": [
@@ -552,7 +552,7 @@
       "link": [2, 1],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "canDodgeWhileShooting",
           "Ice",
@@ -753,7 +753,7 @@
       "link": [2, 1],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canHorizontalShinespark",
         {"useFlashSuit": {}},
         {"or": [
@@ -940,7 +940,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -950,7 +950,7 @@
       "name": "G-Mode Setup - Get hit by Waver",
       "requires": [
         {"or": [
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           "ScrewAttack"
         ]}
       ],
@@ -964,7 +964,7 @@
       "link": [2, 2],
       "name": "G-Mode Setup - Get hit by Waver, Using a Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}

--- a/region/crateria/west/Green Brinstar Elevator Room.json
+++ b/region/crateria/west/Green Brinstar Elevator Room.json
@@ -80,7 +80,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -249,7 +249,7 @@
       "link": [2, 2],
       "name": "Elevator Crystal Flash for Flash Suit",
       "requires": [
-        "h_canElevatorCrystalFlash"
+        "h_elevatorCrystalFlash"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -316,7 +316,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -337,7 +337,7 @@
       },
       "requires": [
         "canInsaneJump",
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -406,10 +406,10 @@
         {"resetRoom": {
           "nodes": [2]
         }},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"partialRefill": {"type": "PowerBomb", "limit": 6}}
       ],
@@ -421,7 +421,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -434,7 +434,7 @@
           "nodes": [2]
         }},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_can10PowerBombCrystalFlash"
+        "h_10PowerBombCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -454,7 +454,7 @@
       "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
           {"and": [
@@ -532,7 +532,7 @@
       "link": [2, 9],
       "name": "Base",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ]
     },
     {
@@ -879,7 +879,7 @@
       },
       "requires": [
         "canInsaneJump",
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1345,7 +1345,7 @@
       "link": [9, 2],
       "name": "Leave With Runway - Single Frozen Beetom",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1369,7 +1369,7 @@
       "link": [9, 2],
       "name": "Leave With Runway - Double Frozen Beetom",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 9}},
         {"or": [
           {"obstaclesCleared": ["A"]},

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -110,7 +110,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -112,7 +112,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 40}
       ],
       "exitCondition": {
@@ -191,7 +191,7 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -204,7 +204,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -322,7 +322,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 40}
       ],
       "exitCondition": {
@@ -401,7 +401,7 @@
       "link": [2, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -108,7 +108,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -251,7 +251,7 @@
       "requires": [
         {"shineChargeFrames": 35},
         "f_TourianOpen",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canShinechargeMovement",
         {"shinespark": {"frames": 21, "excessFrames": 8}}
       ],
@@ -271,7 +271,7 @@
       "requires": [
         {"shineChargeFrames": 20},
         "f_TourianOpen",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canShinechargeMovement",
         {"shinespark": {"frames": 24, "excessFrames": 9}}
       ],
@@ -400,7 +400,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -434,7 +434,7 @@
             "canStationarySpinJump"
           ]}
         ]},
-        "h_canElevatorCrystalFlash"
+        "h_elevatorCrystalFlash"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -139,7 +139,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -278,7 +278,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -621,7 +621,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1139,7 +1139,7 @@
         "h_heatProof",
         "canSuitlessLavaDive",
         "canCrouchJump",
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         "canTrickyJump",
         {"acidFrames": 330},
         {"acidFrames": 1000}
@@ -1167,7 +1167,7 @@
         "HiJump",
         "canTrickyJump",
         "canGravityJump",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canSpringBallJumpMidAir",
         {"heatFrames": 600},
         {"acidFrames": 600}

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -1041,7 +1041,7 @@
         {"or": [
           {"and": [
             {"heatFrames": 50},
-            "h_canUsePowerBombs"
+            "h_usePowerBombs"
           ]},
           {"obstaclesCleared": ["A"]}
         ]}
@@ -1101,7 +1101,7 @@
       "requires": [
         {"shineChargeFrames": 45},
         {"shinespark": {"frames": 12}},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 400}
       ],
       "clearsObstacles": ["A"],
@@ -1182,7 +1182,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1345,7 +1345,7 @@
       "requires": [
         {"shineChargeFrames": 45},
         {"shinespark": {"frames": 12}},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 400}
       ],
       "clearsObstacles": ["A"],
@@ -1609,7 +1609,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1990,7 +1990,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2097,7 +2097,7 @@
         {"heatFrames": 250},
         {"or": [
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 50}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -2125,7 +2125,7 @@
         ]},
         {"heatFrames": 400},
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -2150,11 +2150,11 @@
       "name": "Ice Assist",
       "requires": [
         "canUseFrozenEnemies",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"heatFrames": 700},
         {"or": [
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 50}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -2200,7 +2200,7 @@
         ]},
         {"or": [
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 50}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -2234,7 +2234,7 @@
         ]},
         {"heatFrames": 550},
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -2336,7 +2336,7 @@
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"heatFrames": 185},
-        "h_canHeated10PowerBombCrystalFlash",
+        "h_heated10PowerBombCrystalFlash",
         {"heatFrames": 30}
       ],
       "flashSuitChecked": true,

--- a/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
+++ b/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
@@ -91,7 +91,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -126,7 +126,7 @@
       "requires": [
         {"notable": "Crystal Flash Clip"},
         "h_heatProof",
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "canTrickyJump"
       ],
       "flashSuitChecked": true,
@@ -205,7 +205,7 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 100}
       ]
     },
@@ -406,7 +406,7 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 90}
       ]
     },
@@ -478,7 +478,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -169,7 +169,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -190,7 +190,7 @@
       "link": [1, 2],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 380}
       ]
@@ -206,7 +206,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         "canPrepareForNextRoom",
         {"heatFrames": 260}
@@ -221,7 +221,7 @@
       },
       "requires": [
         {"shineChargeFrames": 15},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canMidairShinespark",
         {"shinespark": {"frames": 57, "excessFrames": 4}},
         {"heatFrames": 230}
@@ -252,7 +252,7 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 135}
       ]
     },
@@ -261,7 +261,7 @@
       "link": [2, 1],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 320}
       ]
@@ -277,7 +277,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 260}
       ]
@@ -291,7 +291,7 @@
       },
       "requires": [
         {"shineChargeFrames": 15},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canMidairShinespark",
         {"shinespark": {"frames": 59, "excessFrames": 5}},
         {"heatFrames": 190}
@@ -393,7 +393,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -433,7 +433,7 @@
       "link": [2, 3],
       "name": "Tricky Jumps",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 215}
       ],
@@ -444,7 +444,7 @@
       "link": [2, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 45}
       ]
     },
@@ -453,7 +453,7 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 145}
       ]
     },
@@ -462,7 +462,7 @@
       "link": [3, 1],
       "name": "Leave With Runway - Frozen Zebbo",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"heatFrames": 1000}
       ],
       "exitCondition": {
@@ -543,7 +543,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "Be careful to avoid damage from the respawning Zebbos."
@@ -553,7 +553,7 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canTrickyJump",
           {"heatFrames": 30}
@@ -566,7 +566,7 @@
       "link": [4, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 60}
       ]
     },
@@ -575,7 +575,7 @@
       "link": [4, 2],
       "name": "Leave With Runway - Frozen Zebbo",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"heatFrames": 300},
         {"or": [
           "canInsaneJump",
@@ -603,7 +603,7 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 210}
       ]
     },
@@ -648,7 +648,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "Be careful to avoid damage from the respawning Zebbos."

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -354,7 +354,7 @@
             ]}
           ]}
         ]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"partialRefill": {"type": "Energy", "limit": 340}},
         {"partialRefill": {"type": "Missile", "limit": 6}},
         {"refill": ["PowerBomb"]}
@@ -365,7 +365,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -509,7 +509,7 @@
       "link": [2, 6],
       "name": "Spring Ball",
       "requires": [
-        "h_canUseSpringBall"
+        "h_useSpringBall"
       ],
       "flashSuitChecked": true,
       "note": "Use SpringBall to get up and over the Fune."
@@ -519,7 +519,7 @@
       "link": [2, 6],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           {"and": [
             "canBombHorizontally",
@@ -548,7 +548,7 @@
       "requires": [
         {"notable": "Morph Over the Fune"},
         {"noFlashSuit": {}},
-        "h_canFourTileJumpMorph",
+        "h_fourTileJumpMorph",
         "canTrickyJump",
         {"or": [
           "canInsaneJump",
@@ -672,7 +672,7 @@
         "ScrewAttack",
         {"or": [
           "canCarefulJump",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"ammo": {"type": "Super", "count": 1}},
           {"and": [
             "canDisableEquipment",
@@ -856,7 +856,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1079,7 +1079,7 @@
       "name": "X-Mode Shinespark",
       "requires": [
         "canXMode",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         {"shinespark": {"frames": 14, "excessFrames": 9}}
@@ -1099,7 +1099,7 @@
       "link": [6, 2],
       "name": "Spring Ball",
       "requires": [
-        "h_canUseSpringBall"
+        "h_useSpringBall"
       ],
       "flashSuitChecked": true,
       "note": "Use SpringBall to get up and over the Fune.  Jump when slightly away from the Fune."
@@ -1109,7 +1109,7 @@
       "link": [6, 2],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "flashSuitChecked": true,
       "note": "Use a Bomb to get up and over the Fune."

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -225,7 +225,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -261,7 +261,7 @@
       },
       "requires": [
         "canOffScreenMovement",
-        "h_canBombThings",
+        "h_bombThings",
         "h_HeatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
@@ -284,7 +284,7 @@
       },
       "requires": [
         "canOffScreenMovement",
-        "h_canBombThings",
+        "h_bombThings",
         "h_HeatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
@@ -386,7 +386,7 @@
       "link": [1, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 60}
       ]
     },
@@ -401,7 +401,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 45}
       ]
     },
@@ -410,7 +410,7 @@
       "link": [1, 7],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 160}
       ]
     },
@@ -419,7 +419,7 @@
       "link": [1, 7],
       "name": "Weave",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canDownBack",
           "canCarefulJump"
@@ -446,7 +446,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -457,11 +457,11 @@
       "requires": [
         {"notable": "Crystal Flash Clip"},
         {"heatFrames": 100},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         "canCeilingClip",
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"heatFrames": 175}
       ],
@@ -612,7 +612,7 @@
             "canTrickyDodgeEnemies"
           ]}
         ]},
-        "h_canBombThings",
+        "h_bombThings",
         "h_HeatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
@@ -645,15 +645,15 @@
           ]},
           {"and": [
             "canTrickyUseFrozenEnemies",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           "canSpringBallBombJump"
         ]},
-        "h_canBombThings",
+        "h_bombThings",
         "h_HeatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
@@ -691,7 +691,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -709,7 +709,7 @@
       "link": [3, 3],
       "name": "X-Mode",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -760,7 +760,7 @@
         "canTrickyUseFrozenEnemies",
         {"or": [
           "HiJump",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         "h_DirectHeatedGModeLeaveSameDoor"
       ],
@@ -877,7 +877,7 @@
       "link": [3, 7],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         {"or": [
           "canCarefulJump",
@@ -891,7 +891,7 @@
       "link": [3, 7],
       "name": "Kill While Running",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canDodgeWhileShooting",
         {"or": [
           {"enemyKill": {
@@ -929,7 +929,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 60}
       ],
       "note": "Use blue speed to kill the Alcoons without stopping."
@@ -939,7 +939,7 @@
       "link": [3, 7],
       "name": "Stop To Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Alcoon", "Alcoon"]],
           "explicitWeapons": ["Missile", "Super", "Plasma", "Wave+Spazer"]
@@ -952,7 +952,7 @@
       "link": [3, 7],
       "name": "Jump Over",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canCarefulJump",
         {"heatFrames": 199}
       ]
@@ -962,7 +962,7 @@
       "link": [3, 7],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyDamage": {"enemy": "Alcoon", "type": "contact", "hits": 1}},
         {"heatFrames": 180}
       ]
@@ -1115,7 +1115,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -1127,7 +1127,7 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"obstaclesCleared": ["B"]},
         {"heatFrames": 199}
@@ -1140,9 +1140,9 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 360}
       ],
       "clearsObstacles": ["B"]
@@ -1154,9 +1154,9 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 300}
       ],
       "clearsObstacles": ["B"]
@@ -1166,7 +1166,7 @@
       "link": [4, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"obstaclesCleared": ["A"]},
         {"heatFrames": 150}
       ]
@@ -1176,7 +1176,7 @@
       "link": [4, 6],
       "name": "Quick Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Alcoon"]],
           "explicitWeapons": ["Missile", "Super", "Plasma", "ScrewAttack", "PseudoScrew"]
@@ -1192,7 +1192,7 @@
       "link": [4, 6],
       "name": "Tank Fireball and Run Through",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyDamage": {"enemy": "Alcoon", "type": "fireball", "hits": 1}},
         {"heatFrames": 170}
       ]
@@ -1202,7 +1202,7 @@
       "link": [4, 6],
       "name": "Slow Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           {"and": [
             "canDodgeWhileShooting",
@@ -1245,7 +1245,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "canTrivialMidAirMorph",
             {"heatFrames": 30}
@@ -1264,7 +1264,7 @@
           "canTrivialMidAirMorph",
           {"and": [
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]}
         ]},
         {"heatFrames": 65}
@@ -1279,7 +1279,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1288,7 +1288,7 @@
       "link": [6, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 60}
       ],
       "unlocksDoors": [
@@ -1303,7 +1303,7 @@
       "link": [6, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"obstaclesCleared": ["A"]},
         {"heatFrames": 120}
       ]
@@ -1313,7 +1313,7 @@
       "link": [6, 4],
       "name": "Avoid",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canDodgeWhileShooting",
         {"heatFrames": 120}
       ],
@@ -1325,7 +1325,7 @@
       "link": [6, 4],
       "name": "Kill Without Stopping",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canDodgeWhileShooting",
         {"enemyKill": {
           "enemies": [["Alcoon"]],
@@ -1341,7 +1341,7 @@
       "link": [6, 4],
       "name": "Stop and Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Alcoon"]],
           "explicitWeapons": [
@@ -1365,7 +1365,7 @@
       "link": [6, 4],
       "name": "Slow Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           {"and": [
             "canDodgeWhileShooting",
@@ -1389,11 +1389,11 @@
       "name": "Air Speedball",
       "requires": [
         {"notable": "Air Speedball"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"getBlueSpeed": {"usedTiles": 26, "gentleDownTiles": 2, "openEnd": 1}},
         "canSpeedball",
         "canLateralMidAirMorph",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"heatFrames": 160}
       ],
       "clearsObstacles": ["B"],
@@ -1404,7 +1404,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1413,7 +1413,7 @@
       "link": [6, 7],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 160}
       ]
     },
@@ -1422,7 +1422,7 @@
       "link": [6, 7],
       "name": "Weave",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canDownBack",
           "canCarefulJump"
@@ -1435,7 +1435,7 @@
       "link": [7, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -1456,7 +1456,7 @@
       "link": [7, 1],
       "name": "SpringBall Bomb Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canSpringBallBombJump",
         {"heatFrames": 240}
       ],
@@ -1472,7 +1472,7 @@
       "link": [7, 1],
       "name": "Avoid Spawning Alcoon and IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canIBJ",
         {"or": [
           {"and": [
@@ -1502,7 +1502,7 @@
       "link": [7, 1],
       "name": "Kill Alcoon and IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canIBJ",
         {"or": [
           {"enemyKill": {
@@ -1533,7 +1533,7 @@
       "name": "Tricky Dash Jump",
       "requires": [
         "canTrickyDashJump",
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 200}
       ],
       "unlocksDoors": [
@@ -1549,7 +1549,7 @@
       "link": [7, 1],
       "name": "Frozen Alcoon",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 330}
       ],
@@ -1565,7 +1565,7 @@
       "link": [7, 3],
       "name": "Kill While Running",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canDodgeWhileShooting",
         {"or": [
           {"enemyKill": {
@@ -1594,7 +1594,7 @@
       "link": [7, 3],
       "name": "Stop To Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Alcoon", "Alcoon"]],
           "explicitWeapons": ["Missile", "Super", "Plasma", "Wave+Spazer"]
@@ -1613,7 +1613,7 @@
       "link": [7, 3],
       "name": "Jump Over",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canCarefulJump",
         {"heatFrames": 240}
       ]
@@ -1623,7 +1623,7 @@
       "link": [7, 3],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyDamage": {"enemy": "Alcoon", "type": "contact", "hits": 1}},
         {"heatFrames": 180}
       ],
@@ -1648,7 +1648,7 @@
       "link": [7, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump",
@@ -1663,7 +1663,7 @@
       "link": [7, 6],
       "name": "SpringBall Bomb Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canSpringBallBombJump",
         {"heatFrames": 220}
       ]
@@ -1673,7 +1673,7 @@
       "link": [7, 6],
       "name": "Avoid Spawning Alcoon and IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canIBJ",
         {"or": [
           {"and": [
@@ -1697,7 +1697,7 @@
       "link": [7, 6],
       "name": "Kill Alcoon and IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canIBJ",
         {"or": [
           {"enemyKill": {
@@ -1722,7 +1722,7 @@
       "name": "Tricky Dash Jump",
       "requires": [
         "canTrickyDashJump",
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 180}
       ],
       "note": "Jump from the bottom of the slope with about 6 tiles of run speed."
@@ -1732,7 +1732,7 @@
       "link": [7, 6],
       "name": "Frozen Alcoon",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canUseFrozenEnemies",
         {"heatFrames": 310}
       ]
@@ -1759,7 +1759,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -112,7 +112,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -136,7 +136,7 @@
       "link": [1, 4],
       "name": "Normal Jumps",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 3}},
           {"and": [
@@ -157,7 +157,7 @@
       "link": [1, 4],
       "name": "Careful Jumps",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canCarefulJump",
         {"or": [
           {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 2}},
@@ -176,7 +176,7 @@
       "link": [1, 4],
       "name": "TrickyJumps",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 570}
       ],
@@ -187,7 +187,7 @@
       "link": [1, 4],
       "name": "Power Bomb Clear",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"enemyKill": {
           "enemies": [["Dragon"]],
@@ -210,7 +210,7 @@
       "link": [1, 4],
       "name": "SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 510}
       ]
@@ -224,7 +224,7 @@
       },
       "requires": [
         {"shineChargeFrames": 16},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canShinechargeMovement",
         "canMidairShinespark",
         {"shinespark": {"frames": 75, "excessFrames": 10}},
@@ -308,7 +308,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -317,7 +317,7 @@
       "link": [2, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 360}
       ]
     },
@@ -341,7 +341,7 @@
       "link": [4, 1],
       "name": "SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 450}
       ],
@@ -352,7 +352,7 @@
       "link": [4, 1],
       "name": "Invulnerable SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"or": [
           "ScrewAttack",
@@ -369,7 +369,7 @@
       "link": [4, 1],
       "name": "Shinespark",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canMidairShinespark",
         "canShinechargeMovement",
         {"canShineCharge": {"usedTiles": 24, "openEnd": 1}},
@@ -382,7 +382,7 @@
       "link": [4, 1],
       "name": "Normal Jumps",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 3}},
           {"and": [
@@ -403,7 +403,7 @@
       "link": [4, 1],
       "name": "Careful Jumps",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canCarefulJump",
         {"or": [
           {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 2}},
@@ -422,7 +422,7 @@
       "link": [4, 1],
       "name": "Tricky Jumps",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 500}
       ],
@@ -433,7 +433,7 @@
       "link": [4, 1],
       "name": "Power Bomb Clear",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"enemyKill": {
           "enemies": [["Dragon"], ["Dragon"]],
@@ -489,7 +489,7 @@
       "link": [4, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 330}
       ]
     },
@@ -498,7 +498,7 @@
       "link": [4, 2],
       "name": "SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 250}
       ]
@@ -579,7 +579,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -187,7 +187,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 10},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 10}
       ],
       "flashSuitChecked": true
@@ -215,7 +215,7 @@
       "link": [1, 2],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"or": [
           "canHitbox",
@@ -360,7 +360,7 @@
       "link": [2, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"or": [
           "canHitbox",
@@ -502,7 +502,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 10},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 10}
       ],
       "flashSuitChecked": true

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -433,7 +433,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["C", "E"]},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -771,7 +771,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 15},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -782,7 +782,7 @@
       "name": "Power Bomb",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 180}
       ],
       "clearsObstacles": ["A"],
@@ -802,7 +802,7 @@
         {"or": [
           "ScrewAttack",
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 60}
           ]},
           {"obstaclesCleared": ["B"]}
@@ -821,7 +821,7 @@
         {"obstaclesNotCleared": ["A"]},
         "canPrepareForNextRoom",
         "canChainTemporaryBlue",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"heatFrames": 300}
       ],
       "clearsObstacles": ["B"],
@@ -893,7 +893,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -914,7 +914,7 @@
         {"obstaclesCleared": ["B"]},
         {"heatFrames": 160},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "canSpringBallJumpMidAir",
           "HiJump",
@@ -962,7 +962,7 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "HiJump",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"heatFrames": 130}
       ],
       "note": "Use SpringBall to just bounce on the crumble blocks."
@@ -986,7 +986,7 @@
           ]},
           "canCrumbleJump",
           {"and": [
-            "h_canTrickySpringwall",
+            "h_trickySpringwall",
             "canPreciseWalljump"
           ]}
         ]}
@@ -1040,7 +1040,7 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         "canJumpIntoIBJ",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"or": [
           "canTrickyJump",
           "canDoubleBombJump",
@@ -1069,7 +1069,7 @@
       "link": [4, 3],
       "name": "Power Bomb All the Blocks for Later",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 80}
       ],
       "clearsObstacles": ["A"]
@@ -1080,7 +1080,7 @@
       "name": "Power Bomb the Left Blocks for Later",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 95}
       ],
       "clearsObstacles": ["B"],
@@ -1092,7 +1092,7 @@
       "link": [4, 3],
       "name": "Bomb a Block for Later",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 80}
       ],
       "clearsObstacles": ["B"]
@@ -1102,7 +1102,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1112,7 +1112,7 @@
       "link": [4, 4],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 120}
       ],
       "clearsObstacles": ["A"]
@@ -1123,7 +1123,7 @@
       "name": "Bombs",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 100}
       ],
       "clearsObstacles": ["B"]
@@ -1241,7 +1241,7 @@
       "name": "Crystal Flash Grapple Clip",
       "requires": [
         "h_heatProof",
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "Grapple",
         {"or": [
           {"obstaclesCleared": ["D"]},
@@ -1263,7 +1263,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["F"]},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1698,13 +1698,13 @@
       "requires": [
         {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         "canPartialFloorClip",
         "canTrickyJump",
         "canCrumbleJump",
         {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "canSpringBallJumpMidAir",
           "HiJump",
@@ -1727,9 +1727,9 @@
       "requires": [
         {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
-        "h_canXRayMorphIceClip",
+        "h_XRayMorphIceClip",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "canSpringBallJumpMidAir",
           "HiJump",
@@ -1750,10 +1750,10 @@
       "requires": [
         {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}},
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1772,7 +1772,7 @@
       "requires": [
         {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
-        "h_canXRayMorphIceClip"
+        "h_XRayMorphIceClip"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1787,7 +1787,7 @@
       "requires": [
         {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}},
         "ScrewAttack",
         {"obstaclesNotCleared": ["A"]}
@@ -1808,12 +1808,12 @@
       "requires": [
         {"notable": "Multiviola Ice Clip"},
         "h_heatProof",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "can4HighMidAirMorph"
         ]}
       ],

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -108,7 +108,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"resetRoom": {
           "nodes": [1]
         }}
@@ -491,7 +491,7 @@
       },
       "requires": [
         {"notable": "Bombs"},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "canWallJumpInstantMorph",
         "canInsaneJump",
         "canResetFallSpeed",
@@ -527,7 +527,7 @@
       },
       "requires": [
         {"notable": "Bombs"},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "Gravity",
         "canResetFallSpeed",
         "canJumpIntoIBJ",
@@ -1100,7 +1100,7 @@
       },
       "requires": [
         {"notable": "Bombs"},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "Gravity",
         "canResetFallSpeed",
         "canJumpIntoIBJ",
@@ -1284,7 +1284,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"resetRoom": {
           "nodes": [2]
         }}

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -700,7 +700,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Holtz",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         {"heatFrames": 800},
         {"or": [
           {"and": [
@@ -732,7 +732,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -904,7 +904,7 @@
       "name": "Farm then Leave With Runway - Frozen Holtz",
       "requires": [
         "h_heatResistant",
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         {"heatFrames": 300}
       ],
       "exitCondition": {
@@ -928,7 +928,7 @@
       "name": "Farm then Leave With Runway - Frozen Zebbo",
       "requires": [
         "h_heatResistant",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Morph",
         {"heatFrames": 500}
       ],
@@ -968,7 +968,7 @@
       "name": "Farm then Leave With Runway - Frozen Holtz",
       "requires": [
         "h_heatResistant",
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         {"heatFrames": 300}
       ],
       "exitCondition": {
@@ -992,7 +992,7 @@
       "name": "Farm then Leave With Runway - Frozen Zebbo",
       "requires": [
         "h_heatResistant",
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Morph",
         {"heatFrames": 500}
       ],
@@ -1047,7 +1047,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "Crystal Flash to the left of the pipe to avoid the Holtzes."

--- a/region/lowernorfair/east/Red Kihunter Shaft Save Room.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -279,7 +279,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -479,7 +479,7 @@
       "link": [1, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 40}
       ]
     },
@@ -546,7 +546,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -615,8 +615,8 @@
       "link": [2, 6],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         {"heatFrames": 240}
       ]
     },
@@ -625,8 +625,8 @@
       "link": [2, 6],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         {"heatFrames": 240}
       ]
     },
@@ -635,7 +635,7 @@
       "link": [2, 6],
       "name": "Screw Attack",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         "ScrewAttack",
         {"heatFrames": 220}
@@ -765,7 +765,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 20},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 20}
       ],
       "flashSuitChecked": true,
@@ -840,8 +840,8 @@
       "link": [3, 6],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         {"heatFrames": 410}
       ]
     },
@@ -850,8 +850,8 @@
       "link": [3, 6],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         {"heatFrames": 250}
       ]
     },
@@ -875,7 +875,7 @@
       "link": [3, 7],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyDamage": {"enemy": "Kihunter (red)", "type": "contact", "hits": 1}},
         {"heatFrames": 120}
       ],
@@ -886,7 +886,7 @@
       "link": [3, 7],
       "name": "Ice Wave Spazer Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Wave",
         "Ice",
         "Spazer",
@@ -898,7 +898,7 @@
       "link": [3, 7],
       "name": "Wave Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Wave",
         "Plasma",
         {"heatFrames": 300}
@@ -919,7 +919,7 @@
       "name": "KiHunter Dodge (Bottom)",
       "requires": [
         {"notable": "KiHunter Dodge"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyDodgeEnemies",
         {"heatFrames": 100}
       ],
@@ -931,7 +931,7 @@
       "name": "Kihunter Manipulation from Middle Door (Bottom)",
       "requires": [
         {"notable": "Kihunter Manipulation from Middle Door"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canStopOnADime",
         "canTrickyDodgeEnemies",
         {"or": [
@@ -1210,7 +1210,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1220,7 +1220,7 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 40}
       ]
     },
@@ -1275,7 +1275,7 @@
       "link": [5, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 40}
       ]
     },
@@ -1284,7 +1284,7 @@
       "link": [5, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 40}
       ]
     },
@@ -1293,7 +1293,7 @@
       "link": [5, 7],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           {"and": [
             "ScrewAttack",
@@ -1329,7 +1329,7 @@
       "link": [5, 7],
       "name": "Wait For KiHunters",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 1160}
       ]
     },
@@ -1362,7 +1362,7 @@
       "link": [5, 7],
       "name": "Plasma Run Through Enemies",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canHitbox",
         "Plasma",
         {"or": [
@@ -1382,8 +1382,8 @@
       "link": [6, 2],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         {"heatFrames": 270}
       ]
     },
@@ -1392,8 +1392,8 @@
       "link": [6, 2],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         {"heatFrames": 270}
       ],
       "devNote": "FIXME This strat also unlocks node 2. Could add that in later?"
@@ -1403,7 +1403,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": [
@@ -1416,8 +1416,8 @@
       "link": [6, 7],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         {"or": [
           "ScrewAttack",
           {"and": [
@@ -1436,7 +1436,7 @@
       "link": [6, 7],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"ammo": {"type": "PowerBomb", "count": 2}},
         {"or": [
@@ -1457,8 +1457,8 @@
       "link": [6, 7],
       "name": "X-Ray Clip",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         "canXRayStandUp",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1487,8 +1487,8 @@
       "link": [6, 7],
       "name": "Bomb Block X-Ray Climb",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         "canXRayClimb",
         "canCeilingClip",
         {"or": [
@@ -1513,9 +1513,9 @@
       "link": [6, 7],
       "name": "Spring Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
-        "h_canUseSpringBall",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
+        "h_useSpringBall",
         {"or": [
           "ScrewAttack",
           {"and": [
@@ -1555,7 +1555,7 @@
       "link": [7, 5],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyDamage": {"enemy": "Kihunter (red)", "type": "contact", "hits": 2}},
         {"heatFrames": 480}
       ],
@@ -1566,7 +1566,7 @@
       "link": [7, 5],
       "name": "Super Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Kihunter (red)", "Kihunter (red)"]],
           "explicitWeapons": ["Super"]
@@ -1579,7 +1579,7 @@
       "link": [7, 5],
       "name": "Ice Wave Spazer Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Wave",
         "Ice",
         "Spazer",
@@ -1591,7 +1591,7 @@
       "link": [7, 5],
       "name": "Wave Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Wave",
         "Plasma",
         {"heatFrames": 840}
@@ -1602,7 +1602,7 @@
       "link": [7, 5],
       "name": "Screw Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         {"heatFrames": 450}
       ],
@@ -1614,7 +1614,7 @@
       "name": "KiHunter Dodge (Top)",
       "requires": [
         {"notable": "KiHunter Dodge"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyDodgeEnemies",
         {"heatFrames": 710}
       ],
@@ -1630,7 +1630,7 @@
       "name": "Kihunter Manipulation from Middle Door (Top)",
       "requires": [
         {"notable": "Kihunter Manipulation from Middle Door"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canStopOnADime",
         "canTrickyDodgeEnemies",
         {"or": [

--- a/region/lowernorfair/east/Ridley Tank Room.json
+++ b/region/lowernorfair/east/Ridley Tank Room.json
@@ -92,7 +92,7 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"heatFrames": 50}
       ]
@@ -102,7 +102,7 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 50}
       ]
     },
@@ -111,7 +111,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -688,7 +688,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -228,7 +228,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -459,7 +459,7 @@
         "SpaceJump",
         {"or": [
           "Wave",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"heatFrames": 40}
         ]},
         {"or": [
@@ -497,7 +497,7 @@
         "canMidairWiggle",
         {"or": [
           "Wave",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"heatFrames": 40}
         ]},
         {"heatFrames": 120}
@@ -528,7 +528,7 @@
       "requires": [
         "Plasma",
         "Ice",
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": ["Refreeze the Namihe after laying the Power Bomb, to avoid taking damage."]
@@ -539,7 +539,7 @@
       "name": "Crystal Flash (Floating Platform)",
       "requires": [
         {"heatFrames": 60},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 90},
         {"resetRoom": {
           "nodes": [2]
@@ -724,7 +724,7 @@
         "SpeedBooster",
         "canPreciseWalljump",
         "canTrickyDodgeEnemies",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canTrivialMidAirMorph",
         "canHitbox",
         {"heatFrames": 420},
@@ -746,7 +746,7 @@
       "link": [2, 4],
       "name": "HiJump, Screw, and PowerBomb",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canPreciseWalljump",
         "canConsecutiveWalljump",
         "canTrivialMidAirMorph",
@@ -774,7 +774,7 @@
         {"notable": "PowerBombs and a Jump Assist"},
         "canPreciseWalljump",
         "canHitbox",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canTrivialMidAirMorph",
         "canTrickyJump",
         {"or": [
@@ -810,7 +810,7 @@
         {"or": [
           "ScrewAttack",
           {"and": [
-            "h_canBombThings",
+            "h_bombThings",
             "canMidAirMorph"
           ]},
           {"obstaclesCleared": ["A"]}
@@ -872,7 +872,7 @@
         "canPreciseWalljump",
         "canResetFallSpeed",
         "canWalljumpWithCharge",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "canWallJumpInstantMorph",
         "canTrickyDodgeEnemies",
         {"ammo": {"type": "Missile", "count": 4}},
@@ -907,7 +907,7 @@
         "canFastWalljumpClimb",
         "canWallJumpBombBoost",
         "canDiagonalBombJump",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 930},
         {"or": [
           "h_heatResistant",
@@ -1479,7 +1479,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1534,7 +1534,7 @@
         "canHitbox",
         {"or": [
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 175}
           ]},
           {"and": [
@@ -1565,11 +1565,11 @@
         {"or": [
           "ScrewAttack",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 70}
           ]},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 200}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -1582,7 +1582,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1644,7 +1644,7 @@
       "name": "HitBox",
       "requires": [
         "canHitbox",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 280}
       ],
       "unlocksDoors": [
@@ -1747,7 +1747,7 @@
       "name": "HitBox",
       "requires": [
         "canHitbox",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 180}
       ],
       "unlocksDoors": [{"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}]
@@ -1830,7 +1830,7 @@
       "requires": [
         "Plasma",
         "Ice",
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": ["Refreeze the Namihe after laying the Power Bomb, to avoid taking damage."]
@@ -1842,7 +1842,7 @@
       "requires": [
         {"heatFrames": 40},
         {"enemyDamage": {"enemy": "Namihe", "type": "kago", "hits": 1}},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 40}
       ],
       "flashSuitChecked": true,
@@ -1906,7 +1906,7 @@
           "ScrewAttack",
           {"and": [
             "canTrivialMidAirMorph",
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
               {"and": [
                 "canWalljump",
@@ -1917,7 +1917,7 @@
           ]},
           {"and": [
             "canMidAirMorph",
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"or": [
               {"and": [
                 "canConsecutiveWalljump",
@@ -1941,11 +1941,11 @@
         {"heatFrames": 300},
         {"or": [
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 180}
           ]},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 800}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -1965,13 +1965,13 @@
         {"or": [
           {"and": [
             "canTrivialMidAirMorph",
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 200}
           ]},
           {"and": [
             "canDelayedWalljump",
             "canWallJumpInstantMorph",
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 520}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -1990,7 +1990,7 @@
         {"or": [
           {"and": [
             "canTrivialMidAirMorph",
-            "h_canUsePowerBombs"
+            "h_usePowerBombs"
           ]},
           {"obstaclesCleared": ["A"]}
         ]}
@@ -2022,7 +2022,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -195,7 +195,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -204,7 +204,7 @@
       "link": [1, 4],
       "name": "Kihunters Already Killed",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 400},
         {"obstaclesCleared": ["A"]}
       ]
@@ -214,7 +214,7 @@
       "link": [1, 4],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 400},
         {"enemyDamage": {"enemy": "Kihunter (red)", "type": "contact", "hits": 2}}
       ],
@@ -225,8 +225,8 @@
       "link": [1, 4],
       "name": "Hitbox the Kihunters",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canPlasmaHitbox",
+        "h_navigateHeatRooms",
+        "h_plasmaHitbox",
         {"heatFrames": 420}
       ]
     },
@@ -236,7 +236,7 @@
       "name": "Dodge Going Down",
       "requires": [
         {"notable": "Dodge Going Down"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 500}
       ],
@@ -250,7 +250,7 @@
       "link": [1, 4],
       "name": "Screw Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         {"or": [
           {"heatFrames": 100},
@@ -270,7 +270,7 @@
       "link": [1, 4],
       "name": "Full Combo Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         "Plasma",
         "Ice",
@@ -292,7 +292,7 @@
       "link": [1, 4],
       "name": "Chargeless Wave Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Plasma",
         "Wave",
         {"heatFrames": 720}
@@ -304,7 +304,7 @@
       "link": [1, 4],
       "name": "Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Plasma",
         {"or": [
           "canDodgeWhileShooting",
@@ -323,7 +323,7 @@
       "link": [1, 4],
       "name": "Supers Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Kihunter (red)", "Kihunter (red)", "Kihunter (red)"]],
           "explicitWeapons": ["Super"]
@@ -348,7 +348,7 @@
       "link": [1, 4],
       "name": "Ice Wave Spazer Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Spazer",
         "Ice",
         "Wave",
@@ -412,7 +412,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -421,7 +421,7 @@
       "link": [2, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"heatFrames": 660}
       ]
@@ -431,7 +431,7 @@
       "link": [2, 4],
       "name": "HiJump Speed Mockball (Gravity)",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canMockball",
         "HiJump",
         "SpeedBooster",
@@ -456,7 +456,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canMockball",
         "HiJump",
         "SpeedBooster",
@@ -485,7 +485,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         "Morph",
         "canTrickyJump",
@@ -559,7 +559,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -568,7 +568,7 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"heatFrames": 180}
       ],
@@ -579,10 +579,10 @@
       "link": [4, 1],
       "name": "Kihunters Already Dead",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"obstaclesCleared": ["A"]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           {"and": [
@@ -610,7 +610,7 @@
       "link": [4, 1],
       "name": "Hitbox the Kihunters",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Plasma",
         "canHitbox",
         {"or": [
@@ -618,7 +618,7 @@
           {"enemyDamage": {"enemy": "Kihunter (red)", "type": "contact", "hits": 1}}
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           "SpaceJump"
@@ -638,7 +638,7 @@
       "name": "Dodge Going Up",
       "requires": [
         {"notable": "Dodge Going Up"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canInsaneJump",
         {"or": [
           {"and": [
@@ -690,11 +690,11 @@
       "link": [4, 1],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           {"and": [
             "canUseIFrames",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             "canUseIFrames",
@@ -733,7 +733,7 @@
       "link": [4, 1],
       "name": "Partial Kihunter Dodge",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canWalljump",
           "HiJump"
@@ -760,12 +760,12 @@
       "link": [4, 1],
       "name": "Screw Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         {"or": [
           "canWalljump",
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             {"heatFrames": 120},
             {"or": [
               "canCarefulJump",
@@ -794,7 +794,7 @@
       "link": [4, 1],
       "name": "Ice Wave Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Ice",
         "Wave",
         "Plasma",
@@ -803,7 +803,7 @@
           {"heatFrames": 240}
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           {"and": [
@@ -835,11 +835,11 @@
       "link": [4, 1],
       "name": "Wave Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Wave",
         "Plasma",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           {"and": [
@@ -867,14 +867,14 @@
       "link": [4, 1],
       "name": "Plasma Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Plasma",
         {"or": [
           "canCarefulJump",
           {"heatFrames": 100}
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           {"and": [
@@ -904,7 +904,7 @@
       "link": [4, 1],
       "name": "Supers Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Kihunter (red)", "Kihunter (red)", "Kihunter (red)"]],
           "explicitWeapons": ["Super"]
@@ -914,7 +914,7 @@
           {"heatFrames": 210}
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           {"and": [
@@ -943,7 +943,7 @@
       "link": [4, 1],
       "name": "Ice Wave Spazer Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Ice",
         "Wave",
         "Spazer",
@@ -953,7 +953,7 @@
           "h_heatProof"
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           {"and": [
@@ -989,7 +989,7 @@
           "enemies": [["Kihunter (red)", "Kihunter (red)", "Kihunter (red)"]]
         }},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           "canSpringBallJumpMidAir",
@@ -1016,7 +1016,7 @@
       "link": [4, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"heatFrames": 750},
         {"acidFrames": 16}
@@ -1028,7 +1028,7 @@
       "link": [4, 2],
       "name": "Staggered Wall Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         "canStaggeredWalljump",
         {"heatFrames": 660}
@@ -1040,7 +1040,7 @@
       "link": [4, 2],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         "SpaceJump",
         {"or": [
@@ -1058,7 +1058,7 @@
       "link": [4, 2],
       "name": "Gravity",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         "Gravity",
         {"acidFrames": 32},
@@ -1070,7 +1070,7 @@
       "link": [4, 3],
       "name": "Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         "ScrewAttack",
         {"heatFrames": 200}
@@ -1081,8 +1081,8 @@
       "link": [4, 3],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         {"heatFrames": 250}
       ]
     },
@@ -1091,8 +1091,8 @@
       "link": [4, 3],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         {"heatFrames": 230}
       ]
     },
@@ -1101,7 +1101,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1113,7 +1113,7 @@
         "h_heatedGMode",
         {"obstaclesCleared": ["A"]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           "canSpringBallJumpMidAir",
@@ -1132,7 +1132,7 @@
       "requires": [
         "h_heatedGMode",
         {"notable": "Dodge Going Up"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canInsaneJump",
         {"or": [
           {"and": [
@@ -1219,7 +1219,7 @@
           ]}
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump",
           "HiJump",
           "canSpringBallJumpMidAir",

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -305,7 +305,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -343,7 +343,7 @@
             {"heatFrames": 490}
           ]},
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             {"heatFrames": 610}
           ]}
         ]}
@@ -387,7 +387,7 @@
       },
       "requires": [
         "h_heatedGMode",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 0}
       ],
       "flashSuitChecked": true,
@@ -417,7 +417,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 10},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -587,7 +587,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -596,7 +596,7 @@
       "link": [3, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"heatFrames": 120},
         {"obstaclesCleared": ["B"]}
@@ -607,8 +607,8 @@
       "link": [3, 6],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         {"heatFrames": 160}
       ],
       "clearsObstacles": ["B"]
@@ -618,7 +618,7 @@
       "link": [3, 6],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 180}
       ],
       "clearsObstacles": ["A", "B"]
@@ -629,7 +629,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["D"]},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true
@@ -658,7 +658,7 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
           {"and": [
@@ -786,7 +786,7 @@
       "requires": [
         {"heatFrames": 150},
         "canHitbox",
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B"]
     },
@@ -809,7 +809,7 @@
         {"getBlueSpeed": {"usedTiles": 20, "openEnd": 1}},
         "canSpeedball",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"hibashiHits": 1}
         ]},
         {"heatFrames": 300}
@@ -918,7 +918,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"heatFrames": 240},
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}}
@@ -932,7 +932,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         "ScrewAttack",
         {"heatFrames": 270}
@@ -946,7 +946,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"enemyKill": {
           "enemies": [["Dessgeega"], ["Dessgeega", "Dessgeega", "Dessgeega"]],
@@ -963,7 +963,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         "canDodgeWhileShooting",
         {"enemyKill": {
@@ -1001,7 +1001,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"or": [
           {"and": [
@@ -1042,7 +1042,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true
@@ -1063,7 +1063,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
         {"heatFrames": 255}
@@ -1077,7 +1077,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         "ScrewAttack",
         {"heatFrames": 240}
@@ -1091,7 +1091,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"enemyKill": {
           "enemies": [["Dessgeega"]],
@@ -1108,7 +1108,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"enemyKill": {
           "enemies": [["Dessgeega"]],
@@ -1127,7 +1127,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"or": [
           "Charge",
@@ -1145,7 +1145,7 @@
       "requires": [
         {"notable": "Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "HiJump",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1170,7 +1170,7 @@
       "requires": [
         {"notable": "HiJumpless Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canTrickyJump",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1196,7 +1196,7 @@
       "requires": [
         {"notable": "Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "HiJump",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1207,7 +1207,7 @@
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
         {"heatFrames": 390},
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"hibashiHits": 1}
         ]}
       ],
@@ -1229,7 +1229,7 @@
       "requires": [
         {"notable": "HiJumpless Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canPartialFloorClip",
         "canCeilingClip",
         "canTrickyJump",
@@ -1240,7 +1240,7 @@
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
         {"heatFrames": 390},
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"hibashiHits": 1}
         ]}
       ],
@@ -1282,7 +1282,7 @@
       "link": [6, 3],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 150}
       ],
       "clearsObstacles": ["B"]
@@ -1292,8 +1292,8 @@
       "link": [6, 3],
       "name": "Power Bomb",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         {"heatFrames": 210}
       ],
       "clearsObstacles": ["A", "B"],
@@ -1385,7 +1385,7 @@
       "name": "Take Damage",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]},
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
@@ -1398,7 +1398,7 @@
       "link": [6, 5],
       "name": "HitBox enemy (Power Bomb)",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canHitbox",
         {"heatFrames": 240}
       ],
@@ -1410,7 +1410,7 @@
       "name": "Screw Attack",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]},
         "ScrewAttack",
@@ -1424,7 +1424,7 @@
       "name": "Fast Kill",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]},
         {"enemyKill": {
@@ -1442,7 +1442,7 @@
       "requires": [
         "h_heatProof",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]},
         {"or": [
@@ -1457,7 +1457,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"or": [
           {"obstaclesCleared": ["B"]},
           {"obstaclesCleared": ["C"]}
@@ -1474,7 +1474,7 @@
       "link": [7, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 120},
         {"obstaclesCleared": ["D"]}
       ]
@@ -1515,7 +1515,7 @@
         {"or": [
           "canTrickyJump",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             "canCarefulJump",
             "canHitbox"
           ]}
@@ -1537,7 +1537,7 @@
       "requires": [
         "h_heatProof",
         "canBePatient",
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "clearsObstacles": ["C", "D"],
       "note": [
@@ -1561,7 +1561,7 @@
       "link": [7, 4],
       "name": "Supers Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyKill": {
           "enemies": [["Dessgeega", "Dessgeega", "Dessgeega"]],
           "explicitWeapons": ["Super"]
@@ -1635,7 +1635,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": [
@@ -1668,9 +1668,9 @@
       "name": "Avoid Hibashi",
       "requires": [
         "h_heatResistant",
-        "h_canBombThings",
+        "h_bombThings",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "canInsaneJump",
           {"obstaclesCleared": ["E"]}
         ]},
@@ -1681,14 +1681,14 @@
         "The hibashi hit can be avoided by waiting for the shutter to go up.",
         "That requires the use of one PB and more time than is worth unless heat proof."
       ],
-      "devNote": "Note that if using PBs, two is required. One each from h_canBombThings, h_canUsePowerBombs."
+      "devNote": "Note that if using PBs, two is required. One each from h_bombThings, h_usePowerBombs."
     },
     {
       "id": 88,
       "link": [7, 8],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 350},
         {"hibashiHits": 1}
       ]
@@ -1698,7 +1698,7 @@
       "link": [7, 8],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Morph",
         {"ammo": {"type": "PowerBomb", "count": 2}},
         {"heatFrames": 350},
@@ -1773,7 +1773,7 @@
           "canCarefulJump",
           {"hibashiHits": 1}
         ]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 300}
       ]
     },
@@ -1803,7 +1803,7 @@
       "link": [8, 8],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["E"],
       "flashSuitChecked": true,
@@ -1847,7 +1847,7 @@
       "requires": [
         "h_heatedGMode",
         "canOffScreenMovement",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           "canTrickyGMode",
           {"spikeHits": 1}
@@ -1896,7 +1896,7 @@
         "Morph",
         {"or": [
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 1000}
           ]},
           {"and": [
@@ -1914,7 +1914,7 @@
             {"heatFrames": 60}
           ]},
           {"obstaclesCleared": ["E"]},
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"hibashiHits": 1},
           {"ammo": {"type": "PowerBomb", "count": 1}}
         ]}
@@ -1942,7 +1942,7 @@
         "canSpeedball",
         {"or": [
           "canInsaneJump",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"ammo": {"type": "PowerBomb", "count": 1}},
           {"hibashiHits": 1},
           {"obstaclesCleared": ["E"]}
@@ -1963,7 +1963,7 @@
         "Morph",
         {"or": [
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 800}
           ]},
           {"and": [

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -174,7 +174,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -183,7 +183,7 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 180}
       ]
@@ -196,7 +196,7 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 125},
         {"shinespark": {"frames": 36}}
       ]
@@ -223,7 +223,7 @@
       "link": [1, 3],
       "name": "Gravityless Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canSuitlessLavaDive",
         {"or": [
           "HiJump",
@@ -243,7 +243,7 @@
       "link": [1, 3],
       "name": "Gravity Acid Dive",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canSuitlessLavaDive",
         "Gravity",
         {"or": [
@@ -314,7 +314,7 @@
       },
       "requires": [
         {"heatFrames": 220},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
@@ -337,7 +337,7 @@
         }
       },
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 220},
         "canOffScreenMovement"
       ],
@@ -357,7 +357,7 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
         {"heatFrames": 100}
       ]
@@ -408,7 +408,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -439,7 +439,7 @@
       },
       "requires": [
         {"heatFrames": 220},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
@@ -462,7 +462,7 @@
         }
       },
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 220},
         "canOffScreenMovement"
       ],
@@ -482,7 +482,7 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         {"heatFrames": 270}
       ]
@@ -492,7 +492,7 @@
       "link": [2, 5],
       "name": "Avoid Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canTrickyJump",
           {"and": [
@@ -510,7 +510,7 @@
       "link": [2, 5],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyDamage": {"enemy": "Holtz", "type": "contact", "hits": 1}},
         {"heatFrames": 375}
       ],
@@ -521,7 +521,7 @@
       "link": [2, 5],
       "name": "Full Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         "Ice",
         "Wave",
@@ -537,7 +537,7 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 125},
         {"shinespark": {"frames": 41, "excessFrames": 6}}
       ]
@@ -547,7 +547,7 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 300}
       ]
@@ -557,7 +557,7 @@
       "link": [3, 1],
       "name": "Without Acid",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
         {"heatFrames": 300}
       ]
@@ -567,9 +567,9 @@
       "link": [3, 3],
       "name": "Use Acid Statue",
       "requires": [
-        "h_canActivateAcidChozo",
+        "h_activateAcidChozo",
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 1020}
       ],
       "setsFlags": ["f_UsedAcidChozoStatue"]
@@ -579,7 +579,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -588,8 +588,8 @@
       "link": [3, 3],
       "name": "Crystal Flash, Use Acid Statue",
       "requires": [
-        "h_canHeatedCrystalFlash",
-        "h_canActivateAcidChozo",
+        "h_heatedCrystalFlash",
+        "h_activateAcidChozo",
         {"obstaclesNotCleared": ["A"]},
         {"heatFrames": 920}
       ],
@@ -602,9 +602,9 @@
       "link": [3, 3],
       "name": "Acid Statue with Reserve Trigger",
       "requires": [
-        "h_canActivateAcidChozo",
+        "h_activateAcidChozo",
         {"obstaclesNotCleared": ["A"]},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 180},
         "canManageReserves",
         {"autoReserveTrigger": {}},
@@ -617,7 +617,7 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
         {"heatFrames": 100}
       ]
@@ -627,7 +627,7 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 250}
       ],
       "devNote": "4 requires that the acid is gone."
@@ -637,7 +637,7 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "HiJump",
           "canWalljump",
@@ -658,7 +658,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -667,9 +667,9 @@
       "link": [4, 5],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 400}
       ]
     },
@@ -678,9 +678,9 @@
       "link": [4, 5],
       "name": "PowerBombs",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 250}
       ]
     },
@@ -689,7 +689,7 @@
       "link": [5, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         {"heatFrames": 240}
       ]
@@ -699,7 +699,7 @@
       "link": [5, 2],
       "name": "Avoid Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           "canTrickyJump",
           {"and": [
@@ -717,7 +717,7 @@
       "link": [5, 2],
       "name": "Tank the Damage",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"enemyDamage": {"enemy": "Holtz", "type": "contact", "hits": 1}},
         {"or": [
           {"enemyDamage": {"enemy": "Holtz", "type": "contact", "hits": 1}},
@@ -731,7 +731,7 @@
       "link": [5, 2],
       "name": "Full Beam Kill",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         "Ice",
         "Wave",
@@ -772,9 +772,9 @@
       "link": [5, 4],
       "name": "Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "HiJump",
           "canWalljump",
@@ -792,9 +792,9 @@
       "link": [5, 4],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           "HiJump",
           "canWalljump",
@@ -813,8 +813,8 @@
       "name": "CF Grapple Clip",
       "requires": [
         "h_heatProof",
-        "h_canBombThings",
-        "h_canJumpIntoCrystalFlashClip",
+        "h_bombThings",
+        "h_jumpIntoCrystalFlashClip",
         "HiJump",
         "Grapple"
       ],
@@ -827,7 +827,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -165,7 +165,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"canShineCharge": {"usedTiles": 18, "openEnd": 0}},
         "canShinechargeMovement",
         {"heatFrames": 630},
@@ -451,7 +451,7 @@
       "link": [1, 3],
       "name": "Tank the Rippers",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 450},
         {"enemyDamage": {"enemy": "Ripper 2 (red)", "type": "contact", "hits": 3}}
       ]
@@ -461,7 +461,7 @@
       "link": [1, 3],
       "name": "Screw Attack",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 350},
         "ScrewAttack"
       ]
@@ -471,7 +471,7 @@
       "link": [1, 3],
       "name": "Kill some Rippers",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 450},
         {"enemyKill": {
           "enemies": [["Ripper 2 (red)", "Ripper 2 (red)"]],
@@ -485,7 +485,7 @@
       "link": [1, 3],
       "name": "Farm Rippers and Cross Room",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canFarmWhileShooting",
         {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
         {"enemyKill": {
@@ -750,7 +750,7 @@
       "name": "Leave With Runway (Gate Open)",
       "requires": [
         {"or": [
-          "h_canHeatedGreenGateGlitch",
+          "h_heatedGreenGateGlitch",
           {"obstaclesCleared": ["A"]}
         ]},
         {"enemyDamage": {"enemy": "Ripper 2 (red)", "type": "contact", "hits": 2}}
@@ -768,7 +768,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -843,9 +843,9 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
-          "h_canHeatedGreenGateGlitch",
+          "h_heatedGreenGateGlitch",
           {"obstaclesCleared": ["A"]}
         ]},
         {"heatFrames": 100}
@@ -858,7 +858,7 @@
       "link": [3, 1],
       "name": "Tank the Rippers",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 600},
         {"enemyDamage": {"enemy": "Ripper 2 (red)", "type": "contact", "hits": 2}}
       ]
@@ -868,7 +868,7 @@
       "link": [3, 1],
       "name": "Screw Attack",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 600},
         "ScrewAttack"
       ]
@@ -878,7 +878,7 @@
       "link": [3, 1],
       "name": "Kill some Rippers",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 600},
         {"enemyKill": {
           "enemies": [["Ripper 2 (red)", "Ripper 2 (red)"]],
@@ -892,7 +892,7 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 100},
         {"or": [
           {"and": [
@@ -921,7 +921,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/lowernorfair/west/Golden Torizo Energy Recharge.json
+++ b/region/lowernorfair/west/Golden Torizo Energy Recharge.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -99,14 +99,14 @@
             {
               "name": "Base",
               "requires": [
-                "h_canNavigateHeatRooms",
+                "h_navigateHeatRooms",
                 {"or": [
                   "Wave",
                   {"and": [
-                    "h_canUsePowerBombs",
+                    "h_usePowerBombs",
                     {"or": [
                       "canTrivialMidAirMorph",
-                      "h_canUseSpringBall"
+                      "h_useSpringBall"
                     ]}
                   ]}
                 ]},
@@ -253,7 +253,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -285,7 +285,7 @@
       },
       "requires": [
         "Charge",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "h_HeatedGModeOffCameraDoor"
       ],
       "exitCondition": {
@@ -331,7 +331,7 @@
           ]},
           {"and": [
             "Charge",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]}
         ]},
         "h_HeatedGModeOffCameraDoor"
@@ -369,7 +369,7 @@
       "name": "Crumble Jump to Left Item",
       "requires": [
         {"notable": "Crumble Jump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canCrumbleJump",
         {"heatFrames": 80}
       ],
@@ -381,7 +381,7 @@
       "name": "Bomb Boost to Left Item",
       "requires": [
         {"notable": "Horizontal Bomb Jump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canBombHorizontally",
         {"heatFrames": 160}
       ],
@@ -392,8 +392,8 @@
       "link": [1, 3],
       "name": "Spring Ball",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseSpringBall",
+        "h_navigateHeatRooms",
+        "h_useSpringBall",
         {"heatFrames": 140}
       ]
     },
@@ -402,7 +402,7 @@
       "link": [1, 3],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 70}
       ]
@@ -417,7 +417,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"shinespark": {"frames": 18, "excessFrames": 5}},
         {"heatFrames": 100}
       ],
@@ -437,7 +437,7 @@
         }
       },
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"shinespark": {"frames": 19, "excessFrames": 8}},
         {"heatFrames": 120}
       ],
@@ -500,7 +500,7 @@
       "link": [1, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 200}
       ]
     },
@@ -582,7 +582,7 @@
           "f_DefeatedGoldenTorizo",
           {"heatFrames": 100}
         ]},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"or": [
           {"and": [
             "SpaceJump",
@@ -599,7 +599,7 @@
             "canCrumbleJump"
           ]},
           {"and": [
-            "h_canTrickySpringwall",
+            "h_trickySpringwall",
             "canCrumbleJump"
           ]}
         ]},
@@ -702,7 +702,7 @@
           "canPrepareForNextRoom",
           "f_DefeatedGoldenTorizo"
         ]},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -934,7 +934,7 @@
             {"heatFrames": 70}
           ]},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 250}
           ]},
           {"and": [
@@ -959,7 +959,7 @@
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 50}
       ],
       "clearsObstacles": ["A"]
@@ -1035,7 +1035,7 @@
       "name": "Crumble Jump from Left Item",
       "requires": [
         {"notable": "Crumble Jump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canCrumbleJump",
         {"heatFrames": 100}
       ],
@@ -1047,7 +1047,7 @@
       "name": "Bomb Boost from Left Item",
       "requires": [
         {"notable": "Horizontal Bomb Jump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canBombHorizontally",
         {"heatFrames": 190}
       ],
@@ -1058,8 +1058,8 @@
       "link": [3, 1],
       "name": "Spring Ball",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseSpringBall",
+        "h_navigateHeatRooms",
+        "h_useSpringBall",
         {"heatFrames": 140}
       ]
     },
@@ -1068,7 +1068,7 @@
       "link": [3, 1],
       "name": "Space Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"heatFrames": 90}
       ]
@@ -1078,7 +1078,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1087,7 +1087,7 @@
       "link": [3, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 200}
       ]
     },
@@ -1096,7 +1096,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1105,7 +1105,7 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 100}
       ],
       "clearsObstacles": ["A"]
@@ -1115,7 +1115,7 @@
       "link": [4, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"obstaclesNotCleared": ["A"]},
         {"heatFrames": 100}
       ]
@@ -1125,7 +1125,7 @@
       "link": [5, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 50}
       ]
     },
@@ -1134,11 +1134,11 @@
       "link": [5, 4],
       "name": "Power Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUsePowerBombs",
+        "h_navigateHeatRooms",
+        "h_usePowerBombs",
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"heatFrames": 350},
         {"or": [
@@ -1160,7 +1160,7 @@
       "link": [5, 4],
       "name": "Space Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         "ScrewAttack",
         {"heatFrames": 200}
@@ -1171,7 +1171,7 @@
       "link": [5, 4],
       "name": "Speed HiJump Screw",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "HiJump",
         "SpeedBooster",
         "ScrewAttack",
@@ -1184,7 +1184,7 @@
       "link": [5, 4],
       "name": "GT Supers Screw Walljump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         "canPreciseWalljump",
         "canMidairWiggle",
@@ -1198,7 +1198,7 @@
       "name": "Right Item Walljump Into Double Shinespark",
       "requires": [
         {"notable": "Right Item Double Shinespark"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_DefeatedGoldenTorizo",
         "canShinechargeMovementComplex",
         "canPreciseWalljump",
@@ -1219,7 +1219,7 @@
       "name": "Right Item Double Shinespark With HiJump",
       "requires": [
         {"notable": "Right Item Double Shinespark"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_DefeatedGoldenTorizo",
         "canShinechargeMovementComplex",
         "HiJump",
@@ -1237,7 +1237,7 @@
       "link": [5, 4],
       "name": "GT Supers IBJ",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "f_DefeatedGoldenTorizo",
         {"or": [
           "canLongIBJ",
@@ -1253,8 +1253,8 @@
       "link": [5, 4],
       "name": "Instant Morph Bomb Placement.",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         "can3HighWallMidAirMorph",
         "canConsecutiveWalljump",
         {"heatFrames": 1100}
@@ -1269,8 +1269,8 @@
       "link": [5, 4],
       "name": "Springwall with Bombs",
       "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canUseMorphBombs",
+        "h_navigateHeatRooms",
+        "h_useMorphBombs",
         "h_HeatedSpringwall",
         {"heatFrames": 900}
       ],
@@ -1312,7 +1312,7 @@
       "name": "Safe Spot Supers",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 1200},
         {"ammo": {"type": "Super", "count": 30}}
       ],
@@ -1334,7 +1334,7 @@
       "name": "Safe Spot Supers (Farming)",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyJump",
         {"ammo": {"type": "Super", "count": 15}},
         {"or": [
@@ -1367,7 +1367,7 @@
       "name": "Safe Spot Supers (Farming, Few Supers)",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canTrickyJump",
         "canBePatient",
         {"ammo": {"type": "Super", "count": 5}},
@@ -1401,7 +1401,7 @@
       "name": "Crystal Flash During Fight",
       "requires": [
         {"notable": "Crystal Flash During Fight"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"or": [
           {"ammo": {"type": "Super", "count": 30}},
           {"and": [
@@ -1412,7 +1412,7 @@
           ]}
         ]},
         {"heatFrames": 800},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 800}
       ],
       "setsFlags": ["f_DefeatedGoldenTorizo"],
@@ -1432,7 +1432,7 @@
       "name": "Safe Spot Full Combo",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         "Ice",
         "Wave",
@@ -1448,7 +1448,7 @@
       "name": "Safe Spot Almost Full Combo",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         "Wave",
         "Plasma",
@@ -1463,7 +1463,7 @@
       "name": "Safe Spot Charge Plasma",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         "Plasma",
         {"heatFrames": 2000}
@@ -1477,7 +1477,7 @@
       "name": "Safe Spot Full Spazer",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         "Ice",
         "Wave",
@@ -1493,7 +1493,7 @@
       "name": "Safe Spot Two Beam Charge",
       "requires": [
         {"notable": "Safe Spot Kill"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "Charge",
         {"heatFrames": 6500},
         {"or": [
@@ -1519,7 +1519,7 @@
       "link": [5, 5],
       "name": "Golden Torizo Fight (Supers)",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 1200},
         {"ammo": {"type": "Super", "count": 30}},
         {"enemyDamage": {"enemy": "Golden Torizo", "type": "super", "hits": 4}},
@@ -1572,7 +1572,7 @@
       "link": [5, 5],
       "name": "Golden Torizo Fight (Full Combo)",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 1800},
         "Charge",
         "Ice",
@@ -1598,7 +1598,7 @@
       "link": [5, 5],
       "name": "Golden Torizo Fight (Almost Full Combo)",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 2150},
         "Charge",
         "Wave",
@@ -1623,7 +1623,7 @@
       "link": [5, 5],
       "name": "Golden Torizo Fight (Charge Plasma)",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 3600},
         "Charge",
         "Plasma",
@@ -1673,7 +1673,7 @@
       "link": [6, 2],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 50}
       ]
     },
@@ -1682,15 +1682,15 @@
       "link": [6, 4],
       "name": "SpaceJump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "SpaceJump",
         {"or": [
           "ScrewAttack",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
               "canTrivialMidAirMorph",
-              "h_canUseSpringBall"
+              "h_useSpringBall"
             ]},
             {"heatFrames": 100}
           ]}
@@ -1704,7 +1704,7 @@
       "link": [6, 4],
       "name": "HiJump and Speed",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "HiJump",
         "SpeedBooster",
         "canCarefulJump",
@@ -1718,14 +1718,14 @@
       "link": [6, 4],
       "name": "Walljump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         "canCarefulJump",
         "canPreciseWalljump",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"or": [
           "HiJump",
@@ -1743,7 +1743,7 @@
       "link": [6, 4],
       "name": "Springball Jump",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"not": "f_DefeatedGoldenTorizo"},
         {"or": [
           "canRiskPermanentLossOfAccess",
@@ -1881,11 +1881,11 @@
         ]},
         {"or": [
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 70}
           ]},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 250}
           ]},
           {"and": [

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -198,7 +198,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 10},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 10}
       ],
       "clearsObstacles": ["B"],
@@ -213,7 +213,7 @@
       },
       "requires": [
         {"shineChargeFrames": 25},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 200},
         {"shinespark": {"frames": 31, "excessFrames": 10}}
       ],
@@ -568,7 +568,7 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 60}
       ]
     },
@@ -1030,7 +1030,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 40},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -1052,7 +1052,7 @@
           "HiJump",
           "canSpringBallJumpMidAir",
           "SpeedBooster",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canIBJ"
         ]}
       ],
@@ -1113,7 +1113,7 @@
         "canCarefulJump",
         {"or": [
           "canTrickyJump",
-          "h_canBackIntoCorner"
+          "h_backIntoCorner"
         ]},
         {"doorUnlockedAtNode": 2},
         {"heatFrames": 160}
@@ -1205,7 +1205,7 @@
       },
       "requires": [
         {"notable": "Transition Screwjump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         "HiJump",
         "canWalljump",
@@ -1226,7 +1226,7 @@
       },
       "requires": [
         {"notable": "Transition Screwjump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         "HiJump",
         "canTrickyJump",
@@ -1248,7 +1248,7 @@
       },
       "requires": [
         {"notable": "Transition Screwjump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         "HiJump",
         {"heatFrames": 150}
@@ -1268,7 +1268,7 @@
       },
       "requires": [
         {"notable": "Transition Screwjump"},
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "ScrewAttack",
         "HiJump",
         "canTrickyDashJump",
@@ -1343,7 +1343,7 @@
         "h_heatProof",
         {"or": [
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "SpaceJump",
           "canIBJ",
@@ -1567,7 +1567,7 @@
         {"notable": "Transition Speedjump with Bombs"},
         "HiJump",
         "canMidAirMorph",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 200}
       ],
       "clearsObstacles": ["A"],
@@ -1588,7 +1588,7 @@
         "HiJump",
         "canTrickyDashJump",
         "canMidAirMorph",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 200}
       ],
       "clearsObstacles": ["A"],
@@ -1631,7 +1631,7 @@
         {"or": [
           "h_canArtificialMorphLongIBJ",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
               "canWalljump",
               "SpaceJump",
@@ -1667,10 +1667,10 @@
             "h_canArtificialMorphSpringBall"
           ]},
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
               "HiJump",
-              "h_canCrouchJumpDownGrab",
+              "h_crouchJumpDownGrab",
               "canSpringBallJumpMidAir"
             ]}
           ]}
@@ -1699,7 +1699,7 @@
         {"or": [
           "h_canArtificialMorphLongIBJ",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
               "canWalljump",
               "SpaceJump",
@@ -1736,10 +1736,10 @@
             "h_canArtificialMorphSpringBall"
           ]},
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
               "HiJump",
-              "h_canCrouchJumpDownGrab",
+              "h_crouchJumpDownGrab",
               "canSpringBallJumpMidAir"
             ]}
           ]}
@@ -2113,7 +2113,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -2326,7 +2326,7 @@
       "link": [3, 5],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 220}
       ],
       "clearsObstacles": ["A"]
@@ -2336,7 +2336,7 @@
       "link": [3, 5],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 220}
       ],
       "clearsObstacles": ["A"]
@@ -2418,7 +2418,7 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         {"heatFrames": 60}
       ]
     },
@@ -2590,7 +2590,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -2619,7 +2619,7 @@
       "link": [4, 5],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 220}
       ],
       "clearsObstacles": ["B"]
@@ -2631,9 +2631,9 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 220}
       ],
       "clearsObstacles": ["B"]
@@ -2648,7 +2648,7 @@
           "HiJump",
           "SpaceJump",
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir",
           {"and": [
             "canIBJ",
@@ -2680,7 +2680,7 @@
       "link": [5, 3],
       "name": "IBJ to Break the Top Blocks",
       "requires": [
-        "h_canNavigateHeatRooms",
+        "h_navigateHeatRooms",
         "canLongIBJ",
         "canPowerBombMidIBJ",
         {"heatFrames": 1300}
@@ -2732,7 +2732,7 @@
       "link": [5, 4],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 140}
       ],
       "clearsObstacles": ["B"]
@@ -2742,7 +2742,7 @@
       "link": [5, 4],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 130}
       ],
       "clearsObstacles": ["B"]
@@ -2752,7 +2752,7 @@
       "link": [5, 5],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canTrivialMidAirMorph",
         {"heatFrames": 150}
       ],
@@ -2779,7 +2779,7 @@
       "link": [5, 5],
       "name": "Space Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "SpaceJump",
         "canMidAirMorph",
         {"heatFrames": 250}
@@ -2791,7 +2791,7 @@
       "link": [5, 5],
       "name": "Springwall with Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "h_HeatedSpringwall",
         {"heatFrames": 250}
       ],
@@ -2804,7 +2804,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 40},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -136,7 +136,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -179,7 +179,7 @@
         "HiJump",
         {"or": [
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseFrozenEnemies"
         ]}
       ]
@@ -190,7 +190,7 @@
       "name": "Max Height SpringBall Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         {"or": [
           "can4HighMidAirMorph",
           "canStationaryLateralMidAirMorph",
@@ -210,7 +210,7 @@
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTwoTileSqueeze",
           "Morph"
         ]}
@@ -358,7 +358,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -394,7 +394,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
         ]}
       ]
@@ -406,7 +406,7 @@
       "requires": [
         {"notable": "Puyo Clip"},
         "Gravity",
-        "h_canXRayMorphIceClip",
+        "h_XRayMorphIceClip",
         {"or": [
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 2}}
@@ -430,7 +430,7 @@
       "name": "Suitless Puyo Clip with Morph and X-Ray",
       "requires": [
         {"notable": "Puyo Clip"},
-        "h_canXRayMorphIceClip",
+        "h_XRayMorphIceClip",
         "canTrickyJump",
         {"or": [
           "canTrickyDodgeEnemies",
@@ -456,7 +456,7 @@
       "requires": [
         {"notable": "Puyo Clip Precise Freeze"},
         "Gravity",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"or": [
           "canTrickyDodgeEnemies",
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}},
@@ -474,7 +474,7 @@
       "requires": [
         {"notable": "Suitless Puyo Clip"},
         "canSuitlessMaridia",
-        "h_canHighPixelIceClip",
+        "h_highPixelIceClip",
         {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 2}},
         {"or": [
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 6}},
@@ -509,7 +509,7 @@
       "link": [3, 2],
       "name": "Crystal Flash Clip with Bombs",
       "requires": [
-        "h_canBombIntoCrystalFlashClip",
+        "h_bombIntoCrystalFlashClip",
         "Gravity"
       ],
       "flashSuitChecked": true,
@@ -520,7 +520,7 @@
       "link": [3, 2],
       "name": "Suitless Crystal Flash Clip",
       "requires": [
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "canSuitlessMaridia"
       ],
       "flashSuitChecked": true,

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -138,7 +138,7 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Evir Projectile",
       "requires": [
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -392,7 +392,7 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
@@ -942,7 +942,7 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
@@ -970,7 +970,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1123,7 +1123,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
@@ -1146,7 +1146,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
@@ -1211,7 +1211,7 @@
         {"or": [
           "canPlayInSand",
           "canWalljump",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"or": [
           "canTrickyJump",
@@ -1436,7 +1436,7 @@
         "canSuitlessMaridia",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canStationaryLateralMidAirMorph"
       ],
       "note": [

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -893,7 +893,7 @@
       },
       "requires": [
         {"shineChargeFrames": 10},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"shinespark": {"frames": 23, "excessFrames": 10}}
       ],
       "flashSuitChecked": true,
@@ -955,7 +955,7 @@
       },
       "requires": [
         {"shineChargeFrames": 25},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"shinespark": {"frames": 10, "excessFrames": 8}},
           {"and": [
@@ -1819,7 +1819,7 @@
       },
       "requires": [
         {"shineChargeFrames": 10},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"shinespark": {"frames": 23, "excessFrames": 10}}
       ],
       "flashSuitChecked": true,
@@ -1897,7 +1897,7 @@
       },
       "requires": [
         {"shineChargeFrames": 25},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"shinespark": {"frames": 10, "excessFrames": 8}},
           {"and": [
@@ -2223,7 +2223,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2250,7 +2250,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2260,7 +2260,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"and": [
             "Gravity",
             "ScrewAttack"
@@ -2270,11 +2270,11 @@
             "canIBJ"
           ]},
           {"and": [
-            "h_canUseMorphBombs",
-            "h_canUseSpringBall"
+            "h_useMorphBombs",
+            "h_useSpringBall"
           ]},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             "canTrivialMidAirMorph",
             "canDisableEquipment"
           ]}
@@ -2333,7 +2333,7 @@
               "canConsecutiveWalljump"
             ]}
           ]},
-          "h_canMaxHeightSpringBallJump"
+          "h_maxHeightSpringBallJump"
         ]}
       ]
     },
@@ -2343,7 +2343,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"and": [
             "Gravity",
             "ScrewAttack"

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -239,7 +239,7 @@
       "requires": [
         {"shineChargeFrames": 150},
         {"notable": "Shinespark"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canShinechargeMovementComplex",
         "Grapple",
         {"shinespark": {"frames": 65}},
@@ -264,7 +264,7 @@
       "requires": [
         {"shineChargeFrames": 100},
         {"notable": "Shinespark"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canShinechargeMovementTricky",
         "canPlayInSand",
         "Grapple",
@@ -283,7 +283,7 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "note": "Jump from door platform to door platform while avoiding the sand."
     },
@@ -328,7 +328,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -361,7 +361,7 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "note": "Jump from door platform to door platform while avoiding the sand."
     },
@@ -392,7 +392,7 @@
       "requires": [
         {"shineChargeFrames": 150},
         {"notable": "Shinespark"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canShinechargeMovementComplex",
         "Grapple",
         {"shinespark": {"frames": 65}},
@@ -430,18 +430,18 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canPlayInSand",
           {"and": [
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "Gravity",
             {"or": [
               "HiJump",
-              "h_canUseSpringBall",
+              "h_useSpringBall",
               "SpaceJump"
             ]}
           ]}
@@ -504,18 +504,18 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canPlayInSand",
           {"and": [
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "Gravity",
             {"or": [
               "HiJump",
-              "h_canUseSpringBall",
+              "h_useSpringBall",
               "SpaceJump"
             ]}
           ]}
@@ -585,7 +585,7 @@
       "requires": [
         "Gravity",
         "Grapple",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         "canJumpIntoIBJ"
       ],
       "note": "Springball can keep Samus out of the sand.  Place the first bomb right after Samus begins falling back towards the sand."
@@ -752,7 +752,7 @@
       "requires": [
         {"notable": "Bomb Jump Water Escape"},
         "HiJump",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canSpringFling",
         "canBombJumpWaterEscape",
         "canJumpIntoIBJ",

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -164,7 +164,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -204,7 +204,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A", "B"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["A", "B"],
@@ -241,7 +241,7 @@
       "name": "Reverse",
       "requires": [
         {"notable": "Reverse"},
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B"],
       "setsFlags": ["f_ShaktoolDoneDigging"],
@@ -570,7 +570,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -72,7 +72,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -82,7 +82,7 @@
       "name": "Base",
       "requires": [
         "Gravity",
-        "h_canBombThings",
+        "h_bombThings",
         "h_additionalBomb"
       ]
     },
@@ -91,7 +91,7 @@
       "link": [1, 2],
       "name": "Spring Ball",
       "requires": [
-        "h_canUseSpringBall"
+        "h_useSpringBall"
       ]
     },
     {
@@ -162,7 +162,7 @@
             ]}
           ]},
           {"and": [
-            "h_canUseSpringBall",
+            "h_useSpringBall",
             {"or": [
               "HiJump",
               "canGravityJump"

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -130,7 +130,7 @@
       "link": [1, 1],
       "name": "Sciser Farm",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"resetRoom": {
           "nodes": [1, 2]
         }},
@@ -144,7 +144,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -148,7 +148,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -291,10 +291,10 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canCarefulJump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "Gravity",
           "canSpringBallJumpMidAir"
@@ -334,7 +334,7 @@
         {"notable": "Insane Bomb Jump"},
         "canTrickyJump",
         "canSandfallBounce",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "canIBJ",
           {"and": [
@@ -559,7 +559,7 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canCarefulJump"
       ],
       "flashSuitChecked": true
@@ -592,7 +592,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -763,10 +763,10 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canCarefulJump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "Gravity",
           "canSpringBallJumpMidAir"
@@ -790,7 +790,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "flashSuitChecked": true
     },
@@ -873,7 +873,7 @@
         {"notable": "Suitless Bootless Spring Ball"},
         "canSuitlessMaridia",
         "canPlayInSand",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canStationaryLateralMidAirMorph",
         "canInsaneJump",
         {"or": [
@@ -938,7 +938,7 @@
         {"or": [
           "canPlayInSand",
           "canWalljump",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canCarefulJump"
         ]},
         {"or": [
@@ -973,7 +973,7 @@
         {"notable": "Suitless Bootless Spring Ball"},
         "canSuitlessMaridia",
         "canPlayInSand",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         {"or": [
           {"enemyKill": {
             "enemies": [["Evir"], ["Evir"]],
@@ -1050,7 +1050,7 @@
       "link": [5, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "canPlayInSand",
@@ -1067,7 +1067,7 @@
         "Morph",
         {"or": [
           "canSunkenTileWideWallClimb",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]}
       ],
       "note": [
@@ -1143,7 +1143,7 @@
         {"notable": "Suitless Bootless Spring Ball"},
         "canSuitlessMaridia",
         "canPlayInSand",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canStationaryLateralMidAirMorph",
         "canInsaneJump"
       ],

--- a/region/maridia/inner-pink/Aqueduct Save Room.json
+++ b/region/maridia/inner-pink/Aqueduct Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -316,7 +316,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -328,7 +328,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "exitCondition": {
@@ -360,7 +360,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -395,11 +395,11 @@
         "canSuitlessMaridia",
         "canLongChainTemporaryBlue",
         {"ammo": {"type": "PowerBomb", "count": 1}},
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         {"or": [
           "canXRayCeilingClip",
           {"and": [
-            "h_canJumpIntoCrystalFlashClip",
+            "h_jumpIntoCrystalFlashClip",
             "Grapple"
           ]}
         ]},
@@ -444,7 +444,7 @@
       },
       "requires": [
         "h_canArtificialMorphBombs",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"and": [
             "Gravity",
@@ -524,7 +524,7 @@
       },
       "requires": [
         "h_canArtificialMorphBombs",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -571,7 +571,7 @@
         ]},
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -654,7 +654,7 @@
         "canSpringBallJumpMidAir",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -669,7 +669,7 @@
         "canConsecutiveWalljump",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -689,7 +689,7 @@
         ]},
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["A"],
@@ -701,11 +701,11 @@
       "name": "Bootless Suitless Snail Climb (Crab Shaft Door)",
       "requires": [
         {"notable": "Bootless Suitless Snail Climb"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "clearsObstacles": ["A"],
@@ -724,7 +724,7 @@
       "requires": [
         {"shineChargeFrames": 130},
         "canSuitlessMaridia",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canShinechargeMovement",
         {"shinespark": {"frames": 25, "excessFrames": 11}}
       ],
@@ -741,10 +741,10 @@
         }
       },
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 25, "excessFrames": 11}},
           {"and": [
@@ -765,11 +765,11 @@
         }
       },
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canPreciseStutterWaterShineCharge",
         "canInsaneJump",
         "canShinechargeMovementTricky",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 25, "excessFrames": 11}},
           {"and": [
@@ -791,9 +791,9 @@
         "Gravity",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovementComplex",
         {"or": [
           {"and": [
@@ -998,7 +998,7 @@
         "canShinechargeMovementComplex",
         "canPreciseStutterWaterShineCharge",
         "canInsaneJump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 12}},
           {"and": [
@@ -1263,7 +1263,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1298,7 +1298,7 @@
           "SpaceJump",
           "canCarefulJump",
           "h_getBlueSpeedMaxRunway",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ]
     },
@@ -1311,7 +1311,7 @@
         {"or": [
           {"and": [
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           "canPlayInSand"
         ]}
@@ -1331,7 +1331,7 @@
         "canShinechargeMovementComplex",
         "canWaterShineCharge",
         "canHorizontalShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 139, "excessFrames": 66}}
       ],
       "note": [
@@ -1407,7 +1407,7 @@
       "name": "Snail Climb",
       "requires": [
         "canSnailClimb",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"or": [
           "Gravity",
           {"and": [
@@ -1423,7 +1423,7 @@
       "name": "Bootless Suitless Snail Climb (Right Door)",
       "requires": [
         {"notable": "Bootless Suitless Snail Climb"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canSnailClimb"
       ],
       "note": [
@@ -1443,7 +1443,7 @@
       },
       "requires": [
         "canWaterShineCharge",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 37, "excessFrames": 3}}
       ],
       "note": [
@@ -1457,7 +1457,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 40, "excessFrames": 7}}
       ]
     },
@@ -1473,7 +1473,7 @@
       },
       "requires": [
         "canWaterShineCharge",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 40, "excessFrames": 7}}
       ],
       "note": [
@@ -1486,7 +1486,7 @@
       "link": [2, 7],
       "name": "Temporary Blue Gravity Jump",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canGravityJump",
         "canTemporaryBlue",
         {"or": [
@@ -1514,12 +1514,12 @@
         {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
         "h_waterGetBlueSpeed",
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         "canChainTemporaryBlue",
         {"or": [
           "canXRayCeilingClip",
           {"and": [
-            "h_canJumpIntoCrystalFlashClip",
+            "h_jumpIntoCrystalFlashClip",
             "Grapple"
           ]}
         ]}
@@ -1542,12 +1542,12 @@
       "requires": [
         {"notable": "Suitless Temporary Blue To Items"},
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         "canChainTemporaryBlue",
         {"or": [
           "canXRayCeilingClip",
           {"and": [
-            "h_canJumpIntoCrystalFlashClip",
+            "h_jumpIntoCrystalFlashClip",
             "Grapple"
           ]}
         ]}
@@ -1576,13 +1576,13 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "h_canUsePowerBombs",
-        "h_canUsePowerBombs",
-        "h_canNavigateUnderwater",
+        "h_usePowerBombs",
+        "h_usePowerBombs",
+        "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
           "Gravity",
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           {"and": [
             "HiJump",
             {"or": [
@@ -1619,7 +1619,7 @@
         "h_canArtificialMorphSpringBall",
         "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphPowerBomb",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
           "Gravity",
@@ -1668,7 +1668,7 @@
       "name": "Snail Climb",
       "requires": [
         "canSnailClimb",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"or": [
           "Gravity",
           {"and": [
@@ -1685,7 +1685,7 @@
       "name": "Bootless Suitless Snail Climb (Top Door)",
       "requires": [
         {"notable": "Bootless Suitless Snail Climb"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canSnailClimb"
       ],
       "note": [
@@ -1700,7 +1700,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 37, "excessFrames": 3}}
       ]
     },
@@ -1771,7 +1771,7 @@
       },
       "requires": [
         "Grapple",
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "flashSuitChecked": true,
       "note": "Overload PLMs using the Grapple Blocks."
@@ -2128,7 +2128,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2343,7 +2343,7 @@
         {"or": [
           "canXRayCeilingClip",
           {"and": [
-            "h_canJumpIntoCrystalFlashClip",
+            "h_jumpIntoCrystalFlashClip",
             "Grapple"
           ]}
         ]}
@@ -2403,13 +2403,13 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "h_canUsePowerBombs",
-        "h_canUsePowerBombs",
-        "h_canNavigateUnderwater",
+        "h_usePowerBombs",
+        "h_usePowerBombs",
+        "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
           "Gravity",
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           {"and": [
             "HiJump",
             {"or": [
@@ -2446,7 +2446,7 @@
         "h_canArtificialMorphSpringBall",
         "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphPowerBomb",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
           "Gravity",
@@ -2560,7 +2560,7 @@
       },
       "requires": [
         "Grapple",
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "flashSuitChecked": true,
       "note": "Overload PLMs using the Grapple Blocks."
@@ -2674,7 +2674,7 @@
       "name": "G-Mode Setup - Snail Platform",
       "requires": [
         "canUpwardGModeSetup",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTwoTileSqueeze"
       ],
       "exitCondition": {
@@ -2803,11 +2803,11 @@
         "canSuitlessMaridia",
         "canChainTemporaryBlue",
         {"ammo": {"type": "PowerBomb", "count": 1}},
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         {"or": [
           "canXRayCeilingClip",
           {"and": [
-            "h_canJumpIntoCrystalFlashClip",
+            "h_jumpIntoCrystalFlashClip",
             "Grapple"
           ]}
         ]}
@@ -2836,7 +2836,7 @@
         "canChainTemporaryBlue",
         "canXRayTurnaround",
         {"ammo": {"type": "PowerBomb", "count": 1}},
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         "canXRayCeilingClip"
       ],
       "note": [
@@ -2863,13 +2863,13 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "h_canUsePowerBombs",
-        "h_canUsePowerBombs",
-        "h_canNavigateUnderwater",
+        "h_usePowerBombs",
+        "h_usePowerBombs",
+        "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
           "Gravity",
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           {"and": [
             "HiJump",
             {"or": [
@@ -2907,7 +2907,7 @@
         "h_canArtificialMorphSpringBall",
         "h_canArtificialMorphPowerBomb",
         "h_canArtificialMorphPowerBomb",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
           "Gravity",
@@ -2965,7 +2965,7 @@
       },
       "requires": [
         "Grapple",
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "flashSuitChecked": true,
       "note": "Overload PLMs using the Grapple Blocks."
@@ -2994,7 +2994,7 @@
       "name": "Base",
       "requires": [
         "Gravity",
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ]
     },
     {
@@ -3002,7 +3002,7 @@
       "link": [9, 1],
       "name": "Suitless",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ]
     },
     {
@@ -3011,7 +3011,7 @@
       "name": "Snail Stuck Moonfall",
       "requires": [
         {"notable": "Snail Stuck Moonfall"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canEnemyStuckMoonfall",
         "canBePatient",
         {"enemyDamage": {"enemy": "Yard", "type": "contact", "hits": 1}}
@@ -3029,7 +3029,7 @@
       "link": [9, 1],
       "name": "G-Mode Setup - Get Hit By Yard, from Above",
       "requires": [
-        "h_canDestroyBombWalls"
+        "h_destroyBombWalls"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -3048,7 +3048,7 @@
       "link": [9, 5],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -3149,7 +3149,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3216,7 +3216,7 @@
       "name": "G-Mode, Overload PLMs - Bomb the Speed Blocks",
       "requires": [
         "canEnterGMode",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "canSnailClimb",
           "Gravity",
@@ -3286,7 +3286,7 @@
         "canSnailClimb",
         {"or": [
           "Gravity",
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           {"and": [
             "HiJump",
             {"or": [

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zoa",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -158,7 +158,7 @@
       "name": "Kill the Owtch",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "Plasma",
           "Charge",
           {"ammo": {"type": "Super", "count": 1}},
@@ -367,7 +367,7 @@
       "link": [1, 3],
       "name": "Frozen Zoa Bridge",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand"
       ]
@@ -390,7 +390,7 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "devNote": "The expectation is to fall down the left side of the sand entrance."
     },
@@ -412,7 +412,7 @@
         {"or": [
           "HiJump",
           "canEscapeSand",
-          "h_canUseMorphBombs"
+          "h_useMorphBombs"
         ]}
       ]
     },
@@ -421,7 +421,7 @@
       "link": [3, 1],
       "name": "Frozen Zoa Bridge",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand"
       ]
@@ -458,7 +458,7 @@
         {"or": [
           "HiJump",
           "canEscapeSand",
-          "h_canUseMorphBombs"
+          "h_useMorphBombs"
         ]}
       ]
     }

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -442,7 +442,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 2}},
           {"enemyKill": {
             "enemies": [["Puyo"], ["Puyo", "Puyo"], ["Puyo"]],
@@ -516,7 +516,7 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ]
     },
     {
@@ -592,9 +592,9 @@
         "h_getBlueSpeedMaxRunway",
         {"or": [
           {"getBlueSpeed": {"usedTiles": 22, "gentleDownTiles": 4, "openEnd": 1}},
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "SpaceJump",
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           "canPlayInSand",
           {"obstaclesCleared": ["A"]}
         ]}
@@ -615,7 +615,7 @@
         "canSuitlessMaridia",
         "HiJump",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canPlayInSand"
         ]},
         {"obstaclesCleared": ["A"]}
@@ -857,7 +857,7 @@
         "Gravity",
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "canIBJ",
             "canBombHorizontally"
@@ -882,7 +882,7 @@
           ]},
           {"and": [
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "HiJump",
@@ -1076,7 +1076,7 @@
       "name": "Sand Grapple Boost",
       "requires": [
         {"notable": "Sand Grapple Boost"},
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canSandGrappleBoost",
         "canInsaneJump",
         "canMidAirMorph"
@@ -1141,7 +1141,7 @@
       "requires": [
         {"notable": "Sand Bomb Boost (Left to Right)"},
         {"tech": "canSandBombBoost"},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canInsaneJump",
         {"or": [
           "can4HighMidAirMorph",
@@ -1202,7 +1202,7 @@
         {"or": [
           "canPlayInSand",
           "SpaceJump",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"obstaclesCleared": ["A"]}
       ]
@@ -1215,7 +1215,7 @@
         "canSuitlessMaridia",
         "HiJump",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canPlayInSand"
         ]},
         {"obstaclesCleared": ["A"]}
@@ -1950,7 +1950,7 @@
       "name": "Bomb Grapple Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canBombGrappleJump"
       ],
       "note": "Use the respawning Zoas to double jump up to the Morph Ball maze."
@@ -1960,7 +1960,7 @@
       "link": [4, 6],
       "name": "Sand Grapple Boost",
       "requires": [
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canSandGrappleBoost",
         "canInsaneJump"
       ],
@@ -1977,7 +1977,7 @@
       "name": "Sand Bomb Boost",
       "requires": [
         {"tech": "canSandBombBoost"},
-        "h_canBombThings",
+        "h_bombThings",
         "canInsaneJump",
         "canDownGrab"
       ],
@@ -2032,10 +2032,10 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "Gravity",
-            "h_canBombThings",
+            "h_bombThings",
             "h_additionalBomb",
             "h_additionalBomb"
           ]}
@@ -2065,10 +2065,10 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "Gravity",
-            "h_canBombThings",
+            "h_bombThings",
             "h_additionalBomb",
             "h_additionalBomb"
           ]}

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -154,7 +154,7 @@
       "requires": [
         "canShinechargeMovement",
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 70}
       ],
       "exitCondition": {
@@ -171,7 +171,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -190,7 +190,7 @@
       "name": "Mochtroid Ice Clip (Left to Right)",
       "requires": [
         {"notable": "Mochtroid Ice Clip"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseFrozenEnemies",
         {"disableEquipment": "Gravity"},
         {"or": [
@@ -299,7 +299,7 @@
       "link": [1, 2],
       "name": "CF Clip with Bombs (Left to Right)",
       "requires": [
-        "h_canBombIntoCrystalFlashClip",
+        "h_bombIntoCrystalFlashClip",
         "Gravity"
       ],
       "flashSuitChecked": true,
@@ -315,13 +315,13 @@
       "link": [1, 2],
       "name": "Suitless CF Clip (Left to Right)",
       "requires": [
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "canSuitlessMaridia",
         {"or": [
           "HiJump",
           "canSpringBallJumpMidAir",
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canCarefulJump"
           ]},
           "canUseFrozenEnemies"
@@ -344,7 +344,7 @@
           "HiJump",
           "canSpringBallJumpMidAir",
           "Gravity",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           {"and": [
             "h_UnderwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
@@ -424,7 +424,7 @@
       "name": "Mochtroid Ice Clip (With Jump Assist)",
       "requires": [
         {"notable": "Mochtroid Ice Clip"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseFrozenEnemies",
         {"or": [
           "HiJump",
@@ -458,7 +458,7 @@
         "canUseFrozenEnemies",
         "canMorphTurnaround",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           {"and": [
             "h_UnderwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
@@ -490,7 +490,7 @@
         "canUseFrozenEnemies",
         "canTrickyJump",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           {"and": [
             "h_UnderwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
@@ -514,7 +514,7 @@
       "link": [2, 1],
       "name": "CF Clip with Bombs (Right to Left)",
       "requires": [
-        "h_canBombIntoCrystalFlashClip",
+        "h_bombIntoCrystalFlashClip",
         "Gravity"
       ],
       "flashSuitChecked": true,
@@ -530,11 +530,11 @@
       "link": [2, 1],
       "name": "Suitless CF Clip (Right to Left)",
       "requires": [
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "canSuitlessMaridia",
         {"or": [
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canTrickyJump"
           ]},
           "HiJump",
@@ -657,7 +657,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Mochtroid",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -675,7 +675,7 @@
       "requires": [
         "canShinechargeMovement",
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 55}
       ],
       "exitCondition": {
@@ -797,7 +797,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -806,10 +806,10 @@
       "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Mochtroid",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canTrickyJump"
           ]},
           "HiJump",

--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -206,7 +206,7 @@
         {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
         {"or": [
           {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "note": [
@@ -322,7 +322,7 @@
         {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
         {"or": [
           {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "note": [
@@ -366,7 +366,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -258,7 +258,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -302,7 +302,7 @@
       "link": [1, 1],
       "name": "Botwoon Microwave",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Charge",
         "Plasma",
         "canXRayWaitForIFrames"
@@ -499,7 +499,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -551,7 +551,7 @@
       "name": "Back-Side Microwave",
       "requires": [
         {"notable": "Back-Side Fight with Charge and Wave"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Charge",
         "Plasma",
         "Wave",
@@ -567,7 +567,7 @@
       "name": "Back-Side Waveless Microwave",
       "requires": [
         {"notable": "Back-Side Magic Pixel Beam Fight"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Charge",
         "Plasma",
         "canXRayWaitForIFrames"
@@ -587,7 +587,7 @@
       "name": "Back-Side Magic Pixel Fight",
       "requires": [
         {"notable": "Back-Side Magic Pixel Beam Fight"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"enemyKill": {
           "enemies": [["Reverse Botwoon 1"], ["Reverse Botwoon 2"]],
           "explicitWeapons": ["Charge+Plasma", "Charge+Ice+Spazer"]
@@ -606,7 +606,7 @@
       "name": "Back-Side Plasma Shield Microwave",
       "requires": [
         {"notable": "Back-Side Plasma Shield Microwave"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canSpecialBeamAttack",
         "Plasma",
         "canXRayWaitForIFrames",
@@ -626,7 +626,7 @@
       "name": "Back-Side Plasma Shield Fight",
       "requires": [
         {"notable": "Back-Side Plasma Shield Fight"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"enemyKill": {
           "enemies": [["Reverse Botwoon 1"], ["Reverse Botwoon 2"]],
           "explicitWeapons": ["Plasma Shield"]
@@ -641,7 +641,7 @@
       "name": "Back-Side Super Only Fight",
       "requires": [
         {"notable": "Back-Side Super Only Fight"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canBeExtremelyPatient",
         {"enemyKill": {
           "enemies": [["Reverse Botwoon 1"], ["Reverse Botwoon 2"]],

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -108,8 +108,8 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Mochtroid",
       "requires": [
-        "h_canNavigateUnderwater",
-        "h_canFrozenEnemyRunway",
+        "h_navigateUnderwater",
+        "h_frozenEnemyRunway",
         {"or": [
           "canMochtroidIceClimb",
           {"and": [
@@ -155,7 +155,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -178,7 +178,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -202,7 +202,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -471,7 +471,7 @@
             "can4HighMidAirMorph",
             "canPlayInSand"
           ]},
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"or": [
           "canDoubleBombJump",
@@ -565,7 +565,7 @@
         "canWalljump",
         "Morph",
         "canUseIFrames",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         "canMockball",
         {"spikeHits": 3},
         {"or": [
@@ -606,7 +606,7 @@
       "link": [1, 3],
       "name": "Mochtroid Ice Climb (Left to Right)",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canMochtroidIceClimb",
         "canPlayInSand",
         "canCameraManip",
@@ -851,8 +851,8 @@
             "canCrouchJump",
             "canCeilingClip"
           ]},
-          "h_canXRayMorphIceClip",
-          "h_canHighPixelIceClip"
+          "h_XRayMorphIceClip",
+          "h_highPixelIceClip"
         ]},
         "canGrappleClip"
       ],
@@ -874,7 +874,7 @@
       "requires": [
         {"notable": "Grapple Bomb Hang Door Lock Skip"},
         "Gravity",
-        "h_canBombThings",
+        "h_bombThings",
         "canGrappleBombHang",
         "canGrappleClip"
       ],
@@ -935,7 +935,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Mochtroid",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Gravity",
         "canPlayInSand",
         {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 1}}
@@ -957,7 +957,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1011,7 +1011,7 @@
       "link": [2, 3],
       "name": "Mochtroid Climb",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canMochtroidIceClimb"
       ]
     },
@@ -1020,7 +1020,7 @@
       "link": [2, 3],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -1033,7 +1033,7 @@
       },
       "requires": [
         {"shineChargeFrames": 20},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"shinespark": {"frames": 24, "excessFrames": 6}}
       ],
       "flashSuitChecked": true
@@ -1045,7 +1045,7 @@
       "requires": [
         {"notable": "Bomb Jump Water Escape"},
         "HiJump",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canSpringFling",
         "canBombJumpWaterEscape",
         "canJumpIntoIBJ"
@@ -1894,7 +1894,7 @@
             "can4HighMidAirMorph",
             "canPlayInSand"
           ]},
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"or": [
           "canDoubleBombJump",
@@ -1951,7 +1951,7 @@
           "canHorizontalDamageBoost",
           {"spikeHits": 1}
         ]},
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         {"or": [
           "canSpringFling",
           {"and": [
@@ -2008,7 +2008,7 @@
       "link": [3, 1],
       "name": "Mochtroid Ice Climb (Right to Left)",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump"
@@ -2347,8 +2347,8 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Mochtroid",
       "requires": [
-        "h_canNavigateUnderwater",
-        "h_canFrozenEnemyRunway",
+        "h_navigateUnderwater",
+        "h_frozenEnemyRunway",
         {"or": [
           "canMochtroidIceClimb",
           {"and": [
@@ -2392,7 +2392,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -2418,7 +2418,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -2556,7 +2556,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -180,7 +180,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 12}},
           {"and": [
@@ -222,7 +222,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -370,7 +370,7 @@
         "canTrickyGMode",
         "Gravity",
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -399,7 +399,7 @@
         {"notable": "Crab High Pixel Ice Clip Door Lock Skip"},
         "canTrickyGMode",
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canHighPixelIceClip"
+        "h_highPixelIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -453,7 +453,7 @@
       },
       "requires": [
         {"shineChargeFrames": 60},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"shinespark": {"frames": 40, "excessFrames": 6}}
       ],
       "flashSuitChecked": true,
@@ -491,7 +491,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 40, "excessFrames": 6}}
       ],
       "note": [
@@ -505,7 +505,7 @@
       "name": "Crab Climb",
       "requires": [
         {"notable": "Ice Only Crab Climb"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyUseFrozenEnemies",
         "canCarefulJump",
         {"or": [
@@ -904,7 +904,7 @@
         "canSuitlessMaridia",
         "HiJump",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir",
           "canUseFrozenEnemies",
           {"and": [
@@ -922,7 +922,7 @@
         "canSuitlessMaridia",
         "canSpringBallJumpMidAir",
         {"or": [
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           "HiJump",
           "canUseFrozenEnemies"
         ]}
@@ -1075,7 +1075,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -1235,7 +1235,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1304,9 +1304,9 @@
         {"notable": "Crab Ice Clip Door Lock Skip"},
         "canTrickyGMode",
         "Gravity",
-        "h_canHighPixelIceClip",
+        "h_highPixelIceClip",
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -1337,7 +1337,7 @@
         {"notable": "Crab High Pixel Ice Clip Door Lock Skip"},
         "canTrickyGMode",
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canHighPixelIceClip"
+        "h_highPixelIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -1464,7 +1464,7 @@
         "canTrickyGMode",
         "Gravity",
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -1495,7 +1495,7 @@
         {"notable": "Crab High Pixel Ice Clip Door Lock Skip"},
         "canTrickyGMode",
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canHighPixelIceClip"
+        "h_highPixelIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -1608,10 +1608,10 @@
           "canTrickySpringBallJump"
         ]},
         {"or": [
-          "h_canXRayMorphIceClip",
+          "h_XRayMorphIceClip",
           {"and": [
             "Gravity",
-            "h_canPreciseIceClip"
+            "h_preciseIceClip"
           ]}
         ]}
       ],
@@ -1640,7 +1640,7 @@
           "canTrickySpringBallJump"
         ]},
         {"ammo": {"type": "Super", "count": 1}},
-        "h_canHighPixelIceClip"
+        "h_highPixelIceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -1657,7 +1657,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/Draygon Save Room.json
+++ b/region/maridia/inner-pink/Draygon Save Room.json
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -211,7 +211,7 @@
         "canChainTemporaryBlue",
         {"or": [
           "f_DefeatedDraygon",
-          "h_canBreakOneDraygonTurret"
+          "h_breakOneDraygonTurret"
         ]}
       ],
       "exitCondition": {
@@ -225,7 +225,7 @@
       "name": "Grapple Kill",
       "requires": [
         {"notable": "Grapple Kill"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseGrapple",
         {"draygonElectricityFrames": 240},
         {"enemyDamage": {"enemy": "Draygon", "type": "contact", "hits": 5}}
@@ -242,9 +242,9 @@
       "name": "Grapple Quick Kill",
       "requires": [
         {"notable": "Grapple Quick Kill"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canPreciseGrapple",
-        "h_canBreakOneDraygonTurret",
+        "h_breakOneDraygonTurret",
         {"draygonElectricityFrames": 240}
       ],
       "setsFlags": ["f_DefeatedDraygon"],
@@ -264,7 +264,7 @@
         "canShinechargeMovementComplex",
         {"or": [
           "canShinechargeMovementTricky",
-          "h_canBreakThreeDraygonTurrets"
+          "h_breakThreeDraygonTurrets"
         ]},
         {"canShineCharge": {"usedTiles": 22, "openEnd": 0}},
         {"or": [
@@ -307,7 +307,7 @@
         {"notable": "Suitless Fight"},
         "canSuitlessMaridia",
         "Morph",
-        "h_canBreakThreeDraygonTurrets",
+        "h_breakThreeDraygonTurrets",
         {"enemyKill": {
           "enemies": [["Draygon"]],
           "farmableAmmo": ["Missile", "Super"]
@@ -322,7 +322,7 @@
       "link": [1, 1],
       "name": "Microwave Fight",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"and": [
             "canTrickyDodgeEnemies",
@@ -332,7 +332,7 @@
               {"enemyDamage": {"enemy": "Draygon", "type": "turretProjectile", "hits": 1}}
             ]}
           ]},
-          "h_canBreakThreeDraygonTurrets"
+          "h_breakThreeDraygonTurrets"
         ]},
         "canXRayWaitForIFrames",
         "Charge",
@@ -362,9 +362,9 @@
       "requires": [
         {"or": [
           "f_DefeatedDraygon",
-          "h_canBreakOneDraygonTurret"
+          "h_breakOneDraygonTurret"
         ]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -401,10 +401,10 @@
       "link": [1, 1],
       "name": "Leave With Grapple Teleport (Bottom Position)",
       "requires": [
-        "h_canBreakOneDraygonTurret",
+        "h_breakOneDraygonTurret",
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings",
+        "h_bombThings",
         {"draygonElectricityFrames": 40},
         {"or": [
           "canInsaneJump",
@@ -438,10 +438,10 @@
       "link": [1, 1],
       "name": "Leave With Grapple Teleport (Top Position)",
       "requires": [
-        "h_canBreakOneDraygonTurret",
+        "h_breakOneDraygonTurret",
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings",
+        "h_bombThings",
         {"draygonElectricityFrames": 40},
         {"or": [
           "canInsaneJump",
@@ -469,9 +469,9 @@
       "link": [1, 1],
       "name": "Leave With Grapple Teleport (Suitless, Bottom Position)",
       "requires": [
-        "h_canBreakOneDraygonTurret",
+        "h_breakOneDraygonTurret",
         "canGrappleBombHang",
-        "h_canBombThings",
+        "h_bombThings",
         {"draygonElectricityFrames": 45},
         {"or": [
           "canInsaneJump",
@@ -500,10 +500,10 @@
       "link": [1, 1],
       "name": "Leave With Grapple Teleport (Suitless, Top Position)",
       "requires": [
-        "h_canBreakOneDraygonTurret",
+        "h_breakOneDraygonTurret",
         "HiJump",
         "canGrappleBombHang",
-        "h_canBombThings",
+        "h_bombThings",
         {"draygonElectricityFrames": 50},
         {"or": [
           "canInsaneJump",
@@ -531,10 +531,10 @@
       "link": [1, 1],
       "name": "Leave With Grapple Teleport (Suitless Bootless, Top Position)",
       "requires": [
-        "h_canBreakOneDraygonTurret",
+        "h_breakOneDraygonTurret",
         "can4HighMidAirMorph",
         "canGrappleBombHang",
-        "h_canBombThings",
+        "h_bombThings",
         "canStationaryLateralMidAirMorph",
         {"draygonElectricityFrames": 50},
         {"or": [
@@ -665,7 +665,7 @@
         "canSuitlessMaridia",
         "canGrappleJump",
         {"draygonElectricityFrames": 60},
-        "h_canBreakOneDraygonTurret"
+        "h_breakOneDraygonTurret"
       ],
       "note": "Performing a grapple jump off of a Draygon turret. Usually done by bouncing off the wall for momentum."
     },
@@ -1157,8 +1157,8 @@
         {"or": [
           "f_DefeatedDraygon",
           {"and": [
-            "h_canBreakOneDraygonTurret",
-            "h_canBreakOneDraygonTurret"
+            "h_breakOneDraygonTurret",
+            "h_breakOneDraygonTurret"
           ]}
         ]}
       ],
@@ -1173,7 +1173,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_DefeatedDraygon",
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "A 10 Power Bomb Crystal Flash strat may also be possible here, but it seems tricky to ensure that health-bomb won't interfere."

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -205,7 +205,7 @@
       "link": [1, 1],
       "name": "X-Mode, Leave Shinecharged",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovementComplex",
         "canXMode",
         "h_XModeSpikeHit",
@@ -250,7 +250,7 @@
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovementTricky",
         "canTrickyJump",
         "Gravity",
@@ -285,7 +285,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -334,7 +334,7 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "h_canArtificialMorphSpringBall",
           "h_canArtificialMorphBombHorizontally"
@@ -533,7 +533,7 @@
         ]},
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 80}
       ],
       "exitCondition": {
@@ -547,7 +547,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -586,7 +586,7 @@
         {"or": [
           "HiJump",
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             "canSpringFling"
           ]}
         ]}
@@ -619,7 +619,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canTrickyJump",
         {"or": [
           "canStationaryLateralMidAirMorph",
@@ -715,7 +715,7 @@
           "h_XModeSpikeHit",
           "canStationarySpinJump"
         ]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 25, "excessFrames": 5}}
       ],
       "flashSuitChecked": true,
@@ -1268,10 +1268,10 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "Gravity",
-            "h_canBombThings"
+            "h_bombThings"
           ]}
         ]}
       ]
@@ -1350,7 +1350,7 @@
         {"notable": "HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump"},
         "canBombGrappleJump",
         "canDoubleSpringBallJumpMidAir",
-        "h_canMaxHeightSpringBallJump"
+        "h_maxHeightSpringBallJump"
       ],
       "note": [
         "1) Crouch jump and then SpringBall jump.",
@@ -1365,7 +1365,7 @@
       "requires": [
         {"notable": "Bomb Jump Water Escape"},
         "HiJump",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canSpringFling",
         "canBombJumpWaterEscape",
         "canJumpIntoIBJ"
@@ -1448,7 +1448,7 @@
           "canSpringBallJumpMidAir",
           {"and": [
             "canJumpIntoIBJ",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"spikeHits": 1}
         ]}
@@ -1491,7 +1491,7 @@
           ]},
           {"and": [
             "canJumpIntoIBJ",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"spikeHits": 1}
         ]}

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -116,7 +116,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -210,7 +210,7 @@
             "canTrickyJump"
           ]},
           {"and": [
-            "h_canUseSpringBall",
+            "h_useSpringBall",
             "canJumpIntoIBJ"
           ]},
           {"and": [
@@ -243,7 +243,7 @@
           "canPrepareForNextRoom",
           "canPlayInSand"
         ]},
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ],
       "note": "Perform a double springball jump with the first jump being a bounce on the sand."
     },
@@ -509,7 +509,7 @@
           "canPlayInSand",
           {"and": [
             "canPrepareForNextRoom",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]}
         ]},
         {"or": [
@@ -526,7 +526,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canPlayInSand",
-        "h_canMaxHeightSpringBallJump"
+        "h_maxHeightSpringBallJump"
       ],
       "note": "It's possible to get out of the sand suitless and without HiJump after falling from the chute, by hugging the left side and moving quickly."
     },
@@ -602,7 +602,7 @@
           {"and": [
             "canSuitlessMaridia",
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "canSuitlessMaridia",
@@ -646,7 +646,7 @@
       "name": "Spring Ball into IBJ",
       "requires": [
         "canSuitlessMaridia",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         "canJumpIntoIBJ"
       ]
     },

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -191,8 +191,8 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Mochtroid",
       "requires": [
-        "h_canNavigateUnderwater",
-        "h_canFrozenEnemyRunway",
+        "h_navigateUnderwater",
+        "h_frozenEnemyRunway",
         {"or": [
           "canMochtroidIceClimb",
           {"and": [
@@ -223,7 +223,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -249,7 +249,7 @@
           "Gravity"
         ]},
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -273,7 +273,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -298,7 +298,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -758,7 +758,7 @@
       "link": [1, 4],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -767,7 +767,7 @@
       "link": [1, 4],
       "name": "Mochtroid Climb",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canMochtroidIceClimb"
       ]
     },
@@ -806,7 +806,7 @@
         "canSuitlessMaridia",
         "HiJump",
         "canTrickyJump",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canStationaryLateralMidAirMorph"
       ],
       "note": [
@@ -1370,7 +1370,7 @@
       "name": "Suitless Double Spring Ball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ]
     },
     {
@@ -1391,7 +1391,7 @@
       "link": [2, 1],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -1400,7 +1400,7 @@
       "link": [2, 1],
       "name": "Mochtroid Climb",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canMochtroidIceClimb",
         {"or": [
           "Gravity",
@@ -1494,7 +1494,7 @@
       },
       "requires": [
         "canStutterWaterShineCharge",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -1524,7 +1524,7 @@
       },
       "requires": [
         "canStutterWaterShineCharge",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -1830,7 +1830,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -1893,7 +1893,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1915,7 +1915,7 @@
       "name": "Leave With Grapple Teleport (Bomb Hang)",
       "requires": [
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -2598,7 +2598,7 @@
       },
       "requires": [
         "canStutterWaterShineCharge",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -2807,7 +2807,7 @@
         "Morph",
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 20, "excessFrames": 3}},
           {"and": [
@@ -3153,7 +3153,7 @@
       "requires": [
         "Gravity",
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 30}
       ],
       "exitCondition": {
@@ -3252,7 +3252,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -3264,7 +3264,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3276,7 +3276,7 @@
         "Morph",
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 39, "excessFrames": 4}},
           {"and": [
@@ -3779,8 +3779,8 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Mochtroid",
       "requires": [
-        "h_canNavigateUnderwater",
-        "h_canFrozenEnemyRunway",
+        "h_navigateUnderwater",
+        "h_frozenEnemyRunway",
         {"or": [
           "canMochtroidIceClimb",
           {"and": [
@@ -3811,7 +3811,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3876,7 +3876,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {
@@ -3902,7 +3902,7 @@
       "requires": [
         "Gravity",
         "canGrappleBombHang",
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "exitCondition": {
         "leaveWithGrappleTeleport": {

--- a/region/maridia/inner-pink/Maridia Health Refill Room.json
+++ b/region/maridia/inner-pink/Maridia Health Refill Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Space Jump Room.json
+++ b/region/maridia/inner-pink/Space Jump Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -131,7 +131,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -166,7 +166,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           "Grapple",
           "SpaceJump"
         ]}
@@ -763,7 +763,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1008,7 +1008,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           "Grapple",
           "SpaceJump"
         ]}
@@ -1041,7 +1041,7 @@
       "name": "Start Shinecharged, Leave With Temporary Blue",
       "startsWithShineCharge": true,
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 0},
         "canXRayTurnaround",
         "canLongChainTemporaryBlue",
@@ -1085,7 +1085,7 @@
       "name": "Start Shinecharged, Leave With Temporary Blue",
       "startsWithShineCharge": true,
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 0},
         "canXRayTurnaround",
         "canChainTemporaryBlue"

--- a/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "A 10 Power Bomb Crystal Flash strat may also be possible here, but it seems tricky to ensure that health-bomb won't interfere."

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -126,7 +126,7 @@
         }},
         "Gravity",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseFrozenEnemies",
           "canGravityJump",
           "canWalljump",
@@ -144,7 +144,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -155,7 +155,7 @@
       "requires": [
         "Gravity",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseFrozenEnemies",
           "canGravityJump",
           "canWalljump",
@@ -1083,7 +1083,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -158,7 +158,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -215,7 +215,7 @@
         {"or": [
           "SpaceJump",
           {"and": [
-            "h_canUseSpringBall",
+            "h_useSpringBall",
             "canJumpIntoIBJ"
           ]}
         ]}
@@ -279,7 +279,7 @@
           "canPlayInSand"
         ]},
         "HiJump",
-        "h_canMaxHeightSpringBallJump"
+        "h_maxHeightSpringBallJump"
       ],
       "note": [
         "HiJump with a good jump from the sand can reach the Solid Rock Maze region.  Use the sandfall if Samus gets stuck in the sand.",
@@ -300,7 +300,7 @@
       },
       "requires": [
         {"shineChargeFrames": 85},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canPlayInSand",
         "canShinechargeMovementComplex",
         "Wave",
@@ -323,7 +323,7 @@
       },
       "requires": [
         {"shineChargeFrames": 55},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canMidairShinespark",
         "canShinechargeMovementComplex",
         "Wave",
@@ -344,14 +344,14 @@
       },
       "requires": [
         {"shineChargeFrames": 150},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canPlayInSand",
         "canShinechargeMovementTricky",
         {"or": [
           "canResetFallSpeed",
           {"and": [
             "canPrepareForNextRoom",
-            "h_canUsePowerBombs"
+            "h_usePowerBombs"
           ]}
         ]},
         {"shinespark": {"frames": 24, "excessFrames": 5}}
@@ -373,7 +373,7 @@
       },
       "requires": [
         {"shineChargeFrames": 160},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canPlayInSand",
         "canHeroShot",
         "canTrickyJump",
@@ -414,7 +414,7 @@
       "requires": [
         "canPlayInSand",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "Wave"
         ]},
         {"useFlashSuit": {}},
@@ -461,14 +461,14 @@
       },
       "requires": [
         "Morph",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           {"and": [
             "HiJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
-          "h_canMaxHeightSpringBallJump"
+          "h_maxHeightSpringBallJump"
         ]}
       ],
       "flashSuitChecked": true,
@@ -492,8 +492,8 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall"
+          "h_bombThings",
+          "h_useSpringBall"
         ]}
       ]
     },
@@ -502,7 +502,7 @@
       "link": [3, 6],
       "name": "MidAir Morph",
       "requires": [
-        "h_canThreeTileJumpMorph"
+        "h_threeTileJumpMorph"
       ]
     },
     {
@@ -519,7 +519,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canIBJ"
         ]}
       ]
@@ -530,7 +530,7 @@
       "name": "MidAir Morph",
       "requires": [
         {"or": [
-          "h_canFourTileJumpMorph",
+          "h_fourTileJumpMorph",
           {"and": [
             "canPreciseWalljump",
             "canWallJumpInstantMorph"
@@ -552,8 +552,8 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall"
+          "h_bombThings",
+          "h_useSpringBall"
         ]}
       ]
     },
@@ -562,7 +562,7 @@
       "link": [6, 3],
       "name": "MidAir Morph",
       "requires": [
-        "h_canThreeTileJumpMorph"
+        "h_threeTileJumpMorph"
       ]
     },
     {
@@ -571,8 +571,8 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall"
+          "h_bombThings",
+          "h_useSpringBall"
         ]}
       ]
     },
@@ -650,11 +650,11 @@
       "name": "Gravity with Springball",
       "requires": [
         "Gravity",
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"or": [
           {"and": [
             {"tech": "canJumpIntoIBJ"},
-            "h_canBombThings"
+            "h_bombThings"
           ]},
           "canSpringBallBombJump",
           "HiJump"

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -147,7 +147,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zoa",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -219,7 +219,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -254,12 +254,12 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump",
           "canUseFrozenEnemies"
         ]}
@@ -1100,7 +1100,7 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Zoa",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -1172,7 +1172,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1207,12 +1207,12 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump",
           "canUseFrozenEnemies"
         ]}
@@ -1318,7 +1318,7 @@
         "canCarefulJump",
         {"or": [
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump"
         ]},
         {"doorUnlockedAtNode": 1}
@@ -1339,7 +1339,7 @@
         {"ammo": {"type": "Super", "count": 1}},
         {"or": [
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump"
         ]},
         {"doorUnlockedAtNode": 1}
@@ -1382,7 +1382,7 @@
         "HiJump",
         {"or": [
           "canPlayInSand",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "SpaceJump"
         ]}
       ],
@@ -1464,7 +1464,7 @@
         "canCarefulJump",
         {"or": [
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump"
         ]},
         {"doorUnlockedAtNode": 3}
@@ -1485,7 +1485,7 @@
         {"ammo": {"type": "Super", "count": 1}},
         {"or": [
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump"
         ]},
         {"doorUnlockedAtNode": 3}
@@ -1522,7 +1522,7 @@
         "HiJump",
         {"or": [
           "canPlayInSand",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "SpaceJump"
         ]}
       ],

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -123,9 +123,9 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zoa",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
-          "h_canTrickyFrozenEnemyRunway",
+          "h_trickyFrozenEnemyRunway",
           {"enemyDamage": {"enemy": "Zoa", "type": "contact", "hits": 1}}
         ]}
       ],
@@ -174,7 +174,7 @@
       "name": "Door Lock Wall Ice Clip",
       "requires": [
         {"notable": "Door Lock Wall Ice Clip"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canWallIceClip",
         "Wave",
         {"enemyDamage": {"enemy": "Zoa", "type": "contact", "hits": 2}}
@@ -232,7 +232,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canPlayInSand",
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "note": "It is relatively easy to get out of the sand by rapidly placing bombs."
     },
@@ -260,7 +260,7 @@
       "link": [1, 2],
       "name": "Suitless Sand Escape (Left to Right)",
       "requires": [
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canEscapeSand"
       ],
       "note": [
@@ -445,7 +445,7 @@
       "name": "Suitless Bombs",
       "requires": [
         "canSuitlessMaridia",
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         "canPlayInSand"
       ],
       "note": "It is relatively easy to get out of the sand with rapidly placing bombs."
@@ -474,7 +474,7 @@
       "link": [2, 1],
       "name": "Suitless Sand Escape (Right to Left)",
       "requires": [
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canEscapeSand"
       ],
       "note": [
@@ -648,9 +648,9 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Zoa",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
-          "h_canTrickyFrozenEnemyRunway",
+          "h_trickyFrozenEnemyRunway",
           {"enemyDamage": {"enemy": "Zoa", "type": "contact", "hits": 1}}
         ]}
       ],
@@ -699,7 +699,7 @@
       "name": "Door Lock Wall Ice Clip",
       "requires": [
         {"notable": "Door Lock Wall Ice Clip"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canWallIceClip",
         "Wave",
         {"enemyDamage": {"enemy": "Zoa", "type": "contact", "hits": 2}}
@@ -734,7 +734,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           "HiJump"
         ]}
       ]
@@ -771,7 +771,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           "HiJump"
         ]}
       ]

--- a/region/maridia/inner-yellow/Forgotten Highway Save Room.json
+++ b/region/maridia/inner-yellow/Forgotten Highway Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -95,7 +95,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Puyo",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -183,7 +183,7 @@
           "Wave",
           "Spazer",
           "Plasma",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Choot", "type": "contact", "hits": 1}}
         ]}
@@ -565,7 +565,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -242,7 +242,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -256,7 +256,7 @@
           "SpaceJump",
           "canIBJ",
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir"
         ]}
       ]
@@ -766,9 +766,9 @@
           ]},
           {"and": [
             "canLongIBJ",
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
-              "h_canUsePowerBombs",
+              "h_usePowerBombs",
               "canStaggeredIBJ"
             ]}
           ]}
@@ -941,7 +941,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1188,9 +1188,9 @@
           ]},
           {"and": [
             "canLongIBJ",
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"or": [
-              "h_canUsePowerBombs",
+              "h_usePowerBombs",
               "canStaggeredIBJ"
             ]}
           ]}
@@ -1265,7 +1265,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -391,7 +391,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -412,8 +412,8 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall"
+          "h_bombThings",
+          "h_useSpringBall"
         ]},
         {"obstaclesCleared": ["A"]}
       ]
@@ -438,7 +438,7 @@
       "link": [2, 3],
       "name": "Suitless MidAir Morph",
       "requires": [
-        "h_canThreeTileJumpMorph",
+        "h_threeTileJumpMorph",
         {"obstaclesCleared": ["A"]}
       ]
     },
@@ -449,7 +449,7 @@
       "requires": [
         {"notable": "Frozen Menu Bridge"},
         "Morph",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyUseFrozenEnemies",
         "canNeutralDamageBoost",
         {"enemyDamage": {"enemy": "Menu", "type": "contact", "hits": 2}}
@@ -496,7 +496,7 @@
       "requires": [
         "SpaceJump",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "ScrewAttack",
           "Plasma",
           {"and": [
@@ -517,7 +517,7 @@
       "requires": [
         "HiJump",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "ScrewAttack",
           "Plasma",
           {"and": [
@@ -714,9 +714,9 @@
           "types": ["missiles", "powerbomb"],
           "requires": [
             {"or": [
-              "h_canUseSpringBall",
-              "h_canBombThings",
-              "h_canThreeTileJumpMorph"
+              "h_useSpringBall",
+              "h_bombThings",
+              "h_threeTileJumpMorph"
             ]}
           ]
         }
@@ -747,9 +747,9 @@
           "types": ["missiles", "powerbomb"],
           "requires": [
             {"or": [
-              "h_canUseSpringBall",
-              "h_canBombThings",
-              "h_canThreeTileJumpMorph"
+              "h_useSpringBall",
+              "h_bombThings",
+              "h_threeTileJumpMorph"
             ]}
           ]
         }

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -248,7 +248,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -286,7 +286,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -444,7 +444,7 @@
         "HiJump",
         "canSpringBallJumpMidAir",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump",
           "canWalljump"
         ]}
@@ -459,7 +459,7 @@
         "HiJump",
         "canTrickyJump",
         "canTrickyUseFrozenEnemies",
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ]
     },
     {
@@ -468,7 +468,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 90, "excessFrames": 50}}
       ],
@@ -518,7 +518,7 @@
       "name": "Gravity Jump, Precise Crouch Jump Down Grab",
       "requires": [
         "canGravityJump",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canInsaneJump"
       ],
       "note": "Gravity jump out of the water then perform a precise crouch jump + down grab to get onto the next ledge."
@@ -607,7 +607,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -634,7 +634,7 @@
         "canSpringBallJumpMidAir",
         {"or": [
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canTrickySpringBallJump"
         ]}
       ],
@@ -651,7 +651,7 @@
         {"or": [
           {"and": [
             "canTrickyJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             "canStationarySpinJump",
@@ -849,7 +849,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 90, "excessFrames": 11}}
       ],
@@ -1071,7 +1071,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1577,7 +1577,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1632,7 +1632,7 @@
       },
       "requires": [
         "canTrickyDashJump",
-        "h_canUseSpringBall"
+        "h_useSpringBall"
       ],
       "note": [
         "Come in rolling with high speed, and use Spring Ball to jump around the ledge."

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -105,7 +105,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
@@ -340,7 +340,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -632,7 +632,7 @@
       "name": "Shinecharge Out Bottom",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 20}
       ],
       "exitCondition": {
@@ -704,7 +704,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -714,7 +714,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           "Plasma",
           {"ammo": {"type": "Super", "count": 1}}
         ]}
@@ -733,7 +733,7 @@
           "SpaceJump",
           "canIBJ",
           "SpeedBooster",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir",
           "canGravityJump"
         ]}
@@ -754,14 +754,14 @@
       "link": [2, 4],
       "name": "Suitless Frozen Skultera",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseFrozenEnemies",
         {"or": [
           "canTrickyUseFrozenEnemies",
           "HiJump",
           "canSpringBallJumpMidAir",
           "Gravity",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]}
       ],
       "note": "The fish can safely be damaged from the door until they are ready to be used as platforms."
@@ -1431,7 +1431,7 @@
       "name": "Crouch Jump Down Grab Escape",
       "requires": [
         "canSuitlessMaridia",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canTrickyJump"
       ],
       "note": "Crouch jump + down grab only works as a way out of the water on the right side."

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -473,7 +473,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -499,7 +499,7 @@
           "ScrewAttack",
           "canBePatient",
           {"resourceCapacity": [{"type": "Missile", "count": 1}]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ]
     },
@@ -508,7 +508,7 @@
       "link": [1, 2],
       "name": "Morph Dodge",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Morph",
         {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}},
         {"or": [
@@ -623,7 +623,7 @@
           "ScrewAttack",
           "canBePatient",
           {"resourceCapacity": [{"type": "Missile", "count": 1}]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ]
     },
@@ -632,7 +632,7 @@
       "link": [2, 1],
       "name": "Morph Dodge",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Morph",
         {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}},
         {"or": [
@@ -1002,7 +1002,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -110,7 +110,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zeb",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -126,7 +126,7 @@
       "name": "Double Frozen Zeb Runway",
       "requires": [
         {"notable": "Double Frozen Zeb Runway"},
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -262,7 +262,7 @@
       "requires": [
         "Gravity",
         "canTrickyJump",
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ],
       "note": [
         "Getting out with only Gravity and no wall jump requires a tight crouch jump and down grab while above the water:",
@@ -275,7 +275,7 @@
       "name": "Suitless Springball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canMaxHeightSpringBallJump"
+        "h_maxHeightSpringBallJump"
       ],
       "note": "This is a max height springball jump.",
       "devNote": "FIXME add a slightly easier variant that damage boosts off of the Choot."

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -178,7 +178,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -153,7 +153,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -167,7 +167,7 @@
       "link": [1, 1],
       "name": "Sciser Farm",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"resetRoom": {
           "nodes": [1, 4]
         }},
@@ -179,7 +179,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -764,7 +764,7 @@
         "canGravityJump",
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ]
     },
@@ -797,7 +797,7 @@
             ]},
             {"or": [
               "canMidAirMorph",
-              "h_canUseSpringBall"
+              "h_useSpringBall"
             ]}
           ]},
           {"and": [
@@ -836,7 +836,7 @@
         "HiJump",
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"or": [
           "canCrouchJump",
@@ -1318,7 +1318,7 @@
       "name": "Double Springball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ]
     },
     {
@@ -1327,16 +1327,16 @@
       "name": "Ice Clip",
       "requires": [
         {"notable": "Ice Clip"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canOffScreenMovement",
         {"or": [
           {"and": [
             "Gravity",
-            "h_canPreciseIceClip"
+            "h_preciseIceClip"
           ]},
           {"and": [
             "HiJump",
-            "h_canHighPixelIceClip"
+            "h_highPixelIceClip"
           ]}
         ]}
       ],
@@ -1681,7 +1681,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -1769,7 +1769,7 @@
       "link": [2, 2],
       "name": "Sciser Farm",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"resetRoom": {
           "nodes": [2, 3]
         }},
@@ -1781,7 +1781,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2122,7 +2122,7 @@
       },
       "requires": [
         "Morph",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -2136,7 +2136,7 @@
           {"and": [
             "canTrickyUseFrozenEnemies",
             "HiJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             {"ammo": {"type": "Super", "count": 1}},
@@ -2576,7 +2576,7 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -3120,7 +3120,7 @@
       },
       "requires": [
         "Morph",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -3134,7 +3134,7 @@
           {"and": [
             "canTrickyUseFrozenEnemies",
             "HiJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             {"ammo": {"type": "Super", "count": 1}},
@@ -3747,7 +3747,7 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -159,7 +159,7 @@
       "link": [1, 1],
       "name": "Sciser Farm",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"resetRoom": {
           "nodes": [1]
         }},
@@ -173,7 +173,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -312,7 +312,7 @@
       "requires": [
         "Gravity",
         {"or": [
-          "h_canGreenGateGlitch",
+          "h_greenGateGlitch",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -326,7 +326,7 @@
       "requires": [
         {"notable": "Suitless Green Gate Glitch"},
         {"or": [
-          "h_canGreenGateGlitch",
+          "h_greenGateGlitch",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -429,7 +429,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -443,7 +443,7 @@
       "link": [2, 2],
       "name": "Sciser Farm",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"resetRoom": {
           "nodes": [2]
         }},
@@ -457,7 +457,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -471,7 +471,7 @@
         {"or": [
           {"canShineCharge": {"usedTiles": 42, "steepDownTiles": 1, "openEnd": 1}},
           {"and": [
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"obstaclesCleared": ["A"]}
           ]}
         ]},

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -358,7 +358,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -635,7 +635,7 @@
             "HiJump",
             "SpeedBooster"
           ]},
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           {"and": [
             "HiJump",
             "canSpringBallJumpMidAir"
@@ -660,7 +660,7 @@
       },
       "requires": [
         {"shineChargeFrames": 30},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"shinespark": {"frames": 55}}
       ],
       "flashSuitChecked": true
@@ -682,7 +682,7 @@
       "name": "Double Springball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ]
     },
     {
@@ -1303,7 +1303,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1407,7 +1407,7 @@
       "requires": [
         "canWaterShineCharge",
         "canTrickyJump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 41, "excessFrames": 7}},
           {"and": [
@@ -1624,7 +1624,7 @@
           ]}
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir",
           {"and": [
             "Ice",
@@ -1652,7 +1652,7 @@
         "canShinechargeMovement",
         "canDodgeWhileShooting",
         "canTrickyJump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 43, "excessFrames": 9}},
           {"and": [
@@ -1680,7 +1680,7 @@
       "requires": [
         "canWaterShineCharge",
         "canTrickyJump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 43, "excessFrames": 26}},
           {"and": [
@@ -1711,7 +1711,7 @@
           ]}
         ]},
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir",
           {"and": [
             "Ice",
@@ -1800,7 +1800,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
@@ -1827,7 +1827,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"and": [
             "h_canArtificialMorphIBJ",
@@ -1923,7 +1923,7 @@
                 "HiJump",
                 "canTrickyDashJump"
               ]},
-              "h_canMaxHeightSpringBallJump",
+              "h_maxHeightSpringBallJump",
               {"and": [
                 "HiJump",
                 "canSpringBallJumpMidAir"
@@ -1943,7 +1943,7 @@
               "canSpringBallJumpMidAir"
             ]}
           ]},
-          "h_canDoubleSpringBallJumpWithHiJump",
+          "h_doubleSpringBallJumpWithHiJump",
           {"and": [
             "canSuitlessMaridia",
             "canTrickyUseFrozenEnemies",
@@ -2022,7 +2022,7 @@
       },
       "requires": [
         {"shineChargeFrames": 10},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canPrepareForNextRoom",
         "canMidairShinespark",
         {"shinespark": {"frames": 3, "excessFrames": 0}}
@@ -2044,7 +2044,7 @@
       },
       "requires": [
         {"notable": "Room Entry Fall onto Frozen Fish"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canPrepareForNextRoom",
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -2328,7 +2328,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "h_canUseSpringBall"
+        "h_useSpringBall"
       ]
     },
     {
@@ -2402,7 +2402,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2611,14 +2611,14 @@
           {"and": [
             "HiJump",
             {"or": [
-              "h_canCrouchJumpDownGrab",
+              "h_crouchJumpDownGrab",
               "canSpringBallJumpMidAir",
               "canDodgeWhileShooting"
             ]}
           ]},
           {"and": [
             "canTrickyJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]}
         ]}
       ],
@@ -2641,7 +2641,7 @@
         }},
         {"or": [
           "HiJump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           {"and": [
             "canTrickyJump",
             "canTrickySpringBallJump"
@@ -2660,7 +2660,7 @@
         {"or": [
           "HiJump",
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseFrozenEnemies"
         ]}
       ],
@@ -2683,7 +2683,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/outer/Glass Tunnel Save Room.json
+++ b/region/maridia/outer/Glass Tunnel Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -207,7 +207,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1335,7 +1335,7 @@
       "link": [2, 2],
       "name": "Break the Tube",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "setsFlags": ["f_MaridiaTubeBroken"]
     },
@@ -3093,7 +3093,7 @@
         {"or": [
           "Gravity",
           "HiJump",
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           {"and": [
             {"not": "f_MaridiaTubeBroken"},
             "canRiskPermanentLossOfAccess"
@@ -3245,7 +3245,7 @@
         {"notable": "Breaking the Tube Gravity Jump"},
         {"not": "f_MaridiaTubeBroken"},
         "canRiskPermanentLossOfAccess",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canSuitlessMaridia",
         "canTrickyJump"
       ],
@@ -3264,7 +3264,7 @@
       "link": [5, 5],
       "name": "Break the Tube with a Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "setsFlags": ["f_MaridiaTubeBroken"]
     },
@@ -3345,7 +3345,7 @@
         {"notable": "Breaking the Tube Gravity Jump"},
         {"not": "f_MaridiaTubeBroken"},
         "canRiskPermanentLossOfAccess",
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canSuitlessMaridia",
         "canTrickyJump"
       ],
@@ -3370,7 +3370,7 @@
       "link": [6, 5],
       "name": "Break the Tube with a Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "setsFlags": ["f_MaridiaTubeBroken"]
     },

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -655,7 +655,7 @@
       "requires": [
         "canCrossRoomJumpIntoWater",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseFrozenEnemies"
         ]}
       ],
@@ -685,7 +685,7 @@
         "canCrossRoomJumpIntoWater",
         "canTrickyJump",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseFrozenEnemies"
         ]}
       ],
@@ -712,7 +712,7 @@
         "canCrossRoomJumpIntoWater",
         "canInsaneJump",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseFrozenEnemies"
         ]}
       ],
@@ -1155,7 +1155,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -1165,7 +1165,7 @@
           {"and": [
             "Gravity",
             "canTrickyUseFrozenEnemies",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             "HiJump",
@@ -1182,7 +1182,7 @@
             ]}
           ]},
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             "canTrickyUseFrozenEnemies",
             "canBeVeryPatient",
             {"or": [
@@ -1207,7 +1207,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -1217,7 +1217,7 @@
           {"and": [
             "Gravity",
             "canTrickyUseFrozenEnemies",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             "HiJump",
@@ -1234,7 +1234,7 @@
             ]}
           ]},
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             "canTrickyUseFrozenEnemies",
             "canBeVeryPatient",
             {"or": [
@@ -1413,7 +1413,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -1581,13 +1581,13 @@
       },
       "requires": [
         {"tech": "canSpringBallBombJump"},
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         "canCrossRoomJumpIntoWater",
         {"or": [
           "Gravity",
           "HiJump",
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]}
       ],
       "note": [
@@ -2181,7 +2181,7 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -2191,7 +2191,7 @@
           {"and": [
             "Gravity",
             "canTrickyUseFrozenEnemies",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             "HiJump",
@@ -2208,7 +2208,7 @@
             ]}
           ]},
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             "canTrickyUseFrozenEnemies",
             "canBeVeryPatient",
             {"or": [
@@ -2232,7 +2232,7 @@
         }
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -2242,7 +2242,7 @@
           {"and": [
             "Gravity",
             "canTrickyUseFrozenEnemies",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             "HiJump",
@@ -2259,7 +2259,7 @@
             ]}
           ]},
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             "canTrickyUseFrozenEnemies",
             "canBeVeryPatient",
             {"or": [
@@ -2467,7 +2467,7 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -2492,7 +2492,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 19}}
       ],
       "exitCondition": {
@@ -2518,7 +2518,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementTricky",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 11}}
       ],
       "exitCondition": {
@@ -2542,7 +2542,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 9}},
           {"and": [
@@ -2564,7 +2564,7 @@
       "link": [3, 3],
       "name": "Sciser Farm",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"resetRoom": {
           "nodes": [3]
         }},
@@ -2578,7 +2578,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2734,7 +2734,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 62, "excessFrames": 2}}
       ],
       "clearsObstacles": ["A"],
@@ -3015,7 +3015,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 35, "excessFrames": 3}}
       ],
       "note": "This can be done with only a door-frame runway in the adjacent room.",
@@ -3121,7 +3121,7 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -3149,7 +3149,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3270,7 +3270,7 @@
       },
       "requires": [
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "h_canNavigateUnderwater"
+        "h_navigateUnderwater"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
@@ -3288,7 +3288,7 @@
       },
       "requires": [
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "h_canArtificialMorphBombs",
         {"or": [
           {"and": [
@@ -3333,7 +3333,7 @@
       },
       "requires": [
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "h_canArtificialMorphBombs",
         {"or": [
           {"and": [
@@ -3385,7 +3385,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3470,10 +3470,10 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "Gravity",
-            "h_canBombThings"
+            "h_bombThings"
           ]}
         ]}
       ],
@@ -3580,10 +3580,10 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "Gravity",
-            "h_canBombThings"
+            "h_bombThings"
           ]}
         ]}
       ]
@@ -3721,7 +3721,7 @@
       "name": "Suitless Frozen Fish with Spring Ball",
       "requires": [
         "canSuitlessMaridia",
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canStationaryLateralMidAirMorph",
         "canTrickyUseFrozenEnemies"
       ],
@@ -3853,7 +3853,7 @@
       "link": [8, 8],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3910,7 +3910,7 @@
           "SpaceJump",
           "canIBJ",
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canGravityJump"
         ]}
       ],
@@ -3972,7 +3972,7 @@
             "Wave"
           ]},
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             {"or": [
               "Wave",
               "Spazer"
@@ -3981,7 +3981,7 @@
           "Plasma"
         ]},
         {"or": [
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           "canStationaryLateralMidAirMorph"
         ]}
       ],
@@ -4067,7 +4067,7 @@
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
         {"or": [
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           "HiJump"
         ]},
         {"or": [
@@ -4094,7 +4094,7 @@
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
         "canBePatient",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "h_canArtificialMorphCrystalFlash",
         {"or": [
           "h_canArtificialMorphPowerBomb",
@@ -4136,7 +4136,7 @@
       "requires": [
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "h_canArtificialMorphPowerBomb",
         {"or": [
           "h_canArtificialMorphPowerBomb",
@@ -4161,7 +4161,7 @@
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
         "canBePatient",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyUseFrozenEnemies",
         {"or": [
           "Gravity",
@@ -4188,7 +4188,7 @@
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
         "canBePatient",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyUseFrozenEnemies",
         {"or": [
           "Gravity",
@@ -4200,7 +4200,7 @@
           {"disableEquipment": "Gravity"},
           "canKago"
         ]},
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -4221,7 +4221,7 @@
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
         "canBePatient",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "h_canArtificialMorphCrystalFlash",
         {"or": [
           "Gravity",
@@ -4275,7 +4275,7 @@
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
         {"obstaclesCleared": ["B"]},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -4305,7 +4305,7 @@
             ]}
           ]},
           {"and": [
-            "h_canMaxHeightSpringBallJump",
+            "h_maxHeightSpringBallJump",
             "canTrickyUseFrozenEnemies",
             "canBeVeryPatient"
           ]}
@@ -4326,8 +4326,8 @@
       "requires": [
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "h_canUseMorphBombs",
-        "h_canNavigateUnderwater",
+        "h_useMorphBombs",
+        "h_navigateUnderwater",
         {"or": [
           "canGravityJump",
           {"and": [
@@ -4349,18 +4349,18 @@
             {"or": [
               "HiJump",
               "Gravity",
-              "h_canMaxHeightSpringBallJump"
+              "h_maxHeightSpringBallJump"
             ]}
           ]}
         ]},
         {"or": [
           {"and": [
             "Gravity",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "HiJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "Gravity",
@@ -4391,7 +4391,7 @@
       "name": "G-Mode Morph Full Climb",
       "requires": [
         "canEnterGMode",
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"and": [
             "h_canArtificialMorphIBJ",
@@ -4416,7 +4416,7 @@
       "requires": [
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"obstaclesCleared": ["B"]},
         {"or": [
           {"and": [
@@ -4457,7 +4457,7 @@
       "requires": [
         "canEnterGMode",
         {"notable": "G-Mode Overload Speed Blocks then use Global Crab"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "h_canArtificialMorphBombs",
         {"or": [
           {"and": [

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -200,7 +200,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 9}},
           {"and": [
@@ -222,7 +222,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -352,7 +352,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 61, "excessFrames": 7}},
           {"and": [
@@ -431,7 +431,7 @@
       "link": [1, 3],
       "name": "Ride Mama Turtle on the Right (Grab Item)",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseEnemies",
         "canCarefulJump",
         {"or": [
@@ -461,7 +461,7 @@
       "name": "Ride Mama Turtle",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseEnemies",
         {"or": [
           "canCarefulJump",
@@ -476,7 +476,7 @@
       "link": [1, 4],
       "name": "Get Back on Mama Turtle",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseEnemies",
         {"or": [
           "canTrickyDodgeEnemies",
@@ -563,7 +563,7 @@
       "link": [1, 6],
       "name": "Ride Mama Turtle on the Right",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseEnemies",
         {"or": [
           "canTrickyDodgeEnemies",
@@ -687,7 +687,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 47, "excessFrames": 5}},
           {"and": [
@@ -762,7 +762,7 @@
           "Gravity",
           "HiJump",
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseEnemies"
         ]}
       ]
@@ -786,7 +786,7 @@
         "canTrickyJump",
         {"or": [
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canUseEnemies"
         ]}
       ],
@@ -872,7 +872,7 @@
         {"or": [
           "Wave",
           "Spazer",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"and": [
             "canTrickyJump",
             "canDodgeWhileShooting",
@@ -1007,7 +1007,7 @@
       "link": [5, 2],
       "name": "Walljumpless SpringFling",
       "requires": [
-        "h_canMaxHeightSpringBallJump",
+        "h_maxHeightSpringBallJump",
         "canSpringFling"
       ],
       "clearsObstacles": ["B"],

--- a/region/maridia/outer/Maridia Map Room.json
+++ b/region/maridia/outer/Maridia Map Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -440,7 +440,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Sciser - Long Lure",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Gravity",
         "canBePatient",
         {"or": [
@@ -473,7 +473,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Sciser - Very Long Lure",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Gravity",
         "canBeVeryPatient",
         {"or": [
@@ -625,7 +625,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -868,7 +868,7 @@
       "link": [1, 9],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -883,7 +883,7 @@
         {"shineChargeFrames": 110},
         {"notable": "Shinespark Down-Grab to the Grapple Blocks (Left to Top)"},
         "canSuitlessMaridia",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 56, "excessFrames": 0}}
       ],
@@ -1002,7 +1002,7 @@
         {"or": [
           {"and": [
             "canCrazyCrabClimb",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           "HiJump",
           "canSpringBallJumpMidAir"
@@ -1069,7 +1069,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 20}
       ],
       "exitCondition": {
@@ -1083,7 +1083,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway"
+        "h_shineChargeMaxRunway"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {
@@ -1119,7 +1119,7 @@
       "name": "Sciser Farm",
       "requires": [
         {"or": [
-          "h_canNavigateUnderwater",
+          "h_navigateUnderwater",
           "Ice",
           "Wave",
           "Spazer",
@@ -1138,7 +1138,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1148,7 +1148,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 65}}
       ],
       "note": "Shinespark up right through the rightmost gap to land directly by the door."
@@ -1281,7 +1281,7 @@
       "name": "Tricky Crouch Jump Down Grab",
       "requires": [
         "Gravity",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canTrickyJump"
       ],
       "note": [
@@ -1337,7 +1337,7 @@
       "name": "Crab HiJump Bomb-Grapple-Jump",
       "requires": [
         {"notable": "Crab HiJump Bomb-Grapple-Jump"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "HiJump",
         "canBombGrappleJump"
       ],
@@ -1351,9 +1351,9 @@
       "name": "Double Crab Bomb-Grapple-Jump",
       "requires": [
         {"notable": "Double Crab Bomb-Grapple-Jump"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canBombGrappleJump",
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ],
       "note": [
         "Position 2 Scisers so that they can each be used for a Bomb-Grapple-Jump, back to back.",
@@ -1366,12 +1366,12 @@
       "link": [2, 7],
       "name": "Sciser Double Damage Boost",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canCrouchJump",
         "canInsaneJump",
         "canReserveDoubleDamageBoost",
         {"or": [
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           "HiJump"
         ]},
         {"or": [
@@ -1678,7 +1678,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 61}}
       ],
@@ -1952,7 +1952,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2026,7 +2026,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyUseFrozenEnemies",
         {"or": [
           {"resetRoom": {
@@ -2524,7 +2524,7 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Sciser",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Gravity",
         {"or": [
           "SpaceJump",
@@ -2703,7 +2703,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2725,7 +2725,7 @@
               "Gravity"
             ]}
           ]},
-          "h_canDoubleSpringBallJumpWithHiJump"
+          "h_doubleSpringBallJumpWithHiJump"
         ]}
       ],
       "exitCondition": {
@@ -2744,7 +2744,7 @@
       "link": [4, 9],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -3156,7 +3156,7 @@
           "SpaceJump"
         ]},
         {"ammo": {"type": "Super", "count": 1}},
-        "h_canXRayMorphIceClip"
+        "h_XRayMorphIceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -3183,7 +3183,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"and": [
             "Gravity",
@@ -3410,7 +3410,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3526,7 +3526,7 @@
       "name": "SpringBall out of Morph Tunnel",
       "requires": [
         "canInsaneJump",
-        "h_canUseSpringBall"
+        "h_useSpringBall"
       ],
       "note": "Jump using Springball with the right timing leaving the Morph tunnel to avoid falling."
     },
@@ -3830,7 +3830,7 @@
       "link": [7, 9],
       "name": "Powamp Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseEnemies",
         "Grapple"
       ],
@@ -3907,7 +3907,7 @@
       "link": [7, 10],
       "name": "Grapple Powamp",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseEnemies",
         "Grapple"
       ],
@@ -3941,7 +3941,7 @@
       "name": "Double Spring Ball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ],
       "clearsObstacles": ["A", "B"],
       "note": "Start the springball jumps from the highest ledge on the wall.",
@@ -4042,7 +4042,7 @@
         "canCameraManip",
         {"or": [
           "canUnderwaterWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canFlatleyJump",
           "canInsaneJump"
         ]}
@@ -4116,9 +4116,9 @@
       "link": [8, 6],
       "name": "Base",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canMidAirMorph",
           {"and": [
             "Gravity",
@@ -4206,7 +4206,7 @@
       "link": [8, 11],
       "name": "Grapple Powamp",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canUseEnemies",
         "Grapple"
       ],
@@ -4251,7 +4251,7 @@
       "link": [9, 1],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -4273,7 +4273,7 @@
       "link": [9, 4],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ]
     },
@@ -4310,7 +4310,7 @@
       "link": [9, 5],
       "name": "Grapple",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "Grapple"
       ],
       "note": "Use the grapple to fling Samus through the door."
@@ -4350,7 +4350,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 61}}
       ],
@@ -4414,7 +4414,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4647,7 +4647,7 @@
       "name": "Double Spring Ball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ]
     },
     {
@@ -5003,7 +5003,7 @@
       "name": "Double Spring Ball Jump",
       "requires": [
         "canSuitlessMaridia",
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ],
       "note": "Start the spring ball jumps from the bottom of the slope."
     },

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -107,7 +107,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Zeb",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -204,8 +204,8 @@
         {"shinespark": {"frames": 25, "excessFrames": 6}},
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ],
       "note": "Enter on the right side of the doorway to be able to get up out of the water and onto the top platform."
@@ -223,8 +223,8 @@
         {"shinespark": {"frames": 25, "excessFrames": 6}},
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ],
       "flashSuitChecked": true
@@ -248,8 +248,8 @@
         ]},
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ],
       "flashSuitChecked": true
@@ -322,7 +322,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -486,7 +486,7 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ],
       "note": [
         "Standing on the platform in the room below, crouch jump up through the door transition, then down-grab onto the platform."
@@ -717,8 +717,8 @@
         ]},
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ]
     },
@@ -731,8 +731,8 @@
         {"shinespark": {"frames": 11, "excessFrames": 8}},
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ],
       "flashSuitChecked": true

--- a/region/maridia/outer/West Glass Tube Tunnel.json
+++ b/region/maridia/outer/West Glass Tube Tunnel.json
@@ -85,7 +85,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -163,7 +163,7 @@
       "requires": [
         "f_DefeatedCrocomire",
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 120}
       ],
       "exitCondition": {
@@ -176,7 +176,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -336,7 +336,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -483,7 +483,7 @@
           {"canShineCharge": {"usedTiles": 22, "openEnd": 1}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_canShineChargeMaxRunway"
+            "h_shineChargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 50}
@@ -505,7 +505,7 @@
           {"canShineCharge": {"usedTiles": 31, "openEnd": 0}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_canShineChargeMaxRunway"
+            "h_shineChargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 100}
@@ -527,7 +527,7 @@
           {"canShineCharge": {"usedTiles": 22, "openEnd": 1}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_canShineChargeMaxRunway"
+            "h_shineChargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 40}
@@ -549,7 +549,7 @@
           {"canShineCharge": {"usedTiles": 22, "openEnd": 1}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_canShineChargeMaxRunway"
+            "h_shineChargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 80}
@@ -569,7 +569,7 @@
           {"canShineCharge": {"usedTiles": 31, "openEnd": 0}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_canShineChargeMaxRunway"
+            "h_shineChargeMaxRunway"
           ]}
         ]},
         {"shinespark": {"frames": 9}}
@@ -645,7 +645,7 @@
       "requires": [
         "f_DefeatedCrocomire",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 45, "excessFrames": 5}},
           {"and": [
@@ -807,7 +807,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -145,7 +145,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -416,7 +416,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -464,7 +464,7 @@
         {"or": [
           "HiJump",
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir"
         ]}
       ]

--- a/region/norfair/crocomire/Grapple Tutorial Room 1.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 1.json
@@ -71,7 +71,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Grapple Tutorial Room 2.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 2.json
@@ -85,7 +85,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -408,7 +408,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -141,11 +141,11 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Gamet",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
-          "h_canTrickyFrozenEnemyRunway",
+          "h_trickyFrozenEnemyRunway",
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             "Morph"
           ]}
         ]}
@@ -176,7 +176,7 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Gamet",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           "Gravity",
           "HiJump",
@@ -216,12 +216,12 @@
       "link": [1, 2],
       "name": "Leave With Runway - Frozen Gamet",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyJump",
         {"or": [
-          "h_canTrickyFrozenEnemyRunway",
+          "h_trickyFrozenEnemyRunway",
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             "Morph"
           ]}
         ]},
@@ -250,7 +250,7 @@
       "link": [1, 2],
       "name": "G-Mode Setup - Get Hit By Gamet",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         {"or": [
           {"resourceCapacity": [{"type": "Super", "count": 1}]},
           {"obstaclesCleared": ["A"]}
@@ -366,7 +366,7 @@
       "name": "Double Gamet Boost",
       "requires": [
         {"notable": "Double Gamet Boost"},
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canTrickyJump",
         "canHorizontalDamageBoost",
         {"enemyDamage": {"enemy": "Gamet", "type": "contact", "hits": 2}}
@@ -579,7 +579,7 @@
       "link": [1, 4],
       "name": "Gamet Boost",
       "requires": [
-        "h_canNavigateUnderwater",
+        "h_navigateUnderwater",
         "canHorizontalDamageBoost",
         "canCarefulJump",
         {"or": [
@@ -605,7 +605,7 @@
       "requires": [
         "canSuitlessMaridia",
         "HiJump",
-        "h_canMaxHeightSpringBallJump"
+        "h_maxHeightSpringBallJump"
       ],
       "note": "Wait for the water to be rising and perform a max height SpringBall Jump."
     },
@@ -811,7 +811,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -836,7 +836,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canGreenGateGlitch",
+          "h_greenGateGlitch",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -989,7 +989,7 @@
         "HiJump",
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "Spazer",
           "Wave",
           "Plasma"
@@ -1036,7 +1036,7 @@
       "requires": [
         "canSuitlessMaridia",
         "canTrickyJump",
-        "h_canDoubleSpringBallJumpWithHiJump"
+        "h_doubleSpringBallJumpWithHiJump"
       ],
       "note": "Jump when the water level is at its lowest."
     },

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -159,9 +159,9 @@
       "requires": [
         "SpaceJump",
         {"or": [
-          "h_canTrickyFrozenEnemyRunway",
+          "h_trickyFrozenEnemyRunway",
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             "Morph"
           ]}
         ]}
@@ -276,7 +276,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -602,7 +602,7 @@
         {"notable": "Damage Boost"},
         "canTrickyJump",
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canWalljump"
         ]},
         "canHorizontalDamageBoost",
@@ -938,7 +938,7 @@
       "link": [3, 4],
       "name": "Crouch Jump Down Grab",
       "requires": [
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canTrickyJump"
       ],
       "note": [
@@ -1365,9 +1365,9 @@
       "name": "Leave With Runway - Frozen Gamet",
       "requires": [
         {"or": [
-          "h_canTrickyFrozenEnemyRunway",
+          "h_trickyFrozenEnemyRunway",
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             "Morph"
           ]}
         ]}
@@ -1498,7 +1498,7 @@
           "canTrickyUseFrozenEnemies",
           {"and": [
             "canTrickyJump",
-            "h_canCrouchJumpDownGrab"
+            "h_crouchJumpDownGrab"
           ]},
           {"and": [
             "canInsaneJump",

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -190,7 +190,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -482,7 +482,7 @@
         {"or": [
           {"canShineCharge": {"usedTiles": 32, "gentleUpTiles": 6, "openEnd": 1}},
           {"and": [
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"obstaclesCleared": ["A"]}
           ]}
         ]},
@@ -608,7 +608,7 @@
       "name": "Leave With Spark (Long Speedy Jump)",
       "requires": [
         {"obstaclesCleared": ["A", "B", "E"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovementComplex",
         {"shinespark": {"frames": 53}}
       ],
@@ -625,7 +625,7 @@
       "link": [2, 2],
       "name": "Break Power Bomb Blocks",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A"]
     },
@@ -655,7 +655,7 @@
       "name": "Mella Ice Clip Door Lock Skip",
       "requires": [
         "canManipulateMellas",
-        "h_canIceClip",
+        "h_iceClip",
         {"or": [
           "Morph",
           "canInsaneJump",
@@ -738,7 +738,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -914,8 +914,8 @@
       "requires": [
         "canManipulateMellas",
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]},
         {"or": [
           "Morph",
@@ -947,7 +947,7 @@
         {"or": [
           {"canShineCharge": {"usedTiles": 32, "gentleUpTiles": 6, "openEnd": 1}},
           {"and": [
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"obstaclesCleared": ["A"]}
           ]}
         ]},
@@ -1183,7 +1183,7 @@
       "link": [5, 1],
       "name": "Tricky Spring Wall",
       "requires": [
-        "h_canTrickySpringwall"
+        "h_trickySpringwall"
       ]
     },
     {
@@ -1194,7 +1194,7 @@
         {"notable": "Spring Ball Unmorph Bomb Boost"},
         "canSpringBallJumpMidAir",
         "canUnmorphBombBoost",
-        "h_canCrouchJumpDownGrab"
+        "h_crouchJumpDownGrab"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1301,7 +1301,7 @@
         "canSuitlessLavaDive",
         "canShinechargeMovement",
         "canHorizontalShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"acidFrames": 140},
         {"shinespark": {"frames": 35}}
       ],
@@ -1363,7 +1363,7 @@
       "requires": [
         {"notable": "Springwall"},
         "HiJump",
-        "h_canTrickySpringwall",
+        "h_trickySpringwall",
         "canPreciseWalljump",
         "can3HighWallMidAirMorph"
       ],
@@ -1433,7 +1433,7 @@
         "Morph",
         "canMoonwalk",
         "canManipulateMellas",
-        "h_canPreciseIceClip",
+        "h_preciseIceClip",
         {"or": [
           "canConsecutiveWalljump",
           {"and": [
@@ -1517,8 +1517,8 @@
         "canEnterGMode",
         "canManipulateMellas",
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]},
         {"or": [
           "Morph",

--- a/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
+++ b/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Post Crocomire Save Room.json
+++ b/region/norfair/crocomire/Post Crocomire Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -148,7 +148,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Viola",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"ammo": {"type": "Super", "count": 1}},
         {"or": [
           "canConsecutiveWalljump",
@@ -506,7 +506,7 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Viola",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -533,7 +533,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -638,7 +638,7 @@
       "name": "Viola Ice Clip Door Lock Skip",
       "requires": [
         {"ammo": {"type": "Super", "count": 2}},
-        "h_canXRayMorphIceClip",
+        "h_XRayMorphIceClip",
         {"or": [
           "canConsecutiveWalljump",
           "SpaceJump",
@@ -660,7 +660,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies",
         {"ammo": {"type": "Super", "count": 1}},
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         "canUpwardGModeSetup",
         {"or": [
           "canConsecutiveWalljump",
@@ -803,7 +803,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -262,8 +262,8 @@
       },
       "requires": [
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]}
       ],
       "exitCondition": {
@@ -428,7 +428,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -619,7 +619,7 @@
       "link": [2, 3],
       "name": "Leave With Platform Below (Full Runway)",
       "requires": [
-        "h_canBackIntoCorner",
+        "h_backIntoCorner",
         {"heatFrames": 100}
       ],
       "exitCondition": {
@@ -721,8 +721,8 @@
       },
       "requires": [
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]}
       ],
       "exitCondition": {
@@ -949,8 +949,8 @@
       },
       "requires": [
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]}
       ],
       "exitCondition": {
@@ -1147,7 +1147,7 @@
       "name": "Gamet Ice Clip Door Lock Skip",
       "requires": [
         {"heatFrames": 560},
-        "h_canIceClip"
+        "h_iceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -116,7 +116,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -605,7 +605,7 @@
         "canOffScreenMovement",
         {"or": [
           "ScrewAttack",
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           "Grapple"
         ]},
         {"or": [

--- a/region/norfair/east/Bubble Mountain Save Room.json
+++ b/region/norfair/east/Bubble Mountain Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -349,10 +349,10 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings"
+          "h_bombThings"
         ]},
         {"or": [
           "canTrickyJump",
@@ -387,7 +387,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1327,10 +1327,10 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings"
+          "h_bombThings"
         ]}
       ],
       "exitCondition": {
@@ -2059,7 +2059,7 @@
       "link": [3, 3],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -2077,7 +2077,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings"
+          "h_bombThings"
         ]}
       ],
       "exitCondition": {
@@ -2421,7 +2421,7 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           {"resetRoom": {
             "nodes": [4, 5]
@@ -2449,7 +2449,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -2532,7 +2532,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         "canTrickyUseFrozenEnemies",
         "canEnemyStuckMoonfall",
         "canFreeFallClip"
@@ -2769,7 +2769,7 @@
       "name": "Power Bomb Blocks",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -2781,10 +2781,10 @@
       "link": [5, 9],
       "name": "Morph Maze",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canIBJ"
         ]}
       ]
@@ -2794,7 +2794,7 @@
       "link": [5, 9],
       "name": "Ice Clip",
       "requires": [
-        "h_canIceClip"
+        "h_iceClip"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -3733,12 +3733,12 @@
       "link": [7, 7],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "SpaceJump",
         "canBePatient",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canBombThings"
+          "h_bombThings"
         ]}
       ],
       "exitCondition": {
@@ -3772,7 +3772,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3887,7 +3887,7 @@
         "canBounceBall",
         "canLateralMidAirMorph",
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "h_XModeSpikeHitLeniency",
         "h_XModeSpikeHitLeniency",
         {"shinespark": {"frames": 6}}
@@ -3957,7 +3957,7 @@
           "canWalljump",
           "HiJump",
           "canSpringBallJumpMidAir",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]}
       ]
     },
@@ -3969,7 +3969,7 @@
         "HiJump",
         "SpeedBooster",
         "canPreciseGrapple",
-        "h_canMidAirShootUp"
+        "h_midAirShootUp"
       ],
       "flashSuitChecked": true,
       "note": "Jump from the Save room door runway and use Grapple to grab onto the Grapple Blocks."
@@ -4006,7 +4006,7 @@
       "name": "Power Bomb Blocks",
       "requires": [
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -4017,7 +4017,7 @@
       "link": [9, 5],
       "name": "Morph Maze",
       "requires": [
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ]
     },
     {
@@ -4087,7 +4087,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -159,7 +159,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -334,7 +334,7 @@
         {"notable": "10 Power Bomb Crystal Flash"},
         "canPrepareForNextRoom",
         {"heatFrames": 570},
-        "h_canHeated10PowerBombCrystalFlash"
+        "h_heated10PowerBombCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -371,8 +371,8 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
-          "h_canUseSpringBall",
+          "h_bombThings",
+          "h_useSpringBall",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {"enemy": "Sova", "type": "contact", "hits": 1}},
@@ -461,7 +461,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -551,7 +551,7 @@
         {"notable": "10 Power Bomb Crystal Flash"},
         "canPrepareForNextRoom",
         {"heatFrames": 420},
-        "h_canHeated10PowerBombCrystalFlash"
+        "h_heated10PowerBombCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -578,7 +578,7 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         {"heatFrames": 450}
       ],
       "note": "Only one bomb is needed after using a spinjump to get into the two tile tunnel."
@@ -588,7 +588,7 @@
       "link": [3, 1],
       "name": "Base with Spring Ball",
       "requires": [
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"heatFrames": 375}
       ]
     },
@@ -712,7 +712,7 @@
             {"or": [
               "canWalljump",
               "SpaceJump",
-              "h_canUseSpringBall"
+              "h_useSpringBall"
             ]}
           ]},
           {"and": [
@@ -736,7 +736,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1008,7 +1008,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1189,7 +1189,7 @@
       "name": "Sova Boost (Reserve Delay Bomb Boost and Sova Boost)",
       "requires": [
         {"notable": "Sova Boost"},
-        "h_canBombThings",
+        "h_bombThings",
         "canMidAirMorph",
         "canTrickyJump",
         "canCrouchJump",

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -151,7 +151,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -474,7 +474,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -780,7 +780,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -211,7 +211,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -305,7 +305,7 @@
       "requires": [
         {"or": [
           "SpaceJump",
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           "canWalljump",
           {"and": [
             "HiJump",
@@ -1118,7 +1118,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1176,7 +1176,7 @@
       "requires": [
         {"or": [
           "SpaceJump",
-          "h_canMaxHeightSpringBallJump",
+          "h_maxHeightSpringBallJump",
           "canWalljump",
           {"and": [
             "HiJump",
@@ -1976,7 +1976,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1995,7 +1995,7 @@
           {"obstaclesCleared": ["A"]},
           "Wave",
           {"and": [
-            "h_canHeatedBlueGateGlitch",
+            "h_heatedBlueGateGlitch",
             {"heatFrames": 60}
           ]}
         ]},
@@ -2073,7 +2073,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canWalljump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"heatFrames": 540},
         {"shinespark": {"frames": 5}}
       ],
@@ -2093,7 +2093,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "HiJump",
         {"heatFrames": 480},
         {"shineChargeFrames": 140}
@@ -2166,7 +2166,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
@@ -2397,7 +2397,7 @@
         "h_XModeSpikeHit",
         "canTrickyJump",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"heatFrames": 400},
         {"shinespark": {"frames": 12, "excessFrames": 4}}
       ],
@@ -2491,7 +2491,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
@@ -2574,7 +2574,7 @@
           {"and": [
             "canBombHorizontally",
             "canIBJ",
-            "h_canUsePowerBombs"
+            "h_usePowerBombs"
           ]}
         ]},
         {"heatFrames": 0}
@@ -2600,7 +2600,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
@@ -2685,7 +2685,7 @@
           {"and": [
             "canBombHorizontally",
             "canIBJ",
-            "h_canUsePowerBombs"
+            "h_usePowerBombs"
           ]}
         ]},
         {"heatFrames": 0}
@@ -2710,7 +2710,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
@@ -2743,7 +2743,7 @@
       "name": "Gate Glitch",
       "requires": [
         {"heatFrames": 250},
-        "h_canHeatedBlueGateGlitch"
+        "h_heatedBlueGateGlitch"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -2899,7 +2899,7 @@
         "canTrickyJump",
         "canUseIFrames",
         "canMidairShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"heatFrames": 480},
         {"shinespark": {"frames": 11, "excessFrames": 4}}
       ],
@@ -2926,7 +2926,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2953,7 +2953,7 @@
       "name": "Crystal Flash Clip",
       "requires": [
         "h_heatProof",
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "Grapple"
       ],
       "flashSuitChecked": true,
@@ -2985,7 +2985,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Frog Savestation.json
+++ b/region/norfair/east/Frog Savestation.json
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -103,7 +103,7 @@
           "h_getBlueSpeedMaxRunway",
           {"and": [
             "Ice",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]},
           {"and": [
             "Morph",
@@ -128,7 +128,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -148,7 +148,7 @@
             }}
           ]}
         ]},
-        "h_can10PowerBombCrystalFlash"
+        "h_10PowerBombCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -226,7 +226,7 @@
       "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -254,7 +254,7 @@
       "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -363,7 +363,7 @@
       "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -392,7 +392,7 @@
       "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -499,7 +499,7 @@
           "ScrewAttack",
           {"and": [
             {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}},
-            "h_canBombThings"
+            "h_bombThings"
           ]},
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 15}}
         ]}
@@ -550,7 +550,7 @@
           {"ammo": {"type": "Missile", "count": 6}},
           {"ammo": {"type": "Super", "count": 6}},
           "ScrewAttack",
-          "h_canBombThings",
+          "h_bombThings",
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 15}}
         ]}
       ],
@@ -760,7 +760,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -100,7 +100,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -267,10 +267,10 @@
           "Wave",
           {"ammo": {"type": "Super", "count": 1}},
           {"ammo": {"type": "Missile", "count": 3}},
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"and": [
             "Charge",
-            "h_canUseMorphBombs"
+            "h_useMorphBombs"
           ]},
           {"and": [
             "h_lavaProof",
@@ -349,7 +349,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -401,9 +401,9 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 260}
           ]},
           {"and": [
@@ -468,7 +468,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -194,7 +194,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -204,7 +204,7 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         {"heatFrames": 260},
-        "h_canHeated10PowerBombCrystalFlash",
+        "h_heated10PowerBombCrystalFlash",
         {"heatFrames": 80}
       ],
       "flashSuitChecked": true,
@@ -491,7 +491,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -618,7 +618,7 @@
       "requires": [
         "Morph",
         {"heatFrames": 260},
-        "h_canHeatedBlueGateGlitch"
+        "h_heatedBlueGateGlitch"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -720,7 +720,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -730,7 +730,7 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         {"heatFrames": 240},
-        "h_canHeated10PowerBombCrystalFlash",
+        "h_heated10PowerBombCrystalFlash",
         {"heatFrames": 70}
       ],
       "flashSuitChecked": true,
@@ -1080,7 +1080,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1090,7 +1090,7 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         {"heatFrames": 270},
-        "h_canHeated10PowerBombCrystalFlash",
+        "h_heated10PowerBombCrystalFlash",
         {"heatFrames": 90}
       ],
       "flashSuitChecked": true,
@@ -1201,7 +1201,7 @@
       "requires": [
         "Morph",
         {"heatFrames": 150},
-        "h_canHeatedBlueGateGlitch"
+        "h_heatedBlueGateGlitch"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1247,7 +1247,7 @@
       "requires": [
         "Morph",
         {"heatFrames": 150},
-        "h_canHeatedBlueGateGlitch"
+        "h_heatedBlueGateGlitch"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -1400,7 +1400,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -221,7 +221,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -589,7 +589,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -834,7 +834,7 @@
       "name": "Jump Into Crystal Flash Clip",
       "requires": [
         "h_heatProof",
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "Grapple"
       ],
       "flashSuitChecked": true,
@@ -848,7 +848,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1007,7 +1007,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedLavaCrystalFlash"
+        "h_heatedLavaCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1193,7 +1193,7 @@
       "name": "Double Spring Ball Jump with HiJump",
       "requires": [
         "canSuitlessLavaDive",
-        "h_canDoubleSpringBallJumpWithHiJump",
+        "h_doubleSpringBallJumpWithHiJump",
         {"heatFrames": 255},
         {"gravitylessLavaFrames": 225}
       ],
@@ -1273,7 +1273,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedLavaCrystalFlash"
+        "h_heatedLavaCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/east/Lower Norfair Elevator Save Room.json
+++ b/region/norfair/east/Lower Norfair Elevator Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -123,7 +123,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -669,7 +669,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1017,7 +1017,7 @@
       "name": "Elevator Crystal Flash for Flash Suit",
       "requires": [
         "h_heatProof",
-        "h_canElevatorCrystalFlash"
+        "h_elevatorCrystalFlash"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -97,7 +97,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -315,7 +315,7 @@
           "ScrewAttack",
           {"ammo": {"type": "Missile", "count": 1}},
           {"ammo": {"type": "Super", "count": 1}},
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}}
         ]},
         "h_HeatedGModeOpenDifferentDoor"
@@ -554,7 +554,7 @@
           "ScrewAttack",
           {"ammo": {"type": "Missile", "count": 1}},
           {"ammo": {"type": "Super", "count": 1}},
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}}
         ]},
         "h_HeatedGModeOpenDifferentDoor"
@@ -674,7 +674,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -154,7 +154,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -634,7 +634,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Nutella Refill.json
+++ b/region/norfair/east/Nutella Refill.json
@@ -91,7 +91,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -90,7 +90,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 10},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 40}
       ],
       "flashSuitChecked": true,
@@ -552,7 +552,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1242,7 +1242,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -102,7 +102,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -214,7 +214,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Geemer",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "Plasma",
         {"ammo": {"type": "Super", "count": 1}}
       ],
@@ -231,7 +231,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -107,7 +107,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -646,7 +646,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -225,7 +225,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -553,7 +553,7 @@
       },
       "requires": [
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "canWalljump",
           "SpaceJump",
@@ -662,7 +662,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -698,7 +698,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"heatFrames": 280}
       ]
@@ -712,7 +712,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"heatFrames": 260}
       ],
@@ -858,7 +858,7 @@
       },
       "requires": [
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "canWalljump",
           "SpaceJump",
@@ -922,7 +922,7 @@
       },
       "requires": [
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "canWalljump",
           "SpaceJump",
@@ -958,11 +958,11 @@
           "canSpringBallJumpMidAir",
           "canIBJ",
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canBombHorizontally"
           ]},
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canTrickyUseFrozenEnemies"
           ]}
         ]},
@@ -1069,7 +1069,7 @@
       },
       "requires": [
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "canWalljump",
           "SpaceJump",
@@ -1327,7 +1327,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1340,7 +1340,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"heatFrames": 310}
       ]
@@ -1354,7 +1354,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"heatFrames": 290}
       ],
@@ -1500,7 +1500,7 @@
       },
       "requires": [
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "canWalljump",
           "SpaceJump",
@@ -1536,11 +1536,11 @@
           "canSpringBallJumpMidAir",
           "canIBJ",
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canBombHorizontally"
           ]},
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canTrickyUseFrozenEnemies"
           ]}
         ]},
@@ -1677,7 +1677,7 @@
       },
       "requires": [
         {"or": [
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "HiJump",
           "canWalljump",
           "SpaceJump",
@@ -1936,7 +1936,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1949,7 +1949,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "Wave"
         ]},
         {"heatFrames": 950},
@@ -1988,11 +1988,11 @@
           "canSpringBallJumpMidAir",
           "canIBJ",
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canBombHorizontally"
           ]},
           {"and": [
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canTrickyUseFrozenEnemies"
           ]}
         ]},
@@ -2054,7 +2054,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"heatFrames": 200}
       ]
@@ -2142,7 +2142,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2161,7 +2161,7 @@
       "link": [5, 6],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 850}
       ]
     },
@@ -2170,7 +2170,7 @@
       "link": [5, 6],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs",
+        "h_useMorphBombs",
         {"heatFrames": 1130}
       ]
     },
@@ -2183,7 +2183,7 @@
           "canWalljump",
           "HiJump",
           "SpaceJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"heatFrames": 100}
       ],
@@ -2206,7 +2206,7 @@
         {"or": [
           "canWalljump",
           "HiJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"heatFrames": 60}
       ],
@@ -2307,7 +2307,7 @@
         {"or": [
           "canWalljump",
           "HiJump",
-          "h_canCrouchJumpDownGrab"
+          "h_crouchJumpDownGrab"
         ]},
         {"resetRoom": {
           "nodes": [1, 2, 3, 4]

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -142,7 +142,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": [
@@ -239,7 +239,7 @@
       "name": "Speed Run and Leave Shinecharged",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"heatFrames": 360},
         {"shineChargeFrames": 35}
       ],
@@ -488,7 +488,7 @@
       "name": "Speed Run and Leave Shinecharged",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"heatFrames": 360},
         {"shineChargeFrames": 35}
       ],
@@ -531,7 +531,7 @@
         {"obstaclesCleared": ["A"]},
         "canShinechargeMovementComplex",
         "canHorizontalShinespark",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"heatFrames": 335},
         {"shinespark": {"frames": 221}}
       ],

--- a/region/norfair/east/Speed Booster Room.json
+++ b/region/norfair/east/Speed Booster Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -92,7 +92,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1024,7 +1024,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -86,7 +86,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -552,7 +552,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -161,7 +161,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -927,7 +927,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1121,7 +1121,7 @@
       "link": [5, 4],
       "name": "Crouch Jump Down Grab",
       "requires": [
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"heatFrames": 125}
       ]
     },
@@ -1183,7 +1183,7 @@
       "name": "Gate Glitch",
       "requires": [
         {"heatFrames": 135},
-        "h_canHeatedBlueGateGlitch"
+        "h_heatedBlueGateGlitch"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -120,7 +120,7 @@
         {"resetRoom": {
           "nodes": [1]
         }},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "Resetting the room through node 1 ensures that there is no heat."
@@ -372,7 +372,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": [

--- a/region/norfair/east/Wave Beam Room.json
+++ b/region/norfair/east/Wave Beam Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -296,7 +296,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -1071,7 +1071,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -3685,7 +3685,7 @@
       "link": [6, 6],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
@@ -4258,7 +4258,7 @@
       "link": [8, 8],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -119,7 +119,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -222,7 +222,7 @@
       },
       "requires": [
         {"notable": "High Speed Gate Glitch"},
-        "h_canHeatedGreenGateGlitch",
+        "h_heatedGreenGateGlitch",
         {"ammo": {"type": "Super", "count": 1}},
         "canInsaneJump"
       ],
@@ -375,7 +375,7 @@
             "h_lavaProof",
             {"or": [
               "ScrewAttack",
-              "h_canBombThings"
+              "h_bombThings"
             ]}
           ]}
         ]},
@@ -561,7 +561,7 @@
             {"notable": "SpringBall Bomb Boost"},
             "canSpringBallJumpMidAir",
             "canUnmorphBombBoost",
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             {"or": [
               "canInsaneJump",
               "h_additionalBomb"
@@ -627,7 +627,7 @@
       },
       "requires": [
         {"notable": "Frozen Geruta Shinecharge"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "canCarefulJump",
         {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
         "canShinechargeMovementTricky",
@@ -652,7 +652,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -725,7 +725,7 @@
             {"notable": "SpringBall Bomb Boost"},
             "canSpringBallJumpMidAir",
             "canUnmorphBombBoost",
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             "canInsaneJump"
           ]}
         ]},
@@ -829,7 +829,7 @@
         {"notable": "SpringBall Bomb Boost"},
         "canSpringBallJumpMidAir",
         "canUnmorphBombBoost",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"heatFrames": 800},
         {"or": [
           "canInsaneJump",
@@ -1051,7 +1051,7 @@
       },
       "requires": [
         {"notable": "Frozen Geruta Shinecharge"},
-        "h_canTrickyFrozenEnemyRunway",
+        "h_trickyFrozenEnemyRunway",
         "canCarefulJump",
         "canHorizontalShinespark",
         {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
@@ -1123,7 +1123,7 @@
             {"notable": "SpringBall Bomb Boost"},
             "canSpringBallJumpMidAir",
             "canUnmorphBombBoost",
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             {"or": [
               "canInsaneJump",
               "h_additionalBomb"
@@ -1215,7 +1215,7 @@
             {"notable": "SpringBall Bomb Boost"},
             "canSpringBallJumpMidAir",
             "canUnmorphBombBoost",
-            "h_canCrouchJumpDownGrab",
+            "h_crouchJumpDownGrab",
             {"or": [
               "canInsaneJump",
               "h_additionalBomb"
@@ -1475,7 +1475,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/west/Crocomire Save Room.json
+++ b/region/norfair/west/Crocomire Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -262,7 +262,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -400,7 +400,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -496,7 +496,7 @@
         {"notable": "Speed Block Moondance"},
         "h_heatProof",
         "h_getBlueSpeedMaxRunway",
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "canTemporaryBlue",
@@ -526,7 +526,7 @@
         {"notable": "Speed Block Moondance"},
         "h_heatProof",
         "h_getBlueSpeedMaxRunway",
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "canTemporaryBlue",
@@ -653,7 +653,7 @@
       "requires": [
         {"or": [
           "canTrickyDodgeEnemies",
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           "ScrewAttack",
           "h_hasBeamUpgrade",
           {"ammo": {"type": "Missile", "count": 2}},
@@ -670,11 +670,11 @@
         ]},
         "Morph",
         {"or": [
-          "h_canUsePowerBombs",
+          "h_usePowerBombs",
           {"and": [
             {"or": [
-              "h_canUseSpringBall",
-              "h_canUseMorphBombs"
+              "h_useSpringBall",
+              "h_useMorphBombs"
             ]},
             {"or": [
               "canLateralMidAirMorph",
@@ -909,7 +909,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1308,7 +1308,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1916,7 +1916,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1981,7 +1981,7 @@
       "requires": [
         "h_heatProof",
         {"obstaclesCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 80}
       ],
       "exitCondition": {
@@ -2018,7 +2018,7 @@
         "h_heatProof",
         {"obstaclesCleared": ["A"]},
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 120}
       ],
       "exitCondition": {
@@ -2044,7 +2044,7 @@
         "h_heatProof",
         {"obstaclesCleared": ["A"]},
         "canShinechargeMovementTricky",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 12}}
       ],
       "exitCondition": {
@@ -2177,7 +2177,7 @@
         {"or": [
           {"heatFrames": 160},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             {"heatFrames": 85}
           ]},
           {"and": [

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -124,7 +124,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -292,7 +292,7 @@
       "link": [1, 3],
       "name": "Spring Ball",
       "requires": [
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"heatFrames": 200}
       ],
       "note": "Shoot the shot block, then Spring Ball on the middle platform."
@@ -347,7 +347,7 @@
       "link": [2, 1],
       "name": "Spring Ball",
       "requires": [
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"heatFrames": 800}
       ],
       "note": "Hold jump to easily do 9 successive spring ball bounces up the platforms."
@@ -407,7 +407,7 @@
       "link": [2, 1],
       "name": "WallJump and SpringBall",
       "requires": [
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         "canConsecutiveWalljump",
         {"heatFrames": 500}
       ],
@@ -484,7 +484,7 @@
       "requires": [
         {"heatFrames": 2060},
         {"or": [
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
             "canStaggeredWalljump",
             {"heatFrames": 100}
@@ -590,7 +590,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"heatFrames": 360},
         {"or": [
           "canCrumbleJump",
@@ -639,7 +639,7 @@
             "canCrumbleJump",
             "canConsecutiveWalljump"
           ]},
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"resetRoom": {
           "nodes": [1, 2]
@@ -657,7 +657,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 20},
-        "h_canHeatedCrystalFlash",
+        "h_heatedCrystalFlash",
         {"heatFrames": 20}
       ],
       "flashSuitChecked": true
@@ -687,7 +687,7 @@
           "HiJump",
           "SpaceJump",
           "canWalljump",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canCrumbleJump",
           "canTrickyJump",
           {"ammo": {"type": "Super", "count": 1}},
@@ -770,7 +770,7 @@
       "link": [3, 1],
       "name": "Spring Ball",
       "requires": [
-        "h_canUseSpringBall",
+        "h_useSpringBall",
         {"heatFrames": 250}
       ]
     },

--- a/region/norfair/west/Hi Jump Boots Room.json
+++ b/region/norfair/west/Hi Jump Boots Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -416,7 +416,7 @@
           ]},
           {"and": [
             "canUseFrozenEnemies",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             "HiJump",
@@ -599,7 +599,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -699,12 +699,12 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["C"]}
         ]},
         {"or": [
           "canMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           "canIBJ"
         ]}
       ],
@@ -743,7 +743,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["C"]}
         ]}
       ],
@@ -776,7 +776,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["B"]}
         ]}
       ],

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -96,7 +96,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -565,7 +565,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -251,7 +251,7 @@
           "canCrumbleJump",
           {"and": [
             "canPrepareForNextRoom",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]}
         ]},
         {"doorUnlockedAtNode": 1}
@@ -263,7 +263,7 @@
           "requires": [
             {"or": [
               "canTrickyJump",
-              "h_canUseSpringBall"
+              "h_useSpringBall"
             ]}
           ]
         }
@@ -296,7 +296,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -316,7 +316,7 @@
           "canCrumbleJump",
           {"and": [
             "canPrepareForNextRoom",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]}
         ]},
         {"doorUnlockedAtNode": 1}
@@ -328,7 +328,7 @@
           "requires": [
             {"or": [
               "canTrickyJump",
-              "h_canUseSpringBall"
+              "h_useSpringBall"
             ]}
           ]
         }
@@ -422,7 +422,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Slow Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"obstaclesCleared": ["A", "B", "C"]},
         {"or": [
           "canBeVeryPatient",
@@ -450,7 +450,7 @@
       "link": [2, 2],
       "name": "Power Bomb the Blocks",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -459,7 +459,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "flashSuitChecked": true
@@ -664,7 +664,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           "ScrewAttack",
           {"obstaclesCleared": ["A"]}
         ]}
@@ -676,7 +676,7 @@
       "link": [2, 5],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -833,7 +833,7 @@
             "explicitWeapons": ["Missile", "Super"]
           }}
         ]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "Kill some or all of the enemies before Crystal Flashing."
@@ -879,7 +879,7 @@
           "Wave",
           {"and": [
             "canDodgeWhileShooting",
-            "h_canUsePowerBombs"
+            "h_usePowerBombs"
           ]},
           {"enemyKill": {
             "enemies": [["Sm. Dessgeega"], ["Sm. Dessgeega"]],
@@ -1014,7 +1014,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 50}
       ],
       "exitCondition": {
@@ -1198,7 +1198,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1226,7 +1226,7 @@
       "name": "Screw or Bombs",
       "requires": [
         {"or": [
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           "ScrewAttack",
           {"obstaclesCleared": ["A"]}
         ]}
@@ -1238,7 +1238,7 @@
       "link": [5, 2],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -1249,7 +1249,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canUseMorphBombs",
+          "h_useMorphBombs",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -1260,7 +1260,7 @@
       "link": [5, 4],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -1285,7 +1285,7 @@
       "name": "Shinespark",
       "requires": [
         {"obstaclesCleared": ["C", "D"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"or": [
           {"shinespark": {"frames": 19, "excessFrames": 4}},
@@ -1303,7 +1303,7 @@
       "name": "Frozen Sova Platform",
       "requires": [
         {"notable": "Frozen Sova Platform"},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canTrickyUseFrozenEnemies"
       ],
       "clearsObstacles": ["A", "B", "C"],
@@ -1320,7 +1320,7 @@
       "name": "Sova Boost",
       "requires": [
         {"notable": "Sova Boost"},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         "canCrouchJump",
         "canCarefulJump",
         "canNeutralDamageBoost",
@@ -1382,7 +1382,7 @@
           "Wave",
           {"and": [
             "canDodgeWhileShooting",
-            "h_canUsePowerBombs"
+            "h_usePowerBombs"
           ]},
           {"enemyKill": {
             "enemies": [["Sm. Dessgeega"], ["Sm. Dessgeega"]],
@@ -1445,7 +1445,7 @@
       "link": [7, 7],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": "Placing the Power Bomb high enough will also break the bomb blocks in the ceiling."
@@ -1455,7 +1455,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true

--- a/region/norfair/west/Ice Beam Room.json
+++ b/region/norfair/west/Ice Beam Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -165,7 +165,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "canBePatient",
         {"heatFrames": 4800}
       ],
@@ -206,7 +206,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"heatFrames": 40},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -601,7 +601,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sova",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           {"and": [
             "h_heatProof",
@@ -650,7 +650,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -785,7 +785,7 @@
         {"shineChargeFrames": 85},
         {"doorUnlockedAtNode": 1},
         "canMidAirMorph",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         "canShinechargeMovementTricky",
         {"shinespark": {"frames": 20, "excessFrames": 0}},
         {"heatFrames": 285}
@@ -809,7 +809,7 @@
         {"doorUnlockedAtNode": 1},
         "canShinechargeMovementTricky",
         "canMidAirMorph",
-        "h_canCrouchJumpDownGrab",
+        "h_crouchJumpDownGrab",
         {"shinespark": {"frames": 19, "excessFrames": 0}},
         {"heatFrames": 370}
       ],
@@ -912,7 +912,7 @@
           "canTrickyJump",
           "canTrickyUseFrozenEnemies",
           {"ammo": {"type": "Super", "count": 1}},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]}
       ],
       "flashSuitChecked": true,
@@ -953,7 +953,7 @@
         "canShinechargeMovementTricky",
         "canMidAirMorph",
         {"shinespark": {"frames": 20, "excessFrames": 0}},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 385}
       ]
     },
@@ -989,7 +989,7 @@
         "canShinechargeMovementTricky",
         "canMidAirMorph",
         {"shinespark": {"frames": 19, "excessFrames": 0}},
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 465}
       ]
     },
@@ -1084,7 +1084,7 @@
         {"or": [
           {"ammo": {"type": "Super", "count": 1}},
           {"and": [
-            "h_canUsePowerBombs",
+            "h_usePowerBombs",
             {"heatFrames": 190}
           ]}
         ]}
@@ -1103,7 +1103,7 @@
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 20},
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "Kill the Fune before Crystal Flashing."
@@ -1144,7 +1144,7 @@
         {"or": [
           "canTrivialMidAirMorph",
           {"and": [
-            "h_canUseSpringBall",
+            "h_useSpringBall",
             "HiJump"
           ]}
         ]},
@@ -1178,7 +1178,7 @@
             "HiJump",
             {"or": [
               "canTrivialMidAirMorph",
-              "h_canUseSpringBall"
+              "h_useSpringBall"
             ]}
           ]},
           {"and": [
@@ -1220,7 +1220,7 @@
             "HiJump",
             {"or": [
               "canTrivialMidAirMorph",
-              "h_canUseSpringBall"
+              "h_useSpringBall"
             ]}
           ]},
           {"and": [
@@ -1257,7 +1257,7 @@
             "Wave",
             "Plasma"
           ]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"heatFrames": 260}
       ]
@@ -1390,7 +1390,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1449,7 +1449,7 @@
       "link": [5, 2],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"heatFrames": 200}
       ]
     },

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -86,7 +86,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -98,7 +98,7 @@
         "Gravity",
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]},
         {"heatFrames": 330},
         {"lavaFrames": 25}
@@ -290,9 +290,9 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
-            "h_canBombThings",
+            "h_bombThings",
             {"heatFrames": 80}
           ]}
         ]},
@@ -317,9 +317,9 @@
       "requires": [
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
+          "h_useSpringBall",
           {"and": [
-            "h_canBombThings",
+            "h_bombThings",
             {"heatFrames": 80}
           ]}
         ]},
@@ -503,7 +503,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canHeatedCrystalFlash"
+        "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/west/Norfair Map Room.json
+++ b/region/norfair/west/Norfair Map Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -683,7 +683,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -582,7 +582,7 @@
       "requires": [
         {"notable": "Crystal Flash"},
         "canTrickyDodgeEnemies",
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canCameraManip"
       ],
       "flashSuitChecked": true,

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -195,7 +195,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Lower Tourian Save Room.json
+++ b/region/tourian/main/Lower Tourian Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -124,7 +124,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Rinka",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -304,7 +304,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_KilledMetroidRoom1",
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1365,9 +1365,9 @@
       "name": "Leave With Runway - Frozen Rinka or Metroid",
       "requires": [
         {"or": [
-          "h_canTrickyFrozenEnemyRunway",
+          "h_trickyFrozenEnemyRunway",
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             {"not": "f_KilledMetroidRoom1"},
             "canRiskPermanentLossOfAccess"
           ]}
@@ -1549,7 +1549,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -104,7 +104,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Rinka",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -617,7 +617,7 @@
         }
       },
       "requires": [
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"autoReserveTrigger": {}},
         "canXRayClimb",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
@@ -979,7 +979,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Rinka",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -1117,7 +1117,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_KilledMetroidRoom2",
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
       ],
       "flashSuitChecked": true,

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -101,7 +101,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Rinka",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -908,7 +908,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_KilledMetroidRoom3",
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": ["Be at a safe distance from Rinkas before performing the Crystal Flash."]

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -104,7 +104,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Rinka",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -126,7 +126,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -143,7 +143,7 @@
           "Ice",
           "f_KilledMetroidRoom4"
         ]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -393,7 +393,7 @@
             "nodes": [2]
           }},
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             "canDodgeWhileShooting",
             "canEscapeEnemyGrab",
             {"metroidFrames": 120}

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -467,7 +467,7 @@
       "link": [2, 2],
       "name": "Destroy First Zebetite",
       "requires": [
-        "h_canOpenZebetites",
+        "h_openZebetites",
         {"or": [
           "canDodgeWhileShooting",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
@@ -623,9 +623,9 @@
       "link": [3, 3],
       "name": "Break Mother Brain Glass",
       "requires": [
-        "h_canPartiallyBreakMotherBrainGlass",
-        "h_canPartiallyBreakMotherBrainGlass",
-        "h_canPartiallyBreakMotherBrainGlass"
+        "h_partiallyBreakMotherBrainGlass",
+        "h_partiallyBreakMotherBrainGlass",
+        "h_partiallyBreakMotherBrainGlass"
       ],
       "setsFlags": ["f_MotherBrainGlassBroken"],
       "devNote": [
@@ -639,7 +639,7 @@
       "link": [3, 4],
       "name": "Missiles",
       "requires": [
-        "h_canPartiallyBreakMotherBrainGlass",
+        "h_partiallyBreakMotherBrainGlass",
         {"ammo": {"type": "Missile", "count": 30}},
         {"or": [
           "canTrickyUseFrozenEnemies",
@@ -661,7 +661,7 @@
       "link": [3, 4],
       "name": "Supers",
       "requires": [
-        "h_canPartiallyBreakMotherBrainGlass",
+        "h_partiallyBreakMotherBrainGlass",
         {"or": [
           {"ammo": {"type": "Super", "count": 14}},
           {"and": [
@@ -684,7 +684,7 @@
       "link": [3, 4],
       "name": "Combined Ammo",
       "requires": [
-        "h_canPartiallyBreakMotherBrainGlass",
+        "h_partiallyBreakMotherBrainGlass",
         {"or": [
           {"and": [
             {"ammo": {"type": "Super", "count": 5}},
@@ -789,15 +789,15 @@
           ]},
           {"and": [
             "canCarefulJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
             {"or": [
               "canTrivialMidAirMorph",
               "canNeutralDamageBoost",
-              "h_canUseSpringBall",
-              "h_canBombThings"
+              "h_useSpringBall",
+              "h_bombThings"
             ]}
           ]}
         ]}
@@ -834,7 +834,7 @@
       "requires": [
         {"notable": "R-Mode Reduced Tanks"},
         {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"enemyKill": {
           "enemies": [["Mother Brain 2"]]
         }},
@@ -867,7 +867,7 @@
       "requires": [
         {"notable": "R-Mode Light Pillar"},
         {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"enemyKill": {
           "enemies": [["Mother Brain 2"]]
         }},
@@ -900,7 +900,7 @@
       "link": [5, 5],
       "name": "Destroy Second Zebetite",
       "requires": [
-        "h_canOpenZebetites",
+        "h_openZebetites",
         {"or": [
           {"and": [
             "canDodgeWhileShooting",
@@ -925,15 +925,15 @@
           ]},
           {"and": [
             "canCarefulJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
             {"or": [
               "canTrivialMidAirMorph",
               "canNeutralDamageBoost",
-              "h_canUseSpringBall",
-              "h_canBombThings"
+              "h_useSpringBall",
+              "h_bombThings"
             ]}
           ]}
         ]},
@@ -954,15 +954,15 @@
           ]},
           {"and": [
             "canCarefulJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
             {"or": [
               "canTrivialMidAirMorph",
               "canNeutralDamageBoost",
-              "h_canUseSpringBall",
-              "h_canBombThings"
+              "h_useSpringBall",
+              "h_bombThings"
             ]}
           ]}
         ]},
@@ -974,7 +974,7 @@
       "link": [6, 6],
       "name": "Destroy Third Zebetite",
       "requires": [
-        "h_canOpenZebetites",
+        "h_openZebetites",
         {"or": [
           {"and": [
             "canDodgeWhileShooting",
@@ -1011,15 +1011,15 @@
           ]},
           {"and": [
             "canCarefulJump",
-            "h_canUseSpringBall"
+            "h_useSpringBall"
           ]},
           {"and": [
             {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
             {"or": [
               "canTrivialMidAirMorph",
               "canNeutralDamageBoost",
-              "h_canUseSpringBall",
-              "h_canBombThings"
+              "h_useSpringBall",
+              "h_bombThings"
             ]}
           ]}
         ]}
@@ -1042,7 +1042,7 @@
       "link": [7, 7],
       "name": "Destroy Fourth Zebetite",
       "requires": [
-        "h_canOpenZebetites",
+        "h_openZebetites",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
       ],
       "setsFlags": ["f_KilledZebetites4"]

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -196,7 +196,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -527,7 +527,7 @@
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Rinka",
       "requires": [
-        "h_canTrickyFrozenEnemyRunway"
+        "h_trickyFrozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -694,7 +694,7 @@
         }
       },
       "requires": [
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"autoReserveTrigger": {}},
         "canXRayClimb",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}
@@ -846,7 +846,7 @@
         }
       },
       "requires": [
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         {"autoReserveTrigger": {}},
         "canXRayClimb",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -140,7 +140,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "If it is needed to use one of the extended runways, then the Crystal Flash can be performed on the opposite side of the room from the needed runway."

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -85,7 +85,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -83,7 +83,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -117,8 +117,8 @@
       "name": "Pirate Ice Clip Door Lock Skip",
       "requires": [
         {"or": [
-          "h_canXRayMorphIceClip",
-          "h_canPreciseIceClip"
+          "h_XRayMorphIceClip",
+          "h_preciseIceClip"
         ]}
       ],
       "bypassesDoorShell": true,
@@ -194,7 +194,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -321,7 +321,7 @@
         }
       },
       "requires": [
-        "h_canPreciseIceClip"
+        "h_preciseIceClip"
       ],
       "exitCondition": {
         "leaveWithGMode": {

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -109,7 +109,7 @@
       "link": [1, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 45}
       ],
@@ -204,7 +204,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -528,7 +528,7 @@
           "canTemporaryBlue",
           {"and": [
             "canUseSpeedEchoes",
-            "h_canShineChargeMaxRunway",
+            "h_shineChargeMaxRunway",
             {"shinespark": {"frames": 2, "excessFrames": 2}}
           ]}
         ]}
@@ -699,7 +699,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 60}
       ],
       "exitCondition": {
@@ -770,7 +770,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "can4HighMidAirMorph",
         "canChainTemporaryBlue"
       ],
@@ -787,7 +787,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -242,7 +242,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -549,7 +549,7 @@
       "link": [2, 4],
       "name": "Crystal Flash Grapple Clip",
       "requires": [
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "HiJump",
         "Grapple"
       ],
@@ -940,7 +940,7 @@
           "HiJump",
           "SpaceJump",
           "canWalljump",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canJumpIntoIBJ",
           "canSpringBallJumpMidAir"
         ]},
@@ -961,7 +961,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "The Crystal Flash should be performed on a platform away from the acid trigger or any Pirates."

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Tourian First Room.json
+++ b/region/tourian/main/Tourian First Room.json
@@ -211,7 +211,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Upper Tourian Save Room.json
+++ b/region/tourian/main/Upper Tourian Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Assembly Line.json
+++ b/region/wreckedship/main/Assembly Line.json
@@ -143,7 +143,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "The Workrobot projectiles aren't a problem."

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -185,7 +185,7 @@
       "name": "Leave With Runway - Frozen Atomic",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         "f_DefeatedPhantoon"
       ],
       "exitCondition": {
@@ -541,7 +541,7 @@
             {"or": [
               "Spazer",
               "Ice",
-              "h_canUseMorphBombs",
+              "h_useMorphBombs",
               "canUseSpeedEchoes"
             ]}
           ]}
@@ -562,7 +562,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "If the leftmost Kihunter is still alive, lay the Power Bomb with it on screen, to kill it before the Crystal Flash refill begins."
@@ -832,7 +832,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1052,7 +1052,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -133,7 +133,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Atomic",
       "requires": [
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -207,7 +207,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 45}
       ],
       "exitCondition": {
@@ -298,7 +298,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -345,8 +345,8 @@
       "requires": [
         "f_DefeatedPhantoon",
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]}
       ],
       "exitCondition": {
@@ -421,7 +421,7 @@
       "name": "Atomic Ice Clip Door Lock Skip",
       "requires": [
         "f_DefeatedPhantoon",
-        "h_canIceClip"
+        "h_iceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -436,7 +436,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 70}
       ],
       "exitCondition": {
@@ -613,8 +613,8 @@
       "requires": [
         "f_DefeatedPhantoon",
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]}
       ],
       "exitCondition": {
@@ -636,7 +636,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"and": [
             "Morph",
             {"obstaclesCleared": ["A"]}
@@ -816,7 +816,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"and": [
             "Morph",
             {"obstaclesCleared": ["A"]}
@@ -939,13 +939,13 @@
       "requires": [
         "f_DefeatedPhantoon",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"and": [
             "Morph",
             {"obstaclesCleared": ["A"]}
           ]}
         ]},
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Atomic", "type": "contact", "hits": 1}},
           "h_pauseAbuseMinimalReserveRefill"
@@ -989,7 +989,7 @@
       "link": [3, 3],
       "name": "Leave With Spark",
       "requires": [
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovementTricky",
         "canMockball",
         {"obstaclesCleared": ["A"]},
@@ -1005,7 +1005,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "f_DefeatedPhantoon",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovementComplex",
         {"obstaclesCleared": ["A"]},
         {"shineChargeFrames": 130}
@@ -1020,7 +1020,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -1033,7 +1033,7 @@
       "requires": [
         "f_DefeatedPhantoon",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"and": [
             "Morph",
             {"obstaclesCleared": ["A"]}

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -306,7 +306,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -316,7 +316,7 @@
       "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
@@ -344,7 +344,7 @@
       "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
@@ -373,7 +373,7 @@
       "name": "Speed Block Moondance (Moonfall Clip)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
@@ -478,7 +478,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canUseIFrames",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 80}
       ],
@@ -495,7 +495,7 @@
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 40}
       ],
@@ -659,7 +659,7 @@
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -672,7 +672,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -965,7 +965,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -974,7 +974,7 @@
       "link": [3, 4],
       "name": "Bomb the blocks",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "note": "If using PBs, place it far enough right to reach the shot blocks."
     },
@@ -1035,7 +1035,7 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_canBombThings",
+        "h_bombThings",
         {"obstaclesNotCleared": ["B"]}
       ],
       "note": "The bomb block respawns. It must be broken on the way back too."
@@ -1115,7 +1115,7 @@
       "name": "Blind Traversal",
       "requires": [
         {"obstaclesCleared": ["A", "B"]},
-        "h_canBombThings",
+        "h_bombThings",
         "canOffScreenMovement",
         {"or": [
           {"and": [
@@ -1132,7 +1132,7 @@
               ]},
               "f_DefeatedPhantoon"
             ]},
-            "h_canCrystalFlash"
+            "h_crystalFlash"
           ]}
         ]}
       ],
@@ -1170,13 +1170,13 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"or": [
           {"canShineCharge": {"usedTiles": 35, "openEnd": 1}},
           {"and": [
             "f_DefeatedPhantoon",
-            "h_canShineChargeMaxRunway"
+            "h_shineChargeMaxRunway"
           ]}
         ]},
         {"or": [
@@ -1232,7 +1232,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_canUsePowerBombs"
+          "h_usePowerBombs"
         ]},
         {"useFlashSuit": {}},
         {"or": [
@@ -1262,7 +1262,7 @@
       "link": [5, 1],
       "name": "Crystal Flash Grapple Clip",
       "requires": [
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "Grapple",
         {"obstaclesNotCleared": ["B"]}
       ],
@@ -1276,7 +1276,7 @@
       "requires": [
         {"obstaclesCleared": ["B"]},
         "h_ShinesparksCostEnergy",
-        "h_canJumpIntoCrystalFlashClip",
+        "h_jumpIntoCrystalFlashClip",
         "Grapple",
         "canOffScreenMovement",
         {"canShineCharge": {"usedTiles": 25, "openEnd": 1}},
@@ -1310,7 +1310,7 @@
       "link": [5, 4],
       "name": "Power Bomb the Chozo Statue",
       "requires": [
-        "h_canUsePowerBombs",
+        "h_usePowerBombs",
         {"or": [
           {"obstaclesNotCleared": ["B"]},
           "canOffScreenMovement"

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -29,7 +29,7 @@
             {
               "name": "Base",
               "requires": [
-                "h_canOpenRedDoors"
+                "h_openRedDoors"
               ]
             }
           ],
@@ -231,7 +231,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -125,7 +125,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -237,7 +237,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -111,7 +111,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 100}
       ],
@@ -127,7 +127,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -220,7 +220,7 @@
             {"enemyDamage": {"enemy": "Kzan", "type": "contact", "hits": 1}}
           ]},
           {"and": [
-            "h_canNavigateUnderwater",
+            "h_navigateUnderwater",
             "canCarefulJump",
             {"spikeHits": 2},
             {"or": [
@@ -231,7 +231,7 @@
             ]}
           ]},
           {"and": [
-            "h_canNavigateUnderwater",
+            "h_navigateUnderwater",
             "canDodgeWhileShooting",
             {"or": [
               "Gravity",
@@ -497,7 +497,7 @@
             {"enemyDamage": {"enemy": "Kzan", "type": "contact", "hits": 1}}
           ]},
           {"and": [
-            "h_canNavigateUnderwater",
+            "h_navigateUnderwater",
             "canCarefulJump",
             {"spikeHits": 2},
             {"or": [
@@ -508,7 +508,7 @@
             ]}
           ]},
           {"and": [
-            "h_canNavigateUnderwater",
+            "h_navigateUnderwater",
             "canDodgeWhileShooting",
             {"or": [
               "Gravity",
@@ -826,7 +826,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "Gravity",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 100}
       ],
@@ -920,7 +920,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -106,7 +106,7 @@
         ]},
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 20}}
       ],
       "exitCondition": {
@@ -134,7 +134,7 @@
           "canSpaceJumpWaterBounce",
           "HiJump"
         ]},
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 29}}
       ],
       "exitCondition": {
@@ -168,7 +168,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -410,7 +410,7 @@
       "name": "Stutter Water Shinecharge",
       "requires": [
         "canStutterWaterShineCharge",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 7, "excessFrames": 2}}
       ],
       "note": "If Phantoon is defeated, start at least 2 tiles from the water line, and stutter just before entering it in order to charge a spark in room."
@@ -558,7 +558,7 @@
         "canShinechargeMovementComplex",
         "canWalljump",
         "canSpaceJumpWaterBounce",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 150}
       ],
       "exitCondition": {
@@ -582,7 +582,7 @@
         "canShinechargeMovementComplex",
         "canWalljump",
         "HiJump",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shineChargeFrames": 105}
       ],
       "exitCondition": {
@@ -1167,7 +1167,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -362,7 +362,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "The Bull and Workrobot projectiles aren't a problem."
@@ -438,12 +438,12 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        "h_canDestroyBombWalls",
+        "h_destroyBombWalls",
         "f_DefeatedPhantoon",
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings",
+          "h_useSpringBall",
+          "h_bombThings",
           {"and": [
             "Morph",
             "canUseEnemies"
@@ -469,8 +469,8 @@
         {"getBlueSpeed": {"usedTiles": 18, "openEnd": 1}},
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ],
       "note": [
@@ -487,7 +487,7 @@
       "name": "Robot Clip (Left to Right)",
       "requires": [
         "canMidAirMorph",
-        "h_canDestroyBombWalls",
+        "h_destroyBombWalls",
         "canKago"
       ],
       "note": [
@@ -547,8 +547,8 @@
         "f_DefeatedPhantoon",
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ],
       "note": "By normal means, the path can't be passed unless the Workrobot is activated (so Phantoon dead)",
@@ -562,10 +562,10 @@
         {"notable": "Crystal Flash Clip"},
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]},
-        "h_canCrystalFlash",
+        "h_crystalFlash",
         "canCeilingClip"
       ],
       "flashSuitChecked": true,
@@ -597,8 +597,8 @@
         ]},
         {"or": [
           "canTrivialMidAirMorph",
-          "h_canUseSpringBall",
-          "h_canBombThings"
+          "h_useSpringBall",
+          "h_bombThings"
         ]}
       ],
       "note": [

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -146,7 +146,7 @@
         "SpaceJump",
         "HiJump",
         "canShinechargeMovementComplex",
-        "h_canShineChargeMaxRunway",
+        "h_shineChargeMaxRunway",
         {"shinespark": {"frames": 21}},
         {"or": [
           "Gravity",
@@ -170,7 +170,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship Entrance.json
+++ b/region/wreckedship/main/Wrecked Ship Entrance.json
@@ -109,7 +109,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -335,7 +335,7 @@
       "link": [1, 1],
       "name": "Covern or Atomic Ice Clip Door Lock Skip",
       "requires": [
-        "h_canIceClip"
+        "h_iceClip"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -464,8 +464,8 @@
           ]}
         ]},
         {"or": [
-          "h_canPreciseIceClip",
-          "h_canHighPixelIceClip"
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
         ]}
       ],
       "exitCondition": {
@@ -511,7 +511,7 @@
       "name": "Leave With Runway - Frozen Atomic",
       "requires": [
         "f_DefeatedPhantoon",
-        "h_canFrozenEnemyRunway"
+        "h_frozenEnemyRunway"
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -741,7 +741,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "flashSuitChecked": true
@@ -779,7 +779,7 @@
           "SpaceJump",
           "canIBJ",
           "SpeedBooster",
-          "h_canCrouchJumpDownGrab",
+          "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir",
           "canSpringBallBombJump",
           "canUseFrozenEnemies"
@@ -800,7 +800,7 @@
       "link": [3, 6],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "clearsObstacles": ["A"]
     },
@@ -809,7 +809,7 @@
       "link": [3, 6],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B"]
     },
@@ -943,7 +943,7 @@
       "link": [3, 8],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "clearsObstacles": ["C"]
     },
@@ -952,7 +952,7 @@
       "link": [3, 8],
       "name": "Power Bombs",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": [
@@ -968,12 +968,12 @@
         {"or": [
           {"canShineCharge": {"usedTiles": 11, "steepUpTiles": 3, "openEnd": 2}},
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             {"or": [
               "f_DefeatedPhantoon",
               {"and": [
                 "SpaceJump",
-                "h_canTrickyFrozenEnemyRunway"
+                "h_trickyFrozenEnemyRunway"
               ]}
             ]},
             {"canShineCharge": {"usedTiles": 13, "steepUpTiles": 3, "openEnd": 1}}
@@ -1263,10 +1263,10 @@
       "link": [4, 4],
       "name": "Leave With Runway - Frozen Atomic or Covern",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "f_DefeatedPhantoon",
-          "h_canTrickyFrozenEnemyRunway"
+          "h_trickyFrozenEnemyRunway"
         ]}
       ],
       "exitCondition": {
@@ -1307,7 +1307,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "flashSuitChecked": true
@@ -1527,12 +1527,12 @@
       "link": [5, 5],
       "name": "Leave With Runway - Frozen Atomic or Covern",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"or": [
           "f_DefeatedPhantoon",
           {"and": [
             "SpaceJump",
-            "h_canTrickyFrozenEnemyRunway"
+            "h_trickyFrozenEnemyRunway"
           ]}
         ]}
       ],
@@ -1631,12 +1631,12 @@
             {"canShineCharge": {"usedTiles": 11, "steepUpTiles": 7, "openEnd": 2}}
           ]},
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             {"or": [
               "f_DefeatedPhantoon",
               {"and": [
                 "SpaceJump",
-                "h_canTrickyFrozenEnemyRunway"
+                "h_trickyFrozenEnemyRunway"
               ]}
             ]},
             "can4HighMidAirMorph",
@@ -1645,12 +1645,12 @@
           ]},
           {"canShineCharge": {"usedTiles": 10, "steepUpTiles": 7, "openEnd": 2}},
           {"and": [
-            "h_canFrozenEnemyRunway",
+            "h_frozenEnemyRunway",
             {"or": [
               "f_DefeatedPhantoon",
               {"and": [
                 "SpaceJump",
-                "h_canTrickyFrozenEnemyRunway"
+                "h_trickyFrozenEnemyRunway"
               ]}
             ]},
             {"canShineCharge": {"usedTiles": 12, "steepUpTiles": 7, "openEnd": 1}}
@@ -1713,7 +1713,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1784,7 +1784,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1795,7 +1795,7 @@
       "name": "G-Mode Setup - Get Hit By Covern or Atomic",
       "requires": [
         {"or": [
-          "h_canBombThings",
+          "h_bombThings",
           {"obstaclesCleared": ["A"]},
           {"and": [
             {"not": "f_DefeatedPhantoon"},
@@ -1832,7 +1832,7 @@
             "canMidAirMorph",
             "canDisableEquipment"
           ]},
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ],
       "note": [
@@ -1845,7 +1845,7 @@
       "link": [7, 3],
       "name": "Bombs",
       "requires": [
-        "h_canUseMorphBombs"
+        "h_useMorphBombs"
       ],
       "clearsObstacles": ["B"]
     },
@@ -1864,7 +1864,7 @@
             "canMidAirMorph",
             "canDisableEquipment"
           ]},
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ],
       "clearsObstacles": ["B"],
@@ -1878,7 +1878,7 @@
       "link": [7, 3],
       "name": "Power Bomb",
       "requires": [
-        "h_canUsePowerBombs"
+        "h_usePowerBombs"
       ],
       "clearsObstacles": ["A", "B"],
       "note": [
@@ -1902,7 +1902,7 @@
             "canMidAirMorph",
             "canDisableEquipment"
           ]},
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ],
       "clearsObstacles": ["B"],
@@ -1932,7 +1932,7 @@
             "canMidAirMorph",
             "canDisableEquipment"
           ]},
-          "h_canUseSpringBall"
+          "h_useSpringBall"
         ]}
       ],
       "clearsObstacles": ["B"],
@@ -1955,7 +1955,7 @@
           "Spazer",
           "Plasma",
           {"and": [
-            "h_canUseMorphBombs",
+            "h_useMorphBombs",
             "ScrewAttack"
           ]}
         ]},
@@ -2016,7 +2016,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true
@@ -2051,7 +2051,7 @@
       "link": [8, 3],
       "name": "Base",
       "requires": [
-        "h_canBombThings"
+        "h_bombThings"
       ],
       "clearsObstacles": ["C"]
     },

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Covern",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
@@ -107,7 +107,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Covern",
       "requires": [
-        "h_canFrozenEnemyRunway",
+        "h_frozenEnemyRunway",
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
@@ -107,7 +107,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship West Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship West Super Room.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_canCrystalFlash"
+        "h_crystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/strats.md
+++ b/strats.md
@@ -996,7 +996,7 @@ A `comeInStutterShinecharging` condition must match with a `leaveWithRunway` con
 A `comeInWithBombBoost` entrance condition indicates that Samus must come into the room with a horizontal bomb boost. This object has no properties.
 
 A `comeInWithBombBoost` condition must match with a `leaveWithRunway` condition on the other side of the door, which must have an "air" environment. A match comes with the following implicit requirements for actions to be performed in the previous room:
-- A requirement `h_canBombThings`, to be able to use Bombs or a Power Bomb, as well as the tech `canBombHorizontally`.
+- A requirement `h_bombThings`, to be able to use Bombs or a Power Bomb, as well as the tech `canBombHorizontally`.
 - If the previous room is heated, a requirement of `{"heatFrames": 100}` is included, for positioning, placing the bomb, and waiting for it to detonate.
 
 #### Example
@@ -1679,7 +1679,7 @@ An `unlocksDoors` array lists possibilities of doors that can be unlocked as par
 - _useImplicitRequires_: A boolean, true by default, indicating whether standard requirements should be implicitly appended to the `requires` in this object. This can be set this to false if the standard requirements are already accounted for in the strat `requires`, for example if the strat involves using a Power Bomb which would already unlock the door as a side effect, or if it uses a Super as a hero shot to open the door. If this property is set to true, the implicit standard requirements are based on the door type, as follows:
     - For "missiles", the implicit requirement is `{"ammo": {"type": "Missile", "count": 5}}`.
     - For "super", the implicit requirement is `{"ammo": {"type": "Super", "count": 1}}`.
-    - For "powerbomb", the implicit requirement is `h_canUsePowerBombs`.
+    - For "powerbomb", the implicit requirement is `h_usePowerBombs`.
     - For "gadoraMissiles", the implicit requirement is `{"ammo": {"type": "Missile", "count": 3}}`.
     - For "gadoraSuper", the implicit requirement is `{"ammo": {"type": "Super", "count": 1}}`.
     
@@ -1749,7 +1749,7 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
   "link": [5, 6],
   "name": "Break the Tube",
   "requires": [
-    "h_canUsePowerBombs"
+    "h_usePowerBombs"
   ],
   "setsFlags": ["f_MaridiaTubeBroken"]
 }

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -320,7 +320,7 @@ def check_shinespark_req(req):
 
 def check_shinecharge_req(req):
     if isinstance(req, str):
-        if req in ["h_canShineChargeMaxRunway", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge"]:
+        if req in ["h_shineChargeMaxRunway", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge"]:
             return True
     if isinstance(req, dict):
         if "canShineCharge" in req:
@@ -332,8 +332,8 @@ def check_shinecharge_req(req):
 
 def check_heat_req(req):
     if isinstance(req, str):
-        if req in ["h_heatProof", "h_canHeatedCrystalFlash", "h_canHeatedLavaCrystalFlash", "h_LowerNorfairElevatorDownwardFrames",
-                   "h_LowerNorfairElevatorUpwardFrames", "h_MainHallElevatorFrames", "h_canHeatedGreenGateGlitch",
+        if req in ["h_heatProof", "h_heatedCrystalFlash", "h_heatedLavaCrystalFlash", "h_LowerNorfairElevatorDownwardFrames",
+                   "h_LowerNorfairElevatorUpwardFrames", "h_MainHallElevatorFrames", "h_heatedGreenGateGlitch",
                    "h_DirectHeatedGModeLeaveSameDoor", "h_IndirectHeatedGModeOpenSameDoor",
                    "h_HeatedGModeOpenDifferentDoor", "h_HeatedGModeOffCameraDoor", "h_heatedGModePauseAbuse"]:
             return True
@@ -473,7 +473,7 @@ def covers_shinecharge_frames(req):
 
 def process_req_speed_state(req, states, err_fn):
     if isinstance(req, str):
-        if req in ["h_canShineChargeMaxRunway", "canWaterShineCharge", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge", "h_shinechargeSlideTemporaryBlue"]:
+        if req in ["h_shineChargeMaxRunway", "canWaterShineCharge", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge", "h_shinechargeSlideTemporaryBlue"]:
             states = {"shinecharging"}
         elif req in ["h_getBlueSpeedMaxRunway", "canSpeedKeep", "h_waterGetBlueSpeed", "h_stutterWaterGetBlueSpeed"]:
             # Note: "canSpeedKeep" can be used for other purposes than obtaining blue, but its presence should be


### PR DESCRIPTION
`can` is use for tech names, so I dont think it should be used for helpers. This is split into 2 PRs. All the artificial morph ones will be separate