### PR TITLE
Green Hill Zone more leaveShinecharged

### DIFF
--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -210,45 +210,30 @@
       "flashSuitChecked": true
     },
     {
-      "id": 2,
-      "link": [1, 1],
-      "name": "Leave Shinecharged (HiJump)",
-      "requires": [
-        "HiJump",
-        {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
-        "canShinechargeMovementTricky",
-        {"shineChargeFrames": 130}
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {}
-      },
-      "flashSuitChecked": true,
-      "note": [
-        "Use the runway below the bug pipe to gain a shinecharge.",
-        "Use HiJump to reach the door with shinecharge frames remaining."
-      ],
-      "devNote": [
-        "One tile of runway is considered unusable in order to have space to quickly jump up onto the bomb blocks above.",
-        "It could also be possible to break the bomb blocks, but this doesn't seem very worth considering."
-      ]
-    },
-    {
       "id": 3,
       "link": [1, 1],
-      "name": "Leave Shinecharged (Wall Jump)",
-      "requires": [
-        "canWalljump",
+      "name": "Leave Shinecharged (Far Runway)",
+      "requires": [        
         {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
         "canShinechargeMovementTricky",
-        {"shineChargeFrames": 170}
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 130}    
+          ]},
+          {"and": [
+            "canWalljump",
+            {"shineChargeFrames": 170}
+          ]},
+          {"shineChargeFrames": 175}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
       },
       "flashSuitChecked": true,
       "note": [
-        "Use the runway below the bug pipe to gain a shinecharge.",
-        "Use a wall jump to reach the door with shinecharge frames remaining."
+        "Use the runway below the bug pipe to gain a shinecharge and reach the door with shinecharge frames remaining."
       ],
       "devNote": [
         "One tile of runway is considered unusable in order to have space to quickly jump up onto the bomb blocks above.",
@@ -256,25 +241,29 @@
       ]
     },
     {
-      "id": 4,
       "link": [1, 1],
-      "name": "Leave Shinecharged (Ledge Grabs)",
-      "requires": [
-        {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
+      "name": "Leave Shinecharged (Close Runway)",
+      "requires": [        
+        {"canShineCharge": {"usedTiles": 14, "openEnd": 1}},
+        {"or": [
+          {"canShineCharge": {"usedTiles": 14, "openEnd": 0}},
+          {"shineChargeFrames": 15}
+        ]},
         "canShinechargeMovementTricky",
-        {"shineChargeFrames": 175}
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 75}
+          ]},
+          {"shineChargeFrames": 80}
+        ]}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
       },
       "flashSuitChecked": true,
       "note": [
-        "Use the runway below the bug pipe to gain a shinecharge.",
-        "Use precise ledge grabs to barely reach the door with shinecharge frames remaining."
-      ],
-      "devNote": [
-        "One tile of runway is considered unusable in order to have space to quickly jump up onto the bomb blocks above.",
-        "It could also be possible to break the bomb blocks, potentially increasing the framesRemaining slightly."
+        "Use the short runway below the door to gain a shinecharge and reach the door with shinecharge frames remaining."
       ]
     },
     {
@@ -1022,12 +1011,12 @@
     {
       "id": 40,
       "link": [2, 2],
-      "name": "Leave Shinecharged (HiJump)",
+      "name": "Leave Shinecharged (Far Runway)",
       "requires": [
         "HiJump",
         {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
         "canShinechargeMovementComplex",
-        {"shineChargeFrames": 155}
+        {"shineChargeFrames": 150}
       ],
       "exitCondition": {
         "leaveShinecharged": {}
@@ -1035,7 +1024,7 @@
       "flashSuitChecked": true,
       "note": [
         "Use the runway below the bug pipe to gain a shinecharge.",
-        "Use HiJump to reach the door with shinecharge frames remaining."
+        "Use Hi-Jump to reach the door with shinecharge frames remaining."
       ],
       "devNote": [
         "One tile of runway is considered unusable in order to have space to quickly jump up onto the bomb blocks above.",
@@ -1045,7 +1034,7 @@
     {
       "id": 41,
       "link": [2, 2],
-      "name": "Leave With Spark",
+      "name": "Leave With Spark (Far Runway)",
       "requires": [
         "canPreciseWalljump",
         {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
@@ -1063,6 +1052,33 @@
       "devNote": [
         "One tile of runway is considered unusable in order to have space to quickly jump up to the bomb blocks above.",
         "It could also be possible to break the bomb blocks, but this doesn't seem very worth considering."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Shinecharged (Close Runway)",
+      "requires": [
+        {"canShineCharge": {"usedTiles": 14, "openEnd": 1}},
+        "canShinechargeMovementComplex",
+        {"or": [
+          {"and": [
+            "HiJump",
+            {"shineChargeFrames": 135}
+          ]},
+          {"and": [
+            "canTrickyDashJump",
+            "canWalljump",
+            "canShinechargeMovementTricky",
+            {"shineChargeFrames": 155}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "flashSuitChecked": true,
+      "note": [
+        "Use the runway below the door to gain a shinecharge and leave with shinecharge frames remaining."
       ]
     },
     {


### PR DESCRIPTION
Seeing [this video](https://videos.maprando.com/video/6690) from Sam was a reminder to add `leaveShinecharged` strats at the top of Green Hill Zone using the short runway at the top of the room. The shinecharge frames for the lower runway were also able to be tightened a bit. Also it was possible to consolidate several strats into one, using the `shineChargeFrames` logical requirement which I don't think was available at the time these were first written.