### PR TITLE
Wall jump tech adjustments

### DIFF
--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -3228,7 +3228,7 @@
       "name": "Zeb Ice Clip",
       "requires": [
         {"notable": "Zeb Ice Clip"},
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         "canCameraManip",
         {"or": [
           "Wave",
@@ -3253,7 +3253,7 @@
       "name": "Blind Zeb Ice Clip (Preserve Flash Suit)",
       "requires": [
         {"notable": "Blind Zeb Ice Clip (Preserve Flash Suit)"},
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         "canCameraManip",
         "canOffScreenMovement",
         {"or": [
@@ -3281,7 +3281,7 @@
         {"notable": "Zeb Ice Clip"},
         "canSpecialBeamAttack",
         {"ammo": {"type": "PowerBomb", "count": 1}},
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         "h_preciseIceClip",
         {"disableEquipment": "Ice"}
       ],

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -370,7 +370,7 @@
                 {"cycleFrames": 1080}
               ]},
               {"and": [
-                "canStaggeredWalljump",
+                "canTrickyWalljump",
                 {"cycleFrames": 1770}
               ]}
             ]}
@@ -2624,7 +2624,7 @@
         {"notable": "Hero Shot"},
         "canHeroShot",
         "canPreciseWalljump",
-        "canStaggeredWalljump"
+        "canTrickyWalljump"
       ],
       "note": "Wall jump between the Rippers. Either shoot the block, fall, and quickly climb again, or shoot from the bottom and follow Samus's shot up the tower."
     },

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -2623,7 +2623,6 @@
       "requires": [
         {"notable": "Hero Shot"},
         "canHeroShot",
-        "canPreciseWalljump",
         "canTrickyWalljump"
       ],
       "note": "Wall jump between the Rippers. Either shoot the block, fall, and quickly climb again, or shoot from the bottom and follow Samus's shot up the tower."

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -489,7 +489,7 @@
             "HiJump",
             "canSpringBallJumpMidAir"
           ]},
-          "canDelayedWalljump",
+          "canTrickyWalljump",
           {"and": [
             "SpeedBooster",
             "HiJump"
@@ -1631,7 +1631,7 @@
       "link": [5, 7],
       "name": "Gauntlet Walljumps",
       "requires": [
-        "canDelayedWalljump",
+        "canTrickyWalljump",
         {"or": [
           "HiJump",
           "canConsecutiveWalljump"

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -2492,9 +2492,15 @@
       "requires": [
         "canUseEnemies",
         {"or": [
-          "canCarefulJump",
-          "canUseFrozenEnemies",
-          "canPreciseWalljump"
+          {"and": [
+            "canUseFrozenEnemies",
+            "canPreciseWalljump"  
+          ]},
+          "canTrickyWalljump",
+          {"and": [
+            "canCameraManip",
+            "canCarefulJump"
+          ]}
         ]}
       ],
       "note": [

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -1126,7 +1126,7 @@
         {"or": [
           {"and": [
             "canTrickyJump",
-            "canStaggeredWalljump"
+            "canTrickyWalljump"
           ]},
           {"and": [
             "canCarefulJump",

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -491,7 +491,7 @@
         "canChainTemporaryBlue",
         {"acidFrames": 10},
         {"or": [
-          "canStaggeredWalljump",
+          "canTrickyWalljump",
           {"acidFrames": 30}
         ]}
       ],

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -1071,7 +1071,7 @@
       "link": [5, 7],
       "name": "Walljump Damage Boost",
       "requires": [
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         "canCarefulJump",
         "canHorizontalDamageBoost",
         {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 1}}

--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -804,7 +804,7 @@
         "canDodgeWhileShooting",
         "Charge",
         "h_heatProof",
-        "canDelayedWalljump",
+        "canTrickyWalljump",
         {"or": [
           "ScrewAttack",
           {"and": [
@@ -1965,7 +1965,7 @@
             {"heatFrames": 200}
           ]},
           {"and": [
-            "canDelayedWalljump",
+            "canTrickyWalljump",
             "canWallJumpInstantMorph",
             "h_useMorphBombs",
             {"heatFrames": 520}

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -1028,7 +1028,7 @@
       "requires": [
         "h_navigateHeatRooms",
         "Morph",
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         {"heatFrames": 660}
       ],
       "note": "Walljump in place while the acid goes away."

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -1882,7 +1882,7 @@
           {"and": [
             "HiJump",
             {"or": [
-              "canDelayedWalljump",
+              "canTrickyWalljump",
               "canSpringBallJumpMidAir",
               "SpeedBooster"
             ]}
@@ -1922,7 +1922,7 @@
           {"and": [
             "HiJump",
             {"or": [
-              "canDelayedWalljump",
+              "canTrickyWalljump",
               "canSpringBallJumpMidAir",
               "SpeedBooster"
             ]}

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -465,7 +465,7 @@
             "canConsecutiveWalljump",
             {"or": [
               "ScrewAttack",
-              "canStaggeredWalljump"
+              "canTrickyWalljump"
             ]}
           ]},
           "h_pauseAbuseMinimalReserveRefill"
@@ -710,7 +710,7 @@
         "canConsecutiveWalljump",
         {"or": [
           "ScrewAttack",
-          "canStaggeredWalljump",
+          "canTrickyWalljump",
           "canWalljumpWithCharge",
           {"enemyDamage": {"enemy": "Menu", "type": "contact", "hits": 1}}
         ]}
@@ -734,7 +734,7 @@
         {"or": [
           {"enemyDamage": {"enemy": "Menu", "type": "contact", "hits": 1}},
           "ScrewAttack",
-          "canStaggeredWalljump",
+          "canTrickyWalljump",
           "canPseudoScrew",
           "h_pauseAbuseMinimalReserveRefill"
         ]}

--- a/region/maridia/inner-pink/East Cactus Alley.json
+++ b/region/maridia/inner-pink/East Cactus Alley.json
@@ -1265,7 +1265,7 @@
         ]},
         {"or": [
           "canConsecutiveWalljump",
-          "canDelayedWalljump"
+          "canTrickyWalljump"
         ]}
       ]
     },

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -200,7 +200,7 @@
       "name": "Delayed Wall Jump",
       "requires": [
         "Gravity",
-        "canDelayedWalljump"
+        "canTrickyWalljump"
       ]
     },
     {

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -705,10 +705,7 @@
       "requires": [
         {"or": [
           "canTrivialUseFrozenEnemies",
-          {"and": [
-            "canPreciseWalljump",
-            "canTrickyWalljump"
-          ]}
+          "canTrickyWalljump"
         ]}
       ],
       "flashSuitChecked": true
@@ -990,7 +987,6 @@
       "link": [2, 3],
       "name": "Staggered Wall Climb",
       "requires": [
-        "canPreciseWalljump",
         "canTrickyWalljump"
       ]
     },
@@ -1188,10 +1184,7 @@
       "requires": [
         {"or": [
           "canTrivialUseFrozenEnemies",
-          {"and": [
-            "canPreciseWalljump",
-            "canTrickyWalljump"
-          ]}
+          "canTrickyWalljump"
         ]}
       ],
       "flashSuitChecked": true

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -707,7 +707,7 @@
           "canTrivialUseFrozenEnemies",
           {"and": [
             "canPreciseWalljump",
-            "canStaggeredWalljump"
+            "canTrickyWalljump"
           ]}
         ]}
       ],
@@ -991,7 +991,7 @@
       "name": "Staggered Wall Climb",
       "requires": [
         "canPreciseWalljump",
-        "canStaggeredWalljump"
+        "canTrickyWalljump"
       ]
     },
     {
@@ -1190,7 +1190,7 @@
           "canTrivialUseFrozenEnemies",
           {"and": [
             "canPreciseWalljump",
-            "canStaggeredWalljump"
+            "canTrickyWalljump"
           ]}
         ]}
       ],

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -987,7 +987,11 @@
       "link": [2, 3],
       "name": "Staggered Wall Climb",
       "requires": [
-        "canTrickyWalljump"
+        "canTrickyWalljump",
+        {"or": [
+          "canTrickyJump",
+          {"enemyDamage": {"enemy": "Ripper", "type": "contact", "hits": 2}}
+        ]}
       ]
     },
     {

--- a/region/maridia/inner-yellow/The Beach.json
+++ b/region/maridia/inner-yellow/The Beach.json
@@ -1435,7 +1435,17 @@
         "h_crouchJumpDownGrab",
         "canTrickyJump"
       ],
-      "note": "Crouch jump + down grab only works as a way out of the water on the right side."
+      "note": [
+        "Crouch jump just before the water reaches its maximum.",
+        "Wait until Samus reaches the peak of the jump;",
+        "then in quick succession press down and then forward (or diagonal down-forward).",
+        "This only works as a way out of the water on the right side."
+      ],
+      "detailNote": [
+        "The problem with pressing down pre-maturely is that it shrinks Samus' hitbox vertically,",
+        "causing Samus to escape the water, which results in a shortened jump height",
+        "because of the larger vertical acceleration that applies when Samus is in air physics."
+      ]
     },
     {
       "id": 63,
@@ -1443,7 +1453,7 @@
       "name": "Wall Jump Escape",
       "requires": [
         "canSuitlessMaridia",
-        "canPreciseWalljump"
+        "canTrickyWalljump"
       ],
       "note": "Perform a precise wall jump as the water is lowering.  Climbing up the right side of the room is slightly easier."
     },

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -4728,7 +4728,7 @@
       "requires": [
         "Gravity",
         {"or": [
-          "canDelayedWalljump",
+          "canTrickyWalljump",
           {"and": [
             "HiJump",
             "canPreciseWalljump"

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -272,7 +272,7 @@
           ]},
           {"and": [
             "Gravity",
-            "canStaggeredWalljump",
+            "canTrickyWalljump",
             "canInsaneJump"
           ]},
           {"and": [
@@ -892,7 +892,7 @@
           ]},
           {"and": [
             "Gravity",
-            "canStaggeredWalljump"
+            "canTrickyWalljump"
           ]}
         ]}
       ],

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -616,7 +616,7 @@
         "canCarefulJump",
         {"or": [
           "canCameraManip",
-          "canStaggeredWalljump",
+          "canTrickyWalljump",
           {"and": [
             "canNeutralDamageBoost",
             {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
@@ -1608,7 +1608,7 @@
         "canConsecutiveWalljump",
         "canPreciseWalljump",
         {"or": [
-          "canStaggeredWalljump",
+          "canTrickyWalljump",
           "ScrewAttack",
           "canWalljumpWithCharge",
           {"and": [
@@ -1632,7 +1632,7 @@
         "canCarefulJump",
         "canConsecutiveWalljump",
         {"or": [
-          "canStaggeredWalljump",
+          "canTrickyWalljump",
           "ScrewAttack",
           "canWalljumpWithCharge",
           {"and": [
@@ -1656,7 +1656,7 @@
         "canCarefulJump",
         "canConsecutiveWalljump",
         {"or": [
-          "canStaggeredWalljump",
+          "canTrickyWalljump",
           "ScrewAttack",
           "canWalljumpWithCharge",
           {"and": [
@@ -4126,7 +4126,7 @@
       "name": "Right Side Delayed Walljumps",
       "requires": [
         {"notable": "Right Side Delayed Walljumps"},
-        "canDelayedWalljump",
+        "canTrickyWalljump",
         "canConsecutiveWalljump"
       ],
       "note": "A tricky, delayed walljump makes it possible to climb to top right in-room, with nothing."

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -560,7 +560,7 @@
         {"or": [
           {"heatFrames": 560},
           {"and": [
-            "canCarefulJump",
+            "canTrickyWalljump",
             {"heatFrames": 360}
           ]},
           {"and": [

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -613,7 +613,7 @@
       "link": [2, 1],
       "name": "Delayed Walljump",
       "requires": [
-        "canDelayedWalljump",
+        "canTrickyWalljump",
         "canConsecutiveWalljump",
         "canTrickyJump",
         "canUseEnemies",

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -881,7 +881,6 @@
         "HiJump",
         "canSuitlessLavaDive",
         "canUseEnemies",
-        "canPreciseWalljump",
         "canTrickyWalljump",
         {"heatFrames": 270},
         {"gravitylessLavaFrames": 240}

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -1195,7 +1195,7 @@
         {"notable": "HiJumpless Dive"},
         "canSuitlessLavaDive",
         "canUseIFrames",
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         "canFastWalljumpClimb",
         "canUseEnemies",
         "canCameraManip",

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -1133,6 +1133,7 @@
         "canSuitlessLavaDive",
         "canGravityJump",
         "canTrickyWalljump",
+        "canTrickyJump",
         {"heatFrames": 290},
         {"gravitylessLavaFrames": 230},
         {"lavaFrames": 20}

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -495,7 +495,7 @@
             {"gravitylessLavaFrames": 125}
           ]},
           {"and": [
-            "canStaggeredWalljump",
+            "canTrickyWalljump",
             {"lavaFrames": 20},
             {"gravitylessLavaFrames": 230}
           ]}
@@ -882,7 +882,7 @@
         "canSuitlessLavaDive",
         "canUseEnemies",
         "canPreciseWalljump",
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         {"heatFrames": 270},
         {"gravitylessLavaFrames": 240}
       ],
@@ -943,7 +943,7 @@
         "canInsaneWalljump",
         "canInsaneJump",
         "canUseIFrames",
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         "canFastWalljumpClimb",
         "canUseEnemies",
         "canKago",
@@ -1133,7 +1133,7 @@
       "requires": [
         "canSuitlessLavaDive",
         "canGravityJump",
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         {"heatFrames": 290},
         {"gravitylessLavaFrames": 230},
         {"lavaFrames": 20}
@@ -1173,7 +1173,7 @@
         {"notable": "HiJumpless Dive"},
         "canSuitlessLavaDive",
         "canUseIFrames",
-        "canStaggeredWalljump",
+        "canTrickyWalljump",
         "canFastWalljumpClimb",
         "canUseEnemies",
         "canCameraManip",

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -577,7 +577,7 @@
         {"or": [
           "h_useSpringBall",
           {"and": [
-            "canStaggeredWalljump",
+            "canTrickyWalljump",
             {"heatFrames": 100}
           ]},
           {"and": [

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -1086,7 +1086,7 @@
       "requires": [
         {"or": [
           {"and": [
-            "canDelayedWalljump",
+            "canTrickyWalljump",
             {"acidFrames": 20}
           ]},
           {"and": [

--- a/tech.json
+++ b/tech.json
@@ -1168,18 +1168,22 @@
               "extensionTechs": [
                 {
                   "id": 78,
-                  "name": "canDelayedWalljump",
+                  "name": "canTrickyWalljump",
                   "techRequires": [
                     "canPreciseWalljump"
                   ],
                   "otherRequires": [],
-                  "note": "A precise wall jump that needs to done as late as possible by moving away from the wall in order for Samus to start the jump as far from the wall as possible.",
+                  "note": [
+                    "A wall jump that is tricky to perform.",
+                    "This includes 'delayed wall jumps' in which Samus must move away as far from the wall as possible before wall jumping;",
+                    "it also includes cases in which Samus must dodge enemies or other obstacles while wall jumping."
+                  ],
                   "extensionTechs": [
                     {
                       "id": 79,
                       "name": "canInsaneWalljump",
                       "techRequires": [
-                        "canDelayedWalljump"
+                        "canTrickyWalljump"
                       ],
                       "otherRequires": [],
                       "note": "A wall jump with extreme precision, in the vicinity of pixel and frame perfect precision. These jumps are typically delayed wall jumps."
@@ -1205,16 +1209,6 @@
                   ],
                   "otherRequires": [],
                   "note": "Climbing a wall with consecutive wall jumps very quickly, e.g. for setting up a full halfie."
-                },
-                {
-                  "id": 82,
-                  "name": "canStaggeredWalljump",
-                  "techRequires": [
-                    "canConsecutiveWalljump"
-                  ],
-                  "otherRequires": [],
-                  "note": "Controlling wall jump height and positioning to dodge enemies or to wait for something.",
-                  "devNote": "FIXME This could be used to also set up a wall jump that needs a precise starting location."
                 },
                 {
                   "id": 83,


### PR DESCRIPTION
Following a suggestion by @kjbranch this introduces a new tech `canTrickyWalljump` which replaces both `canDelayedWalljump` and `canStaggeredWalljump`. The idea is that individually these tech don't make a lot of sense:
- Staggered walljumps just meant wall jumping in place, but on its own that doesn't really represent any new knowledge or difficulty on top of `canConsecutiveWalljump`. 
- `canDelayedWalljump` made some sense in how it expressed an ability to control the horizontal position of the wall jump. But there's nothing that special about being able to control the horizontal position as opposed to other elements like the vertical position or the timing of the wall jump.

In practice the ability to do wall jump strats seems determined less by specific tech knowledge and more by an overall skill level in wall jumping, and there are many factors that impact the difficulty of a given strat, including details of the geometry, any enemies/obstacles that get in the way, and the level of precision required in terms of timing and positioning; trying to boil it down to specific patterns like `canDelayedWalljump` and `canStaggeredWalljump` was a bit of an awkward simplification that sometimes resulted in inappropriate difficulty placements. So the idea of the new tech `canTrickyWalljump` is to give us a more direct way to describe a Hard-level wall jump difficulty, while `canPreciseWalljump` remains a way to describe a Medium-level difficulty.

To be easier to follow, the PR is split into 3 commits. 
- The first commit defines the new tech (and removes the old ones) and applies a search-and-replace to their uses. 
- The second commit removes occurrences of `canPreciseWalljump` that are redundant with `canTrickyWalljump`, since `canTrickyWalljump` is an extension of `canPreciseWalljump` (whereas `canStaggeredWalljump` wasn't an extension of `canPreciseWalljump`).
- The third commit has the proposed difficulty adjustments, which is where the logically significant changes are happening, e.g. bumping up some `canPreciseWalljump` to `canTrickyWalljump`.
