### PR TITLE
More heated Crystal Flash strats

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -816,7 +816,7 @@
         {
           "name": "h_heatedCrystalFlash",
           "requires": [
-            {"heatFrames": 185},
+            {"simpleHeatFrames": 185},
             {"or": [
               {"and": [
                 "h_heatProof",
@@ -825,7 +825,7 @@
               "canHeatedCrystalFlash"
             ]},
             "h_heatedCrystalFlashRefill",
-            {"heatFrames": 20}
+            {"simpleHeatFrames": 20}
           ],
           "devNote": [
             "These requirements are tight but include time to morph before laying the Power Bomb and to land after the Crystal Flash refill completes."
@@ -834,7 +834,7 @@
         {
           "name": "h_heatedLavaCrystalFlash",
           "requires": [
-            {"heatFrames": 185},
+            {"simpleHeatFrames": 185},
             {"lavaFrames": 185},
             {"or": [
               {"and": [
@@ -862,7 +862,7 @@
         {
           "name": "h_heatedAcidCrystalFlash",
           "requires": [
-            {"heatFrames": 185},
+            {"simpleHeatFrames": 185},
             {"acidFrames": 185},
             "canHeatedCrystalFlash",
             "h_heatedAcidCrystalFlashRefill",

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1212,6 +1212,16 @@
       "clearsObstacles": ["D"]
     },
     {
+      "link": [4, 6],
+      "name": "Cross with Crystal Flash",
+      "requires": [
+        "h_usePowerBomb",
+        {"heatFrames": 260},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 120}
+      ]
+    },    
+    {
       "id": 52,
       "link": [6, 1],
       "name": "Blue Suit Run",

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -2151,7 +2151,7 @@
       "requires": [
         "Morph",
         "ScrewAttack",
-        {"heatFrames": 780}
+        {"heatFrames": 600}
       ]
     },
     {
@@ -2160,7 +2160,7 @@
       "name": "Power Bomb",
       "requires": [
         "h_usePowerBomb",
-        {"heatFrames": 850}
+        {"heatFrames": 660}
       ]
     },
     {
@@ -2169,7 +2169,36 @@
       "name": "Bombs",
       "requires": [
         "h_useMorphBombs",
-        {"heatFrames": 1130}
+        {"heatFrames": 730}
+      ]
+    },
+    {
+      "link": [5, 6],
+      "name": "Cross with Crystal Flash (Early Position)",
+      "requires": [
+        {"heatFrames": 250},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 380}
+      ]
+    },
+    {
+      "link": [5, 6],
+      "name": "Cross with Crystal Flash (Later Position)",
+      "requires": [
+        {"heatFrames": 450},
+        {"or": [
+          "ScrewAttack",
+          {"and": [
+            "h_usePowerBomb",
+            {"heatFrames": 40}
+          ]},
+          {"and": [
+            "h_useMorphBombs",
+            {"heatFrames": 80}
+          ]}
+        ]},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 250}
       ]
     },
     {
@@ -2180,8 +2209,11 @@
         {"or": [
           "canWalljump",
           "HiJump",
-          "SpaceJump",
-          "h_crouchJumpDownGrab"
+          "h_crouchJumpDownGrab",
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 40}
+          ]}
         ]},
         {"heatFrames": 100}
       ],

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -599,6 +599,9 @@
       ],
       "detailNote": [
         "This allows crossing the room without tanks or Speed Booster."
+      ],
+      "devNote": [
+        "FIXME: this may not be possible if the lava is rising (with Speed Booster and the flag not yet set)."
       ]
     },
     {

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -278,6 +278,28 @@
       "note": "Shoot from the middle of the second set of crumble blocks from the left."
     },
     {
+      "link": [1, 2],
+      "name": "Double Crystal Flash",
+      "requires": [
+        {"simpleHeatFrames": 160},
+        {"heatFrames": 40},
+        "h_heatedCrystalFlash",
+        {"simpleHeatFrames": 140},
+        {"heatFrames": 40},
+        "h_heatedCrystalFlash",
+        {"simpleHeatFrames": 240},
+        {"heatFrames": 30}
+      ],
+      "note": [
+        "Use a Crystal Flash after crossing 3 crumble block bridges,",
+        "and a second Crystal Flash after crossing 3 more."
+      ],
+      "detailNote": [
+        "In order to cross without tanks or Speed Booster,",
+        "some arm pumping is helpful but not required."
+      ]
+    },
+    {
       "id": 10,
       "link": [1, 2],
       "name": "Transition with Stored Fall Speed",
@@ -555,6 +577,28 @@
       "devNote": [
         "There is enough time to visit 3 and return to 2 before performing this strat with the shinespark.",
         "The obstacle being broken means Samus has run far enough to charge a shinespark."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Double Crystal Flash",
+      "requires": [
+        {"obstaclesNotCleared": ["A"]},
+        {"simpleHeatFrames": 135},
+        {"heatFrames": 40},
+        "h_heatedCrystalFlash",
+        {"simpleHeatFrames": 130},
+        {"heatFrames": 40},
+        "h_heatedCrystalFlash",
+        {"simpleHeatFrames": 280},
+        {"heatFrames": 30}
+      ],
+      "note": [
+        "Use a Crystal Flash after crossing 4 crumble block bridges,",
+        "and a second Crystal Flash in the middle of the large ramp in the center of the room."
+      ],
+      "detailNote": [
+        "This allows crossing the room without tanks or Speed Booster."
       ]
     },
     {

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -290,6 +290,27 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Crystal Flash and Lava Bath",
+      "requires": [
+        "canSuitlessLavaDive",
+        {"heatFrames": 425},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 300},
+        {"lavaFrames": 70}
+      ],
+      "note": [
+        "Ride the first Tripper, using Morph to avoid spike damage, then perform a Crystal Flash.",
+        "The second Tripper will likely either be destroyed or in a bad pattern,",
+        "making it necessary to jump through the lava to cross the rest of the room."
+      ],
+      "detailNote": [
+        "It may help to use the Tripper to do a big jump past the shutter before doing the Crystal Flash;",
+        "otherwise the shutter might end up closed and get in the way."
+      ]
+    },
+
+    {
       "id": 9,
       "link": [2, 1],
       "name": "Gravity",
@@ -421,6 +442,26 @@
         {"lavaFrames": 80}
       ],
       "note": ["Perform a bounceball to minimize lava damage.", "Ride the second Tripper."]
+    },
+    {
+      "link": [2, 1],
+      "name": "Crystal Flash and Lava Bath",
+      "requires": [
+        "canSuitlessLavaDive",
+        {"heatFrames": 425},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 300},
+        {"lavaFrames": 70}
+      ],
+      "note": [
+        "Ride the first Tripper, using Morph to avoid spike damage, then perform a Crystal Flash.",
+        "The second Tripper will likely either be destroyed or in a bad pattern,",
+        "making it necessary to jump through the lava to cross the rest of the room."
+      ],
+      "detailNote": [
+        "It may help to use the Tripper to do a big jump past the shutter before doing the Crystal Flash;",
+        "otherwise the shutter might end up closed and get in the way."
+      ]
     },
     {
       "id": 24,

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -129,6 +129,7 @@
       "to": [
         {"id": 1},
         {"id": 3},
+        {"id": 4},
         {"id": 5}
       ]
     },
@@ -1012,6 +1013,14 @@
           "requires": [{"heatFrames": 110}]
         }
       ]
+    },
+    {
+      "link": [4, 4],
+      "name": "Crystal Flash",
+      "requires": [
+        "h_heatedCrystalFlash"
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 35,

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -379,6 +379,19 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Crystal Flash below Shot Blocks",
+      "requires": [
+        {"heatFrames": 180},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 250}
+      ],
+      "devNote": [
+        "FIXME: by adding a junction here, we could account for more ways of entering the room;",
+        "but a junction would complicate how the heated/unheated state of the room is tracked."
+      ]
+    },
+    {
       "id": 10,
       "link": [2, 1],
       "name": "Come In Getting Blue Speed, Leave With Temporary Blue (Big Jump)",

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -1584,6 +1584,14 @@
       "requires": [
         {"heatFrames": 50}
       ]
+    },
+    {
+      "link": [5, 5],
+      "name": "Crystal Flash",
+      "requires": [
+        "h_heatedCrystalFlash"
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],


### PR DESCRIPTION
This partially addresses #1216.

This also changes the `h_heatedCrystalFlash` helper to use `simpleHeatFrames` since normally you aren't doing anything while waiting for the CF to start. Speed Booster Hall was the main one motivating this change. In theory we could also have `simpleLavaFrames` and `simpleAcidFrames` for the lava/acid CF helpers, but those logical requirements haven't been defined and I'm not sure if it's worth the trouble :shrug: A little extra lenience for lava/acid CF may be fine anyway; for lava/acid there's not really a case like Speed Booster Hall where the movement is very simple.