### PR TITLE
Moat CWJ bomb boost

### DIFF
--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -1106,6 +1106,28 @@
       ]
     },
     {
+      "link": [3, 2],
+      "name": "CWJ Bomb Boost",
+      "requires": [
+        {"notable": "CWJ Bomb Boost"},
+        "canCWJ",
+        "canWallJumpBombBoost",
+        "canResetFallSpeed"
+      ],
+      "note": [
+        "Stand on the item pedestal facing right.",
+        "Perform a short stationary spin jump with some dash speed, and do a continuous wall jump off the item pedestal.",
+        "Lay a Power Bomb (or Bomb) and use it to boost to the right, with a well-timed unmorph to reset fall speed."
+      ],
+      "detailNote": [
+        "It is ideal to gain 3 frames of dash speed, the maximum possible, but lower amounts can work.",
+        "It is even possible to do a regular wall jump instead of a CWJ, but the CWJ makes it significantly more lenient.",
+        "It is best for the wall jump to be performed as high as possible.",
+        "If Speed Booster is available, equipping it will generally be helpful,",
+        "as it will increase the height of Samus' wall jump based on the amount of dash speed."
+      ]
+    },
+    {
       "id": 54,
       "link": [3, 2],
       "name": "Ceiling Bomb Jump",
@@ -1234,8 +1256,17 @@
         "Moonwalk into the transition on the same frame that the Grapple Beam reaches the Grapple block.",
         "Continue holding Grapple through the door transition to initiate a teleport in the next room."
       ]
+    },
+    {
+      "id": 3,
+      "name": "CWJ Bomb Boost",
+      "note": [
+        "Stand on the item pedestal facing right.",
+        "Perform a stationary spin jump with some dash speed, and do a continuous wall jump off the item pedestal.",
+        "Lay a Power Bomb (or Bomb) and use it to boost to the right, with a well-timed unmorph to reset fall speed."
+      ]
     }
   ],
   "nextStratId": 64,
-  "nextNotableId": 3
+  "nextNotableId": 4
 }

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -1314,7 +1314,8 @@
       ],
       "clearsObstacles": ["B"],
       "note": [
-        "Perform a running stationary spinjump from a precise spot, then a CWJ with slightly more speed off the wall one tile further out.",
+        "Perform a running stationary spinjump from a precise spot, with 3 frames of dash speed (the maximum possible);",
+        "then do a CWJ off the wall above, one tile further out.",
         "This makes it possible to just barely walljump off the grapple block."
       ]
     },


### PR DESCRIPTION
This was one of the items on Bobbob's list from a couple years ago (https://github.com/vg-json-data/sm-json-data/issues/2149).

I'm thinking this is probably an Extreme notable, though maybe it could be Insane.

This bomb boost strat can be useful if the door on the left is locked since the usual CWJ strat won't work in that case.

Video: https://videos.maprando.com/video/7142