### PR TITLE
Indiana Jones G-Mode Restructure

### DIFF
--- a/region/norfair/crocomire/Indiana Jones Room.json
+++ b/region/norfair/crocomire/Indiana Jones Room.json
@@ -65,18 +65,6 @@
         [2, 2, 2, 2, 2, 1, 1, 1]
       ],
       "note": "Represents being at the small platforms above the acid."
-    },
-    {
-      "id": 6,
-      "name": "G-Mode Morph Junction (At Speed Blocks)",
-      "nodeType": "junction",
-      "nodeSubType": "g-mode",
-      "mapTileMask": [
-        [1, 1, 1, 1, 1, 0, 0, 0],
-        [1, 1, 1, 1, 1, 0, 0, 0],
-        [1, 1, 1, 1, 2, 2, 1, 1]
-      ],
-      "note": "Represents being at the bottom of the room with G-Mode Morph (artificial morph)"
     }
   ],
   "obstacles": [

--- a/region/norfair/crocomire/Indiana Jones Room.json
+++ b/region/norfair/crocomire/Indiana Jones Room.json
@@ -91,18 +91,6 @@
       "obstacleType": "inanimate"
     },
     {
-      "id": "C",
-      "name": "G-Mode Get to the Left Door",
-      "obstacleType": "abstract",
-      "note": "Samus has all of the items to get to the left door while in G-Mode Morph, without including the item if it is being remote acquired."
-    },
-    {
-      "id": "D",
-      "name": "G-Mode Morph Direct",
-      "obstacleType": "abstract",
-      "note": "Samus enters the room in direct G-Mode with artificial morph, in order to be able to remote acquire the item."
-    },
-    {
       "id": "E",
       "name": "Left door open",
       "obstacleType": "inanimate"
@@ -131,8 +119,7 @@
         {"id": 1},
         {"id": 2},
         {"id": 3},
-        {"id": 5},
-        {"id": 6}
+        {"id": 5}
       ]
     },
     {
@@ -141,8 +128,7 @@
         {"id": 1},
         {"id": 2},
         {"id": 3},
-        {"id": 5},
-        {"id": 6}
+        {"id": 5}
       ]
     },
     {
@@ -159,16 +145,6 @@
         {"id": 1},
         {"id": 2},
         {"id": 3}
-      ]
-    },
-    {
-      "from": 6,
-      "to": [
-        {"id": 1},
-        {"id": 2},
-        {"id": 3},
-        {"id": 5},
-        {"id": 6}
       ]
     }
   ],
@@ -222,8 +198,46 @@
         "SpaceJump",
         "ScrewAttack"
       ],
-      "resetsObstacles": ["A", "B", "C", "D", "E"],
+      "resetsObstacles": ["A", "B", "E"],
       "farmCycleDrops": [{"enemy": "Ripper 2 (green)", "count": 4}]
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Morph Spring Ball, IBJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphJumpIntoIBJ",
+        "h_artificialMorphLongIBJ"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": "Spring Ball across the platforms, IBJ to the item, then return."
+    },
+    {
+      "link": [1, 1],
+      "name": "G-Mode Morph Long Diagonal Bomb Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+        "h_artificialMorphDiagonalBombJump",
+        "h_artificialMorphLongIBJ"
+      ],
+      "flashSuitChecked": true,
+      "collectsItems": [3],
+      "note": [
+        "Perform a long diagonal bomb jump from the left door to the solid platforms above the acid.",
+        "Touch the item and perform another long diagonal bomb jump back."
+      ]
     },
     {
       "id": 3,
@@ -242,6 +256,158 @@
       ],
       "clearsObstacles": ["B"],
       "note": "The blocks can be broken if you can generate a blue suit using the previous room's runway, and carry it to the blocks by slowing floating down with Space Jump."
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode Morph",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"or": [
+          "h_artificialMorphSpringBall",
+          {"and": [
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump",
+            "h_artificialMorphLongIBJ"
+          ]}
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "Cross the room with Spring Ball or a long diagonal bomb jump to the solid platforms above the acid.",
+        "Go to the right of the speed blocks before unmorphing and exiting G-mode."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Direct G-Mode Morph, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphLongIBJ",
+        {"or": [
+          "h_artificialMorphSpringBall",
+          {"and": [
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump"
+          ]}
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "Cross the room with Spring Ball or a long diagonal bomb jump to the solid platforms above the acid.",
+        "IBJ to the item, touch it, and drop back down to the right of the speed blocks before unmorphing and exiting G-mode."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode Morph, Power Bomb the Blocks",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphPowerBomb",
+        {"or": [
+          "h_artificialMorphSpringBall",
+          {"and": [
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump"
+          ]}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "note": [
+        "Cross the room with Spring Ball or a long diagonal bomb jump to the solid platforms above the acid.",
+        "Power Bomb the blocks before unmorphing and exiting G-mode."
+      ],
+      "devNote": "FIXME: There could be a 1->3 or 2->3 and breaks the PB blocks, then uses speed from the left to break the blocks."
+    },
+    {
+      "link": [1, 2],
+      "name": "Direct G-Mode Morph, Power Bomb the Blocks, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphPowerBomb",
+        "h_artificialMorphLongIBJ",
+        {"or": [
+          "h_artificialMorphSpringBall",
+          {"and": [
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump"
+          ]}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "Cross the room with Spring Ball or a long diagonal bomb jump to the solid platforms above the acid.",
+        "IBJ to the item, touch it, and drop back down to the right of the speed blocks. Place a Power Bomb then quickly exit G-mode before it explodes to break the blocks."
+      ]
+    },
+    {
+      "id": 86,
+      "link": [1, 2],
+      "name": "G-Mode Morph Mella Ice Clip, Door Lock Skip",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"or": [
+          "Morph",
+          "h_artificialMorphSpringBall",
+          {"and": [
+            "h_artificialMorphLongIBJ",
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump"
+          ]}
+        ]},
+        "canManipulateMellas",
+        {"or": [
+          "h_preciseIceClip",
+          "h_highPixelIceClip"
+        ]},
+        {"or": [
+          "Morph",
+          "canInsaneJump",
+          {"enemyDamage": {"enemy": "Mella", "type": "contact", "hits": 1}}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithGMode": {
+          "morphed": false
+        }
+      },
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Cross the room with Morph, Spring Ball, or a long diagonal bomb jump to the solid platforms above the acid.",
+        "It can help to moonwalk towards a Mella that has never been on screen, so that it starts swooping immediately as it first enters the screen.",
+        "This will make it so that when Samus is below it, it will always swoop and go up slightly compared to the previous swoop.",
+        "Once it is close to the right height, move away so it stops swooping, freeze it and quickly try the clip, if it doesn't work, quickly leave and try again."
+      ]
     },
     {
       "id": 4,
@@ -386,15 +552,8 @@
       "note": "Grapple off several Ripper 2."
     },
     {
-      "id": 12,
-      "link": [1, 5],
-      "name": "Base",
-      "requires": []
-    },
-    {
-      "id": 13,
-      "link": [1, 6],
-      "name": "G-Mode Morph Spring Ball",
+      "link": [1, 3],
+      "name": "G-Mode Morph",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
@@ -402,96 +561,23 @@
         }
       },
       "requires": [
-        "h_artificialMorphSpringBall"
-      ],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 14,
-      "link": [1, 6],
-      "name": "G-Mode Direct Morph Spring Ball",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "h_artificialMorphSpringBall"
-      ],
-      "clearsObstacles": ["D"],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 15,
-      "link": [1, 6],
-      "name": "G-Mode Morph Long Diagonal Bomb Jump (Indirect)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "indirect",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
-        "h_artificialMorphDiagonalBombJump",
-        "canLongIBJ"
-      ],
-      "flashSuitChecked": true,
-      "note": "Perform a long diagonal bomb jump from the left door to the solid platforms above the acid."
-    },
-    {
-      "id": 16,
-      "link": [1, 6],
-      "name": "G-Mode Morph Long Diagonal Bomb Jump (Direct)",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": true
-        }
-      },
-      "requires": [
-        {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
-        "h_artificialMorphDiagonalBombJump",
-        "canLongIBJ"
-      ],
-      "clearsObstacles": ["D"],
-      "flashSuitChecked": true,
-      "note": "Perform a long diagonal bomb jump from the left door to the solid platforms above the acid."
-    },
-    {
-      "id": 17,
-      "link": [1, 6],
-      "name": "G-Mode Morph Acid Dive IBJ",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "Gravity",
-        "h_artificialMorphIBJ",
-        "h_artificialMorphBombHorizontally",
-        "canSuitlessLavaDive",
+        "h_artificialMorphLongIBJ",
         {"or": [
-          {"acidFrames": 280},
+          "h_artificialMorphSpringBall",
           {"and": [
-            "canTrickyJump",
-            {"acidFrames": 220}
-          ]},
-          {"and": [
-            "canInsaneJump",
-            "h_artificialMorphDoubleBombJump",
-            {"acidFrames": 175}
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump"
           ]}
         ]}
       ],
       "flashSuitChecked": true,
-      "note": [
-        "Bomb boost horizontally at the top of an IBJ and land in the acid, then roll to the right and bomb out to safety.",
-        "To save some Energy, it is possible to IBJ or double IBJ out of the acid onto the first solid platform."
-      ]
+      "note": "Cross the room with Spring Ball or a long diagonal bomb jump to the solid platforms above the acid, then IBJ to the item."
+    },
+    {
+      "id": 12,
+      "link": [1, 5],
+      "name": "Base",
+      "requires": []
     },
     {
       "id": 18,
@@ -643,6 +729,71 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "G-Mode Morph",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "h_artificialMorphIBJ",
+        {"or": [
+          "h_artificialMorphSpringBall",
+          "h_artificialMorphPowerBomb",
+          "canTrickyDodgeEnemies",
+          {"enemyDamage": {"enemy": "Mella", "type": "contact", "hits": 1}}
+        ]},
+        {"or": [
+          "h_artificialMorphJumpIntoIBJ",
+          {"and": [
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "With just Bombs, killing the Mellas can be a bit tricky; it is recommended to use one to boost and place some midair before luring a Mella to more easily kill it.",
+        "Then use Spring Ball and an IBJ or a long diagonal IBJ to get to the left."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Direct G-Mode Morph, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "h_artificialMorphLongIBJ",
+        {"or": [
+          "h_artificialMorphSpringBall",
+          "h_artificialMorphPowerBomb",
+          "canTrickyDodgeEnemies",
+          {"enemyDamage": {"enemy": "Mella", "type": "contact", "hits": 1}}
+        ]},
+        {"or": [
+          "h_artificialMorphJumpIntoIBJ",
+          {"and": [
+            {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
+            "h_artificialMorphDiagonalBombJump"
+          ]}
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "With just Bombs, killing the Mellas can be a bit tricky; it is recommended to use one to boost and place some midair before luring a Mella to more easily kill it.",
+        "IBJ to the item, touch it, and use Spring Ball and an IBJ or a long diagonal IBJ to get to the left."
+      ]
+    },
+    {
       "id": 22,
       "link": [2, 2],
       "name": "Break Power Bomb Blocks",
@@ -748,7 +899,7 @@
           ]}
         ]}
       ],
-      "resetsObstacles": ["A", "B", "C", "D", "E"],
+      "resetsObstacles": ["A", "B", "E"],
       "farmCycleDrops": [{"enemy": "Mella", "count": 5}],
       "note": "Shoot the Mellas when they first begin to come on screen, and they will not move."
     },
@@ -980,6 +1131,54 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 2],
+      "name": "Direct G-Mode Morph, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "h_artificialMorphLongIBJ",
+        {"or": [
+          "h_artificialMorphSpringBall",
+          "h_artificialMorphPowerBomb",
+          "canTrickyDodgeEnemies",
+          {"enemyDamage": {"enemy": "Mella", "type": "contact", "hits": 1}}
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "note": [
+        "With just Bombs, killing the Mellas can be a bit tricky; it is recommended to use one to boost and place some midair before luring a Mella to more easily kill it.",
+        "IBJ to the item, touch it, and return to the right of the speed blocks before unmorphing and exiting G-mode."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Direct G-Mode Morph, Power Bomb the Blocks, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "h_artificialMorphPowerBomb",
+        "h_artificialMorphLongIBJ"
+      ],
+      "collectsItems": [3],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "note": [
+        "Use a Power Bomb to kill the Mellas and this will break the Power Bomb blocks after exiting G-mode.",
+        "IBJ to the item, touch it, and return to the right of the speed blocks before unmorphing and exiting G-mode."
+      ]
+    },
+    {
       "id": 85,
       "link": [2, 2],
       "name": "G-Mode Mella Ice Clip, Door Lock Skip",
@@ -1046,6 +1245,30 @@
           "canSpringBallJumpMidAir",
           "canWalljump"
         ]}
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "G-Mode Morph",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        },
+        "comesThroughToilet": "any"
+      },
+      "requires": [
+        "h_artificialMorphLongIBJ",
+        {"or": [
+          "h_artificialMorphSpringBall",
+          "h_artificialMorphPowerBomb",
+          "canTrickyDodgeEnemies",
+          {"enemyDamage": {"enemy": "Mella", "type": "contact", "hits": 1}}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "With just Bombs, killing the Mellas can be a bit tricky; it is recommended to use one to boost and place some midair before luring a Mella to more easily kill it."
       ]
     },
     {
@@ -1121,7 +1344,7 @@
     },
     {
       "id": 44,
-      "link": [2, 6],
+      "link": [2, 5],
       "name": "G-Mode Morph",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1139,7 +1362,7 @@
           ]},
           {"and": [
             "h_artificialMorphBombs",
-            "canTrickyJump"
+            "canTrickyDodgeEnemies"
           ]},
           {"and": [
             "h_artificialMorphBombs",
@@ -1147,37 +1370,6 @@
           ]}
         ]}
       ],
-      "flashSuitChecked": true,
-      "note": [
-        "A single horizontal Power Bomb boost can get Samus on top of the blocks and kill most of the Mellas.",
-        "With Bombs, killing the Mellas can be a bit tricky; it is recommended to use one to boost and place some midair before luring a Mella to more easily kill it."
-      ]
-    },
-    {
-      "id": 45,
-      "link": [2, 6],
-      "name": "G-Mode Direct Morph",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "direct",
-          "morphed": true
-        },
-        "comesThroughToilet": "any"
-      },
-      "requires": [
-        {"or": [
-          "h_artificialMorphSpringBall",
-          {"and": [
-            {"tech": "canBombHorizontally"},
-            "h_artificialMorphPowerBomb"
-          ]},
-          {"and": [
-            "h_artificialMorphBombs",
-            "canTrickyJump"
-          ]}
-        ]}
-      ],
-      "clearsObstacles": ["D"],
       "flashSuitChecked": true,
       "note": [
         "A single horizontal Power Bomb boost can get Samus on top of the blocks and kill most of the Mellas.",
@@ -1194,26 +1386,6 @@
         "canPreciseGrapple"
       ],
       "note": "Involves grappling off several Ripper 2."
-    },
-    {
-      "id": 47,
-      "link": [3, 1],
-      "name": "G-Mode Morph Remote Acquire - to Left Door (Using Previous Strat)",
-      "requires": [
-        "canEnterGMode",
-        {"obstaclesCleared": ["C", "D"]}
-      ],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 48,
-      "link": [3, 2],
-      "name": "G-Mode Morph Remote Acquire - to Right Door",
-      "requires": [
-        "canEnterGMode",
-        {"obstaclesCleared": ["D"]}
-      ],
-      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1562,130 +1734,6 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true
-    },
-    {
-      "id": 65,
-      "link": [6, 1],
-      "name": "G-Mode Morph to Left Door (Using Previous Strat)",
-      "requires": [
-        "canEnterGMode",
-        {"obstaclesCleared": ["C"]}
-      ],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 66,
-      "link": [6, 2],
-      "name": "G-Mode Morph",
-      "requires": [
-        "canEnterGMode"
-      ],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 67,
-      "link": [6, 2],
-      "name": "G-Mode Morph Power Bomb the Blocks",
-      "requires": [
-        "canEnterGMode",
-        "h_artificialMorphPowerBomb"
-      ],
-      "clearsObstacles": ["A"],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 86,
-      "link": [6, 2],
-      "name": "G-Mode Mella Ice Clip, Door Lock Skip",
-      "requires": [
-        "canEnterGMode",
-        "canManipulateMellas",
-        {"or": [
-          "h_preciseIceClip",
-          "h_highPixelIceClip"
-        ]},
-        {"or": [
-          "Morph",
-          "canInsaneJump",
-          {"enemyDamage": {"enemy": "Mella", "type": "contact", "hits": 1}}
-        ]}
-      ],
-      "exitCondition": {
-        "leaveWithGMode": {
-          "morphed": false
-        }
-      },
-      "bypassesDoorShell": true,
-      "flashSuitChecked": true,
-      "note": [
-        "It can help to moonwalk towards a Mella that has never been on screen, so that it starts swooping immediately as it first enters the screen.",
-        "This will make it so that when Samus is below it, it will always swoop and go up slightly compared to the previous swoop.",
-        "Once it is close to the right height, move away so it stops swooping, freeze it and quickly try the clip, if it doesn't work, quickly leave and try again."
-      ]
-    },
-    {
-      "id": 68,
-      "link": [6, 3],
-      "name": "G-Mode Morph IBJ",
-      "requires": [
-        "canEnterGMode",
-        "h_artificialMorphLongIBJ"
-      ],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 69,
-      "link": [6, 5],
-      "name": "Base",
-      "requires": [
-        "canEnterGMode"
-      ],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 70,
-      "link": [6, 6],
-      "name": "G-Mode Morph Spring Ball IBJ",
-      "requires": [
-        "canEnterGMode",
-        "h_artificialMorphJumpIntoIBJ",
-        {"or": [
-          "h_artificialMorphLongIBJ",
-          "HiJump"
-        ]}
-      ],
-      "clearsObstacles": ["C"],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 71,
-      "link": [6, 6],
-      "name": "G-Mode Morph Diagonal Bomb Jump",
-      "requires": [
-        "canEnterGMode",
-        "h_artificialMorphDiagonalBombJump"
-      ],
-      "clearsObstacles": ["C"],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 72,
-      "link": [6, 6],
-      "name": "G-Mode Morph Acid Dive IBJ",
-      "requires": [
-        "canEnterGMode",
-        "Gravity",
-        "h_artificialMorphLongIBJ",
-        "h_artificialMorphBombHorizontally",
-        "canSuitlessLavaDive",
-        {"acidFrames": 150}
-      ],
-      "clearsObstacles": ["C"],
-      "flashSuitChecked": true,
-      "note": [
-        "Cross the solid platforms then horizontally boost into the acid and begin an IBJ.",
-        "With more limited Energy, it is possible to IBJ high into the room and boost horizontally to fall into the acid a bit further to the left."
-      ]
     }
   ],
   "notables": [


### PR DESCRIPTION
This was done to clean up the strats and make it more clear what to do. There is a lot going on still, so maybe it would be worth adding a junction node back, but it is not immediately clear how to best do that.

Also worth noting that the some of the old artificial morph strats required "canIBJ" instead of its morphless variant.