### PR TITLE
Golden Torizo side platform jumps

### DIFF
--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -905,6 +905,102 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Side Platform Cross Room Jump",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "obstructions": [[1, 0]],
+              "minTiles": 27.4375,
+              "speedBooster": true,
+              "note": ["This applies to Dust Torizo Room and Noob Bridge."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "obstructions": [[1, 0]],
+              "minTiles": 28.2472,
+              "speedBooster": true,
+              "note": ["This applies to Double Chamber."]
+            },
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "obstructions": [[3, 0]],
+              "minTiles": 28.2472,
+              "speedBooster": true,
+              "environment": "water",
+              "requires": [
+                "canGravityJump"
+              ],
+              "note": ["This applies to Below Botwoon Energy Tank and Botwoon Energy Tank Room."]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "obstructions": [[3, 0]],
+              "minTiles": 31,
+              "speedBooster": true,
+              "requires": [
+                "canInsaneMidAirMorph"
+              ],
+              "note": ["This applies to Metroid Room 1, Statues Hallway, and Baby Kraid Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "obstructions": [[3, 0]],
+              "minTiles": 41.4375,
+              "speedBooster": true,
+              "requires": [
+                "canInsaneMidAirMorph"
+              ],
+              "note": ["This applies to Blue Brinstar Energy Tank Room (Power Bomb blocks broken), Bowling Alley (middle, power off), and Basement (power on)."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "obstructions": [[3, 2]],
+              "minTiles": 39.4375,
+              "speedBooster": true,
+              "note": ["This applies to Metal Pirates Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "obstructions": [[5, 2]],
+              "minTiles": 37.4375,
+              "speedBooster": true,
+              "requires": [
+                "canInsaneMidAirMorph"
+              ],
+              "note": ["This applies to Flyway."]
+            }
+          ]
+        }
+      },
+      "requires": [
+        "f_DefeatedGoldenTorizo",
+        "HiJump",
+        "canMomentumConservingMorph",
+        "canInsaneJump",
+        {"heatFrames": 120}
+      ],
+      "note": [
+        "Perform a momentum conserving morph through the transition.",
+        "After the transition, quickly unmorph and continue holding up to retain temporary blue and break the bomb blocks."
+      ],
+      "detailNote": [
+        "It may help (but is not required) to pause buffer the morph input."
+      ],
+      "devNote": [
+        "FIXME: This could maybe be possible without HiJump? If so, it would be significantly more difficult."
+      ]
+    },
+    {
       "id": 73,
       "link": [2, 4],
       "name": "G-Mode Morph, IBJ",


### PR DESCRIPTION
When I looked at this a few months ago, I thought some of these would be Beyond. But with a better understanding now of how to set these up, they are seeming fine in Extreme and Insane. The main things that make it easier are
1. Pause buffering the morph input. This breaks up the tight input sequence, and makes it more reliable to use a visual cue for the pause press to get a consistently timed morph.
2. Using a shorter runway (in the long setup rooms). Having too much horizontal speed makes the timing for the unmorph tighter, or even impossible depending on the morph timing. Since you have to wait for the morph animation to finish before unmorphing, in that time you could overshoot past the bomb blocks if your speed is too high. And of course, at lower speeds it is also easier to time a last-frame jump.