### PR TITLE
Refine Seaweed Room shinecharges

### DIFF
--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -711,7 +711,7 @@
     },
     {
       "link": [3, 1],
-      "name": "Come in Shinecharging, Leave Shinecharged",
+      "name": "Come in Shinecharging, Leave Shinecharged (Wave)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 0,
@@ -739,6 +739,67 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {}
+      }
+    },
+    {
+      "link": [3, 1],
+      "name": "Come in Shinecharging, Leave Shinecharged (Power Beam, Hi-Jump, Wall Jump)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"shineChargeFrames": 165},
+        "HiJump",
+        "canWalljump",
+        "canShinechargeMovementTricky"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      }
+    },
+    {
+      "link": [3, 1],
+      "name": "Come in Shinecharging, Leave with Spark (Power Beam, Bootless, Low Position)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canConsecutiveWalljump",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 170},
+        {"shinespark": {"frames": 6, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      }
+    },
+    {
+      "link": [3, 1],
+      "name": "Come in Shinecharging, Leave with Spark (Power Beam, Bootless, High Position)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canConsecutiveWalljump",
+        "canShinechargeMovementTricky",
+        {"shineChargeFrames": 176},
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
       }
     },
     {

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -458,7 +458,7 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
-        {"shineChargeFrames": 100}
+        {"shineChargeFrames": 105}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -473,9 +473,8 @@
       ]
     },
     {
-      "id": 23,
       "link": [2, 3],
-      "name": "Come in Shinecharging, Leave with Spark",
+      "name": "Come in Shinecharging, Leave Shinecharged (Power Beam)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 2,
@@ -484,20 +483,17 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
-        {"shinespark": {"frames": 5}}
+        {"shineChargeFrames": 140}
       ],
       "exitCondition": {
-        "leaveWithSpark": {
-          "position": "bottom"
-        }
+        "leaveShinecharged": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "note": [
         "Gain a shinecharge while entering the room.",
-        "Angle down to shoot the first seaweed block at the level of Samus' knees.",
-        "Take four tiny steps forward, firing a shot with forward momentum on each step, destroying the seaweed at the level of Samus' head, with the last shot continuing on to open the door.",
-        "Do one more angle down shot to destroy the last seaweed block at Samus' knees.",
-        "To minimize energy usage, jump across the room before shinesparking through the door."
+        "Shoot three times to break the lower two rows of seaweed.",
+        "Shoot one more time while moving forward to break the upper row of seaweed.",
+        "Spin jump across the room."
       ]
     },
     {
@@ -520,16 +516,37 @@
       "note": "Use Wave to clear the seaweed quickly."
     },
     {
-      "id": 25,
       "link": [2, 3],
-      "name": "Come in Shinecharged, Leave with Spark",
+      "name": "Carry Shinecharge (Power Beam)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 110},
-        "canShinechargeMovementTricky",
-        {"shinespark": {"frames": 18}}
+        {"shineChargeFrames": 145},
+        "canShinechargeMovementTricky"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "note": [
+        "Crouch and shoot three times to break the lower two rows of seaweed.",
+        "Shoot one more time while moving forward to break the upper row of seaweed.",
+        "Then spin jump across the room."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharged, Leave with Spark (Wave, Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        "Wave",
+        {"shineChargeFrames": 10},
+        "canShinechargeMovementComplex",
+        {"shinespark": {"frames": 22}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -539,9 +556,57 @@
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
       "note": [
-        "Angle down to shoot the first seaweed block at the level of Samus' knees.",
-        "Take four tiny steps forward, firing a shot with forward momentum on each step, destroying the seaweed at the level of Samus' head, with the last shot continuing on to open the door.",
-        "Do one more angle down shot to destroy the last seaweed block at Samus' knees.",
+        "Hold an angle button through the transition to stop Samus' momentum.",
+        "Release angle, fire a Wave shot horizontally to break the seaweed and open the door.",
+        "Then shinespark through the door."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Come in Shinecharged, Leave with Spark (Wave, Top Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        "Wave",
+        {"shineChargeFrames": 10},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 22}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "note": [
+        "Perform a small spin jump and fire a well-timed Wave shot to break the blocks.",
+        "Then activate the shinespark mid-air."
+      ]
+    },
+    {
+      "id": 25,
+      "link": [2, 3],
+      "name": "Come in Shinecharged, Leave with Spark (Power Beam)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 75},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 21}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "note": [
+        "Crouch and shoot three times to break the lower two rows of seaweed.",
+        "Shoot one more time while moving forward to break the upper row of seaweed.",
         "Then shinespark through the door."
       ]
     },
@@ -645,16 +710,60 @@
       "requires": []
     },
     {
-      "id": 32,
       "link": [3, 1],
-      "name": "Carry Shinecharge (HiJump Wall Jump)",
+      "name": "Come in Shinecharging, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "Wave",
+        {"or": [
+          {"and": [
+            "HiJump",
+            "canWalljump",
+            {"shineChargeFrames": 115}
+          ]},
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 125}
+          ]},
+          {"and": [
+            "canWalljump",
+            {"shineChargeFrames": 130}
+          ]}
+        ]},
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      }
+    },
+    {
+      "link": [3, 1],
+      "name": "Carry Shinecharge",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 120},
-        "HiJump",
-        "canWalljump",
+        "Wave",
+        {"or": [
+          {"and": [
+            "HiJump",
+            "canWalljump",
+            {"shineChargeFrames": 115}
+          ]},
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 125}
+          ]},
+          {"and": [
+            "canWalljump",
+            {"shineChargeFrames": 130}
+          ]}
+        ]},
         "canShinechargeMovementComplex"
       ],
       "exitCondition": {
@@ -663,35 +772,27 @@
       "flashSuitChecked": true
     },
     {
-      "id": 33,
       "link": [3, 1],
-      "name": "Carry Shinecharge (HiJump)",
+      "name": "Come In Shinecharged, Leave With Spark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 125},
-        "HiJump",
+        "Wave",
+        {"or": [
+          {"and": [
+            "HiJump",
+            "canWalljump",
+            {"shineChargeFrames": 100},
+            {"shinespark": {"frames": 5}}
+          ]},
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 110},
+            {"shinespark": {"frames": 6}}
+          ]}
+        ]},
         "canShinechargeMovementComplex"
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {}
-      },
-      "flashSuitChecked": true
-    },
-    {
-      "id": 34,
-      "link": [3, 1],
-      "name": "Come In Shinecharged, Leave With Spark (HiJump Wall Jump)",
-      "entranceCondition": {
-        "comeInShinecharged": {}
-      },
-      "requires": [
-        {"shineChargeFrames": 100},
-        "HiJump",
-        "canWalljump",
-        "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 5}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -701,18 +802,21 @@
     {
       "id": 35,
       "link": [3, 1],
-      "name": "Come In Shinecharged, Leave With Spark (Wall Jump)",
+      "name": "Come In Shinecharged, Leave With Spark (Bottom Position)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 130},
+        "Wave",
+        {"shineChargeFrames": 120},
         "canWalljump",
         "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 4}}
+        {"shinespark": {"frames": 6}}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
       },
       "flashSuitChecked": true
     },
@@ -721,6 +825,53 @@
       "link": [3, 2],
       "name": "Base",
       "requires": []
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (Wave)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"shineChargeFrames": 105},
+        "Wave",
+        "canShinechargeMovementComplex"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [3, 2],
+      "name": "Come in Shinecharging, Leave Shinecharged (Power Beam)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 0,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"shineChargeFrames": 130},
+        "canTwoTileSqueeze",
+        "canShinechargeMovementTricky"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "Squeeze underneath the seaweed, then clear a path to the door from below."
+      ]
     },
     {
       "id": 37,
@@ -745,6 +896,29 @@
       "note": "Use single well-timed Wave shot to clear the seaweed quickly."
     },
     {
+      "link": [3, 2],
+      "name": "Carry Shinecharge (Power Beam)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 140},
+        "canShinechargeMovementTricky"
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Buffer a shot while entering the room.",
+        "Jump underneath the seaweed, then clear a path to the door from below."
+      ]
+    },
+    {
       "id": 38,
       "link": [3, 2],
       "name": "Come in Shinecharged, Leave with Spark (Wave)",
@@ -767,16 +941,37 @@
       "note": ["Use single well-timed Wave shot to clear the seaweed quickly."]
     },
     {
-      "id": 39,
       "link": [3, 2],
-      "name": "Come in Shinecharged, Leave with Spark",
+      "name": "Come in Shinecharged, Leave with Spark (Wave, Top Position)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 100},
-        "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 14}}
+        {"shineChargeFrames": 40},
+        "Wave",
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 18}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "top"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "note": ["Use single well-timed mid-air Wave shot to clear the seaweed quickly."]
+    },
+    {
+      "id": 39,
+      "link": [3, 2],
+      "name": "Come in Shinecharged, Leave with Spark (Power Beam)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 80},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 15}}
       ],
       "exitCondition": {
         "leaveWithSpark": {


### PR DESCRIPTION
- Bugfix: the 3->1 strats were missing a Wave requirement.
- Add strats based on Sam's method to carry a shinecharge from bottom-right to bottom-left without Wave.
- Likewise, add strats to carry shinecharge from bottom-left to bottom-right without Wave.
- Refine/tighten shinecharge frames throughout (and add videos to document them).
- Include comeInShinecharging+leaveShinecharged variants that were skipped before.