### PR TITLE
Refine Botwoon ETank right-side shinecharges

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -2124,7 +2124,6 @@
       "requires": [
         "h_waterGetBlueSpeed"
       ],
-      "clearsObstacles": ["A"],
       "devNote": [
         "This is just a rough estimate of the minimum number of tiles that this runway can represent.",
         "It is designed for a skill level that won't be able to use canStutterWaterShineCharge."
@@ -2141,8 +2140,7 @@
       },
       "requires": [
         "h_stutterWaterGetBlueSpeed"
-      ],
-      "clearsObstacles": ["A"]
+      ]
     },
     {
       "link": [4, 7],
@@ -2155,7 +2153,6 @@
       "requires": [
         "h_stutterWaterGetBlueSpeed"
       ],
-      "clearsObstacles": ["A"],
       "note": [
         "With only 1 tile of runway, this requires releasing forward for 1 or 2 frames",
         "and repressing forward on the last possible frame."
@@ -2192,7 +2189,7 @@
       "requires": [],
       "devNote": [
         "With a mid-air spring ball jump it would be possible to go through the morph tunnel.",
-        "This strat exists mainly as a way to avoid collecting the item."
+        "This strat exists mainly as a way to avoid collecting the item, by passing through the Speed blocks."
       ]
     },
     {
@@ -2297,6 +2294,7 @@
       "link": [7, 1],
       "name": "Base",
       "requires": [],
+      "clearsObstacles": ["A"],
       "note": [
         "Use blue speed to pass through the speed blocks."
       ]

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -76,6 +76,19 @@
       "mapTileMask": [
         [1, 1, 1, 1, 2, 1, 1]
       ]
+    },
+    {
+      "id": 7,
+      "name": "Right of Sand with Blue Speed",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "mapTileMask": [
+        [1, 1, 1, 1, 1, 2, 1]
+      ],
+      "devNote": [
+        "This represents having gained blue speed while moving right-to-left,",
+        "including running, speedballing, or blue spring ball bouncing."
+      ]
     }
   ],
   "obstacles": [
@@ -156,7 +169,8 @@
         {"id": 3},
         {"id": 4},
         {"id": 5},
-        {"id": 6}
+        {"id": 6},
+        {"id": 7}
       ]
     },
     {
@@ -173,6 +187,13 @@
         {"id": 4},
         {"id": 5},
         {"id": 6}
+      ]
+    },
+    {
+      "from": 7,
+      "to": [
+        {"id": 1},
+        {"id": 4}
       ]
     }
   ],
@@ -1262,7 +1283,7 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 80},
+        {"shineChargeFrames": 55},
         "Gravity",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 115, "excessFrames": 12}}
@@ -1278,148 +1299,15 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 160},
+        {"shineChargeFrames": 135},
         "canSuitlessMaridia",
         "canHorizontalShinespark",
         "canShinechargeMovement",
-        {"shinespark": {"frames": 147, "excessFrames": 15}}
+        {"shinespark": {"frames": 148, "excessFrames": 15}}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": "Coming in with zero momentum, all it takes is one non-HiJump full height jump forward, then activate."
-    },
-    {
-      "id": 53,
-      "link": [4, 1],
-      "name": "Suitless Water Shinecharge, Blue Speed Run",
-      "entranceCondition": {
-        "comeInGettingBlueSpeed": {
-          "length": 6,
-          "openEnd": 1
-        }
-      },
-      "requires": [
-        "h_waterGetBlueSpeed"
-      ],
-      "clearsObstacles": ["A"],
-      "devNote": [
-        "This is just a rough estimate of the minimum number of tiles that this runway can represent.",
-        "It is designed for a skill level that won't be able to use canStutterWaterShineCharge."
-      ]
-    },
-    {
-      "id": 54,
-      "link": [4, 1],
-      "name": "Suitless Stutter Water Shinecharge",
-      "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
-          "minTiles": 2
-        }
-      },
-      "requires": [
-        "h_stutterWaterGetBlueSpeed"
-      ],
-      "clearsObstacles": ["A"]
-    },
-    {
-      "id": 55,
-      "link": [4, 1],
-      "name": "Stutter Water Shinecharge, Leave With Temporary Blue",
-      "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
-          "minTiles": 2
-        }
-      },
-      "requires": [
-        "canStutterWaterShineCharge",
-        "canChainTemporaryBlue"
-      ],
-      "exitCondition": {
-        "leaveWithTemporaryBlue": {}
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
-    },
-    {
-      "id": 56,
-      "link": [4, 1],
-      "name": "Speedball",
-      "entranceCondition": {
-        "comeInSpeedballing": {
-          "runway": {
-            "length": 6,
-            "openEnd": 1
-          }
-        }
-      },
-      "requires": [
-        "canSpeedball"
-      ],
-      "note": [
-        "This is just a rough estimate of the minimum number of tiles that this runway can represent."
-      ]
-    },
-    {
-      "id": 57,
-      "link": [4, 1],
-      "name": "Speedball, Leave With Temporary Blue",
-      "entranceCondition": {
-        "comeInSpeedballing": {
-          "runway": {
-            "length": 6,
-            "openEnd": 1
-          }
-        }
-      },
-      "requires": [
-        "canSpeedball",
-        "canChainTemporaryBlue"
-      ],
-      "exitCondition": {
-        "leaveWithTemporaryBlue": {}
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "note": [
-        "This is just a rough estimate of the minimum number of tiles that this runway can represent."
-      ]
-    },
-    {
-      "id": 58,
-      "link": [4, 1],
-      "name": "Blue Spring Ball Bounce",
-      "entranceCondition": {
-        "comeInWithBlueSpringBallBounce": {
-          "movementType": "controlled"
-        }
-      },
-      "requires": [],
-      "note": ["Bounce through the Speed blocks."],
-      "devNote": [
-        "With a mid-air spring ball jump it would be possible to go through the morph tunnel.",
-        "This strat exists mainly as a way to avoid collecting the item."
-      ]
-    },
-    {
-      "id": 59,
-      "link": [4, 1],
-      "name": "Blue Spring Ball Bounce, Leave With Temporary Blue",
-      "entranceCondition": {
-        "comeInWithBlueSpringBallBounce": {
-          "movementType": "controlled"
-        }
-      },
-      "requires": [
-        "canChainTemporaryBlue"
-      ],
-      "exitCondition": {
-        "leaveWithTemporaryBlue": {}
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "note": [
-        "Bounce through the Speed blocks.",
-        "Then unmorph and chain temporary blue into the next room."
-      ]
     },
     {
       "id": 60,
@@ -1711,7 +1599,7 @@
     {
       "id": 70,
       "link": [4, 4],
-      "name": "Stutter Water Shinecharge, Leave Shinesparking",
+      "name": "Stutter Water Shinecharge, Leave With Spark",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": true,
@@ -1735,6 +1623,231 @@
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Precise Stutter Water Shinecharge, Leave With Spark",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 15}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["missiles", "super"], "requires": []},
+        {"types": ["powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (5-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 5
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shineChargeFrames": 130},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 15}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With a runway of 5 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 5 frames, and repress forward on the last possible frame before the transition.",
+        "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (4-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 4
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shineChargeFrames": 140},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 10}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only a runway of 4 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 4 frames, and repress forward on the last possible frame before the transition.",
+        "It also works well to release forward for 3 frames and repress on the last possible frame.",
+        "Other timings can also work, but may gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (3-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 3
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shineChargeFrames": 145},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 10}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only a runway of 3 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 3 or 4 frames, and repress forward on the last possible frame before the transition.",
+        "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge.",
+        "Alternatively, with greater difficulty but saving some shinecharge frames,",
+        "after performing the turnaround spin jump, briefly moonwalk back, then retain momentum by boomeranging forward",
+        "(switching from pressing backward to pressing forward on the next frame),",
+        "and arm pump to reach the door quickly."
+      ],
+      "devNote": [
+        "The same shinecharge frames could be achieved with a closed end runway (effective length of 2.4375),",
+        "with a 3-frame stutter, but there doesn't appear to be any application."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (2-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        "canInsaneJump",
+        {"shineChargeFrames": 150},
+        {"or": [
+          "canBeVeryPatient",
+          {"shineChargeFrames": 15}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only a runway of 2 tiles (open end) in the other room,",
+        "the ideal timing for the stutter is to release forward for 3 frames, and repress forward on the last possible frame before the transition.",
+        "Other timings can work, but will gain the shinecharge further from the door, leaving fewer shinecharge frames remaining.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge.",
+        "Alternatively, with greater difficulty but saving some shinecharge frames,",
+        "after performing the turnaround spin jump, briefly moonwalk back, then retain momentum by boomeranging forward",
+        "(switching from pressing backward to pressing forward on the next frame),",
+        "and arm pump to reach the door quickly."
+      ],
+      "devNote": [
+        "FIXME: The canBeVeryPatient requirement is for difficulty placement of the boomerang method;",
+        "but the boomerang (or maybe specifically the moonwalk boomerang) should possibly be its own tech,",
+        "and the same with rapid arm pumping."
+      ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Precise Stutter Shinecharge, Leave Shinecharged (1-tile runway)",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canInsaneJump",
+        "canBeVeryPatient",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 160}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only 1 tile of runway in the other room, Samus should ideally start on the last pixel of runway with X subpixels of $3FFF or less.",
+        "Run toward the door, releasing forward for exactly 1 frame and pressing it again on the last possible frame before the transition.",
+        "Starting with X subpixels of $7FFF can also work (e.g., by simply backing against the door ledge, then jumping and turning around mid-air);",
+        "in this case, Samus must advance 1 or 2 pixels with an arm pump before the transition (e.g., firing a shot or pressing and/or releasing an angle button),",
+        "and the shinecharge will be gained slightly further away from the door.",
+        "After gaining the shinecharge, continue holding forward in order to make Samus stand.",
+        "Then turnaround spin jump back toward the door, and continue spin jumping to reach the transition with a shinecharge.",
+        "Alternatively, with greater difficulty but saving some shinecharge frames,",
+        "after performing the turnaround spin jump, briefly moonwalk back, then retain momentum by boomeranging forward",
+        "(switching from pressing backward to pressing forward on the next frame),",
+        "and arm pump to reach the door quickly."
+      ],
+      "detailNote": [
+        "Ideal subpixels ($3FFF) can be achieved using one of several methods:",
+        "1) press forward against the door ledge (or a wall aligned with it);",
+        "jump, and while mid-air, tap forward for exactly 1 frame to land with subpixels $BFFF,",
+        "moonwalk back for exactly 1 frame to end with subpixels $3FFF.",
+        "2) press forward against the door ledge (from a platform below, assuming one exists)",
+        "turn around (while on the ground), and moonwalk back two pixels,",
+        "then jump and mid-air turnaround onto the ledge;",
+        "if Samus jumped from the correct pixel but does not land on the ledge, then it was needed to moonwalk back 1 more frame;",
+        "in this case it is possible to retry by doing a mid-air turnaround back onto the platform, and moonwalking back for 1 frame.",
+        "3) if X-Ray is available, press against the door ledge (from a platform below, assuming one exists)",
+        "turn around (while on the ground), then jump and mid-air turnaround toward the door,",
+        "and use X-Ray to turnaround in place away from the door;",
+        "repeat this sequence 3 more times: jump, mid-air turnaround, X-Ray turnaround;",
+        "then do one more jump and mid-air turnaround, high enough to land on the door ledge,",
+        "and Samus should be in the correct position with subpixels $3FFF."
       ]
     },
     {
@@ -1999,6 +2112,90 @@
       ]
     },
     {
+      "id": 53,
+      "link": [4, 7],
+      "name": "Suitless Water Shinecharge, Blue Speed Run",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 6,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "h_waterGetBlueSpeed"
+      ],
+      "clearsObstacles": ["A"],
+      "devNote": [
+        "This is just a rough estimate of the minimum number of tiles that this runway can represent.",
+        "It is designed for a skill level that won't be able to use canStutterWaterShineCharge."
+      ]
+    },
+    {
+      "id": 54,
+      "link": [4, 7],
+      "name": "Suitless Stutter Water Shinecharge",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "h_stutterWaterGetBlueSpeed"
+      ],
+      "clearsObstacles": ["A"]
+    },
+    {
+      "link": [4, 7],
+      "name": "Precise Suitless Stutter Water Shinecharge",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "h_stutterWaterGetBlueSpeed"
+      ],
+      "clearsObstacles": ["A"],
+      "note": [
+        "With only 1 tile of runway, this requires releasing forward for 1 or 2 frames",
+        "and repressing forward on the last possible frame."
+      ]
+    },
+    {
+      "id": 56,
+      "link": [4, 7],
+      "name": "Speedball",
+      "entranceCondition": {
+        "comeInSpeedballing": {
+          "runway": {
+            "length": 6,
+            "openEnd": 1
+          }
+        }
+      },
+      "requires": [
+        "canSpeedball"
+      ],
+      "note": [
+        "This is just a rough estimate of the minimum number of tiles that this runway can represent."
+      ]
+    },
+    {
+      "id": 58,
+      "link": [4, 7],
+      "name": "Blue Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInWithBlueSpringBallBounce": {
+          "movementType": "controlled"
+        }
+      },
+      "requires": [],
+      "devNote": [
+        "With a mid-air spring ball jump it would be possible to go through the morph tunnel.",
+        "This strat exists mainly as a way to avoid collecting the item."
+      ]
+    },
+    {
       "id": 86,
       "link": [5, 1],
       "name": "Base",
@@ -2094,6 +2291,54 @@
       "name": "Zoa Farm",
       "requires": [
         {"refill": ["Energy"]}
+      ]
+    },
+    {
+      "link": [7, 1],
+      "name": "Base",
+      "requires": [],
+      "note": [
+        "Use blue speed to pass through the speed blocks."
+      ]
+    },
+    {
+      "id": 55,
+      "link": [7, 1],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "h_getBlueSpeedMaxRunway",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Use blue speed to pass through the speed blocks, then chain temporary blue through the door."
+      ],
+      "devNote": [
+        "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
+        "since we don't yet have a way to represent that being at node 7 implies already having blue speed."
+      ]
+    },
+    {
+      "link": [7, 4],
+      "name": "Leave With Temporary Blue",
+      "requires": [
+        "h_getBlueSpeedMaxRunway",
+        "canXRayTurnaround",
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "note": [
+        "Use X-Ray to turn around, then chain temporary blue back through the door."
+      ],
+      "devNote": [
+        "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
+        "since we don't yet have a way to represent that being at node 7 implies already having blue speed."
       ]
     }
   ],

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1601,8 +1601,7 @@
       "link": [4, 4],
       "name": "Stutter Water Shinecharge, Leave With Spark",
       "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
+        "comeInStutterShinecharging": {
           "minTiles": 2
         }
       },
@@ -1629,8 +1628,7 @@
       "link": [4, 4],
       "name": "Precise Stutter Water Shinecharge, Leave With Spark",
       "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
+        "comeInStutterShinecharging": {
           "minTiles": 1
         }
       },
@@ -1988,14 +1986,28 @@
       "link": [4, 6],
       "name": "Stutter Water Shinecharge",
       "entranceCondition": {
-        "comeInRunning": {
-          "speedBooster": true,
+        "comeInStutterShinecharging": {
           "minTiles": 2
         }
       },
       "requires": [
         "Morph",
         "canStutterWaterShineCharge",
+        {"shinespark": {"frames": 8}}
+      ],
+      "note": "Shinespark diagonally over the zoa pit or run through the speed blocks and shinespark after turning around."
+    },
+    {
+      "link": [4, 6],
+      "name": "Precise Stutter Water Shinecharge",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "Morph",
+        "canPreciseStutterWaterShineCharge",
         {"shinespark": {"frames": 8}}
       ],
       "note": "Shinespark diagonally over the zoa pit or run through the speed blocks and shinespark after turning around."


### PR DESCRIPTION
- The existing strats required 2 runway tiles in order to stutter water shinecharge here. This PR adds 1-tile options, with the `canPreciseStutterWaterShineCharge` tech. With 1 runway tile, it requires a 1 or 2 frame release of forward, and a last-frame forward repress, which seems ok for Expert.
- Options are added to go back out through the right door with temporary blue or shinecharged. For the "Leave Shinecharged" variants, I just copied the strats from Aqueduct. In theory, the slopes will slow down your horizontal movement while running into the room, making it so you cover relatively more ground while spin jumping back out. So for some of these it should be possible to leave with slightly more frames remaining here compared to Aqueduct, but I don't think it's significant enough to bother changing the strats. 
- I added a junction node (7), since like in other rooms, there are several ways to gain the blue speed and also several ways to use it.