### PR TITLE
Pink Brinstar farms

### DIFF
--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -188,13 +188,59 @@
       "link": [1, 1],
       "name": "Zeela and Reo Farm",
       "requires": [
-        {"resetRoom": {
-          "nodes": [1]
-        }},
-        {"partialRefill": {"type": "Super", "limit": 8}},
-        {"refill": ["Energy", "Missile"]}
+        {"or": [
+          {"resetRoom": {
+            "nodes": [1]
+          }},
+          {"and": [
+            {"resetRoom": {
+              "nodes": [2]
+            }},
+            {"or": [
+              {"and": [
+                "h_getBlueSpeedMaxRunway",
+                "canCarefulJump",
+                {"cycleFrames": 500}
+              ]},
+              {"and": [
+                "ScrewAttack",
+                {"cycleFrames": 620}
+              ]},
+              {"and": [
+                "h_useMorphBombs",
+                {"cycleFrames": 1100}
+              ]}
+            ]}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Plasma",
+            {"cycleFrames": 360}
+          ]},
+          {"and": [
+            "Wave",
+            {"cycleFrames": 360}
+          ]},
+          {"and": [
+            "Spazer",
+            {"cycleFrames": 400}
+          ]},
+          {"and": [
+            "ScrewAttack",
+            {"cycleFrames": 490}
+          ]},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"cycleFrames": 540}
+          ]}
+        ]}
       ],
-      "resetsObstacles": ["A"]
+      "resetsObstacles": ["A"],
+      "farmCycleDrops": [
+        {"enemy": "Zeela", "count": 2},
+        {"enemy": "Reo", "count": 3}
+      ]
     },
     {
       "id": 5,

--- a/region/brinstar/pink/Mission Impossible Room.json
+++ b/region/brinstar/pink/Mission Impossible Room.json
@@ -301,6 +301,54 @@
       }
     },
     {
+      "link": [1, 1],
+      "name": "Sidehopper Farm",
+      "requires": [
+        {"resetRoom": {"nodes": [1]}},
+        {"or": [
+          {"and": [
+            "ScrewAttack",
+            {"cycleFrames": 310}
+          ]},
+          {"and": [
+            "Plasma",
+            {"cycleFrames": 440}
+          ]},
+          {"and": [
+            "Wave",
+            "Spazer",
+            "canDodgeWhileShooting",
+            {"cycleFrames": 500}
+          ]},
+          {"and": [
+            {"notable": "Doorway Sidehopper Kill"},
+            {"doorUnlockedAtNode": 1},
+            "canTrickyDodgeEnemies",
+            {"or": [
+              {"and": [
+                "Wave",
+                {"cycleFrames": 750}
+              ]},
+              {"and": [
+                "Spazer",
+                {"cycleFrames": 840}
+              ]},
+              {"and": [
+                "Ice",
+                {"cycleFrames": 1000}
+              ]},
+              {"cycleFrames": 1440}
+            ]}
+          ]}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "resetsObstacles": ["B"],
+      "farmCycleDrops": [
+        {"enemy": "Sidehopper", "count": 2}
+      ]
+    },
+    {
       "id": 10,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -481,26 +529,26 @@
       "link": [1, 4],
       "name": "Doorway Sidehopper Kill",
       "requires": [
+        {"notable": "Doorway Sidehopper Kill"},
         {"doorUnlockedAtNode": 1},
-        "canDodgeWhileShooting",
-        {"or": [
-          "Morph",
-          "Spazer",
-          "Wave",
-          "Plasma",
-          {"enemyKill": {
-            "enemies": [["Sidehopper"]],
-            "explicitWeapons": ["Missile"]
-          }},
-          {"enemyDamage": {"enemy": "Sidehopper", "type": "contact", "hits": 2}},
-          "canTrickyJump"
-        ]}
+        "canTrickyDodgeEnemies"
       ],
       "clearsObstacles": ["A"],
       "note": [
-        "Open the door and kill the first hopper from inside the doorway. It won't be able to hit Samus for many jumps.",
-        "It is possible to quickly get back to the right and crouch against the the ledge while aiming upward to safely kill the Sidehopper.",
-        "Alternatively, morph can help with the second hopper, as it won't be able to hit Samus."
+        "Open the door, walk a safe distance into the doorway, and turn around.",
+        "Wait for the Sidehopper to do 4 hops before beginning to shoot it.",
+        "It can then be safely killed from inside the doorway.",
+        "It is not recommended to moonwalk into the doorway,",
+        "as this carries risk of shooting the Sidehopper pre-maturely.",
+        "After bringing the second Hopper on camera,",
+        "quickly get back to the right and crouch against the the ledge while aiming upward to safely kill it."
+      ],
+      "detailNote": [
+        "Shooting the Sidehopper delays its AI, which affects its RNG on later hops.",
+        "If the Sidehopper is shot too early, it may do a short hop directly into the doorway.",
+        "After the Sidehopper initiates its 4th hop (in which it will land on the ground in front of the ledge),",
+        "it will be stuck in a safe pattern for long enough to kill it,",
+        "regardless of whether it does large or small hops afterward."
       ]
     },
     {
@@ -889,8 +937,18 @@
         "Break spin just before you would hit the respawning crumble block, in order to clip up through it.",
         "Then perform a crumble jump to make it out."
       ]
+    },
+    {
+      "id": 5,
+      "name": "Doorway Sidehopper Kill",
+      "note": [
+        "Open the door, walk a safe distance into the doorway, and turn around.",
+        "Wait for the Sidehopper to do 4 hops before beginning to shoot it.",
+        "After bringing the second Hopper on camera,",
+        "quickly get back to the right and crouch against the the ledge while aiming upward to safely kill it."
+      ]
     }
   ],
   "nextStratId": 41,
-  "nextNotableId": 5
+  "nextNotableId": 6
 }

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -565,6 +565,30 @@
       "note": "Kill the Sidehoppers with a Power Bomb upon entry."
     },
     {
+      "link": [1, 1],
+      "name": "Sidehopper Farm",
+      "requires": [
+        "canPrepareForNextRoom",
+        {"resetRoom": {"nodes": [1]}},
+        {"or":[
+          {"and": [
+            "ScrewAttack",
+            {"cycleFrames": 130}    
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"cycleFrames": 170}
+          ]}
+        ]}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Sidehopper", "count": 1},
+        {"enemy": "Sm. Sidehopper", "count": 2}
+      ],
+      "clearsObstacles": ["A"],
+      "resetsObstacles": ["B", "C"]
+    },
+    {
       "id": 17,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -1189,6 +1213,35 @@
           "openEnd": 1
         }
       }
+    },
+    {
+      "link": [2, 2],
+      "name": "Sidehopper Farm",
+      "requires": [
+        "canWalljump",
+        "canTrickyJump",
+        {"resetRoom": {"nodes": [2]}},
+        {"or": [
+          {"and": [
+            "ScrewAttack",
+            {"cycleFrames": 600}    
+          ]},
+          {"and": [
+            "Plasma",
+            {"cycleFrames": 690}
+          ]},
+          {"and": [
+            "Wave",
+            {"cycleFrames": 810}
+          ]}
+        ]}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Sidehopper", "count": 1},
+        {"enemy": "Sm. Sidehopper", "count": 2}
+      ],
+      "clearsObstacles": ["A", "B"],
+      "resetsObstacles": ["C"]
     },
     {
       "id": 43,

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -80,7 +80,24 @@
       "link": [1, 1],
       "name": "Zeb Farm",
       "requires": [
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"cycleFrames": 105}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Zeb", "count": 1}
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Double Zeb Farm",
+      "requires": [
+        "canDodgeWhileShooting",
+        {"cycleFrames": 105}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Zeb", "count": 2}
+      ],
+      "note": [
+        "Jump back and forth between the left two bug pipes to farm them simultaneously."
       ]
     },
     {

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -119,7 +119,10 @@
       "link": [1, 1],
       "name": "Zeb Farm",
       "requires": [
-        {"refill": ["Energy", "Missile", "Super"]}
+        {"cycleFrames": 105}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Zeb", "count": 1}
       ]
     },
     {

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -178,11 +178,11 @@
                   "Spazer",
                   "Plasma"
                 ]},
-                {"cycleFrames": 360}    
+                {"cycleFrames": 340}
               ]},
               {"and": [
                 "ScrewAttack",
-                {"cycleFrames": 385}  
+                {"cycleFrames": 370}
               ]},
               {"and": [
                 "Grapple",

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -167,19 +167,75 @@
       "link": [1, 1],
       "name": "Zero Farm",
       "requires": [
-        "h_heatProof",
+        {"resetRoom": {"nodes": [1]}},
         {"or": [
           {"and": [
             "Gravity",
-            {"refill": ["PowerBomb"]}
+            {"or": [
+              {"and": [
+                {"or": [
+                  "Wave",
+                  "Spazer",
+                  "Plasma"
+                ]},
+                {"cycleFrames": 360}    
+              ]},
+              {"and": [
+                "ScrewAttack",
+                {"cycleFrames": 385}  
+              ]},
+              {"and": [
+                "Grapple",
+                {"cycleFrames": 400}
+              ]},
+              {"cycleFrames": 530}
+            ]}
           ]},
-          {"partialRefill": {"type": "PowerBomb", "limit": 6}}
+          {"and": [
+            {"or": [
+              "Wave",
+              "Spazer",
+              "Plasma"
+            ]},
+            {"cycleFrames": 690}
+          ]},
+          {"and": [
+            "Grapple",
+            {"cycleFrames": 760}
+          ]},
+          {"cycleFrames": 840}
         ]}
       ],
-      "devNote": [
-        "FIXME: The h_heatProof requirement is because Zeros only drop small energy, not enough to guarantee progress if the neighboring room is heated",
-        "Later we should remove this in favor of some way to require that the neighboring room is not heated."
-      ]
+      "farmCycleDrops": [
+        {"enemy": "Zero", "count": 2}
+      ],
+      "resetsObstacles": ["A"]
+    },
+    {
+      "link": [1, 1],
+      "name": "Zero, Puyo, and Skultera Farm",
+      "requires": [
+        {"resetRoom": {"nodes": [1]}},
+        "Gravity",
+        "h_getBlueSpeedMaxRunway",
+        {"or": [
+          {"and": [
+            {"or": [
+              "Plasma",
+              "Wave",
+              "Spazer"
+            ]},
+            {"cycleFrames": 440}
+          ]},
+          {"cycleFrames": 510}
+        ]}
+      ],
+      "farmCycleDrops": [
+        {"enemy": "Zero", "count": 2},
+        {"enemy": "Puyo", "count": 3},
+        {"enemy": "Skultera", "count": 2}
+      ],
+      "resetsObstacles": ["A"]
     },
     {
       "id": 5,

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -186,24 +186,21 @@
               ]},
               {"and": [
                 "Grapple",
-                {"cycleFrames": 400}
+                {"cycleFrames": 360}
               ]},
-              {"cycleFrames": 530}
+              {"cycleFrames": 420}
             ]}
           ]},
           {"and": [
             {"or": [
+              "Charge",
               "Wave",
               "Spazer",
               "Plasma"
             ]},
             {"cycleFrames": 690}
           ]},
-          {"and": [
-            "Grapple",
-            {"cycleFrames": 760}
-          ]},
-          {"cycleFrames": 840}
+          {"cycleFrames": 780}
         ]}
       ],
       "farmCycleDrops": [

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -182,7 +182,7 @@
               ]},
               {"and": [
                 "ScrewAttack",
-                {"cycleFrames": 370}
+                {"cycleFrames": 360}
               ]},
               {"and": [
                 "Grapple",


### PR DESCRIPTION
Aside from the farm migration, this PR reworks the "Doorway Sidehopper Kill" strat in Mission Impossible Room and turns it into a notable strat. This is moving it up from Very Hard to Expert as I found it was trickier to do reliably than I had expected; the trick I found was to delay shooting the Hopper until after it hops 4 times, which is not very intuitive. For the doorway strat, I don't think additional beams or Morph really affect the difficulty, as the main thing is knowing how to manipulate the Hopper RNG to avoid getting hit in the doorway. And of course, if you have strong enough weapons then it's already covered by other strats that don't involve getting in the doorway.