### PR TITLE
Add reqs to deal with Pirates in Escape Room 4 L->R

### DIFF
--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -269,11 +269,70 @@
           "HiJump",
           "SpaceJump",
           "canWalljump",
-          "canIBJ",
+          "canJumpIntoIBJ",
+          {"and": [
+            "canIBJ",
+            "canBePatient"
+          ]},
           "canSpringBallJumpMidAir"
+        ]},
+        {"or": [
+          "canBePatient",
+          {"enemyKill": {
+            "enemies": [
+              ["Tourian Space Pirate (all)"],
+              ["Tourian Space Pirate (all)"],
+              ["Tourian Space Pirate (all)"],
+              ["Tourian Space Pirate (all)"]
+            ],
+            "explicitWeapons": [
+              "Missile", "Super", "PowerBomb", "Wave", "Spazer", "Plasma", "ScrewAttack"
+            ]
+          }}
         ]}
       ],
-      "note": "The pirates are free to kill, although they take some time."
+      "note": ["Go up safely by killing the Pirates."]
+    },
+    {
+      "link": [1, 4],
+      "name": "Evade Pirates",
+      "requires": [
+        "canDodgeWhileShooting",
+        {"or": [
+          "HiJump",
+          "canWalljump",
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"or": [
+              "SpaceJump",
+              "canSpringBallJumpMidAir"
+            ]}
+          ]}
+        ]}
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Tank Damage",
+      "requires": [
+        "canCarefulJump",
+        {"enemyDamage": {
+          "enemy": "Tourian Space Pirate (all)",
+          "type": "contact",
+          "hits": 2
+        }},
+        {"or": [
+          "HiJump",
+          "canWalljump",
+          {"and": [
+            "canTrickyJump",
+            {"or": [
+              "SpaceJump",
+              "canSpringBallJumpMidAir"
+            ]}
+          ]}
+        ]}
+      ]
     },
     {
       "id": 35,

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -323,7 +323,6 @@
         }},
         {"or": [
           "HiJump",
-          "canWalljump",
           {"and": [
             "canTrickyJump",
             {"or": [


### PR DESCRIPTION
With nothing, killing all the Pirates here takes quite a long time, which doesn't seem fair for Basic. And even for Hard, if you were in a situation where you really had to kill them (e.g. walljumpless with IBJ) and had no weapons, I think it would feel pretty bad. So this splits off "Evade Pirates" and "Tank Damage" strats from the "Base" kill strat. There could possibly be more options here, so let me know if I missed something.