### PR TITLE
Amphitheatre CF strats and a few other refinements

### DIFF
--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -180,6 +180,7 @@
       "from": 3,
       "to": [
         {"id": 1},
+        {"id": 3},
         {"id": 4},
         {"id": 5}
       ]
@@ -189,7 +190,8 @@
       "to": [
         {"id": 1},
         {"id": 2},
-        {"id": 3}
+        {"id": 3},
+        {"id": 4}
       ]
     },
     {
@@ -652,22 +654,17 @@
             "canCarefulJump"
           ]}
         ]},
-        {"heatFrames": 140},
-        {"or": [
-          "canResetFallSpeed",
-          "canPreciseWalljump",
-          {"and": [
-            {"heatFrames": 60},
-            {"acidFrames": 60}
-          ]}
-        ]},
-        {"heatFrames": 330},
-        {"acidFrames": 330}
+        {"heatFrames": 320},
+        {"acidFrames": 195}
       ],
       "note": [
         "Dive into the acid to the left of the first floating platform to quickly sink to the bottom of the room.",
         "It is possible to jump directly over the pirate at the bottom of the ramp directly to the gap between platforms.",
-        "Falling in this way will land between platforms at the bottom of the room unless Samus slows or catches herself on the way down."
+        "Falling in this way will land between the platforms at the bottom of the room."
+      ],
+      "devNote": [
+        "It is faster to fall all the way to the bottom and then jump onto the platform to the left,",
+        "than to morph/unmorph to reset fall speed to reach it directly."
       ]
     },
     {
@@ -818,6 +815,31 @@
       "devNote": ["This strat is only used to avoid walljumping."]
     },
     {
+      "link": [3, 3],
+      "name": "Crystal Flash (In Acid)",
+      "requires": [
+        {"obstaclesNotCleared": ["A"]},
+        {"heatFrames": 170},
+        {"acidFrames": 170},
+        "canHeatedCrystalFlash",
+        "h_heatedAcidCrystalFlashRefill",
+        {"heatFrames": 20},
+        {"acidFrames": 20},
+        {"or": [
+          "Gravity",
+          {"and": [
+            {"heatFrames": 5},
+            {"acidFrames": 5}
+          ]}
+        ]}
+      ],
+      "devNote": [
+        "We list the requirements explicitly rather than using the helper `h_heatedAcidCrystalFlash`",
+        "to reflect that it's possible to save some heat/acid frames with a soft morph while landing;",
+        "this makes the difference in being able to make the CF with 3 tanks with Gravity."
+      ]
+    },
+    {
       "id": 45,
       "link": [3, 4],
       "name": "Base - Space Jump",
@@ -897,8 +919,8 @@
         {"or": [
           {"and": [
             "Gravity",
-            {"heatFrames": 120},
-            {"acidFrames": 120}
+            {"heatFrames": 105},
+            {"acidFrames": 105}
           ]},
           {"and": [
             {"heatFrames": 170},
@@ -907,6 +929,50 @@
         ]}
       ],
       "note": "Avoid the pirate while moving through the acid to get closer to the wall."
+    },
+    {
+      "link": [3, 5],
+      "name": "Kill Pirate and Crystal Flash",
+      "requires": [
+        {"notable": "Reverse Acid Dive"},
+        {"obstaclesNotCleared": ["A"]},
+        "canSuitlessLavaDive",
+        {"or": [
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"enemyKill": {
+              "enemies": [["Yellow Space Pirate (standing)"]],
+              "explicitWeapons": ["Super", "Charge+Plasma"]
+            }}
+          ]},
+          {"enemyKill": {
+            "enemies": [["Yellow Space Pirate (standing)"]],
+            "explicitWeapons": ["Charge+Ice+Wave+Plasma"]
+          }},
+          {"and": [
+            "Gravity",
+            {"enemyKill": {
+              "enemies": [["Yellow Space Pirate (standing)"]],
+              "explicitWeapons": ["ScrewAttack"]
+            }}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Gravity",
+            {"heatFrames": 80},
+            {"acidFrames": 80}
+          ]},
+          {"and": [
+            {"heatFrames": 130},
+            {"acidFrames": 130}
+          ]}
+        ]},
+        "h_heatedAcidCrystalFlash",
+        {"heatFrames": 35},
+        {"acidFrames": 35}
+      ],
+      "note": "Kill the Pirate and perform a Crystal Flash."
     },
     {
       "id": 26,
@@ -928,7 +994,11 @@
         "Land on the fourth platform from the top and build some speed to spacejump across straight to the door.",
         "The optimal platform can be hit by simpily holding right when entering the acid."
       ],
-      "devNote": "Includes a little bit extra frame count to drop down two platforms first."
+      "devNote": [
+        "Includes a little bit extra frame count to drop down two platforms first.",
+        "FIXME: this lower platform could be modeled more cleanly as a separate junction node;",
+        "it would be useful as another place to Crystal Flash when traversing the room left-to-right."
+      ]
     },
     {
       "id": 27,
@@ -1042,6 +1112,22 @@
         ]}
       ],
       "note": "Jump off the platform to the left with low horizontal speed and hold left to avoid landing on any pirates."
+    },
+    {
+      "link": [4, 4],
+      "name": "Crystal Flash (Acidless)",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        "h_heatedCrystalFlash"
+      ],
+      "devNote": [
+        "This requires acting quickly enough that the acid does not catch Samus,",
+        "but this is not difficult to do.",
+        "A Crystal Flash could also be performed in acid here, while traversing the room right-to-left,",
+        "but it would have no benefit compared to Crystal Flashing on room entry and taking the 2->3 path.",
+        "FIXME: add another Crystal Flash strat at a junction two platforms lower,",
+        "which has a more significant movement requirement to avoid getting caught by the acid."
+      ]
     },
     {
       "id": 31,

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -332,7 +332,8 @@ def check_shinecharge_req(req):
 
 def check_heat_req(req):
     if isinstance(req, str):
-        if req in ["h_heatProof", "h_heatedCrystalFlash", "h_heatedLavaCrystalFlash", "h_LowerNorfairElevatorDownwardFrames",
+        if req in ["h_heatProof", "h_heatedCrystalFlash", "h_heatedLavaCrystalFlash", "h_heatedAcidCrystalFlash",
+                   "h_LowerNorfairElevatorDownwardFrames",
                    "h_LowerNorfairElevatorUpwardFrames", "h_MainHallElevatorFrames", "h_heatedGreenGateGlitch",
                    "h_heatedDirectGModeLeaveSameDoor", "h_heatedIndirectGModeOpenSameDoor",
                    "h_heatedGModeOpenDifferentDoor", "h_heatedGModeOffCameraDoor", "h_heatedGModePauseAbuse"]:


### PR DESCRIPTION
The existing 2->3 strat seemed not right to me: the heat/acid frames seemed very loose, and I couldn't see any benefit from the reset fall speed or wall jump options; it's possible I'm missing something though.

Normally traversing the room right-to-left needs at least 5 tanks with either Varia or Gravity. With a CF in the safe place at the bottom of the room, this can be reduced to 4 tanks with Varia or 3 tanks with Gravity (very tight). If weapons are available to kill the bottom-left Pirate, 3 tanks with Varia also becomes possible.

Videos:
- Crystal Flash in safe spot with Varia (4 tanks): https://videos.maprando.com/video/7404
- Crystal Flash in safe spot with Gravity (3 tanks): https://videos.maprando.com/video/7407
- Kill Pirates and CF with Varia (3 tanks, Charge+Plasma): https://videos.maprando.com/video/7406
- Kill Pirates and CF with Varia (3 tanks, Supers): https://videos.maprando.com/video/7405