### PR TITLE
Fix some issues with auto-formatting

### DIFF
--- a/.github/workflows/run_scripts.yml
+++ b/.github/workflows/run_scripts.yml
@@ -58,12 +58,15 @@ jobs:
           python ./resources/ci/common/list_actions.py
       # Run Strat ID validator
       # Run Autoformatter
-      - name: Run Strat ID Generator & Autoformatter
+      - name: Run Strat ID Generator
         working-directory: scripts
         run: python populate_strat_ids.py
-      - name: Run Tech ID Generator & Autoformatter
+      - name: Run Tech ID Generator
         working-directory: scripts
         run: python populate_tech_ids.py
+      - name: Run Autoformatter
+        working-directory: scripts
+        run: python autoformat.py
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6.1.0
         with:

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1263,13 +1263,13 @@
               "description": "Represents that Samus can leave through this door by jumping from a platform to the side, carrying upward momentum into the next room.",
               "required": ["runway", "height", "obstruction"],
               "properties": {
-                "runway": {
-                  "$ref": "#/definitions/runway",
-                  "description": "Runway available to jump through the door, including unusable parts of the runway near an obstruction."
-                },
                 "height": {
                   "type": "number",
                   "description": "The vertical position of the runway, measured in number of tiles below the doorway, at the location where Samus would jump."
+                },
+                "runway": {
+                  "$ref": "#/definitions/runway",
+                  "description": "Runway available to jump through the door, including unusable parts of the runway near an obstruction."
                 },
                 "obstruction": {
                   "type": "array",

--- a/scripts/format_json.py
+++ b/scripts/format_json.py
@@ -25,7 +25,7 @@ def is_one_liner_dict(obj, parent_keys, nesting_allowed=True):
         return False
     if any(not is_allowed_one_line_key(x, parent_keys) for x in obj.keys()):
         return False
-    if len(obj) == 0:
+    if all(is_simple_value(x) for x in obj.values()):
         return True
     if len(obj) == 1:
         key, value = next(iter(obj.items()))
@@ -33,7 +33,7 @@ def is_one_liner_dict(obj, parent_keys, nesting_allowed=True):
             return False
         return is_one_liner(value, parent_keys + [key], nesting_allowed=nesting_allowed)
     else:
-        return all(is_simple_value(x) for x in obj.values())
+        return False
 
 
 def is_one_liner_list(obj, parent_keys, nesting_allowed=True):


### PR DESCRIPTION
This fixes a couple issues with auto-formatting:
- Certain kinds of objects weren't being formatted on one line when they should have been. Most noticeably this was affecting `resetRoom` requirements.
- The GitHub action ("Run Scripts") was not performing schema ordering as part of auto-formatting.

This is also switching the order of a couple things in `leaveWithSidePlatform` to align with what is used in most places.