### PR TITLE
Add missing spring ball jump options in Escape Room 3

### DIFF
--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -293,7 +293,8 @@
           "HiJump",
           "canWalljump",
           "SpaceJump",
-          "canIBJ"
+          "canIBJ",
+          "canSpringBallJumpMidAir"
         ]}
       ]
     },
@@ -306,7 +307,8 @@
           "HiJump",
           "canWalljump",
           "SpaceJump",
-          "canIBJ"
+          "canIBJ",
+          "canSpringBallJumpMidAir"
         ]},
         {"or": [
           {"enemyDamage": {


### PR DESCRIPTION
Was going through Sam's videos and noticed this was missing: https://videos.maprando.com/video/5861