### PR TITLE
Add canLongXRayClimb tech

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -1262,7 +1262,7 @@
         {"notable": "Geemer Ice Stuck XRay Climb"},
         "h_ZebesIsAwake",
         "canWallIceClip",
-        "canXRayClimb",
+        "canLongXRayClimb",
         "Grapple",
         {"ammo": {"type": "Super", "count": 1}},
         {"enemyDamage": {"enemy": "Geemer (blue)", "type": "contact", "hits": 1}}

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -2364,7 +2364,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -3043,7 +3043,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -3615,7 +3615,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,
@@ -3907,7 +3907,7 @@
     {
       "id": 167,
       "link": [7, 12],
-      "name": "Right-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -3953,7 +3953,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
@@ -4018,7 +4018,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
@@ -4061,7 +4061,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,
@@ -4275,7 +4275,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -922,10 +922,10 @@
     {
       "id": 38,
       "link": [2, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29], [2, 34]]
+          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
         }
       },
       "requires": [
@@ -936,7 +936,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
+        "Samus will not be visible during the climb."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },
@@ -1252,7 +1272,7 @@
     {
       "id": 54,
       "link": [3, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -1266,7 +1286,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
+        "Samus will not be visible during the climb."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1098,11 +1098,12 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "note": [
         "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the morph tunnel and bomb block.",
+        "After teleporting and passing through the transition, X-Ray climb (about 2 screens) to reach the space above,",
+        "to the left of the morph tunnel and bomb block.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": ["Other Samus Eaters can also probably work."]
@@ -1281,12 +1282,13 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "note": [
         "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the morph tunnel and bomb block.",
+        "After teleporting and passing through the transition, X-Ray climb (about 3 screens) to reach the space above,",
+        "to the left of the morph tunnel and bomb block.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": ["Other Samus Eaters can also probably work."]
@@ -1624,12 +1626,13 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "note": [
         "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the morph tunnel and bomb block.",
+        "After teleporting and passing through the transition, X-Ray climb (about 4 screens) to reach the space above,",
+        "to the left of the morph tunnel and bomb block.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": ["Other Samus Eaters can also probably work."]
@@ -1637,7 +1640,7 @@
     {
       "id": 40,
       "link": [5, 4],
-      "name": "Left-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -1733,7 +1736,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,
@@ -2298,7 +2301,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
@@ -2319,7 +2322,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -2339,12 +2342,12 @@
         }
       },
       "requires": [
-        "canXRayClimb",
-        "canBePatient"
+        "canXRayClimb"
       ],
       "note": [
         "Jump into the second Samus Eater in the ceiling of Hellway.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the right of the morph tunnel and Super block.",
+        "After teleporting and passing through the transition, X-Ray climb 1 screen to reach the space above,",
+        "to the right of the morph tunnel and Super block.",
         "Samus will be off-camera, so it may be hard to tell when the climb is done;",
         "moving left and right is a safe way to test, as it will cause the camera to scroll if Samus is at the top."
       ],
@@ -2463,7 +2466,7 @@
     {
       "id": 77,
       "link": [8, 13],
-      "name": "Right-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -2471,7 +2474,7 @@
         "canXRayClimb"
       ],
       "flashSuitChecked": true,
-      "note": "Climb up 1 screen."
+      "note": "Climb up 1 screen (or 2 tiles less than a screen)."
     },
     {
       "id": 69,
@@ -3119,7 +3122,8 @@
         "Likewise, with the Reo knockback method either 2 or 4 pixels can work, though it is more reliable in the 2-pixel position;",
         "it helps to take the knockback a few pixels away from the wall, as it takes a few frames for the horizontal speed of the knockback to reach its maximum.",
         "The trick can work with Samus facing either toward or away from the wall when taking knockback;",
-        "facing away makes it easier to quickly kill the Reo afterward to avoid taking a second hit."
+        "facing away makes it easier to quickly kill the Reo afterward to avoid taking a second hit.",
+        "FIXME: describe how to do this by freezing the Zeb higher, above node 5."
       ]
     },
     {

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -532,7 +532,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "flashSuitChecked": true,
@@ -549,7 +549,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
@@ -971,10 +971,10 @@
     {
       "id": 48,
       "link": [3, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29], [2, 34]]
+          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
         }
       },
       "requires": [
@@ -985,7 +985,26 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -162,7 +162,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "flashSuitChecked": true,
@@ -179,7 +179,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -572,7 +572,7 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
         {"enemyDamage": {"enemy": "Ripper", "type": "contact", "hits": 1}},
         "canWallIceClip",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1275,7 +1275,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -1465,7 +1465,7 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
         {"enemyDamage": {"enemy": "Ripper", "type": "contact", "hits": 1}},
         "canWallIceClip",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1930,7 +1930,7 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
         {"enemyDamage": {"enemy": "Ripper", "type": "contact", "hits": 1}},
         "canWallIceClip",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -2277,7 +2277,7 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
         {"enemyDamage": {"enemy": "Ripper", "type": "contact", "hits": 1}},
         "canWallIceClip",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -960,7 +960,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "flashSuitChecked": true,
@@ -977,7 +977,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
@@ -1272,7 +1272,7 @@
         "Morph",
         {"or": [
           "canRiskPermanentLossOfAccess",
-          "canXRayClimb"
+          "canLongXRayClimb"
         ]},
         {"ammo": {"type": "PowerBomb", "count": 9}},
         "canBeVeryPatient",

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -1284,7 +1284,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "flashSuitChecked": true,
@@ -1301,7 +1301,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
@@ -1761,7 +1761,7 @@
         "ScrewAttack",
         "Morph",
         "canBeVeryPatient",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -1345,7 +1345,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,
@@ -1377,7 +1377,7 @@
       },
       "requires": [
         {"notable": "Crystal Flash X-Ray Climb"},
-        "canXRayClimb",
+        "canLongXRayClimb",
         "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
@@ -1401,7 +1401,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -613,11 +613,11 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "note": [
         "Fall into the first Samus Eater in Hellway or Alpha Power Bomb Room.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space behind the bomb blocks at the top of the room.",
+        "After teleporting and passing through the transition, X-Ray climb 2 screens to reach the space behind the bomb blocks at the top of the room.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": [
@@ -887,12 +887,12 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "note": [
         "Fall into the first Samus Eater in Hellway or Alpha Power Bomb Room.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space behind the bomb blocks at the top of the room.",
+        "After teleporting and passing through the transition, X-Ray climb 3 screens to reach the space behind the bomb blocks at the top of the room.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": [
@@ -1236,10 +1236,10 @@
     {
       "id": 42,
       "link": [4, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29], [2, 34]]
+          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
         }
       },
       "requires": [
@@ -1250,7 +1250,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
+        "Samus will not be visible during the climb."
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },
@@ -1440,7 +1460,7 @@
     {
       "id": 54,
       "link": [5, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -1454,7 +1474,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screeto get up to the door transition, without needing to open the door.",
+        "Samus will not be visible during the climb."
+      ]
+    },
+    {
+      "link": [5, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },
@@ -1796,11 +1836,11 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "note": [
         "Jump into the second Samus Eater in the ceiling of Hellway.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the top of the room.",
+        "After teleporting and passing through the transition, X-Ray climb about 2 screens to reach the top of the room.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": ["Several other Samus Eaters could probably also work."]
@@ -1882,7 +1922,7 @@
     {
       "id": 76,
       "link": [6, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -1896,7 +1936,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
+        "Samus will not be visible during the climb."
+      ]
+    },
+    {
+      "link": [6, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -191,10 +191,10 @@
     {
       "id": 9,
       "link": [2, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29], [2, 34]]
+          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
         }
       },
       "requires": [
@@ -205,7 +205,26 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -763,7 +763,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1494,7 +1494,7 @@
             {"shinespark": {"frames": 35, "excessFrames": 10}}
           ]}
         ]},
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -1510,7 +1510,7 @@
         {"shineChargeFrames": 1},
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canShinesparkDeepStuck",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -1574,7 +1574,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,
@@ -1595,7 +1595,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,
@@ -1612,7 +1612,7 @@
         {"shineChargeFrames": 1},
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canShinesparkDeepStuck",
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,
@@ -1629,7 +1629,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -620,7 +620,7 @@
     {
       "id": 17,
       "link": [2, 9],
-      "name": "Xray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -629,7 +629,8 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "Climb until the camera fully shows Samus on the bottom of the screen.  Shoot up to clear the shot blocks and resume climbing until you can walk out to the left.",
+        "Climb until the camera fully shows Samus on the bottom of the screen.",
+        "Shoot up to clear the shot blocks and resume climbing until you can walk out to the left.",
         "Fix the camera by shooting the floor shot block and jumping down."
       ]
     },
@@ -885,7 +886,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"or": [
           {"enemyDamage": {
             "enemy": "Green Space Pirate (standing)",
@@ -1047,7 +1048,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"enemyKill": {
           "enemies": [["Green Space Pirate (standing)"]],
           "explicitWeapons": ["Charge", "Ice", "Wave", "Spazer", "Plasma", "Missile", "Super"]
@@ -1072,7 +1073,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"or": [
           "h_artificialMorphPowerBomb",
           "h_artificialMorphIBJ"
@@ -1283,7 +1284,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"or": [
           {"enemyDamage": {
             "enemy": "Green Space Pirate (standing)",
@@ -1384,7 +1385,7 @@
       "name": "Beetom X-Ray Climb",
       "requires": [
         {"notable": "Beetom X-Ray Climb"},
-        "canXRayClimb",
+        "canLongXRayClimb",
         "Morph",
         "canWallIceClip",
         "canBeVeryPatient",

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -1680,13 +1680,13 @@
       },
       "requires": [
         "h_heatProof",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
-        "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+        "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -646,10 +646,10 @@
     {
       "id": 25,
       "link": [3, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29], [2, 34]]
+          "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
         }
       },
       "requires": [
@@ -660,7 +660,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
+        "Samus will not be visible during the climb."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -433,7 +433,7 @@
       },
       "requires": [
         "h_heatProof",
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBeVeryPatient"
       ],
       "bypassesDoorShell": true,
@@ -938,7 +938,7 @@
       },
       "requires": [
         {"notable": "X-Ray Climb"},
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 2}},
         {"enemyDamage": {
           "enemy": "Yellow Space Pirate (wall)",
@@ -952,7 +952,7 @@
         "Climb the room while avoiding wall pirates and Namihe flames.",
         "Immediately climb above the Namihe flames and wait for the wall pirate to jump across into Samus.",
         "Once the pirate starts going up, resume X-Ray climbing.",
-        "This is a Two screen X-Ray climb.  Watch for enemies when fixing the camera after the climb."
+        "This is a 2-screen X-Ray climb.  Watch for enemies when fixing the camera after the climb."
       ],
       "devNote": "Two Namihe hits as leniency."
     },
@@ -1308,14 +1308,14 @@
     {
       "id": 32,
       "link": [3, 1],
-      "name": "Grapple Teleport X-Ray Climb (Two Screens)",
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"heatFrames": 2800},
         {"enemyDamage": {"enemy": "Namihe", "type": "kago", "hits": 9}},
         {"enemyDamage": {
@@ -1329,7 +1329,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door.",
         "Climb quickly in order to minimize damage from the Namihe and the Pirate."
       ]
     },

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -406,7 +406,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"heatFrames": 2840}
       ],
       "note": "Climb up 2 screens."

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -444,7 +444,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"heatFrames": 2800}
       ],
       "flashSuitChecked": true,
@@ -767,7 +767,7 @@
     {
       "id": 10,
       "link": [1, 5],
-      "name": "Left-Side X-Ray Climb (to Middle Door)",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -206,12 +206,12 @@
     {
       "id": 3,
       "link": [1, 2],
-      "name": "Left-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient",
         "canOffScreenMovement",
         {"or": [
@@ -296,12 +296,12 @@
     {
       "id": 8,
       "link": [1, 5],
-      "name": "Left-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,
@@ -368,12 +368,12 @@
     {
       "id": 14,
       "link": [3, 2],
-      "name": "Right-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -2615,7 +2615,7 @@
     {
       "id": 91,
       "link": [5, 8],
-      "name": "Right-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -835,7 +835,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
@@ -2144,7 +2144,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/maridia/inner-pink/East Cactus Alley.json
+++ b/region/maridia/inner-pink/East Cactus Alley.json
@@ -457,7 +457,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -254,7 +254,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -270,13 +270,13 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
-        "Climb up 1 screen, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
+        "Climb up 2 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
       ]
     },
     {

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -295,7 +295,7 @@
         {"shineChargeFrames": 1},
         "canShinesparkDeepStuck",
         {"shinespark": {"frames": 1, "excessFrames": 1}},
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient",
         "canOffScreenMovement"
       ],
@@ -319,7 +319,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient",
         "canOffScreenMovement"
       ],

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -712,7 +712,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,
@@ -1150,7 +1150,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 1.5 screens."

--- a/region/maridia/inner-yellow/Maridia Swiss Cheese Room.json
+++ b/region/maridia/inner-yellow/Maridia Swiss Cheese Room.json
@@ -295,7 +295,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -1013,7 +1013,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -1029,7 +1029,7 @@
         {"shineChargeFrames": 1},
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canShinesparkDeepStuck",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -1045,7 +1045,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -1822,7 +1822,7 @@
       },
       "requires": [
         {"notable": "X-Ray Climb Into Fake Kassiuz Room"},
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -816,7 +816,7 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Left-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },
@@ -2691,7 +2691,7 @@
     {
       "id": 83,
       "link": [3, 4],
-      "name": "Right-Side X-Ray Climb",
+      "name": "X-Ray Climb",
       "entranceCondition": {
         "comeInWithDoorStuckSetup": {}
       },

--- a/region/maridia/outer/Maridia Tube.json
+++ b/region/maridia/outer/Maridia Tube.json
@@ -2286,7 +2286,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ],
       "devNote": [
         "This strat is only useful if the room were modified to have a door lock on the left."

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -2552,7 +2552,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb.",
         "It is necessary to enter a horizontal position of 20 pixel or less, otherwise the climb will stop in the air pocket below the door."
       ]
@@ -3811,7 +3811,8 @@
       "note": [
         "Perform a horizontal shinespark through the top of the door transition, from a horizontal position that triggers a deep door transition.",
         "Sparking from one or two pixels away from the door is an example position that works (if possible in the neighboring room).",
-        "If successful, after the shinespark crash animation ends Samus should be standing inside the wall and be able to X-Ray climb."
+        "If successful, after the shinespark crash animation ends Samus should be standing inside the wall and be able to X-Ray climb.",
+        "X-Ray climb up a little less than 1 screen, and the slopes will push Samus up."
       ],
       "devNote": [
         "If the morph tunnel is not expanded, then a deep transition is not necessary; any horizontal shinespark in top position would work."
@@ -3832,7 +3833,7 @@
       ],
       "note": [
         "Jump into the first Samus Eater in the ceiling of Hellway.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the ledge above.",
+        "After teleporting and passing through the transition, X-Ray climb about 1 screen to reach the ledge above.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": [

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -317,7 +317,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -333,7 +333,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -778,7 +778,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -800,7 +800,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
@@ -1340,7 +1340,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -628,7 +628,7 @@
       },
       "requires": [
         "canBePatient",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": [

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -1810,7 +1810,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -1826,7 +1826,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -2280,7 +2280,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "flashSuitChecked": true,
@@ -2297,7 +2297,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,
@@ -2318,7 +2318,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -2840,10 +2840,10 @@
     {
       "id": 94,
       "link": [6, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 28], [2, 29], [2, 34]]
+          "blockPositions": [[2, 28], [2, 29]]
         }
       },
       "requires": [
@@ -2854,7 +2854,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition above, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition above, without needing to open the door.",
+        "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the lower door."
+      ]
+    },
+    {
+      "link": [6, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition above, without needing to open the door.",
         "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the lower door."
       ]
     },
@@ -2939,7 +2959,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition above, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition above, without needing to open the door.",
         "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the lower door."
       ]
     },
@@ -3432,10 +3452,10 @@
     {
       "id": 119,
       "link": [7, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
-          "blockPositions": [[2, 28], [2, 29], [2, 34]]
+          "blockPositions": [[2, 28], [2, 29]]
         }
       },
       "requires": [
@@ -3446,7 +3466,27 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition above, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition above, without needing to open the door.",
+        "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the lower door."
+      ]
+    },
+    {
+      "link": [7, 1],
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
+      "entranceCondition": {
+        "comeInWithGrappleTeleport": {
+          "blockPositions": [[2, 34]]
+        }
+      },
+      "requires": [
+        "canLongXRayClimb"
+      ],
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
+        "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
+        "Then X-ray climb 2 screens to get up to the door transition above, without needing to open the door.",
         "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the lower door."
       ]
     },
@@ -3531,7 +3571,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition above, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition above, without needing to open the door.",
         "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the lower door."
       ]
     },

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -452,7 +452,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -1716,7 +1716,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb.",
         "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the bottom door."
       ]

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -657,7 +657,7 @@
       ],
       "note": [
         "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the blue gate.",
+        "After teleporting and passing through the transition, X-Ray climb 1 screen to reach the space above, to the left of the blue gate.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done."
       ],
       "devNote": [
@@ -683,7 +683,7 @@
       ],
       "note": [
         "Jump into the first ceiling Samus Eater in Hellway.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the right of the blue gate.",
+        "After teleporting and passing through the transition, X-Ray climb 1 screen to reach the space above, to the right of the blue gate.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done.",
         "Off-camera the gate can be opened with Wave beam but not with a gate glitch."
       ],
@@ -1060,7 +1060,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -383,7 +383,7 @@
     {
       "id": 9,
       "link": [2, 1],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -399,20 +399,20 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
       "id": 10,
       "link": [2, 1],
-      "name": "Grapple Teleport X-Ray Climb (Two Screens)",
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"heatFrames": 2800},
         {"lavaFrames": 2500}
       ],
@@ -421,7 +421,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -641,7 +641,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
@@ -1140,7 +1140,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
@@ -1748,7 +1748,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
@@ -2122,7 +2122,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -637,7 +637,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ],
       "devNote": [
         "FIXME: Add a way to model the flag that gets set in this room after outrunning the lava, with SpeedBooster collected.",

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -740,7 +740,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled) with a horizontal position of 21 (as far right as possible).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get to the door transition above, without needing to open the door.",
+        "Then X-ray climb 1 screen to get to the door transition above, without needing to open the door.",
         "Samus will not be visible during the climb.",
         "At the beginning of the climb, avoid pressing left without X-Ray being held, to prevent triggering the transition of the bottom door."
       ]

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -1554,7 +1554,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -2549,7 +2549,7 @@
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,
@@ -3179,7 +3179,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -348,7 +348,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door.",
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door.",
         "Samus will not be visible during the climb."
       ]
     },

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -1232,7 +1232,7 @@
     {
       "id": 23,
       "link": [4, 2],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -1247,20 +1247,20 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
       "id": 24,
       "link": [4, 2],
-      "name": "Grapple Teleport X-Ray Climb (Two Screens)",
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"heatFrames": 2800}
       ],
       "bypassesDoorShell": true,
@@ -1268,7 +1268,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 2 screens to get up to the door transition, without needing to open the door."
       ]
     },
     {
@@ -1778,7 +1778,7 @@
     {
       "id": 37,
       "link": [5, 2],
-      "name": "Grapple Teleport X-Ray Climb",
+      "name": "Grapple Teleport X-Ray Climb (1 Screen)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
@@ -1793,20 +1793,20 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
       "id": 38,
       "link": [5, 2],
-      "name": "Grapple Teleport X-Ray Climb (Two Screens)",
+      "name": "Grapple Teleport X-Ray Climb (2 Screens)",
       "entranceCondition": {
         "comeInWithGrappleTeleport": {
           "blockPositions": [[2, 34]]
         }
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"heatFrames": 2800}
       ],
       "bypassesDoorShell": true,

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -464,7 +464,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"heatFrames": 4000},
         "canBePatient"
       ],
@@ -484,7 +484,7 @@
       },
       "requires": [
         "h_heatProof",
-        "canXRayClimb",
+        "canLongXRayClimb",
         "canBePatient"
       ],
       "bypassesDoorShell": true,

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -365,7 +365,7 @@
         "comeInWithDoorStuckSetup": {}
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
       "note": "Climb up 2 screens."
@@ -381,7 +381,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -643,7 +643,7 @@
       },
       "requires": [
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -672,7 +672,7 @@
       },
       "requires": [
         "Ice",
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
@@ -696,7 +696,7 @@
       "requires": [
         "h_CrystalFlash",
         {"autoReserveTrigger": {}},
-        "canXRayClimb",
+        "canLongXRayClimb",
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}
       ],
       "bypassesDoorShell": true,

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -1490,7 +1490,7 @@
       "note": [
         "Jump or Spring Ball jump into a breakable Grapple block.",
         "The timing is precise and it can help to break two Grapple blocks to use one as a cue.",
-        "Crystal Flash then X-ray climb to the region above.",
+        "Crystal Flash then X-ray climb to the region above (less than 1 screen).",
         "There is a chance that Samus will not be able to Crystal Flash unless first placing a Bomb or Power Bomb."
       ],
       "devNote": "FIXME: This may be possible with a spike hit and speedy jump."
@@ -1520,7 +1520,7 @@
       "note": [
         "IBJ into a breakable Grapple block.",
         "The timing is very precise and requires a quick morph and ascent with precisely placed double bomb jumps.",
-        "Crystal Flash then X-ray climb to the region above.",
+        "Crystal Flash then X-ray climb to the region above (less than 1 screen).",
         "There is a chance that Samus will not be able to Crystal Flash unless first placing a Bomb or Power Bomb."
       ],
       "devNote": "FIXME: This may be possible without a spike hit."

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -210,7 +210,7 @@
       "note": [
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
-        "Then X-ray climb to get up to the door transition, without needing to open the door."
+        "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
       ]
     },
     {
@@ -301,7 +301,7 @@
         }
       },
       "requires": [
-        "canXRayClimb"
+        "canLongXRayClimb"
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -1157,7 +1157,7 @@
       ],
       "note": [
         "Fall into the first Samus Eater in Hellway or the second Samus Eater of Alpha Power Bomb Room.",
-        "After teleporting and passing through the transition, X-Ray climb to reach the space above, to the left of the bomb blocks.",
+        "After teleporting and passing through the transition, X-Ray climb to reach the space above (about 1 screen), to the left of the bomb blocks.",
         "Samus will be off-camera, but the slopes at the top will push the camera up, indicating when the climb is done.",
         "Equip Morph Ball and touch the scroll PLMs in the morph tunnel, to fix the camera to be able to see the way to the item."
       ],

--- a/tech.json
+++ b/tech.json
@@ -2362,6 +2362,16 @@
               ],
               "extensionTechs": [
                 {
+                  "name": "canLongXRayClimb",
+                  "techRequires": [
+                    "canXRayClimb"
+                  ],
+                  "otherRequires": [],
+                  "note": [
+                    "Performing an X-Ray climb of distance approximately two screens or more."
+                  ]
+                },
+                {
                   "id": 157,
                   "name": "canRightSideDoorStuck",
                   "techRequires": [


### PR DESCRIPTION
The new tech `canLongXRayClimb` distinguishes climbs of length ~2 screens or more. For Map Rando this will help us to put only ~1 screen climbs into Very Hard logic. The idea is that when first learning to X-Ray climb it is nicer to only have to start out with relatively short ones.

For some grapple teleport X-Ray climb strats, this required splitting off a second strat for the 2-screen variant. This is helpful anyway because now we can make the note more specific, telling the player how far to climb.

In Green Hill Zone, there was one case where the 2-screen grapple teleport X-ray climb variant was missing, so that is added here.

I also took the opportunity to clean up some of the older strat names, removing "Left-Side"/"Right-Side" since that information is redundant with the node that you're entering through.