### PR TITLE
Standardize capitalization in helper names

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -135,7 +135,7 @@
           "devNote": "In Vanilla, when entering the bottom left door of the Climb, there is rising Lava if Zebes is awake (this is instead acid in the escape)."
         },
         {
-          "name": "h_missileRefillStationAllAmmo",
+          "name": "h_MissileRefillStationAllAmmo",
           "requires": [ "never" ],
           "devNote": "In Vanilla, Missile refill stations only refill Missiles. This and 'h_useMissileRefillStation' can be changed if the stations refill Missiles, Supers, and Power Bombs."
         },
@@ -148,7 +148,7 @@
         {
           "name": "h_useMissileRefillAllAmmoCrystalFlash",
           "requires": [
-            "h_missileRefillStationAllAmmo",
+            "h_MissileRefillStationAllAmmo",
             "h_10PowerBombCrystalFlash",
             {"refill": ["Missile", "Super", "PowerBomb"]}
           ],

--- a/helpers.json
+++ b/helpers.json
@@ -46,7 +46,7 @@
           ]
         },
         {
-          "name": "h_AllItemsSpawned",
+          "name": "h_allItemsSpawned",
           "requires": [ "never" ],
           "devNote": [
             "In the original game, some items don't spawn until certain conditions are met.",
@@ -114,7 +114,7 @@
           "devNote": "In Vanilla, the camera is messed up when entering from the left with Crocomire alive."
         },
         {
-          "name": "h_EquipmentScreenFix",
+          "name": "h_equipmentScreenFix",
           "requires": [],
           "devNote": [
             "In Vanilla, the equipment screen behaves oddly which can cause difficulty when disabling equipment.",
@@ -135,7 +135,7 @@
           "devNote": "In Vanilla, when entering the bottom left door of the Climb, there is rising Lava if Zebes is awake (this is instead acid in the escape)."
         },
         {
-          "name": "h_MissileRefillStationAllAmmo",
+          "name": "h_missileRefillStationAllAmmo",
           "requires": [ "never" ],
           "devNote": "In Vanilla, Missile refill stations only refill Missiles. This and 'h_useMissileRefillStation' can be changed if the stations refill Missiles, Supers, and Power Bombs."
         },
@@ -148,7 +148,7 @@
         {
           "name": "h_useMissileRefillAllAmmoCrystalFlash",
           "requires": [
-            "h_MissileRefillStationAllAmmo",
+            "h_missileRefillStationAllAmmo",
             "h_10PowerBombCrystalFlash",
             {"refill": ["Missile", "Super", "PowerBomb"]}
           ],
@@ -162,7 +162,7 @@
           "devNote": "In Vanilla, Energy refill stations only refill regular energy. This can be changed if the stations refill Reserve energy as well."
         },
         {
-          "name": "h_AccessTourianEscape1RightDoor",
+          "name": "h_openTourianEscape1RightDoor",
           "requires": [ "never" ],
           "devNote": "In Vanilla, there is a wall preventing the player from accessing the right door."
         },
@@ -196,7 +196,7 @@
           ]
         },
         {
-          "name": "h_AcidCrystalFlashRefill",
+          "name": "h_acidCrystalFlashRefill",
           "requires": [
             {"or": [
               {"partialRefill": {"type": "Energy", "limit": 1120}},
@@ -212,7 +212,7 @@
           ]
         },
         {
-          "name": "h_HeatedCrystalFlashRefill",
+          "name": "h_heatedCrystalFlashRefill",
           "requires": [
             {"or": [
               {"partialRefill": {"type": "Energy", "limit": 1440}},
@@ -228,7 +228,7 @@
           ]
         },
         {
-          "name": "h_HeatedLavaCrystalFlashRefill",
+          "name": "h_heatedLavaCrystalFlashRefill",
           "requires": [
             {"or": [
               {"partialRefill": {"type": "Energy", "limit": 1330}},
@@ -244,7 +244,7 @@
           ]
         },
         {
-          "name": "h_HeatedAcidCrystalFlashRefill",
+          "name": "h_heatedAcidCrystalFlashRefill",
           "requires": [
             {"or": [
               {"partialRefill": {"type": "Energy", "limit": 1075}},
@@ -260,7 +260,7 @@
           ]
         },
         {
-          "name": "h_DoorImmediatelyClosedFix",
+          "name": "h_doorImmediatelyClosedFix",
           "requires": [ "never" ],
           "devNote": [
             "In Vanilla, there is a bug placing the closing door at the top of the Etecoon Shaft in the wrong location.",
@@ -275,7 +275,7 @@
           "devNote": "In Vanilla, Supers do 300 damage to Mother Brain. Randomizers may want to double this to help prevent Charge being required so frequently."
         },
         {
-          "name": "h_BypassMotherBrainRoom",
+          "name": "h_bypassMotherBrainRoom",
           "requires": [],
           "devNote": [
             "This helper is required on strats that completely bypass the right side of Mother Brain Room.",
@@ -293,7 +293,7 @@
       "description": "Helpers with built in leniency where extra Energy or Ammo are used in a failure.",
       "helpers": [
         {
-          "name": "h_BlueGateGlitchLeniency",
+          "name": "h_blueGateGlitchLeniency",
           "requires": [
             {"or": [
               {"ammo": {"type": "Missile", "count": 1}},
@@ -303,30 +303,30 @@
           "devNote": "Ammo for a second shot for leniency."
         },
         {
-          "name": "h_GreenGateGlitchLeniency",
+          "name": "h_greenGateGlitchLeniency",
           "requires": [
             {"ammo": {"type": "Super", "count": 1}}
           ],
           "devNote": "Ammo for a second shot for leniency."
         },
         {
-          "name": "h_HeatedBlueGateGlitchLeniency",
+          "name": "h_heatedBlueGateGlitchLeniency",
           "requires": [ 
-            "h_BlueGateGlitchLeniency",
+            "h_blueGateGlitchLeniency",
             {"heatFrames": 60}
           ],
           "devNote": "One ammo and 60 heatFrames for a second shot for leniency."
         },
         {
-          "name": "h_HeatedGreenGateGlitchLeniency",
+          "name": "h_heatedGreenGateGlitchLeniency",
           "requires": [ 
-            "h_GreenGateGlitchLeniency",
+            "h_greenGateGlitchLeniency",
             {"heatFrames": 60}
           ],
           "devNote": "One ammo and 60 heatFrames for a second shot for leniency."
         },
         {
-          "name": "h_OpenZebetitesLeniency",
+          "name": "h_openZebetitesLeniency",
           "requires": [
             {"or": [
               "canDodgeWhileShooting",
@@ -336,14 +336,14 @@
           ]
         },
         {
-          "name": "h_BombIntoCrystalFlashClipLeniency",
+          "name": "h_bombIntoCrystalFlashClipLeniency",
           "requires": [
             {"ammo": {"type": "PowerBomb","count": 5}}
           ],
           "devNote": "1 Power bomb leniency per attempt, 5 leniency attempts."
         },
         {
-          "name": "h_JumpIntoCrystalFlashClipLeniency",
+          "name": "h_jumpIntoCrystalFlashClipLeniency",
           "requires": [
             {"ammo": {"type": "PowerBomb","count": 9}}
           ],
@@ -369,25 +369,25 @@
           ]
         },
         {
-          "name": "h_SpikeSuitSpikeHitLeniency",
+          "name": "h_spikeSuitSpikeHitLeniency",
           "requires": [
             {"spikeHits": 2}
           ]
         },
         {
-          "name": "h_SpikeSuitThornHitLeniency",
+          "name": "h_spikeSuitThornHitLeniency",
           "requires": [
             {"thornHits": 2}
           ]
         },
         {
-          "name": "h_SpikeSuitSamusEaterLeniency",
+          "name": "h_spikeSuitSamusEaterLeniency",
           "requires": [
             {"samusEaterFrames": 320}
           ]
         },
         {
-          "name": "h_ExtendedMoondanceBeetomLeniency",
+          "name": "h_extendedMoondanceBeetomLeniency",
           "requires": [
             {"enemyDamage": {
               "enemy": "Beetom",
@@ -422,7 +422,7 @@
           ]
         },
         {
-          "name": "h_HeatedIBJFromSpikes",
+          "name": "h_heatedIBJFromSpikes",
           "requires": [
             "canUseIFrames",
             "canJumpIntoIBJ",
@@ -449,7 +449,7 @@
           "devNote": "2 extra attempts for leniency."
         },
         {
-          "name": "h_HeatedSpringwall",
+          "name": "h_heatedSpringwall",
           "requires": [
             "canSpringwall",
             {"or":[
@@ -494,7 +494,7 @@
           ]
         },
         {
-          "name": "h_usePowerBombs",
+          "name": "h_usePowerBomb",
           "requires": [
             "Morph",
             {"ammo": {"type": "PowerBomb", "count": 1}}
@@ -548,7 +548,7 @@
           ]
         },
         {
-          "name": "h_shineChargeMaxRunway",
+          "name": "h_shinechargeMaxRunway",
           "requires": [ 
             {"canShineCharge": {
               "usedTiles": 45,
@@ -624,7 +624,7 @@
               {"ammo": {"type": "Missile", "count": 1}},
               {"ammo": {"type": "Super", "count": 1}}
             ]},
-            "h_BlueGateGlitchLeniency"
+            "h_blueGateGlitchLeniency"
           ]
         },
         {
@@ -632,7 +632,7 @@
           "requires": [
             "h_gateGlitch",
             {"ammo": {"type": "Super", "count": 1}},
-            "h_GreenGateGlitchLeniency"
+            "h_greenGateGlitchLeniency"
           ]
         },
         {
@@ -645,7 +645,7 @@
               {"ammo": {"type": "Missile", "count": 1}},
               {"ammo": {"type": "Super", "count": 1}}
             ]},
-            "h_HeatedBlueGateGlitchLeniency"
+            "h_heatedBlueGateGlitchLeniency"
           ]
         },
         {
@@ -655,7 +655,7 @@
             {"heatFrames": 100},
             "h_gateGlitch",
             {"ammo": {"type": "Super", "count": 1}},
-            "h_HeatedGreenGateGlitchLeniency"
+            "h_heatedGreenGateGlitchLeniency"
           ]
         },
         {
@@ -666,7 +666,7 @@
           ]
         },
         {
-          "name": "h_UnderwaterCrouchJumpWithFlashSuit",
+          "name": "h_underwaterCrouchJumpWithFlashSuit",
           "requires": [
             {"tech": "canCrouchJump"}
           ],
@@ -677,14 +677,14 @@
           ]
         },
         {
-          "name": "h_UnderwaterMaxHeightSpringBallJumpWithFlashSuit",
+          "name": "h_underwaterMaxHeightSpringBallJumpWithFlashSuit",
           "requires": [
-            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "h_underwaterCrouchJumpWithFlashSuit",
             "canTrickySpringBallJump"
           ]
         },
         {
-          "name": "h_plasmaHitbox",
+          "name": "h_PlasmaHitbox",
           "requires": [
             "Plasma",
             "canHitbox"
@@ -727,7 +727,7 @@
                 {"ammo": {"type": "Super", "count": 1}}
               ]}
             ]},
-            "h_OpenZebetitesLeniency"
+            "h_openZebetitesLeniency"
           ],
           "devNote": "Technically all of the strats that use missiles can be done with 1 fewer missile. It requires fairly precise timing and dodging to open it fast enough."
         },
@@ -770,7 +770,7 @@
           ]
         },
         {
-          "name": "h_crystalFlash",
+          "name": "h_CrystalFlash",
           "requires": [
             "canCrystalFlash",
             {"partialRefill": {"type": "Energy", "limit": 1500}}
@@ -781,7 +781,7 @@
           "requires": [
             {"acidFrames": 185},
             "canHeatedCrystalFlash",
-            "h_AcidCrystalFlashRefill",
+            "h_acidCrystalFlashRefill",
             {"acidFrames": 20},
             {"or": [
               "Gravity",
@@ -803,7 +803,7 @@
               ]},
               "canHeatedCrystalFlash"
             ]},
-            "h_HeatedCrystalFlashRefill",
+            "h_heatedCrystalFlashRefill",
             {"heatFrames": 20}
           ],
           "devNote": [
@@ -823,7 +823,7 @@
               ]},
               "canHeatedCrystalFlash"
             ]},
-            "h_HeatedLavaCrystalFlashRefill",
+            "h_heatedLavaCrystalFlashRefill",
             {"heatFrames": 20},
             {"lavaFrames": 20},
             {"or": [
@@ -844,7 +844,7 @@
             {"heatFrames": 185},
             {"acidFrames": 185},
             "canHeatedCrystalFlash",
-            "h_HeatedAcidCrystalFlashRefill",
+            "h_heatedAcidCrystalFlashRefill",
             {"heatFrames": 20},
             {"acidFrames": 20},
             {"or": [
@@ -864,8 +864,8 @@
           "requires": [
             {"tech": "canBombIntoCrystalFlashClip"},
             "Bombs",
-            "h_crystalFlash",
-            "h_BombIntoCrystalFlashClipLeniency"
+            "h_CrystalFlash",
+            "h_bombIntoCrystalFlashClipLeniency"
           ]
         },
         {
@@ -876,8 +876,8 @@
               "SpringBall",
               "canMidAirMorph"
             ]},
-            "h_crystalFlash",
-            "h_JumpIntoCrystalFlashClipLeniency"
+            "h_CrystalFlash",
+            "h_jumpIntoCrystalFlashClipLeniency"
           ]
         },
         {
@@ -892,7 +892,7 @@
           "requires": [
             "canElevatorCrystalFlash",
             "h_ElevatorCrystalFlashLeniency",
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"resourceAtMost": [
               {"type": "RegularEnergy", "count": 50},
               {"type": "ReserveEnergy", "count": 0}
@@ -912,7 +912,7 @@
               "h_heatProof",
               {"tech": "canHeatedCrystalFlash"}
             ]},
-            "h_HeatedCrystalFlashRefill"
+            "h_heatedCrystalFlashRefill"
           ],
           "devNote": "All heat frames before and after the refill are added on the strats that use the helper."
         },
@@ -1071,7 +1071,7 @@
       "description": "Ammo requirements needed to unlock different door types.",
       "helpers": [
         {
-          "name": "h_openRedDoors",
+          "name": "h_openRedDoor",
           "requires": [
             {"or": [
               {"ammo": {"type": "Missile", "count": 5}},
@@ -1080,15 +1080,15 @@
           ]
         },
         {
-          "name": "h_openGreenDoors",
+          "name": "h_openGreenDoor",
           "requires": [ {"ammo": {"type": "Super", "count": 1}} ]
         },
         {
-          "name": "h_openYellowDoors",
-          "requires": [ "h_usePowerBombs" ]
+          "name": "h_openYellowDoor",
+          "requires": [ "h_usePowerBomb" ]
         },
         {
-          "name": "h_openEyeDoors",
+          "name": "h_openEyeDoor",
           "requires": [
             {"or": [
               {"ammo": {"type": "Missile", "count": 3}},   
@@ -1114,7 +1114,7 @@
           ]
         },
         {
-          "name": "h_DirectHeatedGModeLeaveSameDoor",
+          "name": "h_heatedDirectGModeLeaveSameDoor",
           "requires": [
             "h_heatedGMode",
             {"heatFrames": 1}
@@ -1122,7 +1122,7 @@
           "note": "Leaving the same door only adds one heat frame. This is likely only useful if remote acquiring an item or opening a yellow door."
         },
         {
-          "name": "h_IndirectHeatedGModeOpenSameDoor",
+          "name": "h_heatedIndirectGModeOpenSameDoor",
           "requires": [
             "h_heatedGMode",
             {"heatFrames": 70}
@@ -1130,7 +1130,7 @@
           "note": "This requires extra frames, because the door needs to close fully before it can be shot open."
         },
         {
-          "name": "h_HeatedGModeOpenDifferentDoor",
+          "name": "h_heatedGModeOpenDifferentDoor",
           "requires": [
             "h_heatedGMode",
             {"heatFrames": 35}
@@ -1138,7 +1138,7 @@
           "note": "There is a delay after using X-Ray before shooting. If PLMs are already overloaded, Samus can crouch next to the door, shoot up and very quickly use X-Ray."
         },
         {
-          "name": "h_HeatedGModeOffCameraDoor",
+          "name": "h_heatedGModeOffCameraDoor",
           "requires": [
             "h_heatedGMode",
             {"or": [
@@ -1326,7 +1326,7 @@
             {"tech": "canBombIntoCrystalFlashClip"},
             "Bombs",
             "h_artificialMorphCrystalFlash",
-            "h_BombIntoCrystalFlashClipLeniency"
+            "h_bombIntoCrystalFlashClipLeniency"
           ]
         },
         {

--- a/region/brinstar/blue/Billy Mays Room.json
+++ b/region/brinstar/blue/Billy Mays Room.json
@@ -86,7 +86,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -145,7 +145,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -752,7 +752,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -886,7 +886,7 @@
         "Gravity",
         {"canShineCharge": {"usedTiles": 19, "openEnd": 2}},
         {"spikeHits": 1},
-        "h_SpikeSuitSpikeHitLeniency",
+        "h_spikeSuitSpikeHitLeniency",
         "canSpikeSuit",
         {"shinespark": {"frames": 6, "excessFrames": 6}}
       ],

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -536,7 +536,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true
@@ -825,7 +825,7 @@
           "h_destroyBombWalls",
           {"obstaclesCleared": ["A"]}
         ]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
         {"shinespark": {"frames": 43}}
       ],
@@ -854,7 +854,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -910,7 +910,7 @@
       "name": "Broken Power Bomb Blocks",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["C"]}
         ]}
       ],
@@ -950,7 +950,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["C"]}
         ]},
         {"or": [
@@ -960,7 +960,7 @@
         ]},
         {"or": [
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             "canTrivialMidAirMorph"
           ]},
           "ScrewAttack"
@@ -976,7 +976,7 @@
       "name": "Power Bomb and Bombs",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["C"]}
         ]},
         "h_useMorphBombs",
@@ -999,7 +999,7 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"and": [
             {"obstaclesCleared": ["B"]},
             "Morph"
@@ -1031,14 +1031,14 @@
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"and": [
             {"obstaclesCleared": ["B"]},
             "Morph"
           ]},
           {"obstaclesCleared": ["C"]}
         ]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canTrivialMidAirMorph",
         "canTrickyUseFrozenEnemies",
         "canTrickyJump",
@@ -1059,7 +1059,7 @@
       "name": "Shinespark",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
@@ -1075,7 +1075,7 @@
       "name": "Wall Jump Spark",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
@@ -1098,7 +1098,7 @@
       "requires": [
         {"notable": "Fast Wall Jump Spark"},
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},
@@ -1120,7 +1120,7 @@
       "requires": [
         {"notable": "Fast Wall Jump Spark"},
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["C"]}
         ]},
         {"canShineCharge": {"usedTiles": 42, "openEnd": 0}},

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -135,7 +135,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/blue/First Missile Room.json
+++ b/region/brinstar/blue/First Missile Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -108,7 +108,7 @@
               "requires": [
                 {"or": [
                   "h_ZebesIsAwake",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ]
             }
@@ -369,7 +369,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["C"]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -456,7 +456,7 @@
         {"or": [
           "Plasma",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
               "canTrickyDodgeEnemies",
               {"enemyKill": {
@@ -609,7 +609,7 @@
           "Plasma",
           "ScrewAttack",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"enemyKill": {
               "enemies": [["Sidehopper"]],
               "explicitWeapons": ["Missile", "Super", "PowerBomb"]
@@ -1229,7 +1229,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -1240,7 +1240,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -1281,7 +1281,7 @@
         {"or": [
           "Wave",
           "canDodgeWhileShooting",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "ScrewAttack"
         ]},
         {"obstaclesCleared": ["A"]}
@@ -1296,7 +1296,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["B"]}
         ]}
       ],

--- a/region/brinstar/green/Brinstar Map Room.json
+++ b/region/brinstar/green/Brinstar Map Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -132,7 +132,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -445,7 +445,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -114,7 +114,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -807,7 +807,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -480,7 +480,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1245,7 +1245,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -1472,7 +1472,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {

--- a/region/brinstar/green/Etecoon Save Room.json
+++ b/region/brinstar/green/Etecoon Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Etecoon Super Room.json
+++ b/region/brinstar/green/Etecoon Super Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -260,7 +260,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency",
+        "h_extendedMoondanceBeetomLeniency",
         {"or": [
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 8}},
           {"ammo": {"type": "Missile", "count": 1}},
@@ -286,7 +286,7 @@
           {"obstaclesCleared": ["A"]},
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
         ]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -982,7 +982,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency",
+        "h_extendedMoondanceBeetomLeniency",
         {"or": [
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 8}},
           {"ammo": {"type": "Missile", "count": 1}},

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -86,7 +86,7 @@
         "h_XModeThornHit",
         "h_XModeThornHit",
         "h_XModeThornHit",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 130}
       ],
@@ -182,7 +182,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -263,7 +263,7 @@
         ]},
         {"thornHits": 1},
         {"or": [
-          "h_SpikeSuitThornHitLeniency",
+          "h_spikeSuitThornHitLeniency",
           {"resetRoom": {
             "nodes": [1, 2]
           }}

--- a/region/brinstar/green/Green Brinstar Main Shaft Save Room.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4235,7 +4235,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4250,7 +4250,7 @@
         }
       },
       "requires": [
-        "h_DoorImmediatelyClosedFix"
+        "h_doorImmediatelyClosedFix"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -4271,7 +4271,7 @@
         }
       },
       "requires": [
-        "h_DoorImmediatelyClosedFix"
+        "h_doorImmediatelyClosedFix"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -4501,7 +4501,7 @@
       "link": [10, 10],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4852,7 +4852,7 @@
       "link": [12, 12],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4862,7 +4862,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -4934,7 +4934,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -4959,7 +4959,7 @@
       "link": [13, 13],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/brinstar/green/Green Brinstar Missile Refill.json
+++ b/region/brinstar/green/Green Brinstar Missile Refill.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -978,7 +978,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1352,7 +1352,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -127,7 +127,7 @@
       "link": [1, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 30}
       ],
@@ -207,7 +207,7 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -231,7 +231,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -378,7 +378,7 @@
       "link": [2, 2],
       "name": "Leave Shinecharged (Bridge Runway)",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 130}
       ],

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -213,7 +213,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/green/Spore Spawn Room.json
+++ b/region/brinstar/green/Spore Spawn Room.json
@@ -86,7 +86,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -201,7 +201,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -164,7 +164,7 @@
       "link": [1, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"obstaclesCleared": ["A"]},
         {"shineChargeFrames": 40}
@@ -254,7 +254,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -267,7 +267,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -659,7 +659,7 @@
       "link": [2, 2],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"obstaclesCleared": ["A"]},
         {"shineChargeFrames": 45}
@@ -749,7 +749,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -762,7 +762,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -772,11 +772,11 @@
       "name": "Gain Flash Suit (Spikesuit)",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"thornHits": 1},
         "canSpikeSuit",
         {"or": [
-          "h_SpikeSuitThornHitLeniency",
+          "h_spikeSuitThornHitLeniency",
           {"resetRoom": {
             "nodes": [1, 2]
           }}

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -336,7 +336,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -628,7 +628,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/brinstar/kraid/Kraid Save Room.json
+++ b/region/brinstar/kraid/Kraid Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Varia Suit Room.json
+++ b/region/brinstar/kraid/Varia Suit Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -295,7 +295,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -317,7 +317,7 @@
           "canPrepareForNextRoom",
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
         ]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -136,7 +136,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -146,7 +146,7 @@
       "name": "Super Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"ammo": {"type": "Super", "count": 3}},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canMoondance"
       ],
       "exitCondition": {
@@ -170,7 +170,7 @@
       "name": "Super Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"ammo": {"type": "Super", "count": 3}},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canExtendedMoondance"
       ],
       "exitCondition": {
@@ -609,7 +609,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -253,7 +253,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["C"]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -373,7 +373,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -481,7 +481,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -511,7 +511,7 @@
       "link": [3, 5],
       "name": "Power Bomb the Block",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": [
@@ -752,7 +752,7 @@
       "link": [5, 3],
       "name": "Power Bomb the Block",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": "Placing the Power Bomb against the right wall will not break the shot blocks going down."
@@ -844,7 +844,7 @@
       "link": [5, 4],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "canMidAirMorph",
           "h_useSpringBall",

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -143,7 +143,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -595,7 +595,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Big Pink Save Room.json
+++ b/region/brinstar/pink/Big Pink Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1358,7 +1358,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["B"]},
           {"and": [
             "Morph",
@@ -1431,7 +1431,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -1696,7 +1696,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2646,7 +2646,7 @@
         }
       },
       "requires": [
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canMidAirMorph"
       ],
       "exitCondition": {
@@ -2729,7 +2729,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["E"]}
         ]}
       ],
@@ -2741,7 +2741,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -2803,7 +2803,7 @@
       "requires": [
         "Morph",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["E"]}
         ]}
       ],
@@ -3074,7 +3074,7 @@
         {"notable": "Wall Ice Clip X-Ray Climb"},
         "canWallIceClip",
         {"or": [
-          "h_crystalFlash",
+          "h_CrystalFlash",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {"enemy": "Reo", "type": "contact", "hits": 1}}
@@ -3126,7 +3126,7 @@
         {"notable": "Wall Ice Clip X-Ray Climb"},
         "canWallIceClip",
         {"or": [
-          "h_crystalFlash",
+          "h_CrystalFlash",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {"enemy": "Reo", "type": "contact", "hits": 1}}
@@ -3346,7 +3346,7 @@
       "name": "Crystal Flash Standup - Super Block",
       "requires": [
         "h_bombThings",
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "clearsObstacles": ["F"],

--- a/region/brinstar/pink/Dachora Energy Refill.json
+++ b/region/brinstar/pink/Dachora Energy Refill.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -201,7 +201,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -580,7 +580,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -589,7 +589,7 @@
       "link": [2, 3],
       "name": "Spark from Floor",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 110, "excessFrames": 3}}
       ],
       "note": "Diagonal spark left to save health."
@@ -602,7 +602,7 @@
         "canShinechargeMovement",
         "HiJump",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 85, "excessFrames": 3}}
       ],
       "note": "Diagonal spark left to save health."
@@ -616,7 +616,7 @@
         "canFastWalljumpClimb",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 67, "excessFrames": 3}}
       ]
     },
@@ -629,7 +629,7 @@
         "canFastWalljumpClimb",
         "canShinechargeMovementComplex",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 73, "excessFrames": 3}}
       ],
       "note": "Quickly wall jump up the right wall and shinespark up to barely get above the speed blocks without any tanks.",
@@ -1076,7 +1076,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/brinstar/pink/Hopper Energy Tank Room.json
+++ b/region/brinstar/pink/Hopper Energy Tank Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -344,7 +344,7 @@
         "canPrepareForNextRoom",
         {"tech": "canJumpIntoIBJ"},
         "canResetFallSpeed",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canHitbox",
         {"or": [
           "canPseudoScrew",
@@ -526,7 +526,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1151,7 +1151,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1202,7 +1202,7 @@
       "name": "Elevator with Power Bombs or Wave",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "Wave"
         ]}
       ],

--- a/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
+++ b/region/brinstar/pink/Pink Brinstar Power Bomb Room.json
@@ -193,7 +193,7 @@
       "name": "Leave Shinecharged (X-Mode)",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -306,7 +306,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -344,7 +344,7 @@
         }
       },
       "requires": [
-        "h_DoorImmediatelyClosedFix"
+        "h_doorImmediatelyClosedFix"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -365,7 +365,7 @@
         }
       },
       "requires": [
-        "h_DoorImmediatelyClosedFix"
+        "h_doorImmediatelyClosedFix"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -631,7 +631,7 @@
       "name": "Crystal Flash Clip",
       "requires": [
         {"notable": "Crystal Flash Clip"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canCeilingClip"
       ],
       "flashSuitChecked": true,
@@ -843,7 +843,7 @@
         {"obstaclesNotCleared": ["B"]},
         {"canShineCharge": {"usedTiles": 16, "openEnd": 0}},
         {"spikeHits": 1},
-        "h_SpikeSuitSpikeHitLeniency",
+        "h_spikeSuitSpikeHitLeniency",
         "canSpikeSuit",
         {"shinespark": {"frames": 4, "excessFrames": 4}}
       ],

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -237,7 +237,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -153,7 +153,7 @@
       "name": "Leave Shinecharged (Gravity)",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 35}
       ],
@@ -272,7 +272,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -97,10 +97,10 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"thornHits": 1},
-        "h_SpikeSuitSamusEaterLeniency",
-        "h_SpikeSuitThornHitLeniency",
+        "h_spikeSuitSamusEaterLeniency",
+        "h_spikeSuitThornHitLeniency",
         "canSpikeSuit",
         {"shinespark": {"frames": 5, "excessFrames": 5}}
       ],
@@ -125,7 +125,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 80}
       ],
       "exitCondition": {
@@ -144,7 +144,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canXRayCancelShinecharge",
         "canChainTemporaryBlue"
       ],
@@ -307,7 +307,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -644,7 +644,7 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["B"]
     },
@@ -669,7 +669,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["B"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["B"]

--- a/region/brinstar/red/Bat Room.json
+++ b/region/brinstar/red/Bat Room.json
@@ -219,7 +219,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -575,7 +575,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -842,7 +842,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -107,7 +107,7 @@
         {"obstaclesNotCleared": ["B"]},
         {"canShineCharge": {"usedTiles": 29, "openEnd": 0}},
         {"thornHits": 4},
-        "h_SpikeSuitThornHitLeniency",
+        "h_spikeSuitThornHitLeniency",
         "canSpikeSuit",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
@@ -357,7 +357,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
@@ -390,7 +390,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -596,7 +596,7 @@
       "link": [2, 2],
       "name": "Break the Power Bomb Blocks",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["B"]
     }

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -730,7 +730,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1769,7 +1769,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1957,7 +1957,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Caterpillar Save Room.json
+++ b/region/brinstar/red/Caterpillar Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -151,7 +151,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 100}
       ],
       "exitCondition": {
@@ -170,7 +170,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canXRayCancelShinecharge",
         "canChainTemporaryBlue"
       ],
@@ -409,7 +409,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"thornHits": 1},
         "canSpikeSuit",
         {"shinespark": {"frames": 6, "excessFrames": 6}}
@@ -452,7 +452,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 110}
       ],
       "exitCondition": {
@@ -471,7 +471,7 @@
       "requires": [
         "canSamusEaterStandUp",
         {"samusEaterFrames": 160},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canXRayCancelShinecharge",
         "canLongChainTemporaryBlue"
       ],

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -177,7 +177,7 @@
           "SpaceJump",
           "h_XModeSpikeHit"
         ]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 50}}
       ],
       "exitCondition": {
@@ -195,7 +195,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -472,7 +472,7 @@
         "canMidairShinespark",
         "canXMode",
         {"spikeHits": 2},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 146, "excessFrames": 6}}
       ],
       "flashSuitChecked": true,
@@ -492,7 +492,7 @@
         "canMidairShinespark",
         "canXMode",
         {"spikeHits": 2},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 146}},
           {"and": [
@@ -732,7 +732,7 @@
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 140}
       ],
@@ -831,7 +831,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -422,7 +422,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -457,7 +457,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -469,7 +469,7 @@
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -539,7 +539,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 3}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "note": [
         "Collect the Beetom and freeze it above and left of the Power Bomb Blocks in a way that Samus will be able to Moondance.",
@@ -552,7 +552,7 @@
       "name": "Leave with Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
@@ -578,11 +578,11 @@
       "name": "Leave with Extended Moondance",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -689,7 +689,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -813,7 +813,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 6}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -888,7 +888,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 6}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -1162,7 +1162,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -1242,7 +1242,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -2115,7 +2115,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2397,7 +2397,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2551,7 +2551,7 @@
       "link": [9, 9],
       "name": "Kill the Rippers - Power Bomb Without Breaking the Ledges",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canCarefulJump",
         {"or": [
           "canWalljump",

--- a/region/brinstar/red/Sloaters Refill.json
+++ b/region/brinstar/red/Sloaters Refill.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/Spazer Room.json
+++ b/region/brinstar/red/Spazer Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -25,7 +25,7 @@
             {
               "name": "Power Bomb",
               "requires": [
-                "h_usePowerBombs"
+                "h_usePowerBomb"
               ],
               "note": "Raise the shutter before checking the item to not become stuck."
             }
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -257,7 +257,7 @@
       "link": [2, 2],
       "name": "Power Bomb the Block",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A"]
     },

--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -92,7 +92,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/ceres/main/Ceres Ridley's Room.json
+++ b/region/ceres/main/Ceres Ridley's Room.json
@@ -73,7 +73,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Door",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "bypassesDoorShell": true
     },
@@ -82,7 +82,7 @@
       "link": [1, 1],
       "name": "Leave With Runway, Power Bomb the Door",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "exitCondition": {
         "leaveWithRunway": {

--- a/region/ceres/main/Dead Scientist Room.json
+++ b/region/ceres/main/Dead Scientist Room.json
@@ -95,7 +95,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/ceres/main/Falling Tile Room.json
+++ b/region/ceres/main/Falling Tile Room.json
@@ -99,7 +99,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/ceres/main/Magnet Stairs Room.json
+++ b/region/ceres/main/Magnet Stairs Room.json
@@ -100,7 +100,7 @@
       "link": [1, 1],
       "name": "Power Bomb the Doors",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."

--- a/region/crateria/central/Blue Brinstar Elevator Room.json
+++ b/region/crateria/central/Blue Brinstar Elevator Room.json
@@ -80,7 +80,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -314,7 +314,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -637,7 +637,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",
@@ -1108,7 +1108,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1421,7 +1421,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",
@@ -2295,7 +2295,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"or": [
           "h_ClimbWithoutLava",
           "h_lavaProof",

--- a/region/crateria/central/Crateria Map Room.json
+++ b/region/crateria/central/Crateria Map Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -136,7 +136,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Crateria Save Room.json
+++ b/region/crateria/central/Crateria Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Crateria Super Room.json
+++ b/region/crateria/central/Crateria Super Room.json
@@ -261,7 +261,7 @@
         "h_XModeSpikeHit",
         "canShinechargeMovement",
         "canUseIFrames",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 110}
       ],
       "exitCondition": {
@@ -275,7 +275,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -838,7 +838,7 @@
         {"notable": "In-Room X-Mode BlueSuit"},
         "canSuperJump",
         {"spikeHits": 3},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 5}},
         {"spikeHits": 2},
         {"or": [
@@ -1033,7 +1033,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1075,7 +1075,7 @@
         {"or": [
           {"and": [
             "canTrivialUseFrozenEnemies",
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             "canMidairShinespark",
             {"shinespark": {"frames": 118, "excessFrames": 6}}
           ]},
@@ -1101,7 +1101,7 @@
       "name": "Frozen Boyon Runway",
       "requires": [
         "canTrivialUseFrozenEnemies",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 128, "excessFrames": 6}}
       ]
     },
@@ -1111,7 +1111,7 @@
       "name": "Frozen Boyon Runway (Mid-Air Spark)",
       "requires": [
         "canTrivialUseFrozenEnemies",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canMidairShinespark",
         {"or": [
           {"shinespark": {"frames": 118, "excessFrames": 6}},
@@ -1128,7 +1128,7 @@
       "name": "Frozen Boyon Runway (Speedy Jump Spark)",
       "requires": [
         "canTrivialUseFrozenEnemies",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovementComplex",
         {"or": [
           {"shinespark": {"frames": 111, "excessFrames": 6}},
@@ -1147,7 +1147,7 @@
         "canTrivialUseFrozenEnemies",
         "canShinechargeMovementComplex",
         "canFastWalljumpClimb",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 93, "excessFrames": 6}},
           {"and": [
@@ -1393,7 +1393,7 @@
         {"or": [
           {"and": [
             "canTrivialUseFrozenEnemies",
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             "canMidairShinespark",
             {"shinespark": {"frames": 118, "excessFrames": 6}}
           ]},
@@ -1522,7 +1522,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -377,7 +377,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -39,7 +39,7 @@
               "name": "Base",
               "requires": [
                 {"or": [
-                  "h_openRedDoors",
+                  "h_openRedDoor",
                   "f_ZebesSetAblaze"
                 ]}
               ],
@@ -268,7 +268,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -466,7 +466,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -503,7 +503,7 @@
             ]}
           ]},
           {"and": [
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             "canMidairShinespark",
             {"or": [
               {"shinespark": {"frames": 29, "excessFrames": 1}},
@@ -1007,7 +1007,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1378,7 +1378,7 @@
       "requires": [
         {"notable": "Crystal Flash X-Ray Climb"},
         "canXRayClimb",
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1470,7 +1470,7 @@
       "link": [5, 1],
       "name": "Shinespark",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 40}},
         {"or": [
           "h_destroyBombWalls",
@@ -1485,7 +1485,7 @@
       "link": [5, 1],
       "name": "Speedy Jump Diagonal Spark",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         "canMidairShinespark",
         {"or": [
@@ -1497,7 +1497,7 @@
         ]},
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "ScrewAttack"
         ]}
       ],
@@ -1532,7 +1532,7 @@
       "link": [5, 3],
       "name": "Shinespark",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 78, "excessFrames": 11}},
           {"and": [

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -426,7 +426,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1498,7 +1498,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2554,7 +2554,7 @@
       "name": "G-Mode Setup - Power Bomb the Blocks from Below and Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -2871,7 +2871,7 @@
       "link": [8, 8],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -95,7 +95,7 @@
                     "Morph",
                     "canAwakenZebes"
                   ]},
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "Item doesn't spawn unless Samus has Morph and Missiles, even if Zebes is awake.",
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -167,7 +167,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/central/The Final Missile.json
+++ b/region/crateria/central/The Final Missile.json
@@ -39,7 +39,7 @@
               "requires": [
                 {"or": [
                   "h_ZebesIsAwake",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "devNote": [
@@ -89,7 +89,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Bowling Alley Path.json
+++ b/region/crateria/east/Bowling Alley Path.json
@@ -334,7 +334,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -156,7 +156,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -393,7 +393,7 @@
       "requires": [
         {"or": [
           "canCameraManip",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"enemyDamage": {"enemy": "Sciser", "type": "contact", "hits": 1}}
         ]}
       ],
@@ -474,7 +474,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -360,7 +360,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -814,7 +814,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1002,7 +1002,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1375,7 +1375,7 @@
         {"or": [
           "h_crouchJumpDownGrab",
           {"and": [
-            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "h_underwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
           ]}
         ]},
@@ -1398,7 +1398,7 @@
         {"or": [
           "h_crouchJumpDownGrab",
           {"and": [
-            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "h_underwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
           ]}
         ]},

--- a/region/crateria/east/Forgotten Highway Elbow.json
+++ b/region/crateria/east/Forgotten Highway Elbow.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Forgotten Highway Elevator.json
+++ b/region/crateria/east/Forgotten Highway Elevator.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Forgotten Highway Kago Room.json
+++ b/region/crateria/east/Forgotten Highway Kago Room.json
@@ -114,7 +114,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Homing Geemer Room.json
+++ b/region/crateria/east/Homing Geemer Room.json
@@ -85,7 +85,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/Red Brinstar Elevator Room.json
+++ b/region/crateria/east/Red Brinstar Elevator Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -112,7 +112,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -804,7 +804,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -951,13 +951,13 @@
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"obstaclesNotCleared": ["B", "C"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 19, "excessFrames": 19}}
       ],
       "resetsObstacles": ["A"],
       "devNote": [
         "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark.",
-        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shinechargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },
@@ -968,7 +968,7 @@
       "requires": [
         {"obstaclesCleared": ["A", "C"]},
         {"obstaclesNotCleared": ["B"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 21, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -982,7 +982,7 @@
       ],
       "devNote": [
         "This will continue the Shinespark from the right door. This is needed in case the item is an E-Tank, Samus will not maintain full Energy after the Spark.",
-        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shinechargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },
@@ -1121,12 +1121,12 @@
       "requires": [
         {"obstaclesCleared": ["B"]},
         {"obstaclesNotCleared": ["A", "C"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 23, "excessFrames": 7}}
       ],
       "resetsObstacles": ["B"],
       "devNote": [
-        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shinechargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },
@@ -1137,7 +1137,7 @@
       "requires": [
         {"obstaclesCleared": ["B", "C"]},
         {"obstaclesNotCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 23, "excessFrames": 7}}
       ],
       "exitCondition": {
@@ -1150,7 +1150,7 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "devNote": [
-        "FIXME: The h_shineChargeMaxRunway is to satisfy tests for now;",
+        "FIXME: The h_shinechargeMaxRunway is to satisfy tests for now;",
         "we should add a proper way to represent that the shinespark carries over from the previous strat."
       ]
     },

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -772,7 +772,7 @@
       "link": [2, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canLongChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -1037,7 +1037,7 @@
         "HiJump",
         {"or": [
           {"and": [
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             "canXRayTurnaround"
           ]},
           {"canShineCharge": {
@@ -1166,7 +1166,7 @@
       "requires": [
         "canPrepareForNextRoom",
         {"doorUnlockedAtNode": 4},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "This is to represent the ability to Crystal Flash after coming in jumping, shooting open the door, and landing in the door frame."
@@ -1218,7 +1218,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]}
@@ -1353,7 +1353,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]},
@@ -1429,7 +1429,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]},
@@ -1490,7 +1490,7 @@
             "Gravity",
             "canShinechargeMovement",
             "canMidairShinespark",
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]},
@@ -1704,7 +1704,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 50, "excessFrames": 10}}
       ]
     },
@@ -1716,7 +1716,7 @@
         "Gravity",
         "canShinechargeMovement",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 35, "excessFrames": 10}}
       ],
       "note": "Jump to the submerged platform, then jump again."
@@ -1766,7 +1766,7 @@
         {"notable": "Grapple Clip Door Lock Skip"},
         "canUseEnemies",
         "canGrappleClip",
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canXRayClimb"
       ],
       "bypassesDoorShell": true,
@@ -1797,7 +1797,7 @@
       "name": "Leave With Temporary Blue (Gravity)",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"and": [
             "canSpringBallJumpMidAir",
@@ -1982,7 +1982,7 @@
         {"or": [
           "h_bombThings",
           "h_useSpringBall",
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         "canCameraManip"
       ],
@@ -2011,7 +2011,7 @@
         {"or": [
           "h_bombThings",
           "h_useSpringBall",
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         "canCameraManip"
       ],
@@ -2394,7 +2394,7 @@
         {"notable": "Shinespark, Morph Tunnel Rush"},
         "canShinechargeMovementComplex",
         "h_useSpringBall",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 25}}
       ],
       "exitCondition": {
@@ -2477,7 +2477,7 @@
       "link": [12, 9],
       "name": "Shinespark",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 36}}
       ]
     },
@@ -2505,7 +2505,7 @@
       "link": [12, 12],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2587,7 +2587,7 @@
       "requires": [
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 38}}
       ],
       "exitCondition": {
@@ -2605,7 +2605,7 @@
         "canFastWalljumpClimb",
         "HiJump",
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 162}
       ],
       "exitCondition": {
@@ -2625,7 +2625,7 @@
         "HiJump",
         "Gravity",
         "SpaceJump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 145}
       ],
       "exitCondition": {
@@ -2678,7 +2678,7 @@
       "name": "Gravity Suit and Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 17, "excessFrames": 5}}
       ]
     },
@@ -2693,7 +2693,7 @@
           "HiJump",
           "SpaceJump"
         ]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 140}
       ],
       "exitCondition": {
@@ -2710,7 +2710,7 @@
         "Gravity",
         "canShinechargeMovementComplex",
         "canPreciseWalljump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 15}}
       ],
       "exitCondition": {
@@ -2823,7 +2823,7 @@
       "link": [13, 13],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2941,7 +2941,7 @@
       "requires": [
         {"notable": "G-mode Overload PLMs by Power Bombing Morph Maze Item"},
         "canEnterGMode",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "SpaceJump",
           "canLongIBJ",

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -648,7 +648,7 @@
           {"obstaclesCleared": ["A"]}
         ]},
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["B"]}
         ]}
       ],
@@ -700,7 +700,7 @@
       "link": [1, 4],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"useFlashSuit": {}},
         {"or": [
           {"and": [
@@ -786,7 +786,7 @@
         {"notable": "Spark Master"},
         "canSlowShortCharge",
         "canShinechargeMovementTricky",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "HiJump",
         "Gravity",
         {"acidFrames": 16},
@@ -874,7 +874,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1034,7 +1034,7 @@
       "requires": [
         {"notable": "R-Mode Blue Suit"},
         {"obstaclesCleared": ["D"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 0}
       ],
       "exitCondition": {
@@ -1049,7 +1049,7 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ]
     },
     {
@@ -1167,7 +1167,7 @@
       "link": [4, 1],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canHorizontalShinespark",
         {"useFlashSuit": {}},
         {"or": [
@@ -1185,7 +1185,7 @@
       "link": [4, 3],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "canCarefulJump",
           "h_useSpringBall",

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -175,7 +175,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get hit by Waver, Using a Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -494,7 +494,7 @@
       "link": [1, 2],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"useFlashSuit": {}},
         {"or": [
           {"and": [
@@ -753,7 +753,7 @@
       "link": [2, 1],
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canHorizontalShinespark",
         {"useFlashSuit": {}},
         {"or": [
@@ -940,7 +940,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -964,7 +964,7 @@
       "link": [2, 2],
       "name": "G-Mode Setup - Get hit by Waver, Using a Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}

--- a/region/crateria/west/Green Brinstar Elevator Room.json
+++ b/region/crateria/west/Green Brinstar Elevator Room.json
@@ -80,7 +80,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -316,7 +316,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -337,7 +337,7 @@
       },
       "requires": [
         "canInsaneJump",
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -406,7 +406,7 @@
         {"resetRoom": {
           "nodes": [2]
         }},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "canMidAirMorph",
           "h_useSpringBall"
@@ -421,7 +421,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -454,7 +454,7 @@
       "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
           {"and": [
@@ -532,7 +532,7 @@
       "link": [2, 9],
       "name": "Base",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ]
     },
     {
@@ -879,7 +879,7 @@
       },
       "requires": [
         "canInsaneJump",
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1483,7 +1483,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 4}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -1577,7 +1577,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 10}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -1672,7 +1672,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 10}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -110,7 +110,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -112,7 +112,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 40}
       ],
       "exitCondition": {
@@ -191,7 +191,7 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -204,7 +204,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -322,7 +322,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 40}
       ],
       "exitCondition": {
@@ -401,7 +401,7 @@
       "link": [2, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -108,7 +108,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -400,7 +400,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -139,7 +139,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -364,7 +364,7 @@
             "canTrickyJump"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -1041,7 +1041,7 @@
         {"or": [
           {"and": [
             {"heatFrames": 50},
-            "h_usePowerBombs"
+            "h_usePowerBomb"
           ]},
           {"obstaclesCleared": ["A"]}
         ]}
@@ -1101,7 +1101,7 @@
       "requires": [
         {"shineChargeFrames": 45},
         {"shinespark": {"frames": 12}},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 400}
       ],
       "clearsObstacles": ["A"],
@@ -1345,7 +1345,7 @@
       "requires": [
         {"shineChargeFrames": 45},
         {"shinespark": {"frames": 12}},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 400}
       ],
       "clearsObstacles": ["A"],
@@ -1872,7 +1872,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Avoid getting hit by one of the pirate's stationary, invisible lasers on G-mode exit."
@@ -2097,7 +2097,7 @@
         {"heatFrames": 250},
         {"or": [
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 50}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -2125,7 +2125,7 @@
         ]},
         {"heatFrames": 400},
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -2154,7 +2154,7 @@
         {"heatFrames": 700},
         {"or": [
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 50}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -2200,7 +2200,7 @@
         ]},
         {"or": [
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 50}
           ]},
           {"obstaclesCleared": ["A"]}
@@ -2234,7 +2234,7 @@
         ]},
         {"heatFrames": 550},
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],

--- a/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
+++ b/region/lowernorfair/east/Lower Norfair Escape Power Bomb Room.json
@@ -268,7 +268,7 @@
       "requires": [
         "h_heatedGMode",
         "h_artificialMorphBombs",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Bomb the side of the crumble blocks to overload PLMs and go through to the left door.",
@@ -293,7 +293,7 @@
         {"itemNotCollectedAtNode": 3},
         "canRiskPermanentLossOfAccess",
         {"ammo": {"type": "PowerBomb", "count": 9}},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Use 9 Power Bombs against the right crumble blocks to overload PLMs and roll through the crumble blocks on the left."

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -241,7 +241,7 @@
       "requires": [
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -370,7 +370,7 @@
       "requires": [
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -354,7 +354,7 @@
             ]}
           ]}
         ]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"partialRefill": {"type": "Energy", "limit": 340}},
         {"partialRefill": {"type": "Missile", "limit": 6}},
         {"refill": ["PowerBomb"]}
@@ -365,7 +365,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -416,7 +416,7 @@
         {"canShineCharge": {"usedTiles": 20, "gentleDownTiles": 2, "openEnd": 1}},
         {"spikeHits": 1},
         {"or": [
-          "h_SpikeSuitSpikeHitLeniency",
+          "h_spikeSuitSpikeHitLeniency",
           {"and": [
             {"resourceCapacity": [{"type": "PowerBomb", "count": 1}]},
             {"resetRoom": {
@@ -672,7 +672,7 @@
         "ScrewAttack",
         {"or": [
           "canCarefulJump",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"ammo": {"type": "Super", "count": 1}},
           {"and": [
             "canDisableEquipment",
@@ -856,7 +856,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1079,7 +1079,7 @@
       "name": "X-Mode Shinespark",
       "requires": [
         "canXMode",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         {"shinespark": {"frames": 14, "excessFrames": 9}}

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze Room.json
@@ -240,7 +240,7 @@
         }
       },
       "requires": [
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [4],
       "note": [
@@ -262,7 +262,7 @@
       "requires": [
         "canOffScreenMovement",
         "h_bombThings",
-        "h_HeatedGModeOffCameraDoor",
+        "h_heatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
       "flashSuitChecked": true,
@@ -285,7 +285,7 @@
       "requires": [
         "canOffScreenMovement",
         "h_bombThings",
-        "h_HeatedGModeOffCameraDoor",
+        "h_heatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
       "collectsItems": [4],
@@ -307,7 +307,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -555,7 +555,7 @@
             "canTrickyDodgeEnemies"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -584,7 +584,7 @@
             "h_artificialMorphBombHorizontally"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -613,7 +613,7 @@
           ]}
         ]},
         "h_bombThings",
-        "h_HeatedGModeOffCameraDoor",
+        "h_heatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
       "flashSuitChecked": true,
@@ -654,7 +654,7 @@
           "canSpringBallBombJump"
         ]},
         "h_bombThings",
-        "h_HeatedGModeOffCameraDoor",
+        "h_heatedGModeOffCameraDoor",
         {"heatFrames": 200}
       ],
       "collectsItems": [4],
@@ -709,7 +709,7 @@
       "link": [3, 3],
       "name": "X-Mode",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
@@ -762,7 +762,7 @@
           "HiJump",
           "h_useSpringBall"
         ]},
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -796,7 +796,7 @@
           "HiJump",
           "h_artificialMorphSpringBallBombJump"
         ]},
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -1156,7 +1156,7 @@
           "canTrivialMidAirMorph",
           "h_useSpringBall"
         ]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 300}
       ],
       "clearsObstacles": ["B"]
@@ -1228,7 +1228,7 @@
         {"obstaclesCleared": ["A"]},
         {"canShineCharge": {"usedTiles": 27, "gentleUpTiles": 2, "openEnd": 1}},
         {"spikeHits": 1},
-        "h_SpikeSuitSpikeHitLeniency",
+        "h_spikeSuitSpikeHitLeniency",
         "h_heatProof",
         "canSpikeSuit",
         {"shinespark": {"frames": 6, "excessFrames": 6}}

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -127,7 +127,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -258,7 +258,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -455,7 +455,7 @@
       },
       "requires": [
         "SpaceJump",
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": "Space Jump across without falling. The Hibashi (fire pillars) can not hit Samus while off camera."
@@ -476,7 +476,7 @@
         "canShinechargeMovement",
         {"canShineCharge": {"usedTiles": 24, "openEnd": 1}},
         {"shinespark": {"frames": 75, "excessFrames": 5}},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -514,7 +514,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -215,7 +215,7 @@
       "link": [1, 2],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"or": [
           "canHitbox",
@@ -360,7 +360,7 @@
       "link": [2, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"or": [
           "canHitbox",

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -782,7 +782,7 @@
       "name": "Power Bomb",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 180}
       ],
       "clearsObstacles": ["A"],
@@ -1069,7 +1069,7 @@
       "link": [4, 3],
       "name": "Power Bomb All the Blocks for Later",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 80}
       ],
       "clearsObstacles": ["A"]
@@ -1080,7 +1080,7 @@
       "name": "Power Bomb the Left Blocks for Later",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 95}
       ],
       "clearsObstacles": ["B"],
@@ -1112,7 +1112,7 @@
       "link": [4, 4],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 120}
       ],
       "clearsObstacles": ["A"]
@@ -1753,7 +1753,7 @@
         "h_preciseIceClip",
         {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}},
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -574,7 +574,7 @@
           "SpaceJump",
           "canTrickyJump"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -1226,7 +1226,7 @@
             {"acidFrames": 24}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -340,7 +340,7 @@
         ]},
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -576,7 +576,7 @@
           "Plasma",
           {"enemyDamage": {"enemy": "Zebbo", "type": "contact", "hits": 1}}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/lowernorfair/east/Red Kihunter Shaft Save Room.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -581,7 +581,7 @@
           "ScrewAttack",
           {"enemyDamage": {"enemy": "Kihunter (red)", "type": "contact", "hits": 1}}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -626,7 +626,7 @@
       "name": "Power Bombs",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 240}
       ]
     },
@@ -713,7 +713,7 @@
       "requires": [
         "h_artificialMorphMovement",
         {"heatFrames": 30},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -851,7 +851,7 @@
       "name": "Power Bombs",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 250}
       ]
     },
@@ -1393,7 +1393,7 @@
       "name": "Power Bombs",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 270}
       ],
       "devNote": "FIXME This strat also unlocks node 2. Could add that in later?"
@@ -1458,7 +1458,7 @@
       "name": "X-Ray Clip",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canXRayStandUp",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1488,7 +1488,7 @@
       "name": "Bomb Block X-Ray Climb",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canXRayClimb",
         "canCeilingClip",
         {"or": [
@@ -1514,7 +1514,7 @@
       "name": "Spring Power Bombs",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "h_useSpringBall",
         {"or": [
           "ScrewAttack",

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -459,7 +459,7 @@
         "SpaceJump",
         {"or": [
           "Wave",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"heatFrames": 40}
         ]},
         {"or": [
@@ -497,7 +497,7 @@
         "canMidairWiggle",
         {"or": [
           "Wave",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"heatFrames": 40}
         ]},
         {"heatFrames": 120}
@@ -566,7 +566,7 @@
         "ScrewAttack",
         "SpaceJump",
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "canInsaneJump"
@@ -601,7 +601,7 @@
         "canConsecutiveWalljump",
         "canMidairWiggle",
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "canTrickyGMode"
@@ -724,7 +724,7 @@
         "SpeedBooster",
         "canPreciseWalljump",
         "canTrickyDodgeEnemies",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canTrivialMidAirMorph",
         "canHitbox",
         {"heatFrames": 420},
@@ -746,7 +746,7 @@
       "link": [2, 4],
       "name": "HiJump, Screw, and PowerBomb",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canPreciseWalljump",
         "canConsecutiveWalljump",
         "canTrivialMidAirMorph",
@@ -774,7 +774,7 @@
         {"notable": "PowerBombs and a Jump Assist"},
         "canPreciseWalljump",
         "canHitbox",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canTrivialMidAirMorph",
         "canTrickyJump",
         {"or": [
@@ -907,7 +907,7 @@
         "canFastWalljumpClimb",
         "canWallJumpBombBoost",
         "canDiagonalBombJump",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 930},
         {"or": [
           "h_heatResistant",
@@ -1400,7 +1400,7 @@
       },
       "requires": [
         "ScrewAttack",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1534,7 +1534,7 @@
         "canHitbox",
         {"or": [
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 175}
           ]},
           {"and": [
@@ -1565,7 +1565,7 @@
         {"or": [
           "ScrewAttack",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 70}
           ]},
           {"and": [
@@ -1644,7 +1644,7 @@
       "name": "HitBox",
       "requires": [
         "canHitbox",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 280}
       ],
       "unlocksDoors": [
@@ -1747,7 +1747,7 @@
       "name": "HitBox",
       "requires": [
         "canHitbox",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 180}
       ],
       "unlocksDoors": [{"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}]
@@ -1906,7 +1906,7 @@
           "ScrewAttack",
           {"and": [
             "canTrivialMidAirMorph",
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
               {"and": [
                 "canWalljump",
@@ -1936,12 +1936,12 @@
       "link": [6, 4],
       "name": "Springwall",
       "requires": [
-        "h_HeatedSpringwall",
+        "h_heatedSpringwall",
         "canConsecutiveWalljump",
         {"heatFrames": 300},
         {"or": [
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 180}
           ]},
           {"and": [
@@ -1965,7 +1965,7 @@
         {"or": [
           {"and": [
             "canTrivialMidAirMorph",
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 200}
           ]},
           {"and": [
@@ -1990,7 +1990,7 @@
         {"or": [
           {"and": [
             "canTrivialMidAirMorph",
-            "h_usePowerBombs"
+            "h_usePowerBomb"
           ]},
           {"obstaclesCleared": ["A"]}
         ]}

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -226,7 +226,7 @@
       "name": "Hitbox the Kihunters",
       "requires": [
         "h_navigateHeatRooms",
-        "h_plasmaHitbox",
+        "h_PlasmaHitbox",
         {"heatFrames": 420}
       ]
     },
@@ -1092,7 +1092,7 @@
       "name": "Power Bombs",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 230}
       ]
     },

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -387,7 +387,7 @@
       },
       "requires": [
         "h_heatedGMode",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 0}
       ],
       "flashSuitChecked": true,
@@ -618,7 +618,7 @@
       "link": [3, 6],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 180}
       ],
       "clearsObstacles": ["A", "B"]
@@ -658,7 +658,7 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
           {"and": [
@@ -786,7 +786,7 @@
       "requires": [
         {"heatFrames": 150},
         "canHitbox",
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"]
     },
@@ -918,7 +918,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"heatFrames": 240},
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}}
@@ -932,7 +932,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         "ScrewAttack",
         {"heatFrames": 270}
@@ -946,7 +946,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"enemyKill": {
           "enemies": [["Dessgeega"], ["Dessgeega", "Dessgeega", "Dessgeega"]],
@@ -963,7 +963,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         "canDodgeWhileShooting",
         {"enemyKill": {
@@ -1001,7 +1001,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"or": [
           {"and": [
@@ -1063,7 +1063,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
         {"heatFrames": 255}
@@ -1077,7 +1077,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         "ScrewAttack",
         {"heatFrames": 240}
@@ -1091,7 +1091,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"enemyKill": {
           "enemies": [["Dessgeega"]],
@@ -1108,7 +1108,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"enemyKill": {
           "enemies": [["Dessgeega"]],
@@ -1127,7 +1127,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"or": [
           "Charge",
@@ -1145,7 +1145,7 @@
       "requires": [
         {"notable": "Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "HiJump",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1170,7 +1170,7 @@
       "requires": [
         {"notable": "HiJumpless Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canTrickyJump",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1196,7 +1196,7 @@
       "requires": [
         {"notable": "Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "HiJump",
         "canPartialFloorClip",
         "canCeilingClip",
@@ -1229,7 +1229,7 @@
       "requires": [
         {"notable": "HiJumpless Statue Clip Damage Boost"},
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canPartialFloorClip",
         "canCeilingClip",
         "canTrickyJump",
@@ -1293,7 +1293,7 @@
       "name": "Power Bomb",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 210}
       ],
       "clearsObstacles": ["A", "B"],
@@ -1385,7 +1385,7 @@
       "name": "Take Damage",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]},
         {"enemyDamage": {"enemy": "Dessgeega", "type": "contact", "hits": 1}},
@@ -1398,7 +1398,7 @@
       "link": [6, 5],
       "name": "HitBox enemy (Power Bomb)",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canHitbox",
         {"heatFrames": 240}
       ],
@@ -1410,7 +1410,7 @@
       "name": "Screw Attack",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]},
         "ScrewAttack",
@@ -1424,7 +1424,7 @@
       "name": "Fast Kill",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]},
         {"enemyKill": {
@@ -1442,7 +1442,7 @@
       "requires": [
         "h_heatProof",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]},
         {"or": [
@@ -1515,7 +1515,7 @@
         {"or": [
           "canTrickyJump",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             "canCarefulJump",
             "canHitbox"
           ]}
@@ -1670,7 +1670,7 @@
         "h_heatResistant",
         "h_bombThings",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "canInsaneJump",
           {"obstaclesCleared": ["E"]}
         ]},
@@ -1681,7 +1681,7 @@
         "The hibashi hit can be avoided by waiting for the shutter to go up.",
         "That requires the use of one PB and more time than is worth unless heat proof."
       ],
-      "devNote": "Note that if using PBs, two is required. One each from h_bombThings, h_usePowerBombs."
+      "devNote": "Note that if using PBs, two is required. One each from h_bombThings, h_usePowerBomb."
     },
     {
       "id": 88,
@@ -1847,7 +1847,7 @@
       "requires": [
         "h_heatedGMode",
         "canOffScreenMovement",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "canTrickyGMode",
           {"spikeHits": 1}

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -314,7 +314,7 @@
       },
       "requires": [
         {"heatFrames": 220},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
@@ -337,7 +337,7 @@
         }
       },
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 220},
         "canOffScreenMovement"
       ],
@@ -439,7 +439,7 @@
       },
       "requires": [
         {"heatFrames": 220},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
@@ -462,7 +462,7 @@
         }
       },
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 220},
         "canOffScreenMovement"
       ],
@@ -569,7 +569,7 @@
       "requires": [
         "h_activateAcidChozo",
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 1020}
       ],
       "setsFlags": ["f_UsedAcidChozoStatue"]
@@ -604,7 +604,7 @@
       "requires": [
         "h_activateAcidChozo",
         {"obstaclesNotCleared": ["A"]},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 180},
         "canManageReserves",
         {"autoReserveTrigger": {}},
@@ -680,7 +680,7 @@
       "requires": [
         "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 250}
       ]
     },
@@ -794,7 +794,7 @@
       "requires": [
         "h_navigateHeatRooms",
         "f_UsedAcidChozoStatue",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "HiJump",
           "canWalljump",

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -165,7 +165,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"canShineCharge": {"usedTiles": 18, "openEnd": 0}},
         "canShinechargeMovement",
         {"heatFrames": 630},
@@ -341,7 +341,7 @@
           {"enemyDamage": {"enemy": "Ripper 2 (red)", "type": "contact", "hits": 2}}
         ]},
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "ScrewAttack"
@@ -376,7 +376,7 @@
           {"enemyDamage": {"enemy": "Ripper 2 (red)", "type": "contact", "hits": 1}}
         ]},
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "canTrickyJump",
             "h_heatedGModePauseAbuse",
@@ -593,7 +593,7 @@
           {"enemyDamage": {"enemy": "Ripper 2 (red)", "type": "contact", "hits": 2}}
         ]},
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "ScrewAttack"
@@ -624,7 +624,7 @@
       "requires": [
         "canTrickyGMode",
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             {"ammo": {"type": "Super", "count": 1}}
@@ -657,7 +657,7 @@
           "h_artificialMorphPowerBomb"
         ]},
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             {"ammo": {"type": "Super", "count": 1}}

--- a/region/lowernorfair/west/Golden Torizo Energy Recharge.json
+++ b/region/lowernorfair/west/Golden Torizo Energy Recharge.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -103,7 +103,7 @@
                 {"or": [
                   "Wave",
                   {"and": [
-                    "h_usePowerBombs",
+                    "h_usePowerBomb",
                     {"or": [
                       "canTrivialMidAirMorph",
                       "h_useSpringBall"
@@ -268,7 +268,7 @@
         }
       },
       "requires": [
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true
@@ -286,7 +286,7 @@
       "requires": [
         "Charge",
         "h_useMorphBombs",
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -334,7 +334,7 @@
             "h_useMorphBombs"
           ]}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -648,7 +648,7 @@
             ]}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -812,7 +812,7 @@
           ]}
         ]},
         {"or": [
-          "h_IndirectHeatedGModeOpenSameDoor",
+          "h_heatedIndirectGModeOpenSameDoor",
           "h_heatedGModePauseAbuse"
         ]}
       ],
@@ -859,7 +859,7 @@
             ]}
           ]}
         ]},
-        "h_IndirectHeatedGModeOpenSameDoor"
+        "h_heatedIndirectGModeOpenSameDoor"
       ],
       "setsFlags": ["f_DefeatedGoldenTorizo"],
       "flashSuitChecked": true,
@@ -1135,7 +1135,7 @@
       "name": "Power Bombs",
       "requires": [
         "h_navigateHeatRooms",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "canTrivialMidAirMorph",
           "h_useSpringBall"
@@ -1271,7 +1271,7 @@
       "requires": [
         "h_navigateHeatRooms",
         "h_useMorphBombs",
-        "h_HeatedSpringwall",
+        "h_heatedSpringwall",
         {"heatFrames": 900}
       ],
       "note": [
@@ -1687,7 +1687,7 @@
         {"or": [
           "ScrewAttack",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
               "canTrivialMidAirMorph",
               "h_useSpringBall"
@@ -1722,7 +1722,7 @@
         "ScrewAttack",
         "canCarefulJump",
         "canPreciseWalljump",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           "canTrivialMidAirMorph",
           "h_useSpringBall"
@@ -1799,7 +1799,7 @@
             ]}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1881,7 +1881,7 @@
         ]},
         {"or": [
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 70}
           ]},
           {"and": [

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -510,7 +510,7 @@
       "requires": [
         "ScrewAttack",
         "SpaceJump",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
@@ -533,7 +533,7 @@
           "SpaceJump",
           "canSpringwall"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -555,7 +555,7 @@
         {"itemNotCollectedAtNode": 4},
         "canRiskPermanentLossOfAccess",
         "h_artificialMorphLongIBJ",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -955,7 +955,7 @@
       },
       "requires": [
         "ScrewAttack",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
@@ -1407,7 +1407,7 @@
       "requires": [
         "ScrewAttack",
         "SpaceJump",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -1631,7 +1631,7 @@
         {"or": [
           "h_artificialMorphLongIBJ",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
               "canWalljump",
               "SpaceJump",
@@ -1667,7 +1667,7 @@
             "h_artificialMorphSpringBall"
           ]},
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
               "HiJump",
               "h_crouchJumpDownGrab",
@@ -1699,7 +1699,7 @@
         {"or": [
           "h_artificialMorphLongIBJ",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
               "canWalljump",
               "SpaceJump",
@@ -1736,7 +1736,7 @@
             "h_artificialMorphSpringBall"
           ]},
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
               "HiJump",
               "h_crouchJumpDownGrab",
@@ -1895,7 +1895,7 @@
       },
       "requires": [
         "ScrewAttack",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
@@ -2326,7 +2326,7 @@
       "link": [3, 5],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 220}
       ],
       "clearsObstacles": ["A"]
@@ -2619,7 +2619,7 @@
       "link": [4, 5],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 220}
       ],
       "clearsObstacles": ["B"]
@@ -2707,7 +2707,7 @@
       "name": "Springwall",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_HeatedSpringwall",
+        "h_heatedSpringwall",
         {"heatFrames": 245}
       ]
     },
@@ -2732,7 +2732,7 @@
       "link": [5, 4],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 140}
       ],
       "clearsObstacles": ["B"]
@@ -2752,7 +2752,7 @@
       "link": [5, 5],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canTrivialMidAirMorph",
         {"heatFrames": 150}
       ],
@@ -2792,7 +2792,7 @@
       "name": "Springwall with Bombs",
       "requires": [
         "h_useMorphBombs",
-        "h_HeatedSpringwall",
+        "h_heatedSpringwall",
         {"heatFrames": 250}
       ],
       "clearsObstacles": ["A"],

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -136,7 +136,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -358,7 +358,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -970,7 +970,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -2223,7 +2223,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2250,7 +2250,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2260,7 +2260,7 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"and": [
             "Gravity",
             "ScrewAttack"

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -328,7 +328,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -164,7 +164,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -204,7 +204,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A", "B"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["A", "B"],
@@ -241,7 +241,7 @@
       "name": "Reverse",
       "requires": [
         {"notable": "Reverse"},
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
       "setsFlags": ["f_ShaktoolDoneDigging"],
@@ -570,7 +570,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -72,7 +72,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/West Sand Hall Tunnel.json
+++ b/region/maridia/inner-green/West Sand Hall Tunnel.json
@@ -144,7 +144,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -148,7 +148,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -592,7 +592,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1029,7 +1029,7 @@
         "canInsaneJump",
         {"or": [
           "canCrouchJump",
-          "h_UnderwaterCrouchJumpWithFlashSuit"
+          "h_underwaterCrouchJumpWithFlashSuit"
         ]},
         "canNeutralDamageBoost",
         {"or": [

--- a/region/maridia/inner-pink/Aqueduct Save Room.json
+++ b/region/maridia/inner-pink/Aqueduct Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -316,7 +316,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -328,7 +328,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "exitCondition": {
@@ -360,7 +360,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -571,7 +571,7 @@
         ]},
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -654,7 +654,7 @@
         "canSpringBallJumpMidAir",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -669,7 +669,7 @@
         "canConsecutiveWalljump",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["A"]
@@ -689,7 +689,7 @@
         ]},
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["A"],
@@ -705,7 +705,7 @@
         "canSnailClimb",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "clearsObstacles": ["A"],
@@ -724,7 +724,7 @@
       "requires": [
         {"shineChargeFrames": 130},
         "canSuitlessMaridia",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canShinechargeMovement",
         {"shinespark": {"frames": 25, "excessFrames": 11}}
       ],
@@ -741,10 +741,10 @@
         }
       },
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 25, "excessFrames": 11}},
           {"and": [
@@ -765,11 +765,11 @@
         }
       },
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canPreciseStutterWaterShineCharge",
         "canInsaneJump",
         "canShinechargeMovementTricky",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 25, "excessFrames": 11}},
           {"and": [
@@ -791,9 +791,9 @@
         "Gravity",
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovementComplex",
         {"or": [
           {"and": [
@@ -998,7 +998,7 @@
         "canShinechargeMovementComplex",
         "canPreciseStutterWaterShineCharge",
         "canInsaneJump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 12}},
           {"and": [
@@ -1263,7 +1263,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1331,7 +1331,7 @@
         "canShinechargeMovementComplex",
         "canWaterShineCharge",
         "canHorizontalShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 139, "excessFrames": 66}}
       ],
       "note": [
@@ -1443,7 +1443,7 @@
       },
       "requires": [
         "canWaterShineCharge",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 37, "excessFrames": 3}}
       ],
       "note": [
@@ -1457,7 +1457,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 40, "excessFrames": 7}}
       ]
     },
@@ -1473,7 +1473,7 @@
       },
       "requires": [
         "canWaterShineCharge",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 40, "excessFrames": 7}}
       ],
       "note": [
@@ -1486,7 +1486,7 @@
       "link": [2, 7],
       "name": "Temporary Blue Gravity Jump",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canGravityJump",
         "canTemporaryBlue",
         {"or": [
@@ -1576,8 +1576,8 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "h_usePowerBombs",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
+        "h_usePowerBomb",
         "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -1700,7 +1700,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 37, "excessFrames": 3}}
       ]
     },
@@ -2128,7 +2128,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2403,8 +2403,8 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "h_usePowerBombs",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
+        "h_usePowerBomb",
         "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -2863,8 +2863,8 @@
           {"itemNotCollectedAtNode": 7},
           {"itemNotCollectedAtNode": 8}
         ]},
-        "h_usePowerBombs",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
+        "h_usePowerBomb",
         "h_navigateUnderwater",
         "canSnailClimb",
         {"or": [
@@ -3149,7 +3149,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -158,7 +158,7 @@
       "name": "Kill the Owtch",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "Plasma",
           "Charge",
           {"ammo": {"type": "Super", "count": 1}},

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1141,7 +1141,7 @@
       "requires": [
         {"notable": "Sand Bomb Boost (Left to Right)"},
         {"tech": "canSandBombBoost"},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canInsaneJump",
         {"or": [
           "can4HighMidAirMorph",

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -154,7 +154,7 @@
       "requires": [
         "canShinechargeMovement",
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 70}
       ],
       "exitCondition": {
@@ -171,7 +171,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -346,7 +346,7 @@
           "Gravity",
           "h_crouchJumpDownGrab",
           {"and": [
-            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "h_underwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
           ]}
         ]},
@@ -460,7 +460,7 @@
         {"or": [
           "h_crouchJumpDownGrab",
           {"and": [
-            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "h_underwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
           ]}
         ]},
@@ -492,7 +492,7 @@
         {"or": [
           "h_crouchJumpDownGrab",
           {"and": [
-            "h_UnderwaterCrouchJumpWithFlashSuit",
+            "h_underwaterCrouchJumpWithFlashSuit",
             "canDownGrab"
           ]}
         ]}
@@ -675,7 +675,7 @@
       "requires": [
         "canShinechargeMovement",
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 55}
       ],
       "exitCondition": {
@@ -797,7 +797,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Botwoon Quicksand Room.json
+++ b/region/maridia/inner-pink/Botwoon Quicksand Room.json
@@ -206,7 +206,7 @@
         {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
         {"or": [
           {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "note": [
@@ -322,7 +322,7 @@
         {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
         {"or": [
           {"enemyDamage": {"enemy": "Bull", "type": "contact", "hits": 1}},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "note": [
@@ -366,7 +366,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -258,7 +258,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -499,7 +499,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -155,7 +155,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -957,7 +957,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2556,7 +2556,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -180,7 +180,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 12}},
           {"and": [
@@ -222,7 +222,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -491,7 +491,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 40, "excessFrames": 6}}
       ],
       "note": [
@@ -1235,7 +1235,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1588,7 +1588,7 @@
         "canSuitlessMaridia",
         {"or": [
           "canCrouchJump",
-          "h_UnderwaterCrouchJumpWithFlashSuit"
+          "h_underwaterCrouchJumpWithFlashSuit"
         ]}
       ],
       "flashSuitChecked": true
@@ -1657,7 +1657,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/Draygon Save Room.json
+++ b/region/maridia/inner-pink/Draygon Save Room.json
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -364,7 +364,7 @@
           "f_DefeatedDraygon",
           "h_breakOneDraygonTurret"
         ]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1173,7 +1173,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_DefeatedDraygon",
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/East Aqueduct Quicksand Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "A 10 Power Bomb Crystal Flash strat may also be possible here, but it seems tricky to ensure that health-bomb won't interfere."

--- a/region/maridia/inner-pink/East Cactus Alley Room.json
+++ b/region/maridia/inner-pink/East Cactus Alley Room.json
@@ -205,7 +205,7 @@
       "link": [1, 1],
       "name": "X-Mode, Leave Shinecharged",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovementComplex",
         "canXMode",
         "h_XModeSpikeHit",
@@ -250,7 +250,7 @@
         "canXMode",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovementTricky",
         "canTrickyJump",
         "Gravity",
@@ -285,7 +285,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -533,7 +533,7 @@
         ]},
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 80}
       ],
       "exitCondition": {
@@ -547,7 +547,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -715,7 +715,7 @@
           "h_XModeSpikeHit",
           "canStationarySpinJump"
         ]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 25, "excessFrames": 5}}
       ],
       "flashSuitChecked": true,

--- a/region/maridia/inner-pink/East Sand Hole.json
+++ b/region/maridia/inner-pink/East Sand Hole.json
@@ -116,7 +116,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -559,7 +559,7 @@
       "requires": [
         {"or": [
           "canCrouchJump",
-          "h_UnderwaterCrouchJumpWithFlashSuit"
+          "h_underwaterCrouchJumpWithFlashSuit"
         ]},
         {"useFlashSuit": {}},
         {"or": [

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -223,7 +223,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1494,7 +1494,7 @@
       },
       "requires": [
         "canStutterWaterShineCharge",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -1524,7 +1524,7 @@
       },
       "requires": [
         "canStutterWaterShineCharge",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -1830,7 +1830,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -1893,7 +1893,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2598,7 +2598,7 @@
       },
       "requires": [
         "canStutterWaterShineCharge",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}},
           {"and": [
@@ -2807,7 +2807,7 @@
         "Morph",
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 20, "excessFrames": 3}},
           {"and": [
@@ -3153,7 +3153,7 @@
       "requires": [
         "Gravity",
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 30}
       ],
       "exitCondition": {
@@ -3252,7 +3252,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -3264,7 +3264,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3276,7 +3276,7 @@
         "Morph",
         "Gravity",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 39, "excessFrames": 4}},
           {"and": [
@@ -3811,7 +3811,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3838,7 +3838,7 @@
         }
       },
       "requires": [
-        "h_DoorImmediatelyClosedFix"
+        "h_doorImmediatelyClosedFix"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -3859,7 +3859,7 @@
         }
       },
       "requires": [
-        "h_DoorImmediatelyClosedFix"
+        "h_doorImmediatelyClosedFix"
       ],
       "exitCondition": {
         "leaveWithGMode": {

--- a/region/maridia/inner-pink/Maridia Health Refill Room.json
+++ b/region/maridia/inner-pink/Maridia Health Refill Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/Space Jump Room.json
+++ b/region/maridia/inner-pink/Space Jump Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -131,7 +131,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -763,7 +763,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1041,7 +1041,7 @@
       "name": "Start Shinecharged, Leave With Temporary Blue",
       "startsWithShineCharge": true,
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 0},
         "canXRayTurnaround",
         "canLongChainTemporaryBlue",
@@ -1085,7 +1085,7 @@
       "name": "Start Shinecharged, Leave With Temporary Blue",
       "startsWithShineCharge": true,
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 0},
         "canXRayTurnaround",
         "canChainTemporaryBlue"

--- a/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
+++ b/region/maridia/inner-pink/West Aqueduct Quicksand Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "A 10 Power Bomb Crystal Flash strat may also be possible here, but it seems tricky to ensure that health-bomb won't interfere."

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -144,7 +144,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1083,7 +1083,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -158,7 +158,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -351,7 +351,7 @@
           "canResetFallSpeed",
           {"and": [
             "canPrepareForNextRoom",
-            "h_usePowerBombs"
+            "h_usePowerBomb"
           ]}
         ]},
         {"shinespark": {"frames": 24, "excessFrames": 5}}
@@ -414,7 +414,7 @@
       "requires": [
         "canPlayInSand",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "Wave"
         ]},
         {"useFlashSuit": {}},

--- a/region/maridia/inner-yellow/Bug Sand Hole.json
+++ b/region/maridia/inner-yellow/Bug Sand Hole.json
@@ -219,7 +219,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1172,7 +1172,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Forgotten Highway Save Room.json
+++ b/region/maridia/inner-yellow/Forgotten Highway Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -183,7 +183,7 @@
           "Wave",
           "Spazer",
           "Plasma",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Choot", "type": "contact", "hits": 1}}
         ]}
@@ -565,7 +565,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -242,7 +242,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -766,9 +766,9 @@
           ]},
           {"and": [
             "canLongIBJ",
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
-              "h_usePowerBombs",
+              "h_usePowerBomb",
               "canStaggeredIBJ"
             ]}
           ]}
@@ -941,7 +941,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1188,9 +1188,9 @@
           ]},
           {"and": [
             "canLongIBJ",
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"or": [
-              "h_usePowerBombs",
+              "h_usePowerBomb",
               "canStaggeredIBJ"
             ]}
           ]}
@@ -1265,7 +1265,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
+++ b/region/maridia/inner-yellow/Northwest Maridia Bug Room.json
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -391,7 +391,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -496,7 +496,7 @@
       "requires": [
         "SpaceJump",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "ScrewAttack",
           "Plasma",
           {"and": [
@@ -517,7 +517,7 @@
       "requires": [
         "HiJump",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "ScrewAttack",
           "Plasma",
           {"and": [

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -248,7 +248,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -286,7 +286,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -468,7 +468,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 90, "excessFrames": 50}}
       ],
@@ -607,7 +607,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -849,7 +849,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 90, "excessFrames": 11}}
       ],
@@ -1071,7 +1071,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1577,7 +1577,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -105,7 +105,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Pseudo Plasma Spark Room.json
@@ -340,7 +340,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -632,7 +632,7 @@
       "name": "Shinecharge Out Bottom",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 20}
       ],
       "exitCondition": {
@@ -704,7 +704,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -473,7 +473,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -499,7 +499,7 @@
           "ScrewAttack",
           "canBePatient",
           {"resourceCapacity": [{"type": "Missile", "count": 1}]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ]
     },
@@ -623,7 +623,7 @@
           "ScrewAttack",
           "canBePatient",
           {"resourceCapacity": [{"type": "Missile", "count": 1}]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ]
     },
@@ -1002,7 +1002,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -178,7 +178,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -179,7 +179,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1781,7 +1781,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Crab Tunnel.json
+++ b/region/maridia/outer/Crab Tunnel.json
@@ -173,7 +173,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -457,7 +457,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -471,7 +471,7 @@
         {"or": [
           {"canShineCharge": {"usedTiles": 42, "steepDownTiles": 1, "openEnd": 1}},
           {"and": [
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"obstaclesCleared": ["A"]}
           ]}
         ]},

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -358,7 +358,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1303,7 +1303,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1407,7 +1407,7 @@
       "requires": [
         "canWaterShineCharge",
         "canTrickyJump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 41, "excessFrames": 7}},
           {"and": [
@@ -1652,7 +1652,7 @@
         "canShinechargeMovement",
         "canDodgeWhileShooting",
         "canTrickyJump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 43, "excessFrames": 9}},
           {"and": [
@@ -1680,7 +1680,7 @@
       "requires": [
         "canWaterShineCharge",
         "canTrickyJump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 43, "excessFrames": 26}},
           {"and": [
@@ -2402,7 +2402,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2683,7 +2683,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/maridia/outer/Glass Tunnel Save Room.json
+++ b/region/maridia/outer/Glass Tunnel Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Glass Tunnel.json
+++ b/region/maridia/outer/Glass Tunnel.json
@@ -207,7 +207,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1335,7 +1335,7 @@
       "link": [2, 2],
       "name": "Break the Tube",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "setsFlags": ["f_MaridiaTubeBroken"]
     },
@@ -3245,7 +3245,7 @@
         {"notable": "Breaking the Tube Gravity Jump"},
         {"not": "f_MaridiaTubeBroken"},
         "canRiskPermanentLossOfAccess",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canSuitlessMaridia",
         "canTrickyJump"
       ],
@@ -3264,7 +3264,7 @@
       "link": [5, 5],
       "name": "Break the Tube with a Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "setsFlags": ["f_MaridiaTubeBroken"]
     },
@@ -3345,7 +3345,7 @@
         {"notable": "Breaking the Tube Gravity Jump"},
         {"not": "f_MaridiaTubeBroken"},
         "canRiskPermanentLossOfAccess",
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canSuitlessMaridia",
         "canTrickyJump"
       ],
@@ -3370,7 +3370,7 @@
       "link": [6, 5],
       "name": "Break the Tube with a Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "setsFlags": ["f_MaridiaTubeBroken"]
     },

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -2492,7 +2492,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 19}}
       ],
       "exitCondition": {
@@ -2518,7 +2518,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementTricky",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 11}}
       ],
       "exitCondition": {
@@ -2542,7 +2542,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 9}},
           {"and": [
@@ -2578,7 +2578,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2734,7 +2734,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 62, "excessFrames": 2}}
       ],
       "clearsObstacles": ["A"],
@@ -3015,7 +3015,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 35, "excessFrames": 3}}
       ],
       "note": "This can be done with only a door-frame runway in the adjacent room.",
@@ -3149,7 +3149,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3385,7 +3385,7 @@
       "link": [5, 5],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3853,7 +3853,7 @@
       "link": [8, 8],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -200,7 +200,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 9}},
           {"and": [
@@ -222,7 +222,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -352,7 +352,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 61, "excessFrames": 7}},
           {"and": [
@@ -687,7 +687,7 @@
       "requires": [
         "canStutterWaterShineCharge",
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 47, "excessFrames": 5}},
           {"and": [
@@ -872,7 +872,7 @@
         {"or": [
           "Wave",
           "Spazer",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"and": [
             "canTrickyJump",
             "canDodgeWhileShooting",

--- a/region/maridia/outer/Maridia Map Room.json
+++ b/region/maridia/outer/Maridia Map Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -625,7 +625,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1069,7 +1069,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 20}
       ],
       "exitCondition": {
@@ -1083,7 +1083,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway"
+        "h_shinechargeMaxRunway"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {
@@ -1138,7 +1138,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1148,7 +1148,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 65}}
       ],
       "note": "Shinespark up right through the rightmost gap to land directly by the door."
@@ -1678,7 +1678,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 61}}
       ],
@@ -1952,7 +1952,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2703,7 +2703,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3410,7 +3410,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -4350,7 +4350,7 @@
       "name": "Shinespark",
       "requires": [
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shinespark": {"frames": 61}}
       ],
@@ -4414,7 +4414,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -322,7 +322,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -163,7 +163,7 @@
       "requires": [
         "f_DefeatedCrocomire",
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 120}
       ],
       "exitCondition": {
@@ -176,7 +176,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -336,7 +336,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -483,7 +483,7 @@
           {"canShineCharge": {"usedTiles": 22, "openEnd": 1}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_shineChargeMaxRunway"
+            "h_shinechargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 50}
@@ -505,7 +505,7 @@
           {"canShineCharge": {"usedTiles": 31, "openEnd": 0}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_shineChargeMaxRunway"
+            "h_shinechargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 100}
@@ -527,7 +527,7 @@
           {"canShineCharge": {"usedTiles": 22, "openEnd": 1}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_shineChargeMaxRunway"
+            "h_shinechargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 40}
@@ -549,7 +549,7 @@
           {"canShineCharge": {"usedTiles": 22, "openEnd": 1}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_shineChargeMaxRunway"
+            "h_shinechargeMaxRunway"
           ]}
         ]},
         {"shineChargeFrames": 80}
@@ -569,7 +569,7 @@
           {"canShineCharge": {"usedTiles": 31, "openEnd": 0}},
           {"and": [
             "f_DefeatedCrocomire",
-            "h_shineChargeMaxRunway"
+            "h_shinechargeMaxRunway"
           ]}
         ]},
         {"shinespark": {"frames": 9}}
@@ -645,7 +645,7 @@
       "requires": [
         "f_DefeatedCrocomire",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"or": [
           {"shinespark": {"frames": 45, "excessFrames": 5}},
           {"and": [
@@ -807,7 +807,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -821,7 +821,7 @@
         {"canShineCharge": {"usedTiles": 22, "openEnd": 1}},
         {"spikeHits": 1},
         "canSpikeSuit",
-        "h_SpikeSuitSpikeHitLeniency",
+        "h_spikeSuitSpikeHitLeniency",
         {"shinespark": {"frames": 4, "excessFrames": 4}}
       ],
       "flashSuitChecked": true

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -145,7 +145,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -416,7 +416,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Grapple Tutorial Room 1.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 1.json
@@ -71,7 +71,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Grapple Tutorial Room 2.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 2.json
@@ -85,7 +85,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -408,7 +408,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -811,7 +811,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -276,7 +276,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -190,7 +190,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -482,7 +482,7 @@
         {"or": [
           {"canShineCharge": {"usedTiles": 32, "gentleUpTiles": 6, "openEnd": 1}},
           {"and": [
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"obstaclesCleared": ["A"]}
           ]}
         ]},
@@ -608,7 +608,7 @@
       "name": "Leave With Spark (Long Speedy Jump)",
       "requires": [
         {"obstaclesCleared": ["A", "B", "E"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovementComplex",
         {"shinespark": {"frames": 53}}
       ],
@@ -625,7 +625,7 @@
       "link": [2, 2],
       "name": "Break Power Bomb Blocks",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A"]
     },
@@ -738,7 +738,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -947,7 +947,7 @@
         {"or": [
           {"canShineCharge": {"usedTiles": 32, "gentleUpTiles": 6, "openEnd": 1}},
           {"and": [
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"obstaclesCleared": ["A"]}
           ]}
         ]},
@@ -1301,7 +1301,7 @@
         "canSuitlessLavaDive",
         "canShinechargeMovement",
         "canHorizontalShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"acidFrames": 140},
         {"shinespark": {"frames": 35}}
       ],

--- a/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
+++ b/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
@@ -84,7 +84,7 @@
         }
       },
       "requires": [
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [2],
       "flashSuitChecked": true,

--- a/region/norfair/crocomire/Post Crocomire Save Room.json
+++ b/region/norfair/crocomire/Post Crocomire Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -533,7 +533,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -803,7 +803,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Acid Snakes Tunnel.json
+++ b/region/norfair/east/Acid Snakes Tunnel.json
@@ -181,7 +181,7 @@
       "requires": [
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/east/Bubble Mountain Save Room.json
+++ b/region/norfair/east/Bubble Mountain Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -387,7 +387,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -2449,7 +2449,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -2769,7 +2769,7 @@
       "name": "Power Bomb Blocks",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -3772,7 +3772,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -3887,7 +3887,7 @@
         "canBounceBall",
         "canLateralMidAirMorph",
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "h_XModeSpikeHitLeniency",
         "h_XModeSpikeHitLeniency",
         {"shinespark": {"frames": 6}}
@@ -4006,7 +4006,7 @@
       "name": "Power Bomb Blocks",
       "requires": [
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}
         ]}
       ],
@@ -4087,7 +4087,7 @@
       "link": [9, 9],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -248,7 +248,7 @@
             "h_heatedGModePauseAbuse",
             "canBePatient"
           ]},
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -284,7 +284,7 @@
             "h_heatedGModePauseAbuse",
             "canBePatient"
           ]},
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -388,7 +388,7 @@
         ]},
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -420,7 +420,7 @@
         ]},
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -240,7 +240,7 @@
       "requires": [
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -412,7 +412,7 @@
       "requires": [
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -288,7 +288,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -313,7 +313,7 @@
           ]},
           "canPreciseGrapple"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "With Grapple, a running jump then single Grapple swing can be used before PLMs are overloaded, alternatively jump on the crumble blocks and Grapple the Ripper."
@@ -333,7 +333,7 @@
         "h_artificialMorphBombHorizontally",
         "canCameraManip",
         "canTrickyJump",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -372,7 +372,7 @@
           ]},
           "h_IBJFromSpikes"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Overload PLMs by shooting the gate, then go through the crumble blocks below and get to the door."
@@ -408,7 +408,7 @@
             "h_artificialMorphStaggeredIBJ"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1058,7 +1058,7 @@
             {"shinespark": {"frames": 1, "excessFrames": 1}}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is possible to climb the left side of the room with SpeedBooster alone, with either a tricky dash jump or a vertical shinespark.",
@@ -1076,7 +1076,7 @@
       },
       "requires": [
         "h_artificialMorphIBJ",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -1198,7 +1198,7 @@
             {"shinespark": {"frames": 17, "excessFrames": 4}}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1221,7 +1221,7 @@
         "h_artificialMorphBombHorizontally",
         "canCameraManip",
         "canTrickyJump",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1260,7 +1260,7 @@
           ]},
           "h_IBJFromSpikes"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1300,7 +1300,7 @@
             "h_artificialMorphStaggeredIBJ"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1746,7 +1746,7 @@
             "h_artificialMorphStaggeredIBJ"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -1780,7 +1780,7 @@
             "SpeedBooster"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1814,7 +1814,7 @@
             "h_artificialMorphStaggeredIBJ"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Bomb horizontally on room entry to jump over the Ripper and land on the crumble blocks, or use a Power Bomb to kill the Ripper."
@@ -1873,7 +1873,7 @@
             "h_artificialMorphStaggeredIBJ"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -1907,7 +1907,7 @@
             "SpeedBooster"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1941,7 +1941,7 @@
             "h_artificialMorphStaggeredIBJ"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Bomb horizontally on room entry to jump over the Ripper and land on the crumble blocks, or use a Power Bomb to kill the Ripper."
@@ -2073,7 +2073,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canWalljump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"heatFrames": 540},
         {"shinespark": {"frames": 5}}
       ],
@@ -2093,7 +2093,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "HiJump",
         {"heatFrames": 480},
         {"shineChargeFrames": 140}
@@ -2147,7 +2147,7 @@
             "canMoonwalk"
           ]}
         ]},
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -2166,13 +2166,13 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
         "canIBJ",
         "canBombHorizontally",
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -2203,7 +2203,7 @@
             "h_artificialMorphStaggeredIBJ"
           ]}
         ]},
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -2232,7 +2232,7 @@
       "link": [3, 4],
       "name": "Spike IBJ",
       "requires": [
-        "h_HeatedIBJFromSpikes",
+        "h_heatedIBJFromSpikes",
         {"heatFrames": 1100}
       ]
     },
@@ -2397,7 +2397,7 @@
         "h_XModeSpikeHit",
         "canTrickyJump",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"heatFrames": 400},
         {"shinespark": {"frames": 12, "excessFrames": 4}}
       ],
@@ -2491,7 +2491,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
@@ -2574,7 +2574,7 @@
           {"and": [
             "canBombHorizontally",
             "canIBJ",
-            "h_usePowerBombs"
+            "h_usePowerBomb"
           ]}
         ]},
         {"heatFrames": 0}
@@ -2600,7 +2600,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
@@ -2685,7 +2685,7 @@
           {"and": [
             "canBombHorizontally",
             "canIBJ",
-            "h_usePowerBombs"
+            "h_usePowerBomb"
           ]}
         ]},
         {"heatFrames": 0}
@@ -2710,7 +2710,7 @@
       "requires": [
         {"or": [
           "ScrewAttack",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 1}}
         ]},
@@ -2860,7 +2860,7 @@
       "link": [4, 3],
       "name": "Spike IBJ",
       "requires": [
-        "h_HeatedIBJFromSpikes",
+        "h_heatedIBJFromSpikes",
         {"heatFrames": 1100}
       ]
     },
@@ -2899,7 +2899,7 @@
         "canTrickyJump",
         "canUseIFrames",
         "canMidairShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"heatFrames": 480},
         {"shinespark": {"frames": 11, "excessFrames": 4}}
       ],
@@ -3016,7 +3016,7 @@
             {"shinespark": {"frames": 17, "excessFrames": 4}}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
@@ -3071,7 +3071,7 @@
       "name": "Direct G-Mode, Remote Acquire Item",
       "requires": [
         "Morph",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "collectsItems": [4],
       "flashSuitChecked": true
@@ -3120,7 +3120,7 @@
             {"shinespark": {"frames": 17, "excessFrames": 4}}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is possible to climb the left side of the room with SpeedBooster alone, with either a tricky dash jump or a vertical shinespark."
@@ -3169,7 +3169,7 @@
       "name": "G-Mode",
       "requires": [
         "Morph",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Frog Savestation.json
+++ b/region/norfair/east/Frog Savestation.json
@@ -90,7 +90,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -128,7 +128,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -208,7 +208,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -226,7 +226,7 @@
       "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -254,7 +254,7 @@
       "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -344,7 +344,7 @@
         "canTrickyUseFrozenEnemies",
         "h_getBlueSpeedMaxRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency"
+        "h_extendedMoondanceBeetomLeniency"
       ],
       "exitCondition": {
         "leaveWithStoredFallSpeed": {
@@ -363,7 +363,7 @@
       "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -392,7 +392,7 @@
       "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "h_getBlueSpeedMaxRunway",
@@ -760,7 +760,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -799,7 +799,7 @@
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
-        "h_ExtendedMoondanceBeetomLeniency",
+        "h_extendedMoondanceBeetomLeniency",
         "Wave",
         {"or": [
           "Spazer",

--- a/region/norfair/east/Green Bubbles Missile Room.json
+++ b/region/norfair/east/Green Bubbles Missile Room.json
@@ -267,7 +267,7 @@
           "Wave",
           {"ammo": {"type": "Super", "count": 1}},
           {"ammo": {"type": "Missile", "count": 3}},
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"and": [
             "Charge",
             "h_useMorphBombs"
@@ -364,7 +364,7 @@
         }
       },
       "requires": [
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true
@@ -403,7 +403,7 @@
           "canTrivialMidAirMorph",
           "h_useSpringBall",
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 260}
           ]},
           {"and": [

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -229,7 +229,7 @@
           "h_artificialMorphMovement",
           "h_artificialMorphBombHorizontally"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "It is possible to open the gate as it closes, but isn't expected since this is off camera. To do that would require resetting the room."
@@ -456,7 +456,7 @@
       },
       "requires": [
         "canOffScreenMovement",
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true
     },
@@ -527,7 +527,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true
     },
@@ -575,7 +575,7 @@
       },
       "requires": [
         "canOffScreenMovement",
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true
     },
@@ -635,7 +635,7 @@
       },
       "requires": [
         "h_artificialMorphMovement",
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "It is possible to open the gate as it closes, but isn't expected since this is off camera. To do that would require resetting the room."
@@ -957,7 +957,7 @@
           "h_artificialMorphMovement",
           "h_artificialMorphBombHorizontally"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "It is possible to open the gate as it closes, but isn't expected since this is off camera. To do that would require resetting the room."
@@ -1415,7 +1415,7 @@
             "h_heatedGModePauseAbuse",
             {"heatFrames": 10}
           ]},
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -1433,7 +1433,7 @@
             "h_heatedGModePauseAbuse",
             {"heatFrames": 10}
           ]},
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -1451,7 +1451,7 @@
             "h_heatedGModePauseAbuse",
             {"heatFrames": 10}
           ]},
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -255,7 +255,7 @@
             {"lavaFrames": 30}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": [
@@ -283,7 +283,7 @@
             {"lavaFrames": 260}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -439,7 +439,7 @@
         "SpaceJump",
         {"disableEquipment": "SpeedBooster"},
         {"lavaFrames": 280},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "FIXME: GT Max Suitless climb could be added, but is likely not reasonable."
@@ -461,7 +461,7 @@
         "HiJump",
         "canUseEnemies",
         {"lavaFrames": 180},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -500,7 +500,7 @@
             {"gravitylessLavaFrames": 230}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "FIXME: Many strats without Gravity have been skipped for now."
@@ -519,7 +519,7 @@
         "h_lavaProof",
         "Gravity",
         "h_artificialMorphLongIBJ",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "The Namihe fireballs don't move while in G-mode, making it safe to IBJ straight up and out of the lava."
@@ -539,7 +539,7 @@
         "h_artificialMorphDoubleSpringBallJump",
         "canInsaneJump",
         {"gravitylessLavaFrames": 640},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -564,7 +564,7 @@
         "canInsaneJump",
         {"lavaFrames": 275},
         {"gravitylessLavaFrames": 200},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Lower Norfair Elevator Save Room.json
+++ b/region/norfair/east/Lower Norfair Elevator Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -239,7 +239,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -575,7 +575,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -824,7 +824,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -900,7 +900,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -315,10 +315,10 @@
           "ScrewAttack",
           {"ammo": {"type": "Missile", "count": 1}},
           {"ammo": {"type": "Super", "count": 1}},
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Stand next to the Magdollites while they are rising so that they place their invisible flames low and out of the way."
@@ -554,10 +554,10 @@
           "ScrewAttack",
           {"ammo": {"type": "Missile", "count": 1}},
           {"ammo": {"type": "Super", "count": 1}},
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"enemyDamage": {"enemy": "Multiviola", "type": "contact", "hits": 1}}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Nutella Refill.json
+++ b/region/norfair/east/Nutella Refill.json
@@ -91,7 +91,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Purple Shaft.json
+++ b/region/norfair/east/Purple Shaft.json
@@ -269,7 +269,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true
     },
@@ -285,7 +285,7 @@
         "comesThroughToilet": "any"
       },
       "requires": [
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true
     },
@@ -700,7 +700,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -1221,7 +1221,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -102,7 +102,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -231,7 +231,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -326,7 +326,7 @@
       "requires": [
         {"or": [
           "h_heatedGModePauseAbuse",
-          "h_HeatedGModeOpenDifferentDoor"
+          "h_heatedGModeOpenDifferentDoor"
         ]}
       ],
       "flashSuitChecked": true,
@@ -590,7 +590,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -290,7 +290,7 @@
       },
       "requires": [
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
@@ -343,7 +343,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is important avoid touching the invisible fireballs the Alcoons place."
@@ -418,7 +418,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is important avoid touching the invisible fireballs the Alcoons place.",
@@ -448,7 +448,7 @@
           "canIBJ",
           "canTrickyUseFrozenEnemies"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -487,7 +487,7 @@
           ]},
           "h_artificialMorphSpringBallBombJump"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -560,7 +560,7 @@
           "canSpringBallJumpMidAir"
         ]},
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
@@ -865,7 +865,7 @@
           "canSpringBallJumpMidAir",
           "canIBJ"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is important avoid touching the invisible fireballs the Alcoons place.",
@@ -929,7 +929,7 @@
           "canSpringBallJumpMidAir",
           "canIBJ"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is important avoid touching the invisible fireballs the Alcoons place.",
@@ -966,7 +966,7 @@
             "canTrickyUseFrozenEnemies"
           ]}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1009,7 +1009,7 @@
             ]}
           ]}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1076,7 +1076,7 @@
           "canSpringBallJumpMidAir"
         ]},
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
@@ -1299,7 +1299,7 @@
       },
       "requires": [
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           "h_heatedGModePauseAbuse"
         ]}
       ],
@@ -1507,7 +1507,7 @@
           "canSpringBallJumpMidAir",
           "canIBJ"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is important avoid touching the invisible fireballs the Alcoons place.",
@@ -1544,7 +1544,7 @@
             "canTrickyUseFrozenEnemies"
           ]}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1587,7 +1587,7 @@
             ]}
           ]}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1684,7 +1684,7 @@
           "canSpringBallJumpMidAir"
         ]},
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           {"and": [
             "h_heatedGModePauseAbuse",
             "canFarmWhileShooting",
@@ -1790,7 +1790,7 @@
       },
       "requires": [
         {"or": [
-          "h_HeatedGModeOpenDifferentDoor",
+          "h_heatedGModeOpenDifferentDoor",
           "h_heatedGModePauseAbuse"
         ]}
       ],
@@ -1914,7 +1914,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is important avoid touching the invisible fireballs the Alcoons place."
@@ -1996,7 +1996,7 @@
             "canTrickyUseFrozenEnemies"
           ]}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -2036,7 +2036,7 @@
             "h_additionalBomb"
           ]}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -2161,7 +2161,7 @@
       "link": [5, 6],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 850}
       ]
     },

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -239,7 +239,7 @@
       "name": "Speed Run and Leave Shinecharged",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"heatFrames": 360},
         {"shineChargeFrames": 35}
       ],
@@ -368,7 +368,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -488,7 +488,7 @@
       "name": "Speed Run and Leave Shinecharged",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"heatFrames": 360},
         {"shineChargeFrames": 35}
       ],
@@ -531,7 +531,7 @@
         {"obstaclesCleared": ["A"]},
         "canShinechargeMovementComplex",
         "canHorizontalShinespark",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"heatFrames": 335},
         {"shinespark": {"frames": 221}}
       ],
@@ -721,7 +721,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -420,7 +420,7 @@
       },
       "requires": [
         "SpaceJump",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -468,7 +468,7 @@
             {"lavaFrames": 15}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "FIXME: Grapple could maybe be used to skip some damage by partially swinging across the room."
@@ -486,7 +486,7 @@
       "requires": [
         "h_artificialMorphLongCeilingBombJump",
         "h_artificialMorphResetFallSpeed",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -898,7 +898,7 @@
       },
       "requires": [
         "SpaceJump",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -946,7 +946,7 @@
             {"lavaFrames": 15}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "FIXME: Grapple could maybe be used to skip some damage by partially swinging across the room."
@@ -964,7 +964,7 @@
       "requires": [
         "h_artificialMorphLongCeilingBombJump",
         "h_artificialMorphResetFallSpeed",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -237,7 +237,7 @@
             {"lavaFrames": 35}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -263,7 +263,7 @@
           "Morph",
           "h_artificialMorphSpringBall"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Morph and ride the Trippers.",
@@ -436,7 +436,7 @@
           ]},
           "canInsaneJump"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -465,7 +465,7 @@
             "h_artificialMorphIBJ"
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -381,7 +381,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": [
@@ -668,7 +668,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": [

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -120,7 +120,7 @@
         {"resetRoom": {
           "nodes": [1]
         }},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "Resetting the room through node 1 ensures that there is no heat."

--- a/region/norfair/east/Wave Beam Room.json
+++ b/region/norfair/east/Wave Beam Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -4258,7 +4258,7 @@
       "link": [8, 8],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -139,7 +139,7 @@
           "HiJump",
           "canTrickyDodgeEnemies"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "It is possible to lure the Geruta to be used as a platform with nothing but Ice."
@@ -167,7 +167,7 @@
           ]},
           "h_lavaProof"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "FIXME: Damage through the lava could work, or maybe a Geruta damage boost. (Energy from immobile or CF)"
@@ -184,7 +184,7 @@
       },
       "requires": [
         "h_artificialMorphMovement",
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -530,7 +530,7 @@
           "HiJump",
           "canSpringBallJumpMidAir"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "FIXME: A variant with only ice and reset fall speed could be added, but is probably unreasonable."
@@ -568,7 +568,7 @@
             ]}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "FIXME: A variant with shinesparking can be added. (Energy from immobile, CF, or energy free sparks)"
@@ -588,7 +588,7 @@
           "h_artificialMorphLongIBJ",
           "h_artificialMorphJumpIntoIBJ"
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -693,7 +693,7 @@
           "HiJump",
           "canSpringBallJumpMidAir"
         ]},
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
@@ -729,7 +729,7 @@
             "canInsaneJump"
           ]}
         ]},
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
@@ -754,7 +754,7 @@
           "h_artificialMorphLongIBJ",
           "h_artificialMorphJumpIntoIBJ"
         ]},
-        "h_DirectHeatedGModeLeaveSameDoor"
+        "h_heatedDirectGModeLeaveSameDoor"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true

--- a/region/norfair/west/Crocomire Save Room.json
+++ b/region/norfair/west/Crocomire Save Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -496,7 +496,7 @@
         {"notable": "Speed Block Moondance"},
         "h_heatProof",
         "h_getBlueSpeedMaxRunway",
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "canTemporaryBlue",
@@ -526,7 +526,7 @@
         {"notable": "Speed Block Moondance"},
         "h_heatProof",
         "h_getBlueSpeedMaxRunway",
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         "canTemporaryBlue",
@@ -653,7 +653,7 @@
       "requires": [
         {"or": [
           "canTrickyDodgeEnemies",
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           "ScrewAttack",
           "h_hasBeamUpgrade",
           {"ammo": {"type": "Missile", "count": 2}},
@@ -670,7 +670,7 @@
         ]},
         "Morph",
         {"or": [
-          "h_usePowerBombs",
+          "h_usePowerBomb",
           {"and": [
             {"or": [
               "h_useSpringBall",
@@ -1981,7 +1981,7 @@
       "requires": [
         "h_heatProof",
         {"obstaclesCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 80}
       ],
       "exitCondition": {
@@ -2018,7 +2018,7 @@
         "h_heatProof",
         {"obstaclesCleared": ["A"]},
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 120}
       ],
       "exitCondition": {
@@ -2044,7 +2044,7 @@
         "h_heatProof",
         {"obstaclesCleared": ["A"]},
         "canShinechargeMovementTricky",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 12}}
       ],
       "exitCondition": {
@@ -2061,7 +2061,7 @@
       "link": [7, 1],
       "name": "G-Mode",
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Jump over the Cacatacs. Their projectiles remain inside of them and their hitbox is a bit smaller than it appears."
@@ -2079,7 +2079,7 @@
           "SpeedBooster",
           {"spikeHits": 1}
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -2107,7 +2107,7 @@
       "link": [7, 3],
       "name": "G-Mode",
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -2116,7 +2116,7 @@
       "link": [7, 4],
       "name": "G-Mode",
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -2125,7 +2125,7 @@
       "link": [7, 5],
       "name": "G-Mode",
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Jump over the Cacatacs. Their projectiles remain inside of them and their hitbox is a bit smaller than it appears."
@@ -2141,7 +2141,7 @@
           "HiJump",
           "canSpringBallJumpMidAir"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -2217,7 +2217,7 @@
       "link": [8, 4],
       "name": "G-Mode, Simple Blind Movement",
       "requires": [
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}
@@ -2247,7 +2247,7 @@
           "HiJump",
           "canSpringBallJumpMidAir"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "exitCondition": {
         "leaveNormally": {}

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -523,7 +523,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Climb the solid crumble blocks."

--- a/region/norfair/west/Hi Jump Boots Room.json
+++ b/region/norfair/west/Hi Jump Boots Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -199,7 +199,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -599,7 +599,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Ice Beam Acid Room.json
+++ b/region/norfair/west/Ice Beam Acid Room.json
@@ -296,7 +296,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -527,7 +527,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -296,7 +296,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -450,7 +450,7 @@
       "link": [2, 2],
       "name": "Power Bomb the Blocks",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -459,7 +459,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "flashSuitChecked": true
@@ -676,7 +676,7 @@
       "link": [2, 5],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -833,7 +833,7 @@
             "explicitWeapons": ["Missile", "Super"]
           }}
         ]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "Kill some or all of the enemies before Crystal Flashing."
@@ -879,7 +879,7 @@
           "Wave",
           {"and": [
             "canDodgeWhileShooting",
-            "h_usePowerBombs"
+            "h_usePowerBomb"
           ]},
           {"enemyKill": {
             "enemies": [["Sm. Dessgeega"], ["Sm. Dessgeega"]],
@@ -1014,7 +1014,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 50}
       ],
       "exitCondition": {
@@ -1198,7 +1198,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1238,7 +1238,7 @@
       "link": [5, 2],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -1260,7 +1260,7 @@
       "link": [5, 4],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"]
     },
@@ -1285,7 +1285,7 @@
       "name": "Shinespark",
       "requires": [
         {"obstaclesCleared": ["C", "D"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"or": [
           {"shinespark": {"frames": 19, "excessFrames": 4}},
@@ -1303,7 +1303,7 @@
       "name": "Frozen Sova Platform",
       "requires": [
         {"notable": "Frozen Sova Platform"},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canTrickyUseFrozenEnemies"
       ],
       "clearsObstacles": ["A", "B", "C"],
@@ -1320,7 +1320,7 @@
       "name": "Sova Boost",
       "requires": [
         {"notable": "Sova Boost"},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         "canCrouchJump",
         "canCarefulJump",
         "canNeutralDamageBoost",
@@ -1382,7 +1382,7 @@
           "Wave",
           {"and": [
             "canDodgeWhileShooting",
-            "h_usePowerBombs"
+            "h_usePowerBomb"
           ]},
           {"enemyKill": {
             "enemies": [["Sm. Dessgeega"], ["Sm. Dessgeega"]],
@@ -1445,7 +1445,7 @@
       "link": [7, 7],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": "Placing the Power Bomb high enough will also break the bomb blocks in the ceiling."
@@ -1455,7 +1455,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true

--- a/region/norfair/west/Ice Beam Room.json
+++ b/region/norfair/west/Ice Beam Room.json
@@ -69,7 +69,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -320,7 +320,7 @@
           "canIBJ",
           "canTrickyUseFrozenEnemies"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "It is probably possible to farm the Sovas at this door, but it would be difficult and slow and isn't expected."
@@ -344,7 +344,7 @@
           ]},
           "h_artificialMorphSpringBallBombJump"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "It is probably possible to farm the Sovas at this door, but it would be difficult and slow and isn't expected."
@@ -469,7 +469,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true
     },
@@ -575,7 +575,7 @@
       "requires": [
         "h_artificialMorphMovement",
         "canOffScreenMovement",
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": "Kill the Sovas or wait at around 25 seconds for them to get out of the way before going down and passing them while climbing to the top door.",
@@ -740,7 +740,7 @@
       },
       "requires": [
         "h_artificialMorphMovement",
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "note": "Kill the Sovas or wait at least 20 seconds for them to get out of the way before going to the bottom door.",
@@ -889,7 +889,7 @@
         }
       },
       "requires": [
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "The single tile ledge at this door doesn't seem to make it any slower to exit."
@@ -912,7 +912,7 @@
           "canTrickyJump",
           "canTrickyUseFrozenEnemies",
           {"ammo": {"type": "Super", "count": 1}},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]}
       ],
       "flashSuitChecked": true,
@@ -953,7 +953,7 @@
         "canShinechargeMovementTricky",
         "canMidAirMorph",
         {"shinespark": {"frames": 20, "excessFrames": 0}},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 385}
       ]
     },
@@ -989,7 +989,7 @@
         "canShinechargeMovementTricky",
         "canMidAirMorph",
         {"shinespark": {"frames": 19, "excessFrames": 0}},
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 465}
       ]
     },
@@ -1035,7 +1035,7 @@
           "canIBJ",
           "canTrickyUseFrozenEnemies"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "It is probably possible to farm the Sovas at this door, but it would be difficult and slow and isn't expected."
@@ -1059,7 +1059,7 @@
           ]},
           "h_artificialMorphSpringBallBombJump"
         ]},
-        "h_HeatedGModeOffCameraDoor"
+        "h_heatedGModeOffCameraDoor"
       ],
       "flashSuitChecked": true,
       "devNote": "It is probably possible to farm the Sovas at this door, but it would be difficult and slow and isn't expected."
@@ -1084,7 +1084,7 @@
         {"or": [
           {"ammo": {"type": "Super", "count": 1}},
           {"and": [
-            "h_usePowerBombs",
+            "h_usePowerBomb",
             {"heatFrames": 190}
           ]}
         ]}
@@ -1257,7 +1257,7 @@
             "Wave",
             "Plasma"
           ]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"heatFrames": 260}
       ]
@@ -1449,7 +1449,7 @@
       "link": [5, 2],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"heatFrames": 200}
       ]
     },

--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -275,7 +275,7 @@
             {"lavaFrames": 160}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -440,7 +440,7 @@
             ]}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Getting across the lava while artificially morphed requires an HBJ or Bomb boosting out and freezing a Boyon below.",
@@ -481,7 +481,7 @@
             {"lavaFrames": 25}
           ]}
         ]},
-        "h_HeatedGModeOpenDifferentDoor"
+        "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
       "note": "Spring Fling or IBJ across the right pit and damage boost or lava dive in the second; to Spring Fling, jump immediately before the pause triggers."

--- a/region/norfair/west/Norfair Map Room.json
+++ b/region/norfair/west/Norfair Map Room.json
@@ -68,7 +68,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -683,7 +683,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/tourian/main/Blue Hopper Room.json
+++ b/region/tourian/main/Blue Hopper Room.json
@@ -582,7 +582,7 @@
       "requires": [
         {"notable": "Crystal Flash"},
         "canTrickyDodgeEnemies",
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canCameraManip"
       ],
       "flashSuitChecked": true,

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -195,7 +195,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Lower Tourian Save Room.json
+++ b/region/tourian/main/Lower Tourian Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -304,7 +304,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_KilledMetroidRoom1",
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1549,7 +1549,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -617,7 +617,7 @@
         }
       },
       "requires": [
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"autoReserveTrigger": {}},
         "canXRayClimb",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
@@ -1117,7 +1117,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_KilledMetroidRoom2",
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
       ],
       "flashSuitChecked": true,

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -908,7 +908,7 @@
       "name": "Crystal Flash",
       "requires": [
         "f_KilledMetroidRoom3",
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": ["Be at a safe distance from Rinkas before performing the Crystal Flash."]

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -126,7 +126,7 @@
         "comeInNormally": {}
       },
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -143,7 +143,7 @@
           "Ice",
           "f_KilledMetroidRoom4"
         ]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -341,7 +341,7 @@
         }
       },
       "requires": [
-        "h_BypassMotherBrainRoom"
+        "h_bypassMotherBrainRoom"
       ]
     },
     {
@@ -834,7 +834,7 @@
       "requires": [
         {"notable": "R-Mode Reduced Tanks"},
         {"obstaclesCleared": ["A"]},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"enemyKill": {
           "enemies": [["Mother Brain 2"]]
         }},
@@ -867,7 +867,7 @@
       "requires": [
         {"notable": "R-Mode Light Pillar"},
         {"obstaclesCleared": ["A"]},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"enemyKill": {
           "enemies": [["Mother Brain 2"]]
         }},

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -196,7 +196,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -694,7 +694,7 @@
         }
       },
       "requires": [
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"autoReserveTrigger": {}},
         "canXRayClimb",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}
@@ -846,7 +846,7 @@
         }
       },
       "requires": [
-        "h_crystalFlash",
+        "h_CrystalFlash",
         {"autoReserveTrigger": {}},
         "canXRayClimb",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -140,7 +140,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "If it is needed to use one of the extended runways, then the Crystal Flash can be performed on the opposite side of the room from the needed runway."

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -26,7 +26,7 @@
             {
               "name": "Base",
               "requires": [
-                "h_AccessTourianEscape1RightDoor"
+                "h_openTourianEscape1RightDoor"
               ]
             }
           ]
@@ -85,7 +85,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -83,7 +83,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -109,7 +109,7 @@
       "link": [1, 1],
       "name": "Leave Shinecharged",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 45}
       ],
@@ -204,7 +204,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -528,7 +528,7 @@
           "canTemporaryBlue",
           {"and": [
             "canUseSpeedEchoes",
-            "h_shineChargeMaxRunway",
+            "h_shinechargeMaxRunway",
             {"shinespark": {"frames": 2, "excessFrames": 2}}
           ]}
         ]}
@@ -699,7 +699,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 60}
       ],
       "exitCondition": {
@@ -770,7 +770,7 @@
       "name": "Leave With Temporary Blue",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "can4HighMidAirMorph",
         "canChainTemporaryBlue"
       ],
@@ -787,7 +787,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -242,7 +242,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -961,7 +961,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "The Crystal Flash should be performed on a platform away from the acid trigger or any Pirates."

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -70,7 +70,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Tourian First Room.json
+++ b/region/tourian/main/Tourian First Room.json
@@ -211,7 +211,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/tourian/main/Upper Tourian Save Room.json
+++ b/region/tourian/main/Upper Tourian Save Room.json
@@ -67,7 +67,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Assembly Line.json
+++ b/region/wreckedship/main/Assembly Line.json
@@ -39,7 +39,7 @@
               "requires": [
                 {"or": [
                   "f_DefeatedPhantoon",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "The item doesn't spawn until Phantoon is defeated."
@@ -129,7 +129,7 @@
         "f_DefeatedPhantoon",
         {"canShineCharge": {"usedTiles": 15, "openEnd": 1}},
         {"thornHits": 1},
-        "h_SpikeSuitThornHitLeniency",
+        "h_spikeSuitThornHitLeniency",
         "canSpikeSuit",
         {"shinespark": {"frames": 6, "excessFrames": 6}}
       ],
@@ -143,7 +143,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "The Workrobot projectiles aren't a problem."

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -503,7 +503,7 @@
         "f_DefeatedPhantoon",
         {"canShineCharge": {"usedTiles": 20, "openEnd": 0}},
         {"thornHits": 1},
-        "h_SpikeSuitThornHitLeniency",
+        "h_spikeSuitThornHitLeniency",
         "canSpikeSuit",
         {"shinespark": {"frames": 2, "excessFrames": 2}}
       ],
@@ -562,7 +562,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "note": "If the leftmost Kihunter is still alive, lay the Power Bomb with it on screen, to kill it before the Crystal Flash refill begins."
@@ -832,7 +832,7 @@
       "name": "Crystal Flash",
       "requires": [
         {"obstaclesCleared": ["A"]},
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1052,7 +1052,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -207,7 +207,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 45}
       ],
       "exitCondition": {
@@ -298,7 +298,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -436,7 +436,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "canShinechargeMovement",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 70}
       ],
       "exitCondition": {
@@ -989,7 +989,7 @@
       "link": [3, 3],
       "name": "Leave With Spark",
       "requires": [
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovementTricky",
         "canMockball",
         {"obstaclesCleared": ["A"]},
@@ -1005,7 +1005,7 @@
       "name": "Leave Shinecharged",
       "requires": [
         "f_DefeatedPhantoon",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovementComplex",
         {"obstaclesCleared": ["A"]},
         {"shineChargeFrames": 130}
@@ -1020,7 +1020,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -86,7 +86,7 @@
               "requires": [
                 {"or": [
                   "f_DefeatedPhantoon",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "The item doesn't spawn until Phantoon is defeated."
@@ -117,7 +117,7 @@
               "requires": [
                 {"or": [
                   "f_DefeatedPhantoon",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "The item doesn't spawn until Phantoon is defeated."
@@ -306,7 +306,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -316,7 +316,7 @@
       "name": "Speed Block Moondance (Leave with Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
@@ -344,7 +344,7 @@
       "name": "Speed Block Moondance (Leave with More Stored Fall Speed)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
@@ -373,7 +373,7 @@
       "name": "Speed Block Moondance (Moonfall Clip)",
       "requires": [
         {"notable": "Speed Block Moondance"},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canTrickyJump",
         "canTurnaroundAimCancel",
         {"getBlueSpeed": {"usedTiles": 16, "steepDownTiles": 4, "openEnd": 0}},
@@ -478,7 +478,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "canUseIFrames",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 80}
       ],
@@ -495,7 +495,7 @@
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 40}
       ],
@@ -659,7 +659,7 @@
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canChainTemporaryBlue"
       ],
       "exitCondition": {
@@ -672,7 +672,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -965,7 +965,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -1132,7 +1132,7 @@
               ]},
               "f_DefeatedPhantoon"
             ]},
-            "h_crystalFlash"
+            "h_CrystalFlash"
           ]}
         ]}
       ],
@@ -1157,7 +1157,7 @@
           {"canShineCharge": {"usedTiles": 14, "openEnd": 1}}
         ]},
         {"thornHits": 1},
-        "h_SpikeSuitThornHitLeniency",
+        "h_spikeSuitThornHitLeniency",
         "canSpikeSuit",
         {"shinespark": {"frames": 6, "excessFrames": 6}}
       ],
@@ -1170,13 +1170,13 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"or": [
           {"canShineCharge": {"usedTiles": 35, "openEnd": 1}},
           {"and": [
             "f_DefeatedPhantoon",
-            "h_shineChargeMaxRunway"
+            "h_shinechargeMaxRunway"
           ]}
         ]},
         {"or": [
@@ -1232,7 +1232,7 @@
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
-          "h_usePowerBombs"
+          "h_usePowerBomb"
         ]},
         {"useFlashSuit": {}},
         {"or": [
@@ -1310,7 +1310,7 @@
       "link": [5, 4],
       "name": "Power Bomb the Chozo Statue",
       "requires": [
-        "h_usePowerBombs",
+        "h_usePowerBomb",
         {"or": [
           {"obstaclesNotCleared": ["B"]},
           "canOffScreenMovement"

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -29,7 +29,7 @@
             {
               "name": "Base",
               "requires": [
-                "h_openRedDoors"
+                "h_openRedDoor"
               ]
             }
           ],
@@ -231,7 +231,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -51,7 +51,7 @@
               "requires": [
                 {"or": [
                   "f_DefeatedPhantoon",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "The item doesn't spawn until Phantoon is defeated."
@@ -125,7 +125,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -237,7 +237,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -111,7 +111,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 100}
       ],
@@ -127,7 +127,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -826,7 +826,7 @@
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "Gravity",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         {"shineChargeFrames": 100}
       ],
@@ -920,7 +920,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     }

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -106,7 +106,7 @@
         ]},
         "canStutterWaterShineCharge",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 20}}
       ],
       "exitCondition": {
@@ -134,7 +134,7 @@
           "canSpaceJumpWaterBounce",
           "HiJump"
         ]},
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 29}}
       ],
       "exitCondition": {
@@ -168,7 +168,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },
@@ -410,7 +410,7 @@
       "name": "Stutter Water Shinecharge",
       "requires": [
         "canStutterWaterShineCharge",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 7, "excessFrames": 2}}
       ],
       "note": "If Phantoon is defeated, start at least 2 tiles from the water line, and stutter just before entering it in order to charge a spark in room."
@@ -558,7 +558,7 @@
         "canShinechargeMovementComplex",
         "canWalljump",
         "canSpaceJumpWaterBounce",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 150}
       ],
       "exitCondition": {
@@ -582,7 +582,7 @@
         "canShinechargeMovementComplex",
         "canWalljump",
         "HiJump",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shineChargeFrames": 105}
       ],
       "exitCondition": {
@@ -1167,7 +1167,7 @@
       "link": [2, 2],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -39,7 +39,7 @@
               "requires": [
                 {"or": [
                   "f_DefeatedPhantoon",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "The item doesn't spawn until Phantoon is defeated."
@@ -362,7 +362,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
       "devNote": "The Bull and Workrobot projectiles aren't a problem."
@@ -565,7 +565,7 @@
           "h_useSpringBall",
           "h_bombThings"
         ]},
-        "h_crystalFlash",
+        "h_CrystalFlash",
         "canCeilingClip"
       ],
       "flashSuitChecked": true,

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -41,7 +41,7 @@
               "requires": [
                 {"or": [
                   "f_DefeatedPhantoon",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "The item doesn't spawn until Phantoon is defeated."
@@ -146,7 +146,7 @@
         "SpaceJump",
         "HiJump",
         "canShinechargeMovementComplex",
-        "h_shineChargeMaxRunway",
+        "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 21}},
         {"or": [
           "Gravity",
@@ -170,7 +170,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship Entrance.json
+++ b/region/wreckedship/main/Wrecked Ship Entrance.json
@@ -109,7 +109,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -741,7 +741,7 @@
       "link": [3, 3],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "flashSuitChecked": true
@@ -809,7 +809,7 @@
       "link": [3, 6],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"]
     },
@@ -952,7 +952,7 @@
       "link": [3, 8],
       "name": "Power Bombs",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "note": [
@@ -1307,7 +1307,7 @@
       "link": [4, 4],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A", "B", "C"],
       "flashSuitChecked": true
@@ -1784,7 +1784,7 @@
       "link": [6, 6],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1878,7 +1878,7 @@
       "link": [7, 3],
       "name": "Power Bomb",
       "requires": [
-        "h_usePowerBombs"
+        "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
       "note": [
@@ -2016,7 +2016,7 @@
       "link": [7, 7],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -107,7 +107,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -107,7 +107,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/region/wreckedship/main/Wrecked Ship West Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship West Super Room.json
@@ -39,7 +39,7 @@
               "requires": [
                 {"or": [
                   "f_DefeatedPhantoon",
-                  "h_AllItemsSpawned"
+                  "h_allItemsSpawned"
                 ]}
               ],
               "note": "The item doesn't spawn until Phantoon is defeated."
@@ -129,7 +129,7 @@
       "link": [1, 1],
       "name": "Crystal Flash",
       "requires": [
-        "h_crystalFlash"
+        "h_CrystalFlash"
       ],
       "flashSuitChecked": true
     },

--- a/strats.md
+++ b/strats.md
@@ -1679,7 +1679,7 @@ An `unlocksDoors` array lists possibilities of doors that can be unlocked as par
 - _useImplicitRequires_: A boolean, true by default, indicating whether standard requirements should be implicitly appended to the `requires` in this object. This can be set this to false if the standard requirements are already accounted for in the strat `requires`, for example if the strat involves using a Power Bomb which would already unlock the door as a side effect, or if it uses a Super as a hero shot to open the door. If this property is set to true, the implicit standard requirements are based on the door type, as follows:
     - For "missiles", the implicit requirement is `{"ammo": {"type": "Missile", "count": 5}}`.
     - For "super", the implicit requirement is `{"ammo": {"type": "Super", "count": 1}}`.
-    - For "powerbomb", the implicit requirement is `h_usePowerBombs`.
+    - For "powerbomb", the implicit requirement is `h_usePowerBomb`.
     - For "gadoraMissiles", the implicit requirement is `{"ammo": {"type": "Missile", "count": 3}}`.
     - For "gadoraSuper", the implicit requirement is `{"ammo": {"type": "Super", "count": 1}}`.
     
@@ -1749,7 +1749,7 @@ A `setsFlags` array lists the names of game flags that become set (if not alread
   "link": [5, 6],
   "name": "Break the Tube",
   "requires": [
-    "h_usePowerBombs"
+    "h_usePowerBomb"
   ],
   "setsFlags": ["f_MaridiaTubeBroken"]
 }

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -320,7 +320,7 @@ def check_shinespark_req(req):
 
 def check_shinecharge_req(req):
     if isinstance(req, str):
-        if req in ["h_shineChargeMaxRunway", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge"]:
+        if req in ["h_shinechargeMaxRunway", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge"]:
             return True
     if isinstance(req, dict):
         if "canShineCharge" in req:
@@ -334,8 +334,8 @@ def check_heat_req(req):
     if isinstance(req, str):
         if req in ["h_heatProof", "h_heatedCrystalFlash", "h_heatedLavaCrystalFlash", "h_LowerNorfairElevatorDownwardFrames",
                    "h_LowerNorfairElevatorUpwardFrames", "h_MainHallElevatorFrames", "h_heatedGreenGateGlitch",
-                   "h_DirectHeatedGModeLeaveSameDoor", "h_IndirectHeatedGModeOpenSameDoor",
-                   "h_HeatedGModeOpenDifferentDoor", "h_HeatedGModeOffCameraDoor", "h_heatedGModePauseAbuse"]:
+                   "h_heatedDirectGModeLeaveSameDoor", "h_heatedIndirectGModeOpenSameDoor",
+                   "h_heatedGModeOpenDifferentDoor", "h_heatedGModeOffCameraDoor", "h_heatedGModePauseAbuse"]:
             return True
     if isinstance(req, dict):
         if "heatFrames" in req or "heatFramesWithEnergyDrops" in req:
@@ -473,7 +473,7 @@ def covers_shinecharge_frames(req):
 
 def process_req_speed_state(req, states, err_fn):
     if isinstance(req, str):
-        if req in ["h_shineChargeMaxRunway", "canWaterShineCharge", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge", "h_shinechargeSlideTemporaryBlue"]:
+        if req in ["h_shinechargeMaxRunway", "canWaterShineCharge", "canStutterWaterShineCharge", "canPreciseStutterWaterShineCharge", "h_shinechargeSlideTemporaryBlue"]:
             states = {"shinecharging"}
         elif req in ["h_getBlueSpeedMaxRunway", "canSpeedKeep", "h_waterGetBlueSpeed", "h_stutterWaterGetBlueSpeed"]:
             # Note: "canSpeedKeep" can be used for other purposes than obtaining blue, but its presence should be


### PR DESCRIPTION
This makes it so that the first word is lowercase, unless it would normally be an uppercase word. 
Also slightly rename some helpers, the main one being `h_usePowerBombs -> h_usePowerBomb`

This helps make it more standardized, but there is still some variation based on what the first word is. Alternatively, the first word could always be capitalized?