### PR TITLE
Plowerhouse tricky dodge and cross while farming strats

### DIFF
--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -21,8 +21,7 @@
       "doorEnvironments": [{"physics": "air"}],
       "mapTileMask": [
         [2, 2, 1]
-      ],
-      "devNote": "FIXME can leave charged by charging in the acid"
+      ]
     },
     {
       "id": 2,
@@ -34,8 +33,7 @@
       "doorEnvironments": [{"physics": "air"}],
       "mapTileMask": [
         [1, 2, 2]
-      ],
-      "devNote": "FIXME can leave charged by charging in the acid"
+      ]
     },
     {
       "id": 3,
@@ -235,7 +233,7 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "Avoid the Holtzes",
+      "name": "Zebbo Damage Boost",
       "requires": [
         "canTrickyJump",
         "canHorizontalDamageBoost",
@@ -246,6 +244,50 @@
       "note": [
         "Turn back to the left after entering the room then run under the Holtzes.",
         "Damage from a Zebbo from the right farm to gain invulnerability frames, then jump through the last two Holtzes."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Cross While Farming",
+      "requires": [
+        "canFarmWhileShooting",
+        {"or": [
+          {"and": [
+            {"heatFramesWithEnergyDrops": {
+              "frames": 120,
+              "drops": [{"enemy": "Zebbo", "count": 1}]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 130,
+              "drops": [{"enemy": "Zebbo", "count": 1}]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 140,
+              "drops": [{"enemy": "Zebbo", "count": 1}]
+            }},
+            {"heatFrames": 100}    
+          ]},
+          {"and": [
+            {"or": [
+              "Spazer",
+              "Wave",
+              "Plasma"
+            ]},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 100,
+              "drops": [{"enemy": "Zebbo", "count": 1}]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 100,
+              "drops": [{"enemy": "Zebbo", "count": 1}]
+            }},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 130,
+              "drops": [{"enemy": "Zebbo", "count": 1}]
+            }},
+            {"heatFrames": 100}    
+          ]}
+        ]}
       ]
     },
     {
@@ -470,7 +512,7 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "Quick Run Through",
+      "name": "Zebbo Damage Boost",
       "requires": [
         "canTrickyJump",
         "canHorizontalDamageBoost",
@@ -478,6 +520,38 @@
         {"heatFrames": 315}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Tricky Dodge",
+      "requires": [
+        "canTrickyDodgeEnemies",
+        {"or": [
+          "canInsaneJump",
+          "canPreciseWalljump"
+        ]},
+        {"heatFrames": 325}
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Cross While Farming",
+      "requires": [
+        "canFarmWhileShooting",
+        {"heatFramesWithEnergyDrops": {
+          "frames": 100,
+          "drops": [{"enemy": "Zebbo", "count": 1}]
+        }},
+        {"heatFramesWithEnergyDrops": {
+          "frames": 125,
+          "drops": [{"enemy": "Zebbo", "count": 1}]
+        }},
+        {"heatFramesWithEnergyDrops": {
+          "frames": 125,
+          "drops": [{"enemy": "Zebbo", "count": 1}]
+        }},
+        {"heatFrames": 130}
+      ]
     },
     {
       "id": 42,


### PR DESCRIPTION
I've noticed it's fairly common for Plowerhouse to be a relatively easy sequence break on high-difficulty seeds. So this adds some more options for crossing.