### PR TITLE
Acid Statue shinespark slope clip X-Ray climb

### DIFF
--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -85,14 +85,7 @@
       ]
     }
   ],
-  "obstacles": [
-    {
-      "id": "A",
-      "name": "Camera Broken",
-      "obstacleType": "abstract",
-      "note": "Represents being off-camera in the top part of the room."
-    }
-  ],
+  "obstacles": [],
   "enemies": [
     {
       "id": "e1",
@@ -122,6 +115,7 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 3},
         {"id": 5}
@@ -353,13 +347,11 @@
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
         "Grapple teleporting here will spawn Samus inside the wall behind the Acid Chozo statue.",
         "To escape, perform a Crystal Flash to stand up, then morph and roll out to the right.",
-        "Samus will be visible but off-camera, making the movement tricky.",
-        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
+        "Samus will be visible but off-camera, making the movement tricky."
       ]
     },
     {
@@ -376,15 +368,13 @@
         {"heatFrames": 220},
         "canOffScreenMovement"
       ],
-      "clearsObstacles": ["A"],
       "note": [
         "After teleporting, press down to retract Grapple.",
         "Samus will be inside the Power Bomb blocks behind the Acid Chozo statue hand.",
         "Use a Power Bomb, wait to begin falling, then hold right to roll out under the hand.",
         "Samus will be visible but off-camera, making the movement tricky.",
         "Holding right too early after laying the Power Bomb will cause Samus to get stuck inside the Chozo hand;",
-        "in this case, Samus can get out by unmorphing, remorphing, and rolling to the right on top of the hand.",
-        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
+        "in this case, Samus can get out by unmorphing, remorphing, and rolling to the right on top of the hand."
       ]
     },
     {
@@ -424,6 +414,60 @@
         "The Holtz still damage Samus, and the middle one is low enough to make it difficult to bomb boost across.",
         "Other strats in the room are ignored because Samus needs real Morph and Varia or a lot of Energy to use the statue,",
         "and there is no way to overload PLMs to go through the bomb blocks from the bottom of the room."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Shinespark Slope Clip X-Ray Climb (Come in Shinecharged)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 35},
+        {"shinespark": {"frames": 33, "excessFrames": 0}},
+        "canShinesparkSlopeClip",
+        "canXRayClimb",
+        "canOffScreenMovement",
+        {"heatFrames": 1020}
+      ],
+      "note": [
+        "Gain a shinecharge and spark into the wall at the left side of the room to clip into it.",
+        "From there, X-Ray climb to the top portion of the room (about 0.75 screens).",
+        "Samus will be visible but off-camera, making the movement tricky."
+      ],
+      "detailNote": [
+        "Only certain horizontal positions for the spark will work.",
+        "There are periodic windows of approximately 4 good pixels followed by 8 bad pixels.",
+        "Moonwalking back against the ledge below the door will put Samus into a good position.",
+        "Being centered over this two-tile ledge is another position that works."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Shinespark Slope Clip X-Ray Climb (Come in Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"shinespark": {"frames": 33, "excessFrames": 0}},
+        "canShinesparkSlopeClip",
+        "canXRayClimb",
+        "canOffScreenMovement",
+        {"heatFrames": 1020}
+      ],
+      "note": [
+        "Gain a shinecharge and spark into the wall at the left side of the room to clip into it.",
+        "From there, X-Ray climb to the top portion of the room (about 0.75 screens).",
+        "Samus will be visible but off-camera, making the movement tricky."
+      ],
+      "detailNote": [
+        "Only certain horizontal positions for the spark will work.",
+        "There are periodic windows of approximately 4 good pixels followed by 8 bad pixels.",
+        "Moonwalking back against the ledge below the door will put Samus into a good position.",
+        "Being centered over this two-tile ledge is another position that works."
       ]
     },
     {
@@ -478,13 +522,11 @@
         {"heatFrames": 20},
         "canOffScreenMovement"
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": [
         "Grapple teleporting here will spawn Samus inside the wall behind the Acid Chozo statue.",
         "To escape, perform a Crystal Flash to stand up, then morph and roll out to the right.",
-        "Samus will be visible but off-camera, making the movement tricky.",
-        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
+        "Samus will be visible but off-camera, making the movement tricky."
       ]
     },
     {
@@ -501,15 +543,79 @@
         {"heatFrames": 220},
         "canOffScreenMovement"
       ],
-      "clearsObstacles": ["A"],
       "note": [
         "After teleporting, press down to retract Grapple.",
         "Samus will be inside the Power Bomb blocks behind the Acid Chozo statue hand.",
         "Use a Power Bomb, wait to begin falling, then hold right to roll out under the hand.",
         "Samus will be visible but off-camera, making the movement tricky.",
         "Holding right too early after laying the Power Bomb will cause Samus to get stuck inside the Chozo hand;",
-        "in this case, Samus can get out by unmorphing, remorphing, and rolling to the right on top of the hand.",
-        "While off camera, the Chozo hand will not function (i.e., will not trigger the acid lowering cutscene)."
+        "in this case, Samus can get out by unmorphing, remorphing, and rolling to the right on top of the hand."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Shinespark Slope Clip X-Ray Climb (Come in Shinecharged)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 35},
+        {"shinespark": {"frames": 33, "excessFrames": 0}},
+        "canShinesparkSlopeClip",
+        "canXRayClimb",
+        "canOffScreenMovement",
+        {"or": [
+          "canPreciseWalljump",
+          "SpaceJump",
+          "HiJump",
+          "canTrickySpringBallJump"
+        ]},
+        {"heatFrames": 970}
+      ],
+      "note": [
+        "Gain a shinecharge and spark into the wall at the left side of the room to clip into it.",
+        "From there, X-Ray climb to the top portion of the room (about 0.75 screens).",
+        "Samus will be visible but off-camera, making the movement tricky."
+      ],
+      "detailNote": [
+        "Only certain horizontal positions for the spark will work.",
+        "There are periodic windows of approximately 4 good pixels followed by 8 bad pixels.",
+        "Moonwalking back against the ledge below the door will put Samus into a good position.",
+        "Being centered over this two-tile ledge is another position that works."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Shinespark Slope Clip X-Ray Climb (Come in Shinecharging)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        {"shinespark": {"frames": 33, "excessFrames": 0}},
+        "canShinesparkSlopeClip",
+        "canXRayClimb",
+        "canOffScreenMovement",
+        {"or": [
+          "canPreciseWalljump",
+          "SpaceJump",
+          "HiJump",
+          "canTrickySpringBallJump"
+        ]},
+        {"heatFrames": 970}
+      ],
+      "note": [
+        "Gain a shinecharge and spark into the wall at the left side of the room to clip into it.",
+        "From there, X-Ray climb to the top portion of the room (about 0.75 screens).",
+        "Samus will be visible but off-camera, making the movement tricky."
+      ],
+      "detailNote": [
+        "Only certain horizontal positions for the spark will work.",
+        "There are periodic windows of approximately 4 good pixels followed by 8 bad pixels.",
+        "Moonwalking back against the ledge below the door will put Samus into a good position.",
+        "Being centered over this two-tile ledge is another position that works."
       ]
     },
     {
@@ -603,7 +709,6 @@
       "name": "Use Acid Statue",
       "requires": [
         "h_activateAcidChozo",
-        {"obstaclesNotCleared": ["A"]},
         "h_usePowerBomb",
         {"heatFrames": 1020}
       ],
@@ -625,7 +730,6 @@
       "requires": [
         "h_heatedCrystalFlash",
         "h_activateAcidChozo",
-        {"obstaclesNotCleared": ["A"]},
         {"heatFrames": 920}
       ],
       "setsFlags": ["f_UsedAcidChozoStatue"],
@@ -638,7 +742,6 @@
       "name": "Acid Statue with Reserve Trigger",
       "requires": [
         "h_activateAcidChozo",
-        {"obstaclesNotCleared": ["A"]},
         "h_usePowerBomb",
         {"heatFrames": 180},
         "canManageReserves",


### PR DESCRIPTION
- Adds the shinespark slope clip to X-Ray climb up Acid Statue Room. After the X-Ray climb, you can go either to the door or to the statue. Going directly to the statue can be significantly useful since the acid is gone but would come back if the room were to be reset.
- Fixes an issue with the Grapple Teleport strats: previously I thought that the statue wouldn't work off-camera, but in fact it does. I'm pretty sure that when I tested this before I must have just not had Space Jump collected :facepalm: 