### PR TITLE
Refine some canUnderwaterBombIntoSpringBallJump notes

### DIFF
--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -223,6 +223,22 @@
         "f_TourianOpen",
         "canDoubleSpringBallJumpMidAir",
         "canUnderwaterBombIntoSpringBallJump"
+      ],
+      "note": [
+        "Perform a double Spring Ball jump without Hi-Jump,",
+        "using a Bomb to propel Samus upward just long enough to get the second mid-air Spring Ball jump."
+      ],
+      "detailNote": [
+        "Crouch, press pause, delay the initial jump as long as possible, and perform a very quick mid-air morph;",
+        "it can help to keep holding down when crouching, to buffer the aim-down input.",
+        "Equip Spring Ball, unpause, press Start to pause again, and perform a max-height Spring Ball jump;",
+        "ideally Start should be pressed slightly before the mid-air jump.",
+        "Unequip Spring Ball, unpause, and lay a Bomb slightly after regaining control (do not buffer it).",
+        "The Bomb should be laid between 5 frames and about 10 frames after regaining control, while the screen is still fairly dark.",
+        "Then press pause between 23 and 25 frames later and buffer a second Spring Ball jump.",
+        "The end of the frame window for when the Bomb can be laid depends on how well the first part was done",
+        "(with a larger window being obtained by pausing as early as possible both times and jumping as late as possible both times);",
+        "but the delay between laying the Bomb and performing the final pause is always the same 3-frame window."
       ]
     },
     {

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -205,6 +205,10 @@
       "note": [
         "Wall jump until Samus is just below the water line and then morph and place a Bomb",
         "Use the brief moment during the Bomb explosion that knocks Samus upwards to setup a Springball jump to jump out of the water."
+      ],
+      "devNote": [
+        "FIXME: This can also be done with a double Spring Ball jump (using Bombs) without wall jumping,",
+        "but it seems more difficult than Statues Room and West Cac Alley, because of the water tide."
       ]
     },
     {

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -974,7 +974,7 @@
         "Hold down and back through the transition, to perform a momentum-conserving turnaround past the corner.",
         "Perform a mid-air Spring Ball jump, timing a pause to hit soon after the mid-air jump.",
         "Unequip Spring Ball, lay a Bomb about half a tile below the peak of the jump.",
-        "Press pause at the peak of the jump, tp reequip Spring Ball immediately after Samus is boosted by the bomb.",
+        "Press pause at the peak of the jump, to reequip Spring Ball immediately after Samus is boosted by the bomb.",
         "Buffer a jump out of the unpause, to get a second Spring Ball jump and make it up."
       ]
     },

--- a/region/maridia/inner-pink/West Cactus Alley Room.json
+++ b/region/maridia/inner-pink/West Cactus Alley Room.json
@@ -519,6 +519,22 @@
       "requires": [
         "canDoubleSpringBallJumpMidAir",
         "canUnderwaterBombIntoSpringBallJump"
+      ],
+      "note": [
+        "Perform a double Spring Ball jump without Hi-Jump,",
+        "using a Bomb to propel Samus upward just long enough to get the second mid-air Spring Ball jump."
+      ],
+      "detailNote": [
+        "Crouch, press pause, delay the initial jump as long as possible, and perform a very quick mid-air morph;",
+        "it can help to keep holding down when crouching, to buffer the aim-down input.",
+        "Equip Spring Ball, unpause, press Start to pause again, and perform a max-height Spring Ball jump;",
+        "ideally Start should be pressed slightly before the mid-air jump.",
+        "Unequip Spring Ball, unpause, and lay a Bomb slightly after regaining control (do not buffer it).",
+        "The Bomb should be laid between 5 frames and about 10 frames after regaining control, while the screen is still fairly dark.",
+        "Then press pause between 23 and 25 frames later and buffer a second Spring Ball jump.",
+        "The end of the frame window for when the Bomb can be laid depends on how well the first part was done",
+        "(with a larger window being obtained by pausing as early as possible both times and jumping as late as possible both times);",
+        "but the delay between laying the Bomb and performing the final pause is always the same 3-frame window."
       ]
     },
     {

--- a/tech.json
+++ b/tech.json
@@ -1050,11 +1050,14 @@
                   ],
                   "otherRequires": [],
                   "note": [
-                    "Use the tiny amount of height gain from an underwater Bomb explosion to re-equip Springball and perform a Springball jump.",
-                    "This is most often used to get a second SpringBall jump when underwater without HiJump.",
+                    "Use the tiny amount of height gain from an underwater Bomb explosion to re-equip Spring Ball and perform a mid-air Spring Ball jump.",
+                    "This is most often used to get a second Spring Ball jump when underwater without Hi-Jump.",
                     "Bombs are required since Power Bombs will prevent pausing."
                   ],
-                  "devNote": "Similar to an underwater walljump into springballjump, but that has no applications yet since double springballjump is easier for similar requirements."
+                  "detailNote": [
+                    "There is a 3-frame window for when to perform the final Spring Ball jump relative to when the Bomb was laid.",
+                    "Usually this will be done as a pause-buffered Spring Ball jump, in which case pause must be pressed between 23 and 25 frames after laying the Bomb."
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
This adds some detail to the `canUnderwaterBombIntoSpringBallJump` tech and some strats that use it. For the double spring ball jump, I found the single bomb method to be much more reliable than spamming bombs & pause like we were doing before.

Statues Room video: https://videos.maprando.com/video/6789