### PR TITLE
Downward G-mode setup, wall ice clip method

### DIFF
--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -492,8 +492,9 @@
       },
       "flashSuitChecked": true,
       "note": [
-        "Run from the ledge into the open doorway while hitting the frozen Crab as it thaws and the door transition simultaneously.",
-        "Note that this requires a pixel perfect freeze, a small pixel starting window, and has tight timing. It then has a 50% success rate due to collision oscillation."
+        "Run from the ledge into the open doorway while hitting the frozen crab and the door transition simultaneously, just as the crab thaws and touches Samus during the transition.",
+        "Note that this requires a precise freeze (2 pixel window), a small pixel starting window (approximately 2 pixel window), precise thaw timing, and a 50% success rate due to collision oscillation.",
+        "The positioning of the crab is where its hitbox is one or two pixels away from the edge of the door frame, so that Samus can clip into the wall and stand as she touches the transition."
       ]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -298,6 +298,24 @@
       "note": "Use a Super to knock off the Viola to regain mobility."
     },
     {
+      "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit by Thawing Viola",
+      "requires": [
+        "canWallIceClip",
+        "canDownwardGModeSetup",
+        {"ammo": {"type": "Super", "count": 1}}
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "flashSuitChecked": true,
+      "note": [
+        "Run from the ledge into the open doorway while hitting the frozen Viola and the door transition simultaneously, just as the Viola thaws and touches Samus during the transition.",
+        "Note that this requires a precise freeze (2 pixel window), a small pixel starting window (approximately 1 pixel window), precise thaw timing, and a 50% success rate due to collision oscillation.",
+        "The positioning of the Viola is where its hitbox is one or two pixels away from the edge of the door frame, so that Samus can clip into the wall and stand as she touches the transition."
+      ]
+    },
+    {
       "id": 9,
       "link": [2, 3],
       "name": "Base",

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -856,6 +856,25 @@
       "devNote": "The Kihunter will do more damage than the Covern, so whether Phantoon is dead or not, that strat will be accurate or conservative."
     },
     {
+      "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit by Thawing Atomic",
+      "requires": [
+        "f_DefeatedPhantoon",
+        "canWallIceClip",
+        "canDownwardGModeSetup"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "flashSuitChecked": true,
+      "note": [
+        "Run from the ledge into the open doorway while hitting the frozen Atomic and the door transition simultaneously, just as the Atomic thaws and touches Samus during the transition.",
+        "Note that this requires a precise freeze (3 pixel window), precise thaw timing, and a 50% success rate due to collision oscillation.",
+        "The starting position of Samus is a bit more lenient than other downward G-mode setups, as Samus can have higher run speed when hitting the Atomic than in most other rooms."
+      ],
+      "devNote": "This can not work with a Covern, as it only moves vertically and can't hit Samus in the transition."
+    },
+    {
       "id": 41,
       "link": [2, 3],
       "name": "Leave Shinecharged",

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -930,6 +930,27 @@
       ]
     },
     {
+      "link": [3, 7],
+      "name": "G-Mode Setup - Get Hit by Thawing Atomic",
+      "requires": [
+        "f_DefeatedPhantoon",
+        "canWallIceClip",
+        "canDownwardGModeSetup",
+        "Morph"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "note": [
+        "Run from the ledge into the open doorway while hitting the frozen Atomic and the door transition simultaneously, just as the Atomic thaws and touches Samus during the transition.",
+        "Note that this requires a precise freeze (2 pixel window), a small pixel starting window (approximately 3 pixel window), precise thaw timing, and a 50% success rate due to collision oscillation.",
+        "The positioning of the Atomic is where its hitbox is one or two pixels away from the edge of the door frame, so that Samus can clip into the wall and stand as she touches the transition."
+      ],
+      "devNote": "This can not work with a Covern, as it only moves vertically and can't hit Samus in the transition."
+    },
+    {
       "id": 38,
       "link": [3, 8],
       "name": "Blocks Already Broken",


### PR DESCRIPTION
This does not include the sand transition or ice moonfall methods.

No other room seems to be able to use this method:
- Post Croc Farm - doesnt look like _**any**_ downward setup is possible, because the vertical wall is too high and Samus is force crouched.
- Main St - Samus can't touch the crab and touch the transition simultaneously
- Metroid 4 - It's really dumb, because there's not enough runway to cross the full doorshell, so you would need to use one frozen enemy to wall ice clip while using another to take damage and either open the door or short hop so that Samus can touch the transition and enemies at the same time. An ice moonfall is going to be easier here (if possible).