### PR TITLE
Add Green Hill Zone side platform setup, extend Halfie Climb setup

### DIFF
--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4709,13 +4709,27 @@
         "comeInWithSidePlatform": {
           "platforms": [
             {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 45,
+              "speedBooster": true,
+              "obstructions": [[1, 0]],
+              "requires": [],
+              "note": "Applies to Halfie Climb Room."
+            },
+            {
               "minHeight": 3,
               "maxHeight": 3,
               "minTiles": 39.4375,
               "speedBooster": true,
               "obstructions": [[3, 2]],
               "requires": [],
-              "note": "Applies to Metal Pirates Room."
+              "note": "Applies to Metal Pirates Room.",
+              "detailNote": [
+                "This has a 2-frame window for the jump,",
+                "then a 1-frame or 2-frame window for the morph (after the transition), depending on the jump,",
+                "with a last-frame jump giving a 2-frame morph window."
+              ]
             }
           ]
         }
@@ -4725,12 +4739,7 @@
         "canMomentumConservingMorph",
         "canTrickySpringBallJump"
       ],
-      "wallJumpAvoid": true,
-      "note": [
-        "This has a 2-frame window for the jump,",
-        "then a 1-frame or 2-frame window for the morph (after the transition), depending on the jump,",
-        "with a last-frame jump giving a 2-frame morph window."
-      ]
+      "wallJumpAvoid": true
     },
     {
       "id": 217,

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4702,6 +4702,25 @@
       "note": "With a runway of at least 12 tiles in the adjacent room, Samus should always be able to jump high enough if she jumps just before hitting the right wall."
     },
     {
+      "link": [10, 14],
+      "name": "Cross-Room Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInWithSpringBallBounce": {
+          "movementType": "any",
+          "speedBooster": true,
+          "remoteAndLandingMinTiles": [[42, 0]]
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canSpringBallBounce"
+      ],
+      "devNote": [
+        "This needs a minimum extra run speed of $6.D.",
+        "Speeds of $6.0 or $6.1 can also work but wouldn't provide a benefit over the in-room 'canTrickyDashJump' spring ball jump strat."
+      ]
+    },
+    {
       "id": 252,
       "link": [10, 14],
       "name": "Side Platform Cross Room Jump",

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -4739,7 +4739,10 @@
         "canMomentumConservingMorph",
         "canTrickySpringBallJump"
       ],
-      "wallJumpAvoid": true
+      "wallJumpAvoid": true,
+      "devNote": [
+        "This strat is not very useful, since the in-room tricky dash jump into spring ball jump is easier."
+      ]
     },
     {
       "id": 217,

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -479,7 +479,7 @@
               "requires": [
                 "canLateralMidAirMorph"
               ],
-              "note": ["This applies to Dust Torizo Room."],
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."],
               "detailNote": ["This has a 2-frame window for the jump."]
             },
             {
@@ -695,6 +695,22 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+    },
+    {
+      "link": [1, 3],
+      "name": "Leave With Side Platform Jump",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 30,
+            "openEnd": 0
+          },
+          "obstruction": [4, 0]
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },

--- a/region/brinstar/pink/Pink Brinstar Hopper Room.json
+++ b/region/brinstar/pink/Pink Brinstar Hopper Room.json
@@ -866,7 +866,7 @@
               "requires": [
                 "HiJump"
               ],
-              "note": ["This applies to Ridley Tank Room, Halfie Climb Room, and Dust Torizo Room."],
+              "note": ["This applies to Ridley Tank Room, Dust Torizo Room, and Halfie Climb Room."],
               "detailNote": [
                 "This has a 2-frame window for the jump.",
                 "Getting the jump on the last frame may requiring quickly aiming down (between 1 and 3 frames after the jump)."

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -248,7 +248,7 @@
               "requires": [
                 "canMomentumConservingMorph"
               ],
-              "note": ["This applies to Dust Torizo Room."]
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."]
             },
             {
               "minHeight": 2,

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -606,7 +606,7 @@
               "requires": [
                 {"heatFrames": 100}
               ],
-              "note": ["This applies to Dust Torizo Room."]
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."]
             },
             {
               "minHeight": 3,

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -226,7 +226,7 @@
                 "HiJump",
                 {"heatFrames": 95}
               ],
-              "note": ["This applies to Halfie Climb Room and Dust Torizo Room."]
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."]
             },
             {
               "minHeight": 3,

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -647,7 +647,7 @@
                 {"getBlueSpeed": {"usedTiles": 24, "openEnd": 1}},
                 {"heatFrames": 60}
               ],
-              "note": ["This applies to Dust Torizo Room."]
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."]
             },
             {
               "minHeight": 2,
@@ -662,7 +662,7 @@
                 {"heatFrames": 70}
               ],
               "note": [
-                "This applies to Noob Bridge.",
+                "This applies to Noob Bridge and Halfie Climb Room.",
                 "Use a 2-tap in order to gain blue speed with high momentum."
               ],
               "detailNote": [

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1002,7 +1002,7 @@
                 "canTrickyJump"
               ],
               "note": [
-                "This applies to Dust Torizo Room.",
+                "This applies to Dust Torizo Room and Halfie Climb Room.",
                 "Use the full runway, with a last-frame jump (extra run speed $5.0), and a down-grab."
               ],
               "devNote": [
@@ -2388,7 +2388,7 @@
               "speedBooster": true,
               "obstructions": [[1, 0]],
               "requires": [],
-              "note": ["This applies to Dust Torizo Room."]
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."]
             },
             {
               "minHeight": 3,
@@ -2464,7 +2464,7 @@
               "speedBooster": true,
               "obstructions": [[1, 0]],
               "requires": [],
-              "note": ["This applies to Dust Torizo Room."]
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."]
             },
             {
               "minHeight": 2,
@@ -3138,8 +3138,8 @@
         "leaveWithSidePlatform": {
           "height": 2,
           "runway": {
-            "length": 13,
-            "openEnd": 0
+            "length": 45,
+            "openEnd": 1
           },
           "obstruction": [1, 0]
         }

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -498,7 +498,7 @@
               "minTiles": 27.4375,
               "speedBooster": true,
               "obstructions": [[1, 0]],
-              "note": ["This applies to Dust Torizo Room"]
+              "note": ["This applies to Dust Torizo Room."]
             },
             {
               "minHeight": 3,
@@ -506,7 +506,7 @@
               "minTiles": 39.4375,
               "speedBooster": true,
               "obstructions": [[3, 2]],
-              "note": ["This applies to Metal Pirates Room"]
+              "note": ["This applies to Metal Pirates Room."]
             },
             {
               "minHeight": 2,

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -300,7 +300,7 @@
               "speedBooster": true,
               "obstructions": [[1, 0]],
               "requires": [],
-              "note": ["This applies to Ridley Tank Room, Halfie Climb Room, and Dust Torizo Room."]
+              "note": ["This applies to Ridley Tank Room, Dust Torizo Room, and Halfie Climb Room."]
             },
             {
               "minHeight": 2,
@@ -368,7 +368,7 @@
                 "canMomentumConservingMorph",
                 "canInsaneJump"
               ],
-              "note": ["This applies to Kraid Room and Baby Kraid Room."],
+              "note": ["This applies to Kraid Room, Green Hill Zone, and Baby Kraid Room."],
               "detailNote": [
                 "To reduce Samus' horizontal momentum, avoid holding either forward or backward through the transition.",
                 "If coming from Baby Kraid Room, it is easiest to use only a small part of the available runway."

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -650,7 +650,7 @@
                 "canTrickyJump"
               ],
               "note": [
-                "This applies to Shaktool Room, Ridley Tank Room, Halfie Climb Room, and Dust Torizo Room."
+                "This applies to Shaktool Room, Ridley Tank Room, Dust Torizo Room, and Halfie Climb Room."
               ]
             },
             {

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1195,7 +1195,7 @@
                   "canTrickySpringBallJump"
                 ]}
               ],
-              "note": ["This applies to Dust Torizo Room."],
+              "note": ["This applies to Dust Torizo Room and Halfie Climb Room."],
               "detailNote": [
                 "In the Hi-Jump case, it helps to use a little less than the full available runway,",
                 "in order to get a higher jump and more easily avoid the Waver."


### PR DESCRIPTION
Kyle pointed out this Green Hill Zone setup. It has a 4-tile-long obstruction, which makes it have very limited use. It only seems to be usable with the gate open, with the only application being jumping up the bottom left of Maridia Elevator Room.

The Halfie Climb Room setup was too short because I forgot about being able to shoot out the shot blocks. In theory there could be situations where the Oums get in your way, but it didn't seem like it's really a problem. If needed we could add a `comeInNormally` entrance condition.

This should wrap up the first pass at side platforms.