### PR TITLE
Refine X-Ray dboost strats

### DIFF
--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -510,20 +510,64 @@
         "canHorizontalDamageBoost",
         "canTrickyJump",
         "canUseIFrames",
-        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 6}},
         {"or": [
-          {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 1}},
+          {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 2}},
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 1}}
+          ]},
           "canInsaneJump"
-        ]}
+        ]},
+        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 6}}
       ],
       "note": [
         "A precise strat that involves crossing both gaps by damage boosting off Wavers.",
         "The Wavers are also used for i-frames to avoid taking damage from any spikes.",
-        "It generally best to use a Fireflea to quickly boost to the left,",
+        "It generally best to use a Fireflea (or two) to quickly boost to the left,",
         "in order to boost off the Waver during its first cycle.",
         "Waiting for the Waver to return is possible and does not take long,",
         "but it gives a different pattern at the left side of the room,",
         "making the final damage boost significantly more difficult."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "X-Ray Access Damage Boost Speedy Jump",
+      "requires": [
+        "canHorizontalDamageBoost",
+        "canTrickyJump",
+        "canUseIFrames",
+        "SpeedBooster",
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 1}}
+          ]},
+          {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 2}}
+        ]},
+        {"or": [
+          {"and": [
+            "canInsaneJump",
+            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
+          ]},
+          {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}}
+        ]}
+      ],
+      "note": [
+        "Use a Fireflea (or two) to quickly boost to the left,",
+        "to be able to catch the Waver and boost off it on its first cycle, to cross the first gap.",
+        "Take one or two more hits from the Wavers for i-frames;",
+        "take the last hit close to the ground while holding forward.",
+        "Then gain speed using Speed Booster to jump across the second gap."
+      ],
+      "detailNote": [
+        "Using the second Waver cycle leads to a bad pattern at the end,",
+        "where the path of the speedy jump will be blocked by a Waver,",
+        "which can still be avoided but only with great difficulty."
+      ],
+      "devNote": [
+        "FIXME: Patiently waiting for a different Waver cycle could be another way to avoid Fireflea damage."
       ]
     },
     {
@@ -944,10 +988,16 @@
         "canHorizontalDamageBoost",
         "canTrickyJump",
         "canUseIFrames",
-        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}},
         {"or": [
-          "canTrickyDodgeEnemies",
-          {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
+          {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 5}},
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}}
+          ]},
+          {"and": [
+            "canInsaneJump",
+            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
+          ]}
         ]}
       ],
       "note": [

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -552,6 +552,10 @@
             {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
           ]},
           {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}}
+        ]},
+        {"or": [
+          "canWalljump",
+          "canTrickyDodgeEnemies"
         ]}
       ],
       "note": [
@@ -559,7 +563,8 @@
         "to be able to catch the Waver and boost off it on its first cycle, to cross the first gap.",
         "Take one or two more hits from the Wavers for i-frames;",
         "take the last hit close to the ground while holding forward.",
-        "Then gain speed using Speed Booster to jump across the second gap."
+        "Then gain speed using Speed Booster to jump across the second gap.",
+        "If the jump is slightly short, a wall jump can be used to get up."
       ],
       "detailNote": [
         "Using the second Waver cycle leads to a bad pattern at the end,",

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -572,7 +572,8 @@
         "which can still be avoided but only with great difficulty."
       ],
       "devNote": [
-        "FIXME: Patiently waiting for a different Waver cycle could be another way to avoid Fireflea damage."
+        "FIXME: Patiently waiting for a different Waver cycle could be another way to avoid Fireflea damage.",
+        "FIXME: gaining a shinecharge on the spikes (and hero shot sparking out the left door) is possible though extremely precise."
       ]
     },
     {

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -109,7 +109,8 @@
       "to": [
         {"id": 1},
         {"id": 2},
-        {"id": 3}
+        {"id": 3},
+        {"id": 4}
       ]
     },
     {
@@ -508,11 +509,21 @@
         {"notable": "X-Ray Access Damage Boost"},
         "canHorizontalDamageBoost",
         "canTrickyJump",
-        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 6}}
+        "canUseIFrames",
+        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 6}},
+        {"or": [
+          {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 1}},
+          "canInsaneJump"
+        ]}
       ],
       "note": [
-        "A precise strat that involves crossing both gaps by dboosting off Wavers.",
-        "The Wavers are also used for iframes to avoid taking damage from any spikes."
+        "A precise strat that involves crossing both gaps by damage boosting off Wavers.",
+        "The Wavers are also used for i-frames to avoid taking damage from any spikes.",
+        "It generally best to use a Fireflea to quickly boost to the left,",
+        "in order to boost off the Waver during its first cycle.",
+        "Waiting for the Waver to return is possible and does not take long,",
+        "but it gives a different pattern at the left side of the room,",
+        "making the final damage boost significantly more difficult."
       ]
     },
     {
@@ -923,8 +934,34 @@
       ],
       "note": [
         "Damage boost off of the Fireflea or a Waver in order to get onto the upper spikes.",
+        "It is possible to quickly get into position to use the Waver or to wait for it to return."
+      ]
+    },
+    {
+      "link": [2, 4],
+      "name": "Damage Boost and Use I-Frames",
+      "requires": [
+        "canHorizontalDamageBoost",
+        "canTrickyJump",
+        "canUseIFrames",
+        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}},
+        {"or": [
+          "canTrickyDodgeEnemies",
+          {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
+        ]}
+      ],
+      "note": [
+        "Damage boost off a Waver to get onto the upper spikes,",
+        "then continue taking hits from the Waver to gain i-frames and avoid any spike hits.",
         "It is possible to quickly get into position to use the Waver or to wait for it to return.",
-        "It is also possible (but not required in this strat) to perform a second damage boost off of the Wavers to avoid some spike damage."
+        "There are several possible ways to ensure Samus lands on the safe platform:",
+        "1) align with the right-most vine of the group of 3 vines in the background;",
+        "2) position so that one tile of the doorway ledge is visible on camera; or",
+        "3) take an extra Waver hit, to have i-frames while descending the spike stairs."
+      ],
+      "devNote": [
+        "FIXME: account for the possibility of farming the Waver (or all 3) at the end,",
+        "compensating for some of the damage."
       ]
     },
     {


### PR DESCRIPTION
There is already a 2->3 Damage Boost strat in Very Hard. This PR adds a 2->4 version, which does the same thing except it also continues using the Waver for i-frames and then lands on the safe platform below. I'm thinking this should be fine in Very Hard since it doesn't have to do the tricky damage boost at the end and also has no need to do the entry quickly (since the second Waver cycle is fine). Landing on the safe platform is a bit tricky and we could add a spike hit requirement if it's an issue. 

I'm hoping this will help smooth the difficulty curve, by giving VH players more exposure to this easier version of the damage boost. If the items are available to go 4->1, this new strat can also reduce the logical damage (taking only 3 Waver hits instead of 6).

Videos:
- Extra Waver hits (Very Hard version): https://videos.maprando.com/video/7189
- Minimal damage (Expert version): https://videos.maprando.com/video/7191