### PR TITLE
Restrict position of Kraid Eye Door hero shot spark

### DIFF
--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -324,7 +324,9 @@
         {"shinespark": {"frames": 36}}
       ],
       "exitCondition": {
-        "leaveWithSpark": {}
+        "leaveWithSpark": {
+          "position": "top"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},


### PR DESCRIPTION
I believe the strat is unsound the way it is currently written. With 40 frames there's not enough time to get over the pillar, so top position would be the only option.