### PR TITLE
Add mid-air morph damage boost option to escape beta PBs

### DIFF
--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -522,7 +522,13 @@
       "name": "Damage Boost Escape",
       "requires": [
         {"obstaclesCleared": ["B"]},
-        "canHorizontalDamageBoost",
+        {"or": [
+          {"and": [
+            "canMidAirMorph",
+            "canNeutralDamageBoost"
+          ]},
+          "canHorizontalDamageBoost"
+        ]},
         {"thornHits": 1}
       ]
     },


### PR DESCRIPTION
This is an easier option (if Morph is available) so seems good to include in logic.

Video by Sam: https://videos.maprando.com/video/5804