### PR TITLE
Add dodge option for Pants Room grapple jump

### DIFF
--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -468,7 +468,8 @@
               "canStaggeredWalljump"
             ]}
           ]},
-          "h_pauseAbuseMinimalReserveRefill"
+          "h_pauseAbuseMinimalReserveRefill",
+          "canTrickyDodgeEnemies"
         ]}
       ],
       "note": [


### PR DESCRIPTION
Avoiding the Menus doesn't seem bad, by just grapple jumping up all the way to the top.

Video by Sam: https://videos.maprando.com/video/6717