### PR TITLE
Botwoon E-Tank Room: add left-side suitless leaveShinecharged

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1423,6 +1423,73 @@
       "note": "Coming in with zero momentum, all it takes is one non-HiJump full height jump forward, then activate."
     },
     {
+      "link": [4, 1],
+      "name": "Suitless Water Shinecharge, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 6,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "canWaterShineCharge",
+        {"shineChargeFrames": 55}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": [
+        "This is just a rough estimate of the minimum number of tiles that this runway can represent.",
+        "It is designed for a skill level that won't be able to use canStutterWaterShineCharge."
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Suitless Stutter Water Shinecharge, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        {"shineChargeFrames": 55}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ]
+    },
+    {
+      "link": [4, 1],
+      "name": "Precise Suitless Stutter Water Shinecharge, Leave Shinecharged",
+      "entranceCondition": {
+        "comeInStutterShinecharging": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        {"shineChargeFrames": 55}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "note": [
+        "With only 1 tile of runway, this requires releasing forward for 1 or 2 frames",
+        "and repressing forward on the last possible frame."
+      ]
+    },
+    {
       "id": 60,
       "link": [4, 1],
       "name": "G-Mode Overload PLMs",

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1475,6 +1475,7 @@
         }
       },
       "requires": [
+        "canPreciseStutterWaterShineCharge",
         {"shineChargeFrames": 55}
       ],
       "exitCondition": {


### PR DESCRIPTION
I would have liked for this to be able to start from node 7 to avoid duplication, but that node can be reached while in speedball or blue spring ball bounce so it wouldn't be valid for gaining a shinecharge. Adding another junction node would also be another option; it just seemed maybe not quite worth it.