### PR TITLE
Ridley G-mode and ridleyKill requirement

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -670,7 +670,7 @@ If neither Morph nor Screw Attack are available, then at the highest skill level
 A `ridleyKill` requirement has the following optional properties which modify the assumptions of the fight:
 - _powerBombs_: A boolean indicating if Power Bombs can be used during the fight (default: true).
 - _gMode_: A boolean indicating if the fight happens in G-mode. If true, then Samus will be protected from heat damage, but Ridley's fireballs become invisible and immobile while still being dangerous to Samus.
-- _stuck_: An enum with possible values "top" or "bottom", indicating the part of the room where Ridley gets stuck, allowing Samus can freely avoid damage from Ridley while inflicting damage to Ridley. If Ridley is stuck at the bottom of the room, then damage can be inflicted at a higher rate (not taking into account lag, which may be increased if a Crystal Flash is used in G-mode):
+- _stuck_: An enum with possible values "top" or "bottom", indicating the part of the room where Ridley gets stuck, allowing Samus to freely avoid damage from Ridley while inflicting damage to Ridley. If Ridley is stuck at the bottom of the room, then damage can be inflicted at a higher rate (not taking into account lag, which may be increased if a Crystal Flash is used in G-mode):
   - Supers can be used once every 0.34 seconds.
   - Missiles can be used once every 0.17 seconds.
   - Power Bombs can be used once every 2.65 seconds.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -655,15 +655,13 @@ __Example:__
 
 #### Ridley kill
 
-A `ridleyKill` requirement represents the need to kill Ridley, including ammo and energy requirements depending on the player's assumed skill level and available items. The expected duration of the fight can be estimated based on the following:
+A `ridleyKill` requirement represents the need to kill Ridley, including ammo and energy requirements depending on the player's assumed skill level and available items. The expected duration of the fight can be estimated based on the following assumptions:
 - Supers can be used once every 0.5 seconds.
 - Missiles can be used once every 0.34 seconds.
 - Power Bombs can be used once every 3 seconds.
 - A charged beam shot can be used once every 1.4 seconds.
 
-Patience requirements `canBePatient`, `canBeVeryPatient`, and `canBeExtremelyPatient` should be applied based on the expected duration of the fight.
-
-A leniency multiplier should normally be applied to the time taken between shots, as well as to the accuracy rate of shots hitting Ridley successfully.
+Heat frames are included based on the expected duration of the fight. Patience requirements `canBePatient`, `canBeVeryPatient`, and `canBeExtremelyPatient` are likewise also included. In both cases, a leniency multiplier should be applied to the time taken between shots. Leniency should also be applied based on the assumed accuracy rate of shots hitting Ridley successfully.
 
 Heat frame requirements should be included for the period before the fight begins, as well as after the fight until drops occurs, which can be estimated (slightly generously) at 16 seconds, or 960 heat frames.
 
@@ -672,7 +670,7 @@ If neither Morph nor Screw Attack are available, then at the highest skill level
 A `ridleyKill` requirement has the following optional properties which modify the assumptions of the fight:
 - _powerBombs_: A boolean indicating if Power Bombs can be used during the fight (default: true).
 - _gMode_: A boolean indicating if the fight happens in G-mode. If true, then Samus will be protected from heat damage, but Ridley's fireballs become invisible and immobile while still being dangerous to Samus.
-- _stuck_: An enum with possible values "top" or "bottom", indicating the part of the room where Ridley gets stuck, allowing Samus can freely avoid damage from Ridley while inflicting damage to Ridley. If Ridley is stuck at the bottom of the room, then damage can be inflicted at a higher rate (not taking into account lag, which may be increased by using a Crystal Flash in G-mode):
+- _stuck_: An enum with possible values "top" or "bottom", indicating the part of the room where Ridley gets stuck, allowing Samus can freely avoid damage from Ridley while inflicting damage to Ridley. If Ridley is stuck at the bottom of the room, then damage can be inflicted at a higher rate (not taking into account lag, which may be increased if a Crystal Flash is used in G-mode):
   - Supers can be used once every 0.34 seconds.
   - Missiles can be used once every 0.17 seconds.
   - Power Bombs can be used once every 2.65 seconds.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -7,6 +7,7 @@ A logical requirement is an array of logical elements, which are implicitly link
 * _The name of a tech._ Techs are defined in [tech.json](tech.json).  Those represent a technique that players can perform, which may also imply logical requirements of their own. By convention, a tech's name should start with `can`.
 * _The name of an item._ Those are defined in [items.json](items.json).
 * _The name of a game flag._ Those are defined in [items.json](items.json), and are used to represent game events such as defeating a boss, or breaking the Maridia tube. By convention, a game flag's name should start with `f_`.
+* _"free"._ This indicates a logical element that is automatically fulfilled.
 * _"never"._ This indicates a logical element that cannot be fulfilled under any conditions.
 * More complex elements which will be defined in their own sub-sections
 
@@ -658,8 +659,8 @@ __Example:__
 A `ridleyKill` requirement represents the need to kill Ridley, including ammo and energy requirements depending on the player's assumed skill level and available items. The expected duration of the fight can be estimated based on the following assumptions:
 - Supers can be used once every 0.5 seconds.
 - Missiles can be used once every 0.34 seconds.
-- Power Bombs can be used once every 3 seconds.
 - A charged beam shot can be used once every 1.4 seconds.
+- Power Bombs can be used once every 3 seconds.
 
 Heat frames are included based on the expected duration of the fight. Patience requirements `canBePatient`, `canBeVeryPatient`, and `canBeExtremelyPatient` are likewise also included. In both cases, a leniency multiplier should be applied to the time taken between shots. Leniency should also be applied based on the assumed accuracy rate of shots hitting Ridley successfully.
 
@@ -673,8 +674,8 @@ A `ridleyKill` requirement has the following optional properties which modify th
 - _stuck_: An enum with possible values "top" or "bottom", indicating the part of the room where Ridley gets stuck, allowing Samus to freely avoid damage from Ridley while inflicting damage to Ridley. If Ridley is stuck at the bottom of the room, then damage can be inflicted at a higher rate (not taking into account lag, which may be increased if a Crystal Flash is used in G-mode):
   - Supers can be used once every 0.34 seconds.
   - Missiles can be used once every 0.17 seconds.
-  - Power Bombs can be used once every 2.65 seconds.
   - A charged beam shot can be used once every 1.1 seconds.
+  - Power Bombs can be used once every 2.65 seconds, though because there is no known way to keep Ridley stuck while using Power Bombs, strats should set `powerBombs` to `false` when `stuck` is `true`.
 
 ### Other requirements
 

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -670,8 +670,9 @@ Heat frame requirements should be included for the period before the fight begin
 If neither Morph nor Screw Attack are available, then at the highest skill level it can be assumed that the player takes unavoidable enemy damage at a rate of 10 energy per second. If Morph or Screw Attack is available, then it is possible to avoid all enemy damage, but for leniency normally some damage should still be assumed.
 
 A `ridleyKill` requirement has the following optional properties which modify the assumptions of the fight:
-* _gMode_: A boolean indicating if the fight happens in G-mode. If true, then Samus will be protected from heat damage, but Ridley's fireballs become invisible and immobile while still being dangerous to Samus.
-- _stuck_: A boolean indicating that the fight happens with Ridley stuck in a corner, where Samus can freely avoid damage from Ridley while inflicting damage to Ridley at a higher rate:
+- _powerBombs_: A boolean indicating if Power Bombs can be used during the fight (default: true).
+- _gMode_: A boolean indicating if the fight happens in G-mode. If true, then Samus will be protected from heat damage, but Ridley's fireballs become invisible and immobile while still being dangerous to Samus.
+- _stuck_: An enum with possible values "top" or "bottom", indicating the part of the room where Ridley gets stuck, allowing Samus can freely avoid damage from Ridley while inflicting damage to Ridley. If Ridley is stuck at the bottom of the room, then damage can be inflicted at a higher rate (not taking into account lag, which may be increased by using a Crystal Flash in G-mode):
   - Supers can be used once every 0.34 seconds.
   - Missiles can be used once every 0.17 seconds.
   - Power Bombs can be used once every 2.65 seconds.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -651,6 +651,32 @@ __Example:__
 {"noFlashSuit": {}}
 ```
 
+### Boss requirements
+
+#### Ridley kill
+
+A `ridleyKill` requirement represents the need to kill Ridley, including ammo and energy requirements depending on the player's assumed skill level and available items. The expected duration of the fight can be estimated based on the following:
+- Supers can be used once every 0.5 seconds.
+- Missiles can be used once every 0.34 seconds.
+- Power Bombs can be used once every 3 seconds.
+- A charged beam shot can be used once every 1.4 seconds.
+
+Patience requirements `canBePatient`, `canBeVeryPatient`, and `canBeExtremelyPatient` should be applied based on the expected duration of the fight.
+
+A leniency multiplier should normally be applied to the time taken between shots, as well as to the accuracy rate of shots hitting Ridley successfully.
+
+Heat frame requirements should be included for the period before the fight begins, as well as after the fight until drops occurs, which can be estimated (slightly generously) at 16 seconds, or 960 heat frames.
+
+If neither Morph nor Screw Attack are available, then at the highest skill level it can be assumed that the player takes unavoidable enemy damage at a rate of 10 energy per second. If Morph or Screw Attack is available, then it is possible to avoid all enemy damage, but for leniency normally some damage should still be assumed.
+
+A `ridleyKill` requirement has the following optional properties which modify the assumptions of the fight:
+* _gMode_: A boolean indicating if the fight happens in G-mode. If true, then Samus will be protected from heat damage, but Ridley's fireballs become invisible and immobile while still being dangerous to Samus.
+- _stuck_: A boolean indicating that the fight happens with Ridley stuck in a corner, where Samus can freely avoid damage from Ridley while inflicting damage to Ridley at a higher rate:
+  - Supers can be used once every 0.34 seconds.
+  - Missiles can be used once every 0.17 seconds.
+  - Power Bombs can be used once every 2.65 seconds.
+  - A charged beam shot can be used once every 1.1 seconds.
+
 ### Other requirements
 
 #### tech object

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -401,7 +401,8 @@
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
-          "morphed": false
+          "morphed": false,
+          "mobility": "mobile"
         }
       },
       "requires": [

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -407,21 +407,40 @@
       "requires": [
         {"notable": "G-Mode Crystal Flash Stuck Ridley"},
         "h_CrystalFlash",
-        {"or": [
-          "canArtificialMorph",
-          "canWalljump"
-        ]},
         "h_usePowerBomb",
-        {"ridleyKill": {"gMode": true, "stuck": true}},
+        {"or": [
+          {"and": [
+            {"or": [
+              "canWalljump",
+              "HiJump",
+              "canSpringBallJumpMidAir",
+              "SpaceJump"
+            ]},
+            {"ridleyKill": {
+              "powerBombs": false,
+              "gMode": true,
+              "stuck": "bottom"}
+            }
+          ]},
+          {"ridleyKill": {
+            "powerBombs": false,
+            "gMode": true,
+            "stuck": "top"
+          }}
+        ]},
         {"autoReserveTrigger": {}},
-        {"heatFrames": 600},
+        {"heatFrames": 720},
         {"partialRefill": {"type": "Energy", "limit": 100}}
       ],
       "setsFlags": ["f_DefeatedRidley"],
       "note": [
-        "Enter the room in G-mode, perform a Crystal Flash, then lay a Power Bomb in the top-right.",
-        "The Power Bomb will not explode but will continually force Ridley into the lower-left of the room.",
-        "After reducing Ridley's health to zero, take damage from Ridley to trigger auto-reserves and exit G-mode.",
+        "Enter the room in G-mode, perform a Crystal Flash, then lay an additional Power Bomb, preferably at the top of the room.",
+        "The Power Bomb will not explode but will continually force Ridley into a corner of the room.",
+        "If the Power Bomb is laid near the top of the room, then Ridley will be forced into the bottom of the room,",
+        "making it easy to damage Ridley at the highest possible rate;",
+        "if the Power Bomb is laid lower, Ridley will be forced to the top of room, and Samus will have to jump repeatedly to bring it on camera.",
+        "in which case Ridley can still be damaged but more slowly and with some caution needed to avoid invisible fireballs.",
+        "After reducing Ridley's health to zero, take damage from Ridley or an invisible fireball to trigger auto-reserves and exit G-mode.",
         "Then get grabbed by Ridley to finish the fight."
       ]
     },
@@ -648,22 +667,45 @@
       "requires": [
         {"notable": "G-Mode Crystal Flash Stuck Ridley"},
         "h_CrystalFlash",
-        {"or": [
-          "canArtificialMorph",
-          "canWalljump"
-        ]},
         "h_usePowerBomb",
-        {"ridleyKill": {"gMode": true, "stuck": true}},
+        {"or": [
+          {"and": [
+            {"or": [
+              "canWalljump",
+              "HiJump",
+              "canSpringBallJumpMidAir",
+              "SpaceJump"
+            ]},
+            {"ridleyKill": {
+              "powerBombs": false,
+              "gMode": true,
+              "stuck": "bottom"}
+            }
+          ]},
+          {"ridleyKill": {
+            "powerBombs": false,
+            "gMode": true,
+            "stuck": "top"
+          }}
+        ]},
         {"autoReserveTrigger": {}},
-        {"heatFrames": 600},
+        {"heatFrames": 720},
         {"partialRefill": {"type": "Energy", "limit": 100}}
       ],
       "setsFlags": ["f_DefeatedRidley"],
       "note": [
-        "Enter the room in G-mode, perform a Crystal Flash, then lay a Power Bomb in the top-right.",
-        "The Power Bomb will not explode but will continually force Ridley into the lower-left of the room.",
-        "After reducing Ridley's health to zero, take damage from Ridley to trigger auto-reserves and exit G-mode.",
+        "Enter the room in G-mode, perform a Crystal Flash, then lay an additional Power Bomb, preferably at the top of the room.",
+        "The Power Bomb will not explode but will continually force Ridley into a corner of the room.",
+        "If the Power Bomb is laid near the top of the room, then Ridley will be forced into the bottom of the room,",
+        "making it easy to damage Ridley at the highest possible rate;",
+        "if the Power Bomb is laid lower, Ridley will be forced to the top of room, and Samus will have to jump repeatedly to bring it on camera.",
+        "in which case Ridley can still be damaged but more slowly and with some caution needed to avoid invisible fireballs.",
+        "After reducing Ridley's health to zero, take damage from Ridley or an invisible fireball to trigger auto-reserves and exit G-mode.",
         "Then get grabbed by Ridley to finish the fight."
+      ],
+      "devNote": [
+        "FIXME: artificial morph with direct G-mode is another option for laying a Power Bomb at the top of the room,",
+        "by landing on the door ledge on entry."
       ]
     },
     {

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -452,7 +452,8 @@
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
-          "morphed": false
+          "morphed": false,
+          "mobility": "mobile"
         }
       },
       "requires": [
@@ -670,7 +671,8 @@
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
-          "morphed": false
+          "morphed": false,
+          "mobility": "mobile"
         }
       },
       "requires": [
@@ -724,7 +726,8 @@
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
-          "morphed": false
+          "morphed": false,
+          "mobility": "mobile"
         }
       },
       "requires": [

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -407,6 +407,7 @@
       },
       "requires": [
         {"notable": "G-Mode Crystal Flash Stuck Ridley"},
+        "h_heatedGMode",
         "h_CrystalFlash",
         "h_usePowerBomb",
         {"or": [
@@ -430,7 +431,7 @@
           }}
         ]},
         {"autoReserveTrigger": {}},
-        {"heatFrames": 720},
+        {"heatFrames": 520},
         {"partialRefill": {"type": "Energy", "limit": 100}}
       ],
       "setsFlags": ["f_DefeatedRidley"],
@@ -456,9 +457,17 @@
       },
       "requires": [
         {"notable": "G-Mode Ridley with 30 Supers"},
+        "h_heatedGMode",
         {"heatFrames": 0},
         {"ammo": {"type": "Super", "count": 30}},
-        {"partialRefill": {"type": "Energy", "limit": 100}}
+        {"or": [
+          {"and": [
+            "canPauseAbuse",
+            {"resourceAtMost": [{"type": "Energy", "count": 1}]},
+            {"partialRefill": {"type": "Energy", "limit": 100}}
+          ]},
+          "free"
+        ]}
       ],
       "setsFlags": ["f_DefeatedRidley"],
       "note": [
@@ -467,11 +476,10 @@
         "As long as Ridley is swooping, not many fireballs will be placed, so delaying Ridley from pogoing can be helpful.",
         "Once Ridley begins pogoing, it generally becomes unsafe for Samus to jump high because of the risk of touching a fireball.",
         "By the end of the fight, projectiles will probably be overloaded, causing Ridley's drops not to spawn;",
-        "to solve this, exit G-mode just before drops spawn, and pause abuse in order to collect them."
+        "they can be collected by exiting G-mode just before drops spawn, and pause abusing if necessary."
       ],
       "devNote": [
-        "Leaving back through the open door while still in G-Mode can also be possible,",
-        "but the risk of hitting a fireball is probably too high for that to be reasonable."
+        "FIXME: Leaving back through the open door while still in G-Mode is also possible, and free to do."
       ]
     },
     {
@@ -667,6 +675,7 @@
       },
       "requires": [
         {"notable": "G-Mode Crystal Flash Stuck Ridley"},
+        "h_heatedGMode",
         "h_CrystalFlash",
         "h_usePowerBomb",
         {"or": [
@@ -690,7 +699,7 @@
           }}
         ]},
         {"autoReserveTrigger": {}},
-        {"heatFrames": 720},
+        {"heatFrames": 520},
         {"partialRefill": {"type": "Energy", "limit": 100}}
       ],
       "setsFlags": ["f_DefeatedRidley"],
@@ -706,7 +715,7 @@
       ],
       "devNote": [
         "FIXME: artificial morph with direct G-mode is another option for laying a Power Bomb at the top of the room,",
-        "by landing on the door ledge on entry."
+        "by landing on the door ledge on entry (the Morph item would still be needed since the Crystal Flash forces Samus out of being morphed)."
       ]
     },
     {
@@ -720,9 +729,17 @@
       },
       "requires": [
         {"notable": "G-Mode Ridley with 30 Supers"},
+        "h_heatedGMode",
         {"heatFrames": 0},
         {"ammo": {"type": "Super", "count": 30}},
-        {"partialRefill": {"type": "Energy", "limit": 100}}
+        {"or": [
+          {"and": [
+            "canPauseAbuse",
+            {"resourceAtMost": [{"type": "Energy", "count": 1}]},
+            {"partialRefill": {"type": "Energy", "limit": 100}}
+          ]},
+          "free"
+        ]}
       ],
       "setsFlags": ["f_DefeatedRidley"],
       "note": [
@@ -731,8 +748,11 @@
         "As long as Ridley is swooping, not many fireballs will be placed, so delaying Ridley from pogoing can be helpful.",
         "Once Ridley begins pogoing, it generally becomes unsafe for Samus to jump high because of the risk of touching a fireball.",
         "By the end of the fight, projectiles will probably be overloaded, causing Ridley's drops not to spawn;",
-        "to solve this, exit G-mode just before drops spawn, and pause abuse in order to collect them.",
-        "Leaving back through the open door while still in G-mode is also possible."
+        "they can be collected by exiting G-mode just before drops spawn, and pause abusing if necessary."
+      ],
+      "devNote": [
+        "FIXME: Leaving back through the open door while still in G-Mode is also possible,",
+        "but difficult to do without touching an invisible fireball."
       ]
     },
     {
@@ -857,7 +877,7 @@
       "id": 2,
       "name": "G-Mode Crystal Flash Stuck Ridley",
       "note": [
-        "In G-mode, use a Crystal Flash and additional Power Bomb to get Ridley stuck at the bottom-left of the room.",
+        "In G-mode, use a Crystal Flash and an additional Power Bomb to get Ridley stuck in a corner of the room.",
         "To end the fight, exit G-mode by using damage from Ridley to trigger auto-reserves."
       ]
     },

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -396,6 +396,65 @@
       ]
     },
     {
+      "link": [1, 3],
+      "name": "G-Mode Crystal Flash Stuck Ridley",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Crystal Flash Stuck Ridley"},
+        "h_CrystalFlash",
+        {"or": [
+          "canArtificialMorph",
+          "canWalljump"
+        ]},
+        "h_usePowerBomb",
+        {"ridleyKill": {"gMode": true, "stuck": true}},
+        {"autoReserveTrigger": {}},
+        {"heatFrames": 600},
+        {"partialRefill": {"type": "Energy", "limit": 100}}
+      ],
+      "setsFlags": ["f_DefeatedRidley"],
+      "note": [
+        "Enter the room in G-mode, perform a Crystal Flash, then lay a Power Bomb in the top-right.",
+        "The Power Bomb will not explode but will continually force Ridley into the lower-left of the room.",
+        "After reducing Ridley's health to zero, take damage from Ridley to trigger auto-reserves and exit G-mode.",
+        "Then get grabbed by Ridley to finish the fight."
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "G-Mode Ridley with 30 Supers",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Ridley with 30 Supers"},
+        {"heatFrames": 0},
+        {"ammo": {"type": "Super", "count": 30}},
+        {"partialRefill": {"type": "Energy", "limit": 100}}
+      ],
+      "setsFlags": ["f_DefeatedRidley"],
+      "note": [
+        "Enter the room in G-mode and quickly kill Ridley with 30 Supers.",
+        "G-mode protects against heat damage but also causes Ridley's fireballs to be invisible and not move.",
+        "As long as Ridley is swooping, not many fireballs will be placed, so delaying Ridley from pogoing can be helpful.",
+        "Once Ridley begins pogoing, it generally becomes unsafe for Samus to jump high because of the risk of touching a fireball.",
+        "By the end of the fight, projectiles will probably be overloaded, causing Ridley's drops not to spawn;",
+        "to solve this, exit G-mode just before drops spawn, and pause abuse in order to collect them."
+      ],
+      "devNote": [
+        "Leaving back through the open door while still in G-Mode can also be possible,",
+        "but the risk of hitting a fireball is probably too high for that to be reasonable."
+      ]
+    },
+    {
       "id": 4,
       "link": [2, 2],
       "name": "Leave With Runway",
@@ -578,6 +637,62 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 3],
+      "name": "G-Mode Crystal Flash Stuck Ridley",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Crystal Flash Stuck Ridley"},
+        "h_CrystalFlash",
+        {"or": [
+          "canArtificialMorph",
+          "canWalljump"
+        ]},
+        "h_usePowerBomb",
+        {"ridleyKill": {"gMode": true, "stuck": true}},
+        {"autoReserveTrigger": {}},
+        {"heatFrames": 600},
+        {"partialRefill": {"type": "Energy", "limit": 100}}
+      ],
+      "setsFlags": ["f_DefeatedRidley"],
+      "note": [
+        "Enter the room in G-mode, perform a Crystal Flash, then lay a Power Bomb in the top-right.",
+        "The Power Bomb will not explode but will continually force Ridley into the lower-left of the room.",
+        "After reducing Ridley's health to zero, take damage from Ridley to trigger auto-reserves and exit G-mode.",
+        "Then get grabbed by Ridley to finish the fight."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "G-Mode Ridley with 30 Supers",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Ridley with 30 Supers"},
+        {"heatFrames": 0},
+        {"ammo": {"type": "Super", "count": 30}},
+        {"partialRefill": {"type": "Energy", "limit": 100}}
+      ],
+      "setsFlags": ["f_DefeatedRidley"],
+      "note": [
+        "Enter the room in G-mode and quickly kill Ridley with 30 Supers.",
+        "G-mode protects against heat damage but also causes Ridley's fireballs to be invisible and not move.",
+        "As long as Ridley is swooping, not many fireballs will be placed, so delaying Ridley from pogoing can be helpful.",
+        "Once Ridley begins pogoing, it generally becomes unsafe for Samus to jump high because of the risk of touching a fireball.",
+        "By the end of the fight, projectiles will probably be overloaded, causing Ridley's drops not to spawn;",
+        "to solve this, exit G-mode just before drops spawn, and pause abuse in order to collect them.",
+        "Leaving back through the open door while still in G-mode is also possible."
+      ]
+    },
+    {
       "id": 9,
       "link": [3, 1],
       "name": "Base",
@@ -662,9 +777,7 @@
       "name": "Heat Proof Ridley",
       "requires": [
         "h_heatProof",
-        {"enemyKill": {
-          "enemies": [["Ridley"]]
-        }}
+        {"ridleyKill": {}}
       ],
       "setsFlags": ["f_DefeatedRidley"]
     },
@@ -675,9 +788,7 @@
       "requires": [
         {"notable": "Ridley without Heat Protection"},
         {"heatFrames": 0},
-        {"enemyKill": {
-          "enemies": [["Ridley"]]
-        }}
+        {"ridleyKill": {}}
       ],
       "setsFlags": ["f_DefeatedRidley"],
       "note": "Fight Ridley without immunity to heat damage.",
@@ -698,8 +809,24 @@
       "id": 1,
       "name": "Ridley without Heat Protection",
       "note": "Fight Ridley without immunity to heat damage."
+    },
+    {
+      "id": 2,
+      "name": "G-Mode Crystal Flash Stuck Ridley",
+      "note": [
+        "In G-mode, use a Crystal Flash and additional Power Bomb to get Ridley stuck at the bottom-left of the room.",
+        "To end the fight, exit G-mode by using damage from Ridley to trigger auto-reserves."
+      ]
+    },
+    {
+      "id": 3,
+      "name": "G-Mode Ridley with 30 Supers",
+      "note": [
+        "In G-Mode, use 30 Supers to end the fight quickly, carefully avoiding the invisible fireballs that Ridley spawns.",
+        "Use X-Ray to exit G-Mode precisely at the end of the fight just before drops spawn."
+      ]
     }
   ],
   "nextStratId": 27,
-  "nextNotableId": 2
+  "nextNotableId": 4
 }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -850,15 +850,21 @@
             "description": "Fulfilled by killing Ridley, including ammo, energy, and skill requirements.",
             "additionalProperties": false,
             "properties": {
+              "powerBombs": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether Power Bombs can be used during the fight."
+              },
               "gMode": {
                 "type": "boolean",
                 "default": false,
                 "description": "Whether the Ridley kill happens while in G-mode, preventing heat damage while making Ridley's fireballs immobile."
               },
               "stuck": {
-                "type": "boolean",
-                "default": false,
-                "description": "Whether the Ridley kill happens with Ridley stuck in a corner, preventing body damage."
+                "type": "string",
+                "enum": [null, "top", "bottom"],
+                "default": null,
+                "description": "If applicable, the part of the room where Ridley is stuck."
               }
             }
           }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -844,6 +844,23 @@
             "type": "string",
             "title": "Disable Equipment",
             "description": "A requirement to disable a specific item."
+          },
+          "ridleyKill": {
+            "type": "object",
+            "description": "Fulfilled by killing Ridley, including ammo, energy, and skill requirements.",
+            "additionalProperties": false,
+            "properties": {
+              "gMode": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether the Ridley kill happens while in G-mode, preventing heat damage while making Ridley's fireballs immobile."
+              },
+              "stuck": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether the Ridley kill happens with Ridley stuck in a corner, preventing body damage."
+              }
+            }
           }
         }
       }

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -588,6 +588,7 @@ with open(keywordsPath, encoding="utf-8") as keywordsFile:
 
 keywords["values"] = [
     "never",
+    "free",
     "spinjump"
 ]
 


### PR DESCRIPTION
This replaces the Ridley `enemyKill` requirement with a new logical requirement `ridleyKill`, with some documentation on how the ammo/energy can be calculated. This way it's less of a magical thing happening on the randomizer side. I would like to do this same sort of thing with the other bosses. With this, the existing boss scenarios could probably be removed.

The new G-mode CF Ridley strats still require handling different combinations of ammo/beams/patience which would be unreasonably complicated to handle precisely without the boss calculation, which is the motivation for supporting this using `gMode` and `stuck` properties inside the `ridleyKill` object. The existing `enemyKill` schema was limiting because it didn't allow us to include boss-specific properties like this.

Doing a regular fight in G-mode (i.e. not using a CF to get Ridley stuck) could be possible with less than 30 Supers but I'm not sure if there's a reliable enough method to avoid the invisible fireballs if the fight goes on long. If someone figures that out, it could be added later. The combinations `{"ridleyKill": {"gMode": false, "stuck": true}}` and `{"ridleyKill": {"gMode": true, "stuck": false}}` would not be used currently, but possibly could later if strats are worked out for them.

Videos:
- Crystal Flash Ridley stuck, by Sam: https://videos.maprando.com/video/2488
- 30 Supers: https://videos.maprando.com/video/6508