### PR TITLE
Refine Crumble Shaft

### DIFF
--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -214,7 +214,14 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        {"heatFrames": 200}
+        {"simpleHeatFrames": 150},
+        {"or": [
+          {"and": [
+            "canMoonfall",
+            {"heatFrames": 20}
+          ]},
+          {"heatFrames": 45}
+        ]}
       ]
     },
     {
@@ -396,24 +403,27 @@
       "note": "Shoot the shot block, then Spring Ball on the middle platform."
     },
     {
-      "id": 11,
-      "link": [2, 1],
-      "name": "HiJump Climb",
-      "requires": [
-        "HiJump",
-        "canConsecutiveWalljump",
-        {"heatFrames": 500}
-      ],
-      "note": "Walljump up the right, then setup a walljump on the top-right crumble platform directly from the right wall."
-    },
-    {
       "id": 12,
       "link": [2, 1],
-      "name": "HiJumpless Climb",
+      "name": "Wall Jump Climb",
       "requires": [
         "canPreciseWalljump",
         "canConsecutiveWalljump",
-        {"heatFrames": 500}
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 270}
+          ]},
+          {"heatFrames": 340}
+        ]},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"heatFrames": 300}
+        ]},
+        {"or": [
+          "canTrickyJump",
+          {"heatFrames": 300}
+        ]}
       ],
       "note": "Walljump up the right, then walljump off the top-middle crumble platform then off the top-right one."
     },
@@ -424,21 +434,20 @@
       "requires": [
         "canCrumbleJump",
         "canTrickyJump",
-        {"heatFrames": 800}
+        {"or": [
+          {"and": [
+            "HiJump",
+            "canTrickyDodgeEnemies",
+            {"heatFrames": 370}
+          ]},
+          {"heatFrames": 660}
+        ]}
       ],
-      "note": "Do 9 successive crumble jumps up the platforms.",
-      "devNote": "This is only really useful without wall jumps."
-    },
-    {
-      "id": 14,
-      "link": [2, 1],
-      "name": "Wall Jump Climb Crumble Jump",
-      "requires": [
-        "canCrumbleJump",
-        "canConsecutiveWalljump",
-        {"heatFrames": 600}
-      ],
-      "note": "Walljump up the right then do one crumble jump on the top middle platform."
+      "wallJumpAvoid": true,
+      "note": [
+        "Do 9 successive crumble jumps up the platforms.",
+        "If Hi-Jump is available, then it is possible to skip 4 of the crumble platforms."
+      ]
     },
     {
       "id": 15,
@@ -446,7 +455,7 @@
       "name": "Spring Ball",
       "requires": [
         "h_useSpringBall",
-        {"heatFrames": 800}
+        {"heatFrames": 720}
       ],
       "note": "Hold jump to easily do 9 successive spring ball bounces up the platforms."
     },
@@ -457,9 +466,19 @@
       "requires": [
         "SpaceJump",
         "canConsecutiveWalljump",
-        {"heatFrames": 500}
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 270}
+          ]},
+          {"heatFrames": 340}
+        ]},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"heatFrames": 300}
+        ]}
       ],
-      "note": "Walljump up the right, then use SpaceJump at the top."
+      "note": "Wall jump up the right, then use Space Jump at the top."
     },
     {
       "id": 17,
@@ -467,9 +486,15 @@
       "name": "Space Jump",
       "requires": [
         "SpaceJump",
-        {"heatFrames": 1000}
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 450}
+          ]},
+          {"heatFrames": 720}
+        ]}
       ],
-      "note": "Use SpaceJump to get to the top."
+      "note": "Use Space Jump to get to the top."
     },
     {
       "id": 18,
@@ -492,24 +517,14 @@
       "name": "Heatproof IBJ",
       "requires": [
         "h_heatProof",
-        "canLongIBJ"
+        "canLongIBJ",
+        "canBePatient"
       ],
       "note": [
         "Kill the Sova on the bottom-right platform, then IBJ right next to the left of the platform.",
         "Samus can align with the left side of the platform by jumping into it.",
         "Place bombs to kill the second Sova. Drop to the bottom and restart if necessary."
       ]
-    },
-    {
-      "id": 20,
-      "link": [2, 1],
-      "name": "WallJump and SpringBall",
-      "requires": [
-        "h_useSpringBall",
-        "canConsecutiveWalljump",
-        {"heatFrames": 500}
-      ],
-      "note": "Walljump up the right then SpringBall bounce on top of the highest Crumble Block platform to reach the door."
     },
     {
       "id": 21,
@@ -519,23 +534,12 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 60},
+        {"shineChargeFrames": 35},
         {"shinespark": {"frames": 59}},
-        {"heatFrames": 250}
+        {"heatFrames": 220}
       ],
       "flashSuitChecked": true,
       "note": "It has to be setup really close to the left side of the right platforms, otherwise it also requires a crumble jump at the top."
-    },
-    {
-      "id": 22,
-      "link": [2, 1],
-      "name": "Frozen Sova Climb",
-      "requires": [
-        "canTrickyUseFrozenEnemies",
-        "canConsecutiveWalljump",
-        {"heatFrames": 800}
-      ],
-      "note": "Climb up the left, freeze the top-left Sova, and use it as a platform to reach the door."
     },
     {
       "id": 23,
@@ -550,8 +554,7 @@
         "canBePatient"
       ],
       "flashSuitChecked": true,
-      "note": "Climb up 3 screens.",
-      "devNote": "Heat frames split into the actual climb and the setup in the adjacent room."
+      "note": "Climb up 3 screens."
     },
     {
       "id": 24,
@@ -831,7 +834,28 @@
       "name": "Base",
       "requires": [
         "canConsecutiveWalljump",
-        {"heatFrames": 550}
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"heatFrames": 320}
+          ]},
+          {"heatFrames": 395}
+        ]},
+        {"or": [
+          {"and": [
+            "canPreciseWalljump",
+            "canTrickyJump"
+          ]},
+          {"and": [
+            "canStaggeredWalljump",
+            {"heatFrames": 50}
+          ]},
+          {"heatFrames": 300}
+        ]}
+      ],
+      "note": [
+        "If entering from the bottom door, a Sova will be in the way in the top left:",
+        "either wall jump in place while waiting for it, or wall jump around it using two crumble platforms to the right."
       ]
     },
     {
@@ -851,7 +875,8 @@
       "name": "Heatproof IBJ",
       "requires": [
         "h_heatProof",
-        "canLongIBJ"
+        "canLongIBJ",
+        "canBePatient"
       ],
       "note": "IBJ against the left-most wall. Place bombs to kill the Sova. Drop to the bottom and restart if necessary."
     },
@@ -865,7 +890,7 @@
       "requires": [
         {"shineChargeFrames": 30},
         {"shinespark": {"frames": 59}},
-        {"heatFrames": 250}
+        {"heatFrames": 180}
       ],
       "flashSuitChecked": true,
       "note": "It is easiest to do a diagonal shinespark up the left wall, then hold left, angle down, and spam shoot to easily grab the item."
@@ -916,7 +941,7 @@
       "link": [3, 2],
       "name": "Base",
       "requires": [
-        {"heatFrames": 250}
+        {"heatFrames": 205}
       ]
     }
   ],

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -851,6 +851,10 @@
             {"heatFrames": 50}
           ]},
           {"heatFrames": 300}
+        ]},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"heatFrames": 300}
         ]}
       ],
       "note": [

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -214,14 +214,30 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        {"simpleHeatFrames": 150},
-        {"or": [
-          {"and": [
-            "canMoonfall",
-            {"heatFrames": 20}
-          ]},
-          {"heatFrames": 45}
-        ]}
+        {"simpleHeatFrames": 120},
+        {"heatFrames": 75}
+      ],
+      "note": [
+        "Falling down the right side of the room is safe."
+      ]
+    },
+    {
+      "id": 3,
+      "link": [1, 2],
+      "name": "Moonfall",
+      "requires": [
+        "canMoonfall",
+        "canTrickyJump",
+        {"simpleHeatFrames": 100},
+        {"heatFrames": 60}
+      ],
+      "note": [
+        "Move forward far enough to trigger the crumble block, then quickly moonfall before it respawns.",
+        "It can help to perform the moonfall facing left (backing up to the right),",
+        "then quickly turn back left to clear the platform.",
+        "Press against the wall, aim down, and shoot open the door while falling.",
+        "It is possible to delay the moonfall enough to land on the doorframe,",
+        "by turning around back and forth once mid-air."
       ]
     },
     {
@@ -425,7 +441,10 @@
           {"heatFrames": 300}
         ]}
       ],
-      "note": "Walljump up the right, then walljump off the top-middle crumble platform then off the top-right one."
+      "note": [
+        "Enter with a spin jump, and wall jump up the right side;",
+        "at the end, walljump off the top-middle crumble platform then off the top-right one."
+      ]
     },
     {
       "id": 13,
@@ -434,19 +453,21 @@
       "requires": [
         "canCrumbleJump",
         "canTrickyJump",
+        "canTrickyDodgeEnemies",
         {"or": [
           {"and": [
             "HiJump",
-            "canTrickyDodgeEnemies",
+            "canInsaneJump",
             {"heatFrames": 370}
           ]},
-          {"heatFrames": 660}
+          {"heatFrames": 630}
         ]}
       ],
       "wallJumpAvoid": true,
       "note": [
         "Do 9 successive crumble jumps up the platforms.",
-        "If Hi-Jump is available, then it is possible to skip 4 of the crumble platforms."
+        "If Hi-Jump is available, then it is possible to skip 4 of the crumble platforms, using only the center platforms,",
+        "in which case it is recommended to down-grab the 3rd center platform, though doing a crumble spin jump onto it is also an option."
       ]
     },
     {

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -222,7 +222,6 @@
       ]
     },
     {
-      "id": 3,
       "link": [1, 2],
       "name": "Moonfall",
       "requires": [

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -562,6 +562,18 @@
       "note": "It has to be setup really close to the left side of the right platforms, otherwise it also requires a crumble jump at the top."
     },
     {
+      "link": [2, 1],
+      "name": "Frozen Sova Hi-Jump Climb",
+      "requires": [
+        "HiJump",
+        "canTrickyUseFrozenEnemies",
+        {"heatFrames": 630}
+      ],
+      "note": [
+        "Use the Sovas as platforms to climb the room."
+      ]
+    },
+    {
       "id": 23,
       "link": [2, 1],
       "name": "X-Ray Climb",


### PR DESCRIPTION
- Many heat frames are tightened.
- More lenience is added to the wall-jump climbs on low difficulty (especially Medium)
- Some apparently non-useful strats are removed:
    - HiJump Climb: The instruction to wall jump directly off the top-right crumble block seemed questionable; using the floating crumble platform is much easier and also seems faster. I combined this with the bootless version since there doesn't seem to be a reason for it to be a separate strat.
    - WallJump and SpringBall: The problem is the Sova gets in your way where you want to bounce with Spring Ball. You can wait for it with canStaggeredWalljump, or bounce in a very precise place on the edge of the crumbles; but these both seem more difficult than just wall jumping the regular way off the side of the crumble block.
    - Frozen Sova Climb: With the left-side climb, a Sova gets directly in your way (assuming a bottom-door entry), so you either have to staggered wall jump to wait for it, or carefully wall jump around it. The whole thing seems significantly more difficult than just walljumping up the right side the regular way.

Wall jumping up either side of the room is quite tricky for Medium: I think it can be ok but we have to allow for the fact that the player is expected to fall down many times, either from missing the precise wall jumps or from Sovas getting in the way. So that's the reason for adding the extra lenience heat frames in the absence of `canDodgeWhileShooting` tech. And those will stack on top of the heat damage multiplier, which I think is necessary; at that level, the player is going to want to have a ton of tanks here.