### PR TITLE
Refine fast pillars setup top-left x-ray climb

### DIFF
--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -476,21 +476,40 @@
       "requires": [
         "canXRayClimb",
         {"enemyDamage": {
-          "enemy": "Yellow Space Pirate (wall)",
-          "type": "contact",
-          "hits": 2
+          "enemy": "Yellow Space Pirate (standing)",
+          "type": "laser",
+          "hits": 1
         }},
-        {"enemyKill": {
-          "enemies": [["Yellow Space Pirate (standing)", "Yellow Space Pirate (wall)"]],
-          "explicitWeapons": ["Missile", "Super"]
-        }},
+        {"or": [
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"enemyKill": {
+              "enemies": [["Yellow Space Pirate (standing)", "Yellow Space Pirate (wall)"]],
+              "explicitWeapons": ["Super", "Charge+Plasma"]
+            }}  
+          ]},
+          {"and": [
+            {"enemyDamage": {
+              "enemy": "Yellow Space Pirate (wall)",
+              "type": "contact",
+              "hits": 1
+            }},
+            {"enemyKill": {
+              "enemies": [["Yellow Space Pirate (standing)", "Yellow Space Pirate (wall)"]],
+              "explicitWeapons": ["Missile", "Super", "Charge+Plasma"]
+            }}    
+          ]}
+        ]},
         {"heatFrames": 1260}
       ],
       "flashSuitChecked": true,
       "note": [
         "X-Ray climb up the left wall in order to jump to the center platform.",
-        "Quickly kill the pirates using ammo before beginning the X-Ray climb.",
+        "Quickly kill the pirates before beginning the X-Ray climb.",
         "Climb to just above the door shell and do a turnaround spinjump to reach the platform."
+      ],
+      "devNote": [
+        "FIXME: other weapons could work for killing the Pirates, with more damage taken."
       ]
     },
     {


### PR DESCRIPTION
Sam's video shows doing this with 6 Supers while only taking one Pirate laser hit: https://videos.maprando.com/video/5964. I tried it out and found it works reliably; it's just a little tricky because of the long cooldown coming out of X-ray, and it helps to fire the last shot diagonally. Found that Charge+Plasma also works reliably, with a similar degree of trickiness.
