### PR TITLE
Refine some Metroid Room 2 shinecharges

### DIFF
--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -414,8 +414,9 @@
       "note": [
         "If Metroids are alive, minimizing damage from them requires tricky movement to manipulate them:",
         "the moonfalling option must be done starting from almost a tile to the left of the opening;",
-        "likewise, the morphing option should soft-morph about a tile to the left of the opening. "
-      ]
+        "likewise, the morphing option should soft-morph about a tile to the left of the opening."
+      ],
+      "devNote": ["FIXME: Unmorphing and downbacking through the gap can leave with more frames remaining but is more difficult."]
     },
     {
       "id": 20,

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -805,8 +805,8 @@
         "Go up the left side of the room to make it out the top door with a few shinecharge frames remaining."
       ],
       "detailNote": [
-        "Do a big initial jump to land in the middle of the lower platform,",
-        "and jump before running more than 2.75 tiles, to avoid a Speed Booster dropoff in jump height."
+        "Avoid getting more than 2.75 tiles of run speed on the lower platform (or Speed Booster will shorten Samus' jump):",
+        "either release run early, or do a big initial jump to land in the middle of the lower platform before starting to run."
       ]
     },
     {

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -389,11 +389,16 @@
         "canShinechargeMovementTricky",
         {"or": [
           "canMoonfall",
-          "Morph"
+          "Morph",
+          "canTwoTileSqueeze"
         ]},
         {"or": [
           "f_KilledMetroidRoom2",
-          {"metroidFrames": 25}
+          {"metroidFrames": 100},
+          {"and": [
+            "canInsaneJump",
+            {"metroidFrames": 10}
+          ]}
         ]}
       ],
       "exitCondition": {
@@ -660,7 +665,9 @@
       "note": [
         "Not pressing dash will make the platforming easier, unless HiJump is also equipped."
       ],
-      "devNote": "Metroids randomly block shots fired and can make opening the door unreliable."
+      "devNote": [
+        "FIXME: Add variations for tanking the Metroid damage (taking into account how they can block the shot to open the door)"
+      ]
     },
     {
       "id": 34,
@@ -694,7 +701,9 @@
       ],
       "flashSuitChecked": true,
       "note": ["Spinjump into the opening below the top door."],
-      "devNote": "Metroids randomly block shots fired and can make opening the door unreliable."
+      "devNote": [
+        "FIXME: Add variations for tanking the Metroid damage (taking into account how they can block the shot to open the door)"
+      ]
     },
     {
       "id": 35,
@@ -724,7 +733,9 @@
         "Wall jump up the right wall and either mid-air morph to fit through the gap below the top door.",
         "Alternatively use a mid-air wiggle to reduce the height of Samus' hitbox after the walljump, to be able to fit through the gap without morphing."
       ],
-      "devNote": "Metroids randomly block shots fired and can make opening the door unreliable."
+      "devNote": [
+        "FIXME: Add variations for tanking the Metroid damage (taking into account how they can block the shot to open the door)"
+      ]
     },
     {
       "id": 36,
@@ -754,7 +765,49 @@
       "note": [
         "Use a mid-air wiggle to reduce the height of Samus' hitbox after the walljump, to be able to fit through the gap without morphing."
       ],
-      "devNote": "Metroids randomly block shots fired and can make opening the door unreliable."
+      "devNote": [
+        "FIXME: Add variations for tanking the Metroid damage (taking into account how they can block the shot to open the door)"
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharging, Leave Shinecharged (Left Side, Tricky Dash Jump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"shineChargeFrames": 170},
+        "canTrickyDashJump",
+        "canShinechargeMovementTricky",
+        {"or": [
+          "f_KilledMetroidRoom2",
+          "ScrewAttack",
+          {"metroidFrames": 160}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": [
+          {"or": [
+            "f_KilledMetroidRoom2",
+            "ScrewAttack"
+          ]}
+        ]},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Go up the left side of the room to make it out the top door with a few shinecharge frames remaining."
+      ],
+      "detailNote": [
+        "Do a big initial jump to land in the middle of the lower platform,",
+        "and jump before running more than 2.75 tiles, to avoid a Speed Booster dropoff in jump height."
+      ]
     },
     {
       "id": 37,
@@ -930,6 +983,62 @@
         "Wall jump up the right wall and use a mid-air wiggle to reduce the height of Samus' hitbox after the walljump, to be able to fit through the gap without morphing.",
         "Shoot the door open and spark out."
       ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharged, Leave With Spark (Left Side, Tricky Dash Jump)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 130},
+        "canTrickyDashJump",
+        "canShinechargeMovementTricky",
+        {"or": [
+          {"and": [
+            {"or": [
+              "f_KilledMetroidRoom2",
+              "ScrewAttack",
+              {"and": [
+                {"metroidFrames": 145},
+                {"or": [
+                  "Plasma",
+                  {"ammo": {"type": "Missile", "count": 1}}
+                ]}
+              ]}
+            ]},
+            {"shinespark": {"frames": 13}}  
+          ]},
+          {"and": [
+            {"metroidFrames": 150},
+            {"shineChargeFrames": 10},
+            {"shinespark": {"frames": 7}}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": [
+          {"or": [
+            "f_KilledMetroidRoom2",
+            "ScrewAttack"
+          ]}
+        ]},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Go up the left side of the room and spark out the top door.",
+        "If tanking Metroid damage, then the Metroid can block the shot to open the door;",
+        "to avoid this, it is expected to either jump with dash speed or to use Plasma or a Missile."
+      ],
+      "detailNote": [
+        "Do a big initial jump to land in the middle of the lower platform,",
+        "and jump before running more than 2.75 tiles, to avoid a Speed Booster dropoff in jump height."
+      ]
+
     },
     {
       "id": 43,

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -1003,6 +1003,7 @@
                 {"metroidFrames": 145},
                 {"or": [
                   "Plasma",
+                  "Wave",
                   {"ammo": {"type": "Missile", "count": 1}}
                 ]}
               ]}
@@ -1032,7 +1033,7 @@
       "note": [
         "Go up the left side of the room and spark out the top door.",
         "If tanking Metroid damage, then the Metroid can block the shot to open the door;",
-        "to avoid this, it is expected to either jump with dash speed or to use Plasma or a Missile."
+        "to avoid this, either jump toward the door with dash speed or use Plasma, Wave, or a Missile."
       ],
       "detailNote": [
         "Do a big initial jump to land in the middle of the lower platform,",

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -349,7 +349,8 @@
         {"types": ["powerbomb"], "requires": []},
         {"types": ["missiles", "super"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "devNote": "FIXME: refine this and add a canTwoTileSqueeze option."
     },
     {
       "id": 18,
@@ -397,6 +398,7 @@
           {"metroidFrames": 100},
           {"and": [
             "canInsaneJump",
+            "canTrickyDodgeEnemies",
             {"metroidFrames": 10}
           ]}
         ]}
@@ -408,7 +410,12 @@
         {"types": ["powerbomb"], "requires": []},
         {"types": ["missiles", "super"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "If Metroids are alive, minimizing damage from them requires tricky movement to manipulate them:",
+        "the moonfalling option must be done starting from almost a tile to the left of the opening;",
+        "likewise, the morphing option should soft-morph about a tile to the left of the opening. "
+      ]
     },
     {
       "id": 20,


### PR DESCRIPTION
I started going through the backlog of Incomplete videos by Sam and saw several strat options were missing for going up the left side of Metroid Room 2. These are mostly walljump-avoid strats, but not strictly since they also avoid `canMidairWiggle` tech. 

There's also a two-tile squeeze strat for top-to-bottom which surprisingly appears slightly faster than the moonfall and Morph variants. The difference seemed not quite enough to justify tightening the shinecharge frames though. It feels more difficult than the moonfall/Morph options overall but easier to avoid Metroid damage so it can be a viable strat. The Metroid damage scaling for this strat in general (across all the variants) seemed a bit unreasonable, because if you don't do it just right then you take like 10x more Metroid damage; so I split off a "canInsaneJump" option.

Videos for all the new strats/variants on the video site.