### PR TITLE
Adjust PCJR mella climb patience reqs

### DIFF
--- a/region/norfair/crocomire/Post Crocomire Jump Room.json
+++ b/region/norfair/crocomire/Post Crocomire Jump Room.json
@@ -1388,6 +1388,10 @@
         {"or": [
           {"obstaclesCleared": ["B"]},
           "Morph"
+        ]},
+        {"or": [
+          "canWalljump",
+          "canSpringBallJumpMidAir"
         ]}
       ],
       "note": [
@@ -1402,11 +1406,11 @@
       "requires": [
         "canTrickyUseFrozenEnemies",
         "canManipulateMellas",
+        "canBePatient",
         {"or": [
-          {"and": [
-            "canBePatient",
-            "canWalljump"
-          ]},
+          "canWalljump",
+          "HiJump",
+          "canSpringBallJumpMidAir",
           "canBeVeryPatient"
         ]},
         {"or": [


### PR DESCRIPTION
With HiJump only (no wall jump or Spring Ball), reaching the PCJR item with frozen Mella is pretty slow, so I think it needs `canBePatient` tech. With HiJump and either walljump or Spring Ball jump, it seems fine to stay in Expert. Conversely, it seems that canBeVeryPatient is only needed if none of walljump, HiJump or Spring Ball are available. 