### PR TITLE
Refine Fish Tank 5->4 wall jump option

### DIFF
--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -2613,7 +2613,10 @@
       "requires": [
         "Gravity",
         {"or": [
-          "canConsecutiveWalljump",
+          {"and": [
+            "HiJump",
+            "canWalljump"
+          ]},
           "canPreciseWalljump",
           "SpaceJump",
           "canUseFrozenEnemies"


### PR DESCRIPTION
With HiJump, I think this wall jump should be ok in Basic.

Without HiJump, I think it needs a `canPreciseWalljump`. Doing more than 2 wall jumps doesn't seem helpful here so I think `canConsecutiveWalljump` wouldn't be relevant.