### PR TITLE
Downgrade Plasma Spark precise crouch jump

### DIFF
--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -525,7 +525,7 @@
         {"notable": "Left Shaft Precise Crouch Jump Down Grab"},
         "canGravityJump",
         "h_crouchJumpDownGrab",
-        "canInsaneJump"
+        "canTrickyJump"
       ],
       "note": "Gravity jump out of the water then perform a precise crouch jump + down grab to get onto the next ledge."
     },

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -260,6 +260,7 @@
       "link": [2, 1],
       "name": "Crouch Jump Down Grab",
       "requires": [
+        {"notable": "Precise Crouch Jump Down Grab"},
         "Gravity",
         "canTrickyJump",
         "h_crouchJumpDownGrab"
@@ -342,8 +343,17 @@
         "Freeze both Zebs in order to significantly extend the length of the runway.",
         "Requires a pixel-perfect freeze in order to run onto and off of the frozen Zebs."
       ]
+    },
+    {
+      "id": 2,
+      "name": "Precise Crouch Jump Down Grab",
+      "wallJumpAvoid": true,
+      "note": [
+        "Use a precise crouch jump and down grab to get to the second platform above the water.",
+        "Position very close to the edge, and press forward immediately after crouch jumping (almost simultaneously)."
+      ]
     }
   ],
   "nextStratId": 25,
-  "nextNotableId": 2
+  "nextNotableId": 3
 }


### PR DESCRIPTION
This was supposed to be an Expert notable now, but that isn't working as intended because of the `canInsaneJump` requirement. So this downgrades it to a `canTrickyJump`.