### PR TITLE
Crab Maze leave shinecharged

### DIFF
--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -456,6 +456,27 @@
       }
     },
     {
+      "link": [2, 2],
+      "name": "Leave Shinecharged (Precise Stutter Shinecharge)",
+      "requires": [
+        "canPreciseStutterWaterShineCharge",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 155},
+        {"or": [
+          "canInsaneJump",
+          {"shineChargeFrames": 10}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "note": [
+        "The ideal setup begins by standing 5 tiles away from the water, at the top of the slope.",
+        "Run toward the water, releasing forward for 5 frames before re-pressing it on the last possible frame before entering the water.",
+        "Other positions and timings can work but will gain the shinecharge further from the door."
+      ]
+    },
+    {
       "id": 16,
       "link": [2, 2],
       "name": "Leave With Temporary Blue",

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -461,10 +461,11 @@
       "requires": [
         "canPreciseStutterWaterShineCharge",
         "canShinechargeMovementTricky",
+        "canInsaneJump",
         {"shineChargeFrames": 155},
         {"or": [
-          "canInsaneJump",
-          {"shineChargeFrames": 10}
+          "canBeVeryPatient",
+          {"shineChargeFrames": 15}
         ]}
       ],
       "exitCondition": {


### PR DESCRIPTION
There's already a "Leave with Spark" water shinecharge strat here in Very Hard that can only spark out in bottom position. The new strat can make it out with frames remaining. Without canInsaneJump, the extra lenience is designed to make it so that in Expert you would only be expected to spark at the doorway, not actually leave with frames remaining.

Video: https://videos.maprando.com/video/6401