### PR TITLE
Bootless two-wall UWJ

### DIFF
--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1638,6 +1638,35 @@
       "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
     },
     {
+      "link": [2, 7],
+      "name": "G-Mode Overload PLMs - Power Bomb the Items, Bootless UWJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
+        {"or": [
+          {"itemNotCollectedAtNode": 7},
+          {"itemNotCollectedAtNode": 8}
+        ]},
+        "h_usePowerBomb",
+        "h_usePowerBomb",
+        "canSnailClimb",
+        "canBootless2WideUWJ"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+        "There is a row of tiles that works, just above and to the left of the right door.",
+        "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall.",
+        "Climb one snail to place the Power Bomb, then another to reduce the distance of the wall jump climb."
+      ],
+      "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
+    },
+    {
       "id": 47,
       "link": [2, 9],
       "name": "Base",
@@ -2501,6 +2530,83 @@
       "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
     },
     {
+      "link": [5, 7],
+      "name": "G-Mode Overload PLMs - Power Bomb the Items, Bootless UWJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
+        {"or": [
+          {"itemNotCollectedAtNode": 7},
+          {"itemNotCollectedAtNode": 8}
+        ]},
+        "h_usePowerBomb",
+        "h_usePowerBomb",
+        "canSnailClimb",
+        "canBootless2WideUWJ"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+        "There is a row of tiles that works, just above and to the left of the right door.",
+        "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall.",
+        "Climb one snail to place the Power Bomb, then another to reduce the distance of the wall jump climb."
+      ],
+      "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
+    },
+    {
+      "link": [5, 7],
+      "name": "G-Mode Morph Overload PLMs - Power Bomb the Items, Bootless UWJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
+        {"or": [
+          {"itemNotCollectedAtNode": 7},
+          {"itemNotCollectedAtNode": 8}
+        ]},
+        "h_artificialMorphSpringBall",
+        "h_artificialMorphPowerBomb",
+        "h_artificialMorphPowerBomb",
+        "canSnailClimb",
+        "canBootless2WideUWJ"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+        "There is a row of tiles that works, just above and to the left of the right door.",
+        "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall.",
+        "Climb one snail to place the Power Bomb, then another to reduce the distance of the wall jump climb."
+      ],
+      "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
+    },
+    {
+      "link": [5, 7],
+      "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks, Bootless UWJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphSpringBall",
+        "canSnailClimb",
+        "h_artificialMorphBombs",
+        "canBootless2WideUWJ"
+      ],
+      "flashSuitChecked": true,
+      "note": "Place bombs on the speed blocks to overload PLMs, then climb a snail and bootless UWJ to the items."
+    },
+    {
       "id": 91,
       "link": [5, 8],
       "name": "Right-Side X-Ray Climb",
@@ -2963,6 +3069,36 @@
       "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
     },
     {
+      "link": [6, 7],
+      "name": "G-Mode Overload PLMs - Power Bomb the Items, Bootless UWJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": false
+        },
+        "comesThroughToilet": "no"
+      },
+      "requires": [
+        {"notable": "G-Mode Overload PLMs - Power Bomb the Items"},
+        {"or": [
+          {"itemNotCollectedAtNode": 7},
+          {"itemNotCollectedAtNode": 8}
+        ]},
+        "h_usePowerBomb",
+        "h_usePowerBomb",
+        "canSnailClimb",
+        "canBootless2WideUWJ"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+        "There is a row of tiles that works, just above and to the left of the right door.",
+        "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall.",
+        "Climb one snail to place the Power Bomb, then another to reduce the distance of the wall jump climb."
+      ],
+      "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
+    },
+    {
       "id": 111,
       "link": [6, 9],
       "name": "Base",
@@ -3240,6 +3376,18 @@
       "devNote": "FIXME: This is not a long IBJ if starting from door 5."
     },
     {
+      "link": [10, 7],
+      "name": "Overload PLMs - Bomb the Speed Blocks, Bootless UWJ",
+      "requires": [
+        "canEnterGMode",
+        "canSnailClimb",
+        "h_useMorphBombs",
+        "canBootless2WideUWJ"
+      ],
+      "flashSuitChecked": true,
+      "note": "Place bombs on the speed blocks to overload PLMs, then climb a snail and bootless UWJ to the items."
+    },
+    {
       "id": 134,
       "link": [10, 11],
       "name": "G-Mode Morph, Overload PLMs - Bomb the Speed Blocks",
@@ -3342,6 +3490,17 @@
       ],
       "flashSuitChecked": true,
       "note": "After PLMs are overloaded, use a snail to help climb to the top right items."
+    },
+    {
+      "link": [11, 7],
+      "name": "Overloaded PLMs - Bootless UWJ",
+      "requires": [
+        "canEnterGMode",
+        "canSnailClimb",
+        "canBootless2WideUWJ"
+      ],
+      "flashSuitChecked": true,
+      "note": "After PLMs are overloaded, use a snail to climb to the right then bootless UWJ to the items."
     }
   ],
   "notables": [

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -1071,6 +1071,17 @@
       "devNote": "The requirements are for getting onto the platform."
     },
     {
+      "link": [1, 4],
+      "name": "Bootless Underwater Wall Jump",
+      "requires": [
+        {"notable": "Very Long Bootless Underwater Wall Jump"},
+        "canBootless2WideUWJ",
+        "canBeExtremelyPatient",
+        "canSpringBallJumpMidAir"
+      ],
+      "note": "Perform a very long, very unforgiving, bootless underwater wall jump."
+    },
+    {
       "id": 85,
       "link": [1, 5],
       "name": "Water Shinecharge",
@@ -2049,8 +2060,15 @@
         "Perform a tight down grab to get onto it then jump through the door shell.",
         "Knocking the crab off while it is on the the door or ceiling will not work."
       ]
+    },
+    {
+      "id": 5,
+      "name": "Very Long Bootless Underwater Wall Jump",
+      "note": [
+        "Perform a very long, very unforgiving, bootless underwater wall jump."
+      ]
     }
   ],
   "nextStratId": 92,
-  "nextNotableId": 5
+  "nextNotableId": 6
 }

--- a/region/maridia/inner-pink/West Sand Hole.json
+++ b/region/maridia/inner-pink/West Sand Hole.json
@@ -478,6 +478,20 @@
       ]
     },
     {
+      "link": [1, 7],
+      "name": "Bootless Underwater Wall Jump",
+      "requires": [
+        "canPlayInSand",
+        {"or": [
+          "canSpringBallJumpMidAir",
+          "canSandfallBounce"
+        ]},
+        "canBootless2WideUWJ",
+        "SpaceJump"
+      ],
+      "note": "Sandfall bounce or spring ball jump to the first ledge, then bootless underwater wall jump to the water surface, then use Space Jump to escape."
+    },
+    {
       "id": 15,
       "link": [2, 2],
       "name": "Leave Normally",

--- a/tech.json
+++ b/tech.json
@@ -1256,6 +1256,19 @@
                       "note": [
                         "The ability to underwater wall jump against a single wall and break the water line with HiJump but without Space Jump."
                       ]
+                    },
+                    {
+                      "name": "canBootless2WideUWJ",
+                      "techRequires": [
+                        {"tech": "canUnderwaterWalljump"}
+                      ],
+                      "otherRequires": [],
+                      "note": [
+                        "The ability to underwater wall jump without HiJump between two walls that are two tiles apart.",
+                        "Turn around before reaching the wall, then jump as early as possible to gain a small amount of height.",
+                        "With very precise execution, Samus will gain height very slowly.",
+                        "This requires Space Jump when breaking the water line."
+                      ]
                     }
                   ]
                 }


### PR DESCRIPTION
This addresses Bobbob's Level 5 underwater wall jumps, described in #711. Level 5 looks to be similar or easier to level 4, but more annoying. It also has a small number of uses. This should be enough to close #711, as the remaining levels are unreasonable to implement or expect.

I'm expecting tech to be in `Beyond` and the Crab Shaft notable to be `Ignored`.