### PR TITLE
Kraid X-mode leave shinecharged

### DIFF
--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -231,7 +231,7 @@
     {
       "id": 2,
       "link": [1, 1],
-      "name": "Leave Shinecharged",
+      "name": "Leave Shinecharged (Kraid Defeated)",
       "requires": [
         {"canShineCharge": {"usedTiles": 22, "openEnd": 0}},
         "canShinechargeMovement",
@@ -241,8 +241,46 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Shinecharged (X-Mode or Kraid Defeated)",
+      "requires": [
+        "canXMode",
+        "h_XModeThornHit",
+        "h_XModeThornHit",
+        "h_shinechargeMaxRunway",
+        {"or": [
+          {"canShineCharge": {"usedTiles": 22, "openEnd": 0}},
+          {"and": [
+            {"not": "f_DefeatedKraid"},
+            "canRiskPermanentLossOfAccess"
+          ]}
+        ]},
+        "canShinechargeMovement",
+        {"shineChargeFrames": 55},
+        {"or": [
+          {"and": [
+            "canNeutralDamageBoost",
+            "canBeVeryPatient"
+          ]},
+          {"shineChargeFrames": 10}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
       "flashSuitChecked": true,
-      "devNote": "An X-Mode strat is likely possible but not included. It would require the doors unlocked and canRiskPermanentLossOfAccess."
+      "note": [
+        "If Kraid is alive, use X-mode on the thorns to gain a shinecharge.",
+        "While running on the thorns, Samus' will be flashing as i-frames continually refresh;",
+        "by timing the shinecharge and X-Ray release to happen just before i-frames run out,",
+        "Samus can get a neutral damage boost to quickly put her on the ledge."
+      ],
+      "devNote": [
+        "If Kraid is alive, leaving with a horizontal damage boost is also possible, but not easy to model."
+      ]
     },
     {
       "id": 3,


### PR DESCRIPTION
We had a note about this one, suggesting it was left out because canRiskPermanentLossOfAccess would be required, but it's not really because gaining a shinecharge is also possible with Kraid dead.

Videos:
- the one Sam recently shared: https://videos.maprando.com/video/6505
- variation with a neutral damage boost: https://videos.maprando.com/video/6506