### PR TITLE
Cathedral entrance

### DIFF
--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -1440,6 +1440,22 @@
       "requires": [
         {"heatFrames": 350}
       ]
+    },
+    {
+      "link": [5, 5],
+      "name": "Crystal Flash",
+      "requires": [
+        "h_heatedCrystalFlash"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "If the Dessgeegas are still alive, perform the Crystal Flash on the floating platform to be safe.",
+        "By performing it on the far left edge of the platform (hanging over the edge slightly),",
+        "both Dessgeegas can be killed by the Power Bomb blast."
+      ],
+      "devNote": [
+        "FIXME: Model killing the Dessgeegas using a Power Bomb or Crystal Flash here."
+      ]
     }
   ],
   "notables": [

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -651,6 +651,43 @@
       "devNote": "This is just used to save Energy, when Samus doesn't have a way to get though the morph tunnel."
     },
     {
+      "link": [2, 3],
+      "name": "Dessgeega Dodge",
+      "requires": [
+        "canTrickyDodgeEnemies",
+        "canInsaneJump",
+        {"heatFramesWithEnergyDrops": {
+          "frames": 295,
+          "drops": [{"enemy": "Sova", "count": 1}]
+        }}
+      ],
+      "note": [
+        "Manipulate the movement of the Sm. Dessgeegas by entering the room in a specific way.",
+        "Multiple setups are possible:",
+        "A relatively safe method is to walk into the room (with no dash speed, and any amount of base speed or none at all),",
+        "walk off the ledge, and press against the opposite ledge to align with it.",
+        "After landing, wait a moment, then run off the edge and across the room.",
+        "If successful, the first Sm. Dessgeega should have hopped to the right, out of Samus' way,",
+        "and the second Sm. Dessgeega should do a big hop while Samus runs under it.",
+        "A more aggressive method involves walking into the room,",
+        "and holding dash starting when Samus is about 1 tile from falling off the ledge;",
+        "start holding forward again slightly before landing on the small floating platform, while continuing to hold dash."
+      ],
+      "detailNote": [
+        "Rooms containing hopper-type enemies (including Sm. Dessgeegas) reset RNG on entry,",
+        "which makes it possible to manipulate their movement in a deterministic way.",
+        "It also means the Sova drop can be manipulated by killing it on specific frames relative to room entry.",
+        "Because the Sova is global, its position can be used as a cue for when to kill it.",
+        "If Samus is full on Missiles, there are several 3-frame windows of where it can be killed to obtain a big energy.",
+        "The exact timing required for the shot will depend on the weapon used."
+      ],
+      "devNote": [
+        "Manipulating the second Sm. Dessgeega is much more precise than manipulating the first.",
+        "The way the strat is written, manipulating the Sova drop isn't technically expected,",
+        "though in practice getting a big energy is required to make it through the room tankless."
+      ]
+    },
+    {
       "id": 12,
       "link": [2, 5],
       "name": "Base",
@@ -750,17 +787,26 @@
       "name": "Up from Below",
       "requires": [
         {"or": [
-          "canPreciseWalljump",
-          "SpaceJump",
+          {"and": [
+            "canPreciseWalljump",
+            {"heatFrames": 150}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 210}
+          ]},
           {"and": [
             "HiJump",
-            {"or": [
-              "canWalljump",
-              "SpeedBooster"
-            ]}
+            "canWalljump",
+            {"heatFrames": 180}
+          ]},
+          {"and": [
+            "HiJump",
+            "SpeedBooster",
+            "canCarefulJump",
+            {"heatFrames": 100}
           ]}
-        ]},
-        {"heatFrames": 210}
+        ]}
       ]
     },
     {
@@ -1446,7 +1492,7 @@
         "Jump when passing under the floating platform and barely avoid hitting the rightmost wall.",
         "Wall jump on the horizontal spire near to the door."
       ]
-    }
+    }    
   ],
   "nextStratId": 67,
   "nextNotableId": 7


### PR DESCRIPTION
This adds a new Dessgeega manipulation strat to get through the room right-to-left. Getting through itemless would only be logical be Insane, and you need full Missiles to ensure a Sova energy drop. The buffed energy QoL would be needed to ensure a high enough expected energy drop for the logic, although as far as I can tell, in reality you have to get a big energy in order to make it. The roughly 50/50 drop chance would probably be fair for Insane, but in fact you can manipulate the drop to get a big energy more reliably than that.

The logic for going up the left side of the room is also tightened as part of this; in the existing version the heat frames were based on the Space Jump option, which is significantly slower than wall jumping or speedy jump methods. Also I thought it made sense to add some more lenience in the absence of `canHeroShot` tech.

I think the room could still use some more reworking; the junctions could be defined more precisely, and an obstacle to represent the Dessgeegas could be useful and might be able to replace node 4.

Videos:
- Safer Dodge: https://videos.maprando.com/video/7396
- Aggressive Dodge: https://videos.maprando.com/video/7377