### PR TITLE
Worst Room X-mode temporary blue & refinements

### DIFF
--- a/region/lowernorfair/east/The Worst Room In The Game.json
+++ b/region/lowernorfair/east/The Worst Room In The Game.json
@@ -153,6 +153,7 @@
       "to": [
         {"id": 1},
         {"id": 3},
+        {"id": 4},
         {"id": 5}
       ]
     },
@@ -178,6 +179,7 @@
         {"id": 1},
         {"id": 2},
         {"id": 3},
+        {"id": 4},
         {"id": 5}
       ]
     },
@@ -374,6 +376,20 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 4],
+      "name": "Quick Pirate Avoid and Weave",
+      "requires": [
+        "canInsaneJump",
+        "canTrickyDodgeEnemies",
+        {"heatFrames": 190},
+        {"or": [
+          "canDownBack",
+          "Morph",
+          {"heatFrames": 40}
+        ]}
+      ]
+    },
+    {
       "id": 4,
       "link": [1, 5],
       "name": "Base",
@@ -395,25 +411,19 @@
       "link": [1, 5],
       "name": "Quick Pirate Avoid",
       "requires": [
+        "canTrickyJump",
+        {"heatFrames": 110},
         {"or": [
           {"and": [
             "canInsaneJump",
-            {"heatFrames": 110},
-            {"or": [
-              "canDownBack",
-              "Morph",
-              {"heatFrames": 40}
-            ]}
+            "canTrickyDodgeEnemies"
           ]},
-          {"and": [
-            "canTrickyJump",
-            {"heatFrames": 145},
-            {"or": [
-              "canDownBack",
-              "Morph",
-              {"heatFrames": 40}
-            ]}
-          ]}
+          {"heatFrames": 35}
+        ]},
+        {"or": [
+          "canDownBack",
+          "Morph",
+          {"heatFrames": 40}
         ]}
       ],
       "note": [
@@ -1482,6 +1492,18 @@
       "flashSuitChecked": true
     },
     {
+      "link": [3, 4],
+      "name": "Pirate Jump and Weave",
+      "requires": [
+        "canTrickyJump",
+        {"heatFrames": 175}
+      ],
+      "note": [
+        "Spin jump over the pirate; aiming down mid jump can help.",
+        "Then weave between the platforms below."
+      ]
+    },
+    {
       "id": 35,
       "link": [3, 5],
       "name": "Base",
@@ -1574,6 +1596,27 @@
         ]}
       ],
       "clearsObstacles": ["A"]
+    },
+    {
+      "link": [4, 2],
+      "name": "X-Mode Temporary Blue",
+      "requires": [
+        {"notable": "X-Mode Temporary Blue"},
+        "canLateralMidAirMorph",
+        "canXMode",
+        "h_XModeSpikeHit",
+        "h_shinechargeMaxRunway",
+        "canTemporaryBlue",
+        {"heatFrames": 290}
+      ],
+      "note": [
+        "Starting from approximately the center of the floating platform, run and jump to the left,",
+        "abd perform a lateral mid-air morph to hit the spike from below (landing on the Namihe) and enter X-mode.",
+        "Hold an angle button to turn around to the right while retaining dash speed.",
+        "Arm pump a tile or two to the right, so that the Namihe is no longer below Samus.",
+        "Gain a shinecharge and continue holding down while exiting X-mode to obtain temporary blue,",
+        "and use it to break the bomb blocks below while falling through them."
+      ]
     },
     {
       "id": 39,
@@ -2097,8 +2140,16 @@
         "Break the bomb blocks in The Worst Room In The Game with extremely precise walljumps.",
         "Either with a fully delayed max height jump from the wall, or with an instant turnaround after jumping from the lower layer of bomb blocks."
       ]
+    },
+    {
+      "id": 9,
+      "name": "X-Mode Temporary Blue",
+      "note": [
+        "Enter X-mode using the spike above the lower left Namihe.",
+        "Use it to obtain temporary blue and fall through the bomb blocks."
+      ]
     }
   ],
   "nextStratId": 83,
-  "nextNotableId": 9
+  "nextNotableId": 10
 }


### PR DESCRIPTION
This adds a new notable for the X-mode strat that somerando(caauyjdp) recently shared.

While working on this, I noticed that the heat frames for descending the room (to node 4) were pretty lenient, and it looked like it mostly had to do with the assumption that you stop at node 5 along the way, and node 5 is defined kind of broadly (e.g. it can include being on top of the Namihe doing a CF) which makes those heat frames large. A fairly significant amount of heat frames can be saved by bypassing node 5 and going directly to node 4, weaving between the platforms, so I added strats for that.

Video: https://videos.maprando.com/video/7347