### PR TITLE
Refine Spiky Acid Snakes Tunnel space jump strats

### DIFF
--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -111,17 +111,59 @@
       "name": "Space Jump",
       "requires": [
         "SpaceJump",
-        {"heatFrames": 420}
+        {"heatFrames": 390}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Running Space Jump (1-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": "any",
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 350}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Running Space Jump (2-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": "any",
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 330}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Running Space Jump (3-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": "any",
+          "minTiles": 3
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 310}
       ]
     },
     {
       "id": 5,
       "link": [1, 2],
-      "name": "Running Space Jump",
+      "name": "Running Space Jump (4-tile runway)",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": "any",
-          "minTiles": 3
+          "minTiles": 4
         }
       },
       "requires": [
@@ -531,17 +573,59 @@
       "name": "Space Jump",
       "requires": [
         "SpaceJump",
-        {"heatFrames": 420}
+        {"heatFrames": 390}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Running Space Jump (1-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": "any",
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 350}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Running Space Jump (2-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": "any",
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 330}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Running Space Jump (3-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": "any",
+          "minTiles": 3
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 310}
       ]
     },
     {
       "id": 19,
       "link": [2, 1],
-      "name": "Running Space Jump",
+      "name": "Running Space Jump (4-tile runway)",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": "any",
-          "minTiles": 3
+          "minTiles": 4
         }
       },
       "requires": [

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -172,6 +172,90 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Speedy Running Space Jump (6-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 6
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 250}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Speedy Running Space Jump (9-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 9
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 225}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Speedy Running Space Jump (13-tile runway, closed end)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 12.4375
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 195}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Speedy Running Space Jump (17-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 17
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 175}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Speedy Running Space Jump (26-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 26
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 145}
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Speedy Running Space Jump (max runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 45
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 120}
+      ]
+    },
+    {
       "id": 6,
       "link": [1, 2],
       "name": "Tank the Damage",
@@ -631,6 +715,90 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 285}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Speedy Running Space Jump (6-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 6
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 250}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Speedy Running Space Jump (9-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 9
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 225}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Speedy Running Space Jump (13-tile runway, closed end)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 12.4375
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 195}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Speedy Running Space Jump (17-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 17
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 175}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Speedy Running Space Jump (26-tile runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 26
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 145}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Speedy Running Space Jump (max runway)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "speedBooster": true,
+          "minTiles": 45
+        }
+      },
+      "requires": [
+        "SpaceJump",
+        {"heatFrames": 120}
       ]
     },
     {

--- a/region/norfair/east/Spiky Acid Snakes Tunnel.json
+++ b/region/norfair/east/Spiky Acid Snakes Tunnel.json
@@ -1297,5 +1297,9 @@
     }
   ],
   "nextStratId": 51,
-  "nextNotableId": 3
+  "nextNotableId": 3,
+  "devNote": [
+    "Add `comeInSpinning` Space Jump strats, with variants for different run speeds.",
+    "Add more spring ball bounce variants, for different run speeds and combinations of Gravity and/or HiJump."
+  ]
 }


### PR DESCRIPTION
- With no runway (e.g. water in the other room), this is doable with 390 heat frames, compared to 420 that was listed. This makes it now logical to do tankless (in Insane).
- The existing strat for a 3-tile appeared to be unsound: the heat frames matched what I could get with a 4-tile runway. I'm guessing this was written back when we had some confusion about whether the door shell tile was supposed to be included as part of the runway or not.
- I added strat variants for each of the possible runway lengths up to 4 tiles.
- At 4 tiles, without Speed Booster you already reach max speed, so longer runways above that won't help. But with Speed Booster, longer runways do help, so I included strats for a sample of them.

It's a bit annoying to have to create separate strats for each variant, and I'm hoping to clean this up later. Originally I had thought we could have some logical requirement that could do the math to figure out the heat frames based on runway length and distance; but it would be complicated and I'm not sure if it's worth it. I would like if the different cases could be combined into fewer strats though.