### PR TITLE
Refine spiky platform bounceball strats

### DIFF
--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -165,7 +165,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "Bounceball Double Lava Bath (Longer Runway)",
+      "name": "Bounceball Lava Bath (3-tile runway)",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": false,
@@ -187,7 +187,7 @@
     {
       "id": 8,
       "link": [1, 2],
-      "name": "Bounceball Double Lava Bath (Short Runway)",
+      "name": "Bounceball Lava Bath (1-tile runway)",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": false,
@@ -198,7 +198,23 @@
         "canBounceBall",
         "canWalljump",
         {"heatFrames": 600},
-        {"lavaFrames": 85}
+        {"lavaFrames": 70}
+      ],
+      "note": [
+        "Perform a bounceball to minimize lava damage.",
+        "Move quickly to reach the second Tripper on its first cycle.",
+        "Ride it, morph to avoid spike damage, shoot open the door, and run off of the Tripper (rather than jumping off)."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Bounceball Lava Bath (No runway)",
+      "requires": [
+        "canBounceBall",
+        "canInsaneJump",
+        "canWalljump",
+        {"heatFrames": 600},
+        {"lavaFrames": 80}
       ],
       "note": [
         "Perform a bounceball to minimize lava damage.",
@@ -359,7 +375,7 @@
     {
       "id": 14,
       "link": [2, 1],
-      "name": "Bounceball Double Lava Bath (Longer Runway)",
+      "name": "Bounceball Lava Bath (3-tile runway)",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": false,
@@ -369,7 +385,7 @@
       "requires": [
         "canBounceBall",
         "canWalljump",
-        {"heatFrames": 600},
+        {"heatFrames": 590},
         {"lavaFrames": 60}
       ],
       "note": ["Perform a bounceball to minimize lava damage.", "Ride the second Tripper."]
@@ -377,18 +393,30 @@
     {
       "id": 15,
       "link": [2, 1],
-      "name": "Bounceball Double Lava Bath (Shorter Runway)",
+      "name": "Bounceball Lava Bath (1-tile runway)",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": false,
-          "minTiles": 3
+          "minTiles": 1
         }
       },
       "requires": [
         "canBounceBall",
         "canWalljump",
-        {"heatFrames": 600},
-        {"lavaFrames": 85}
+        {"heatFrames": 590},
+        {"lavaFrames": 70}
+      ],
+      "note": ["Perform a bounceball to minimize lava damage.", "Ride the second Tripper."]
+    },
+    {
+      "link": [2, 1],
+      "name": "Bounceball Lava Bath (No runway)",
+      "requires": [
+        "canInsaneJump",
+        "canBounceBall",
+        "canWalljump",
+        {"heatFrames": 590},
+        {"lavaFrames": 80}
       ],
       "note": ["Perform a bounceball to minimize lava damage.", "Ride the second Tripper."]
     },


### PR DESCRIPTION
I was reviewing Sam's videos and noticed that he managed to get through on 1 tank using no runway: https://videos.maprando.com/video/5104, showing that this could work from a water entrance. So this PR adds this to logic. Looking over the room again, also made a few more fixes/refinements:
- The bounceball strats were misleadingly named "Bounceball Double Lava Bath" even though they only do one lava bath.
- The right-to-left "Shorter runway" was expecting a 3-tile runway when it was supposed to be 1-tile.
- Tightened the heat/lava frames a bit and made videos to demonstrate each of the runway length (0, 1, 3).