### PR TITLE
Most of Pink Maridia G-Mode: Second Pass

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -522,6 +522,11 @@
             "h_artificialMorphSpringBall",
             {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 3}}
           ]},
+          {"and": [
+            "Gravity",
+            "h_artificialMorphSpringBall",
+            "canInsaneJump"
+          ]},
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 7}}
         ]}
       ],
@@ -606,11 +611,14 @@
           {"and": [
             "Gravity",
             "h_artificialMorphSpringBall",
-            {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
+            {"and": [
+              "canInsaneJump",
+              {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
+            ]}
           ]},
           {"and": [
             "h_artificialMorphSpringBall",
-            {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 3}}
+            {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 2}}
           ]},
           {"and": [
             "Gravity",
@@ -1077,8 +1085,9 @@
               "HiJump"
             ]},
             {"or": [
-              "canTrickyJump",
-              "h_artificialMorphPowerBomb"
+              "canInsaneJump",
+              "h_artificialMorphBombThings",
+              {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
             ]}
           ]}
         ]}
@@ -1111,8 +1120,9 @@
               "HiJump"
             ]},
             {"or": [
-              "canTrickyJump",
-              "h_artificialMorphPowerBomb"
+              "canInsaneJump",
+              "h_artificialMorphBombThings",
+              {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
             ]}
           ]}
         ]}

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -526,7 +526,7 @@
           {"and": [
             "Gravity",
             "h_artificialMorphSpringBall",
-            "canInsaneJump"
+            "canTrickyDodgeEnemies"
           ]},
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 7}}
         ]}
@@ -613,7 +613,7 @@
             "Gravity",
             "h_artificialMorphSpringBall",
             {"or": [
-              "canInsaneJump",
+              "canTrickyDodgeEnemies",
               {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
             ]}
           ]},
@@ -1087,6 +1087,10 @@
             ]},
             {"or": [
               "canInsaneJump",
+              {"and": [
+                "Gravity",
+                "canTrickyDodgeEnemies"
+              ]},
               "h_artificialMorphBombThings",
               {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
             ]}
@@ -1122,6 +1126,10 @@
             ]},
             {"or": [
               "canInsaneJump",
+              {"and": [
+                "Gravity",
+                "canTrickyDodgeEnemies"
+              ]},
               "h_artificialMorphBombThings",
               {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
             ]}

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1252,6 +1252,28 @@
       ]
     },
     {
+      "link": [1, 6],
+      "name": "G-Mode Overload PLMs, Speed Block X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canInsaneJump",
+        "canXRayClimb",
+        "Morph"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Overload PLMs by touching the sand, then move through the speed blocks. Avoiding the sand pits is easier without Gravity or HiJump.",
+        "Exit G-mode while inside the speed blocks then X-Ray climb up."
+      ],
+      "devNote": "This requires canInsaneJump even though it is not difficult, because it is not very intuitive."
+    },
+    {
       "id": 45,
       "link": [2, 2],
       "name": "Leave Normally",
@@ -2184,6 +2206,28 @@
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 5, "excessFrames": 2}}
       ]
+    },
+    {
+      "link": [4, 6],
+      "name": "G-Mode Overload PLMs, Speed Block X-Ray Climb",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": false
+        }
+      },
+      "requires": [
+        "canSuitlessMaridia",
+        "canInsaneJump",
+        "canXRayClimb",
+        "Morph"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Overload PLMs by touching the sand, then move through the speed blocks. Avoiding the sand pits is easier without Gravity or HiJump.",
+        "Exit G-mode while inside the speed blocks then X-Ray climb up."
+      ],
+      "devNote": "This requires canInsaneJump even though it is not difficult, because it is not very intuitive."
     },
     {
       "id": 53,

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -143,7 +143,8 @@
           "id": 4,
           "devNote": "Direct link passing below. Passage above should go 1 -> 5 -> 4."
         },
-        {"id": 5}
+        {"id": 5},
+        {"id": 6}
       ]
     },
     {
@@ -611,7 +612,7 @@
           {"and": [
             "Gravity",
             "h_artificialMorphSpringBall",
-            {"and": [
+            {"or": [
               "canInsaneJump",
               {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
             ]}

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1357,13 +1357,23 @@
       "requires": [
         {"or": [
           "Gravity",
-          "h_artificialMorphBombs",
+          {"and": [
+            "h_artificialMorphBombs",
+            "canInsaneJump"
+          ]},
           "h_artificialMorphPowerBomb",
+          {"and": [
+            "h_artificialMorphSpringFling",
+            "canTrickyGMode"
+          ]},
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 1}}
         ]}
       ],
       "flashSuitChecked": true,
-      "note": "Enter morphed and kill the Mochtroid with Bombs or a Power Bomb, or roll off the edge with Gravity to drop fast enough not to lure the Mochtroid."
+      "note": [
+        "Enter morphed and kill the Mochtroid with Bombs or a Power Bomb, or roll off the edge with Gravity to drop fast enough not to lure the Mochtroid.",
+        "It is also possible to Spring Fling by jumping from the ground immediately before the pause fully triggers to move right fast enough to avoid a hit."
+      ]
     },
     {
       "id": 37,
@@ -4094,8 +4104,6 @@
         {"or": [
           "canTrickyDodgeEnemies",
           "Gravity",
-          "h_artificialMorphBombs",
-          "h_artificialMorphPowerBomb",
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 1}}
         ]}
       ],
@@ -4147,6 +4155,7 @@
       "link": [5, 4],
       "name": "G-Mode Morph, Long Blind IBJ",
       "requires": [
+        "canEnterGMode",
         "Gravity",
         "h_artificialMorphLongIBJ",
         "canOffScreenMovement"
@@ -4158,17 +4167,19 @@
       "link": [5, 4],
       "name": "G-Mode Morph, Gravity Jump, Spring Ball Jump",
       "requires": [
+        "canEnterGMode",
         "canGravityJump",
         "HiJump",
         {"tech": "canSpringBallJumpMidAir"},
         "h_artificialMorphSpringBall",
-        "canTrickyJump"
+        "canInsaneJump"
       ],
       "flashSuitChecked": true,
       "note": [
-        "Climb the room with a Gravity jump + Spring Ball jump. Turn off Spring Ball and Gravity at the same time, then repause and turn Spring back on.",
+        "Climb the room with a Gravity jump + Spring Ball jump. Turn off Spring Ball and Gravity at the same time, then repause after a short delay and turn Spring back on.",
         "If coming from the right, Samus will be off camera."
-      ]
+      ],
+      "devNote": "This requires canInsaneJump even though it is not very difficult, because it is not very intuitive and may be off camera."
     },
     {
       "id": 199,

--- a/region/maridia/inner-pink/West Cactus Alley.json
+++ b/region/maridia/inner-pink/West Cactus Alley.json
@@ -719,17 +719,10 @@
         }
       },
       "requires": [
-        "h_artificialMorphDoubleSpringBallJump",
-        {"or": [
-          "h_artificialMorphPowerBomb",
-          {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 2}},
-          {"and": [
-            "canInsaneJump",
-            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
-          ]}
-        ]}
+        "h_artificialMorphDoubleSpringBallJump"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": "Be careful to avoid the stationary, invisible Cacatac spikes."
     },
     {
       "id": 51,


### PR DESCRIPTION
This is the rest of Pink Maridia, excluding East Cac Alley.

I also didn't add any strats for Botwoon. I figured G-mode would help with accuracy, as the rest of the body doesn't appear, but apparently it still has collision. Is it beneficial to add G-mode Botwoon strats just to help avoid the projectiles (from the left and right)? 