### PR TITLE
Tighten Big Pink right-side tunnel leaveShinecharged

### DIFF
--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2064,7 +2064,7 @@
         "canShinechargeMovementComplex",
         "Morph",
         {"obstaclesCleared": ["F"]},
-        {"shineChargeFrames": 155}
+        {"shineChargeFrames": 145}
       ],
       "exitCondition": {
         "leaveShinecharged": {}


### PR DESCRIPTION
I noticed that even sparking out here wasn't in VH logic. It's currently expecting leaving shinecharged with 25 frames remaining, and VH would need 30. My best attempt leaves with 40. Proposed logic would be leaving with 35.

If we didn't want this in VH logic we could upgrade it to canShinechargeMovementTricky. I think it's probably ok though?