### PR TITLE
More East Sand Hall notables

### DIFF
--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -594,6 +594,24 @@
       ]
     },
     {
+      "link": [1, 4],
+      "name": "Suitless Bootless Evir Freeze (Left to Center)",
+      "requires": [
+        {"notable": "Suitless Bootless Evir Freeze (Left to Center)"},
+        "canSuitlessMaridia",
+        "canTrickyJump",
+        "canTrickyUseFrozenEnemies",
+        "canPlayInSand",
+        "canCameraManip"
+      ],
+      "note": [
+        "When entering the room, immediately shoot straight ahead to freeze the second Evir,",
+        "then quickly also freeze the first Evir, with a diagonal-down shot.",
+        "Wait on top of the first Evir for the second Evir to sink far enough to be able to jump onto it,",
+        "then use it as a platform to jump onto the first pillar (either directly or after a jump on the sand)."
+      ]
+    },
+    {
       "id": 24,
       "link": [1, 4],
       "name": "Cross Room Jump with Air Ball",
@@ -1100,6 +1118,33 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Door Stuck Flatley Jump",
+      "entranceCondition": {
+        "comeInWithDoorStuckSetup": {}
+      },
+      "requires": [
+        {"notable": "Door Stuck Flatley Jump"},
+        "canInsaneJump",
+        "h_usePowerBomb",
+        "canTrickyUseFrozenEnemies",
+        "canPlayInSand"
+      ],
+      "note": [
+        "Enter the room with a door stuck setup.",
+        "Perform a frame-perfect Flatley jump from inside the door to just barely reach the first pillar.",
+        "Use a Power Bomb to make the Evir rise.",
+        "Freeze it and use it as a platform to jump across."
+      ],
+      "detailNote": [
+        "Jump must be pressed exactly 8 frames after the turnaround input."
+      ],
+      "devNote": [
+        "This is only really useful when entering from a water room,",
+        "since otherwise there is an easier strat that simply runs into the room with momentum and jumps."
+      ]
+    },
+    {
       "id": 65,
       "link": [3, 1],
       "name": "Use Flash Suit",
@@ -1463,6 +1508,28 @@
       ]
     },
     {
+      "link": [4, 2],
+      "name": "Suitless Bootless Evir Climb",
+      "requires": [
+        {"notable": "Suitless Bootless Evir Climb"},
+        "h_usePowerBomb",
+        "canTrickyUseFrozenEnemies",
+        "canPlayInSand",
+        "canTrickyDodgeEnemies"
+      ],
+      "note": [
+        "Use a Power Bomb to make the right-most Evir rise.",
+        "Freeze it low and jump onto it.",
+        "Crouch and continue holding down;",
+        "when the Evir is about to thaw, jump with a buffered aim-down and refreeze the Evir after it climbs a few pixels.",
+        "Repeat many times until gaining enough height to spin jump onto the pillar."
+      ],
+      "detailNote": [
+        "With each refreeze, it is recommended that Samus switch which side of the Evir to stand on,",
+        "to avoid a risk of getting shot by the Evir."
+      ]
+    },
+    {
       "id": 67,
       "link": [4, 2],
       "name": "Use Flash Suit",
@@ -1591,8 +1658,39 @@
         "Perform a 1-tap to gain blue speed with a significant amount of momentum.",
         "Run through the door, and jump any time after the transition, crossing the room."
       ]
+    },
+    {
+      "id": 13,
+      "name": "Suitless Bootless Evir Freeze (Left to Center)",
+      "note": [
+        "When entering the room, immediately shoot straight ahead to freeze the second Evir,",
+        "then quickly also freeze the first Evir.",
+        "Wait on top of the first Evir for the second Evir to sink far enough to be able to jump onto it,",
+        "then use it as a platform to jump onto the first pillar (either directly or after a jump on the sand)."
+      ]
+    },
+    {
+      "id": 14,
+      "name": "Suitless Bootless Evir Climb",
+      "note": [
+        "Use a Power Bomb to make the right-most Evir rise.",
+        "Freeze it low and jump onto it.",
+        "Crouch and continue holding down;",
+        "when the Evir is about to thaw, jump with a buffered aim-down and refreeze the Evir after it climbs a few pixels.",
+        "Repeat many times until gaining enough height to spin jump onto the pillar."
+      ]
+    },
+    {
+      "id": 15,
+      "name": "Door Stuck Flatley Jump",
+      "note": [
+        "Enter the room with a door stuck setup.",
+        "Perform a frame-perfect Flatley jump from inside the door to just barely reach the first pillar.",
+        "Use a Power Bomb to make the Evir rise.",
+        "Freeze it with Ice to jump across."
+     ]
     }
   ],
   "nextStratId": 70,
-  "nextNotableId": 13
+  "nextNotableId": 16
 }

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -1513,6 +1513,7 @@
       "requires": [
         {"notable": "Suitless Bootless Evir Climb"},
         "h_usePowerBomb",
+        "canBePatient",
         "canTrickyUseFrozenEnemies",
         "canPlayInSand",
         "canTrickyDodgeEnemies"

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -1136,9 +1136,6 @@
         "Use a Power Bomb to make the Evir rise.",
         "Freeze it and use it as a platform to jump across."
       ],
-      "detailNote": [
-        "Jump must be pressed exactly 8 frames after the turnaround input."
-      ],
       "devNote": [
         "This is only really useful when entering from a water room,",
         "since otherwise there is an easier strat that simply runs into the room with momentum and jumps."


### PR DESCRIPTION
Sam shared videos of all of these a while ago.

I wasn't sure if we might want to consolidate some of the notables in this room but figured that can be postponed to a later PR if needed. The existing notable "Cross Room Jump with Ice or Damage Boost" seems maybe obsolete since the "Suitless Bootless Evir Freeze (Left to Center)" is relatively simple and has no runway or damage requirements.

I was thinking probably Insane for the Door Stuck Flatley Jump (especially since in all useful cases it has to be combined with the water-to-water door stuck setup), and Extreme for the others.

Videos:
- Suitless Bootless Evir Freeze (Left to Center): https://videos.maprando.com/video/6774
- Suitless Bootless Evir Climb: https://videos.maprando.com/video/4589
- Door Stuck Flatley Jump: https://videos.maprando.com/video/7261

There's also the original YouTube videos by Bobbob:
- https://www.youtube.com/watch?v=IQ-1eXQXIiM
- https://www.youtube.com/watch?v=d9bF3bkCV3I

I didn't want to try the infinite sand bomb jump method yet, but it would be interesting to look at later.