### PR TITLE
Climb frozen pirate behemoth spark

### DIFF
--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -2117,14 +2117,28 @@
         {"notable": "Behemoth Shinespark"},
         "Morph",
         {"canShineCharge": {"usedTiles": 28, "openEnd": 0}},
-        {"shinespark": {"frames": 147, "excessFrames": 124}},
+        {"or": [
+          {"shinespark": {"frames": 147, "excessFrames": 124}},
+          {"and": [
+            "h_ZebesIsAwake",
+            "canTrickyUseFrozenEnemies",
+            {"shinespark": {"frames": 24, "excessFrames": 1}}
+          ]}
+        ]},
         {"obstaclesCleared": ["A"]},
         {"or": [
           "h_ClimbWithoutLava",
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
-      "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right."
+      "note": [
+        "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right.",
+        "A frozen Pirate can be used to stop the spark just above the bottom tunnel."
+      ],
+      "devNote": [
+        "FIXME: if Zebes is awake, it is possible to farm the Pirates in the room after breaking the blocks;",
+        "this also applies to the other forms of Behemoth spark in this room (as long as the lava is not active)."
+      ]
     },
     {
       "id": 98,


### PR DESCRIPTION
I'm getting interested in generalizing `heatFramesWithEnergyDrops` and `lavaFramesWithEnergyDrops`, rather than adding a new one `shinesparkWithEnergyDrops`, which would apply here.

Video: https://videos.maprando.com/video/6761