### PR TITLE
Refine Big Pink tricky spring ball bounce strat

### DIFF
--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -3029,10 +3029,12 @@
       "link": [13, 4],
       "name": "Leave With Temporary Blue (Tricky Spring Ball Bounce)",
       "requires": [
+        {"notable": "Return Through Crumble Blocks"},
         {"obstaclesCleared": ["C"]},
         {"canShineCharge": {"usedTiles": 16, "openEnd": 0}},
         "canTrickySpringBallBounce",
-        "canChainTemporaryBlue"
+        "canChainTemporaryBlue",
+        "canInsaneJump"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}


### PR DESCRIPTION
Here in Big Pink as in other rooms like Final Missile Bombway or Warehouse Zeela Room, precise unmorphing at the end of a tunnel blue spring ball bounce seems to fit better in Extreme than Expert, especially considering that after getting the trick you likely have to continue chaining it in the next room. So this adds a `canInsaneJump` requirement.

Also adds a `{"notable": "Return Through Crumble Blocks"}` since it is applicable and can help clarify what's happening in the strat.