### PR TITLE
Remove R-mode Req from G-mode

### DIFF
--- a/tech.json
+++ b/tech.json
@@ -2495,189 +2495,199 @@
           "note": [
             "Ability to enter R-mode.",
             "Have some energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray after reserves have finished filling."
+          ]
+        },
+        {
+          "id": 162,
+          "name": "canEnterGMode",
+          "techRequires": [
+            "canUseEnemies",
+            "canPreciseReserveRefill"
+          ],
+          "otherRequires": [
+            "XRayScope",
+            "ReserveTank",
+            {"noFlashSuit": {}}
+          ],
+          "note": [
+            "Ability to enter G-mode and utilize the unusual behaviors that it enables. This requires X-Ray, Reserve Energy, and reserves set to Auto refill.",
+            "In order to enter G-mode, Samus needs to take damage after touching a room transition so that she immediately takes damage and triggers the refill while entering the next room.",
+            "In addition, she needs to be using X-Ray while entering the room and release X-Ray before reserves have finished filling.",
+            "For the simplest cases, Samus will need to start with 4 (or fewer) Reserve Energy, giving a 4-frame window to release X-Ray in the next room (or fewer: 1-frame per Reserve Energy).",
+            "When successfully entering G-mode, the room will darken and the door will remain open (releasing X-Ray too early, neither of these occur; releasing it too late, the room darkens and the door closes - this is R-mode)."
+          ],
+          "detailNote": [
+            "While in G-mode, many things do not behave as expected until exiting G-mode by using X-Ray - Samus can not open doors, collect items, or break blocks, and enemy drops do not spawn and their projectiles are invisible and do not move.",
+            "If Samus can overload PLMs, many types of blocks change their behavior: bomb, crumble, speed blocks, and sand behave as air (Power Bomb, Super, and shot blocks remain solid).",
+            "The most common ways to overload PLMs include: bombing Power Bomb and speed blocks and the side or bottom of crumble blocks that haven't been stepped on (approximately 40 times),",
+            "grappling grapple blocks, rolling through invisible camera scroll blocks (which often appear in morph tunnels), and touching sand.",
+            "Note that stepping on a crumble block or bombing a bomb block will prevent them from behaving like air after PLMs are overloaded.",
+            "When Samus enters G-mode, this is called direct G-mode; if she leaves that room (for example by going back through the open door), she is instead in indirect G-mode.",
+            "When in indirect G-mode, items and blue and green gates do not spawn, and Samus can freely walk through them."
           ],
           "extensionTechs": [
             {
-              "id": 162,
-              "name": "canEnterGMode",
+              "id": 205,
+              "name": "canComplexGMode",
               "techRequires": [
-                "canEnterRMode",
-                "canPreciseReserveRefill"
+                "canEnterGMode"
               ],
               "otherRequires": [],
               "note": [
-                "Ability to enter G-mode and utilize the unusual behaviors that it enables. This requires X-Ray, Reserve Energy, and reserves set to Auto refill.",
-                "In order to enter G-mode, Samus needs to take damage after touching a room transition so that she immediately takes damage and triggers the refill while entering the next room.",
-                "In addition, she needs to be using X-Ray while entering the room and release X-Ray before reserves have finished filling.",
-                "For the simplest cases, Samus will need to start with 4 (or fewer) Reserve Energy, giving a 4-frame window to release X-Ray in the next room (or fewer: 1-frame per Reserve Energy).",
-                "When successfully entering G-mode, the room will darken and the door will remain open (releasing X-Ray too early, neither of these occur; releasing it too late, the room darkens and the door closes - this is R-mode).",
-                "While in G-mode, many things do not behave as expected until exiting G-mode by using X-Ray - Samus can not open doors, collect items, or break blocks, and enemy drops do not spawn and their projectiles are invisible and do not move.",
-                "If Samus can overload PLMs, many types of blocks change their behavior: bomb, crumble, speed blocks, and sand behave as air (Power Bomb, Super, and shot blocks remain solid).",
-                "The most common ways to overload PLMs include: bombing Power Bomb and speed blocks and the side or bottom of crumble blocks that haven't been stepped on (approximately 40 times),",
-                "grappling grapple blocks, rolling through invisible camera scroll blocks (which often appear in morph tunnels), and touching sand.",
-                "Note that stepping on a crumble block or bombing a bomb block will prevent them from behaving like air after PLMs are overloaded.",
-                "When Samus enters G-mode, this is called direct G-mode; if she leaves that room (for example by going back through the open door), she is instead in indirect G-mode.",
-                "When in indirect G-mode, items and blue and green gates do not spawn, and Samus can freely walk through them."
+                "Doing something precise, risky, or unintuitive while in G-mode or while setting up G-mode.",
+                "This includes: enemy dodging that would not normally be an issue and is unintuitive, such as enemies that deal a small amount of damage and awkward dodging while artificially morphed;",
+                "bypassing door locks while in G-mode to maintain indirect G-mode in the next room;",
+                "exiting direct G-mode while in the open door to get very deep doorstuck and X-Ray climb and doorlock bypass a door above;",
+                "exiting G-mode while inside of overloaded blocks in order to have them solidify and be able to X-Ray climb;",
+                "touching an item in direct G-mode before PLMs are overloaded and obtaining the item remotely when exiting G-mode.",
+                "Getting a usable amount of Energy for G-mode setups where there is a high risk of taking extra damage beforehand can often benefit from getting close to the correct position,",
+                "taking an enemy hit and then using X-ray and waiting for Samus's i-frames to expire in order to be able to take additional hits without the enemy moving very much."
               ],
               "extensionTechs": [
                 {
-                  "id": 205,
-                  "name": "canComplexGMode",
+                  "id": 200,
+                  "name": "canTrickyGMode",
                   "techRequires": [
-                    "canEnterGMode"
+                    "canComplexGMode",
+                    "canInsaneJump"
                   ],
                   "otherRequires": [],
                   "note": [
-                    "Doing something precise, risky, or unintuitive while in G-mode or while setting up G-mode.",
-                    "This includes: enemy dodging that would not normally be an issue and is unintuitive, such as enemies that deal a small amount of damage and awkward dodging while artificially morphed;",
-                    "bypassing door locks while in G-mode to maintain indirect G-mode in the next room;",
-                    "exiting direct G-mode while in the open door to get very deep doorstuck and X-Ray climb and doorlock bypass a door above;",
-                    "exiting G-mode while inside of overloaded blocks in order to have them solidify and be able to X-Ray climb;",
-                    "touching an item in direct G-mode before PLMs are overloaded and obtaining the item remotely when exiting G-mode.",
-                    "Getting a usable amount of Energy for G-mode setups where there is a high risk of taking extra damage beforehand can often benefit from getting close to the correct position,",
-                    "taking an enemy hit and then using X-ray and waiting for Samus's i-frames to expire in order to be able to take additional hits without the enemy moving very much."
-                  ],
-                  "extensionTechs": [
-                    {
-                      "id": 200,
-                      "name": "canTrickyGMode",
-                      "techRequires": [
-                        "canComplexGMode",
-                        "canInsaneJump"
-                      ],
-                      "otherRequires": [],
-                      "note": [
-                        "Doing something particularly precise, risky, or unintuitive while in G-mode or while setting up G-mode.",
-                        "This includes very precise movement, enemy manipulation, and timings, where a failure may result in soft-lock or death.",
-                        "This also includes complex dodging of invisible projectiles or camera scroll blocks, and it can be paired with complex off-screen movement."
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "id": 198,
-                  "name": "canHeatedGMode",
-                  "techRequires": [
-                    "canEnterGMode"
-                  ],
-                  "otherRequires": [],
-                  "note": [
-                    "Setting up or using G-mode in a heated environment without heat protection.",
-                    "Positioning an enemy to set up G-mode from a heated room requires precise Energy management.",
-                    "With slightly too much Energy, Samus can take damage then use X-Ray until her i-frames expire to immediately be able to take damage again.",
-                    "While G-mode provides heat protection (sometimes referred to as 'artificial Varia'), entering G-mode in a heated room is risky, as a fail will likely result in death if Samus had only 4 Reserve Energy.",
-                    "Exiting G-mode while in a heated environment will remove Samus' artificial heat protection; luring and killing an enemy near the door to collect its drop with a pause abuse is possible."
-                  ]
-                },
-                {
-                  "id": 163,
-                  "name": "canEnterGModeImmobile",
-                  "techRequires": [
-                    "canEnterGMode"
-                  ],
-                  "otherRequires": [],
-                  "note": [
-                    "Ability to enter G-mode starting with high reserve energy, resulting in Samus being immobilized.",
-                    "Have 5 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window when starting with 12 or more reserve energy, a much larger frame window if you have between 5 and 11).",
-                    "Samus will be unable to move until getting hit by an enemy (or until canceling G-mode by using X-Ray)."
-                  ],
-                  "devNote": "It does not technically require canPreciseReserveRefill to enter immobile, but it is expected to know how to enter G-Mode before learning this."
-                },
-                {
-                  "id": 164,
-                  "name": "canArtificialMorph",
-                  "techRequires": [
-                    "canEnterGMode"
-                  ],
-                  "otherRequires": [],
-                  "note": [
-                    "Ability to obtain artificial morph with G-mode.",
-                    "For low-energy G-mode setups, turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
-                    "For high-energy (immobile) setups, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
-                    "This results in Samus entering a morph ball state without needing to have collected or equipped Morph."
-                  ]
-                },
-                {
-                  "id": 206,
-                  "name": "canPowerBombItemOverloadPLMs",
-                  "techRequires": [
-                    "canEnterGMode"
-                  ],
-                  "otherRequires": [],
-                  "note": [
-                    "Ability to overload PLMs by having a Power Bomb explosion interact with an item, while being able to optimally place them to overload PLMs with as few Power Bombs as possible.",
-                    "The number of PLMs spawned is highly dependent on the distance between the bomb and the item.",
-                    "There is a special distance from the item in which two Power Bombs can fully overload PLMs - 16 tiles away horizontally or 12 tiles vertically away from the item.",
-                    "This magic distance forms a rectangle around the item, which is approximately one tile thick.",
-                    "Slightly outside this rectangle will not spawn any PLMs, slightly inside of it will require dozens of Power Bombs to overload them.",
-                    "Without being able to place a Power Bomb within this special region, then the closer to the item, the more the PLMs are spawned - particularly when extremely close to it.",
-                    "A Power Bomb placed one pixel from the item requires just two Power Bombs, while placing them two tiles away from the item will typically require 7-8 explosions.",
-                    "This requires the item to be uncollected and Samus to be in Direct G-mode for visible and Chozo Ball items, but hidden items can be Power Bombed even if it is collected or in indirect G-mode."
-                  ],
-                  "devNote": "Note that this tech does not have any Power Bomb requirements - those are all included on the strat, because the number required varies significantly."
-                },
-                {
-                  "id": 194,
-                  "name": "canSamusEaterTeleport",
-                  "techRequires": [
-                    "canEnterGMode"
-                  ],
-                  "otherRequires": [],
-                  "note": [
-                    "Ability to use a Samus Eater to teleport when exiting G-mode, just before touching a door transition,",
-                    "modifying where Samus is placed in the next room.",
-                    "Exiting G-mode will teleport Samus to position where she touched the Samus Eater.",
-                    "At the start of the door transition, Samus' X and Y pixel positions are reduced modulo 256 (the size of a screen),",
-                    "so the relative position within the screen is all the matters (not the absolute position in the room).",
-                    "The transition must be touched 2 frames after control is regained after releasing X-Ray.",
-                    "A normalized method to do this is to position Samus slightly more than 1 pixel from the door (but less than $1.3 pixels away),",
-                    "then hold forward toward the door while X-Ray is released.",
-                    "Correct subpixels for this method can be obtained in the following way: 1) jump and press against a wall above,",
-                    "2) jump and do a mid-air turnaround (making sure not to be in front of a wall when turning), which moves Samus back by half a pixel,",
-                    "3) moonwalking back toward the door until 2 pixels away;",
-                    "4) jump and do a turnaround mid-air toward the door.",
-                    "Moonwalking moves back Samus in half-pixel increments, so in the absence of frame-perfect timing there is a 50% chance of ending in the correct position.",
-                    "If Samus is 2 pixels away from the door after the final jump turnaround, then the position is correct;",
-                    "if Samus is 1 pixel away from the door, then the position is incorrect, and the setup should be repeated."
+                    "Doing something particularly precise, risky, or unintuitive while in G-mode or while setting up G-mode.",
+                    "This includes very precise movement, enemy manipulation, and timings, where a failure may result in soft-lock or death.",
+                    "This also includes complex dodging of invisible projectiles or camera scroll blocks, and it can be paired with complex off-screen movement."
                   ]
                 }
+              ]
+            },
+            {
+              "id": 198,
+              "name": "canHeatedGMode",
+              "techRequires": [
+                "canEnterGMode"
+              ],
+              "otherRequires": [],
+              "note": [
+                "Setting up or using G-mode in a heated environment without heat protection.",
+                "Positioning an enemy to set up G-mode from a heated room requires precise Energy management.",
+                "With slightly too much Energy, Samus can take damage then use X-Ray until her i-frames expire to immediately be able to take damage again.",
+                "While G-mode provides heat protection (sometimes referred to as 'artificial Varia'), entering G-mode in a heated room is risky, as a fail will likely result in death if Samus had only 4 Reserve Energy.",
+                "Exiting G-mode while in a heated environment will remove Samus' artificial heat protection; luring and killing an enemy near the door to collect its drop with a pause abuse is possible."
+              ]
+            },
+            {
+              "id": 163,
+              "name": "canEnterGModeImmobile",
+              "techRequires": [
+                "canEnterGMode"
+              ],
+              "otherRequires": [],
+              "note": [
+                "Ability to enter G-mode starting with high reserve energy, resulting in Samus being immobilized.",
+                "Have 5 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window when starting with 12 or more reserve energy, a much larger frame window if you have between 5 and 11).",
+                "Samus will be unable to move until getting hit by an enemy (or until canceling G-mode by using X-Ray)."
+              ],
+              "devNote": "It does not technically require canPreciseReserveRefill to enter immobile, but it is expected to know how to enter G-Mode before learning this."
+            },
+            {
+              "id": 164,
+              "name": "canArtificialMorph",
+              "techRequires": [
+                "canEnterGMode"
+              ],
+              "otherRequires": [],
+              "note": [
+                "Ability to obtain artificial morph with G-mode.",
+                "For low-energy G-mode setups, turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
+                "For high-energy (immobile) setups, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
+                "This results in Samus entering a morph ball state without needing to have collected or equipped Morph."
+              ]
+            },
+            {
+              "id": 206,
+              "name": "canPowerBombItemOverloadPLMs",
+              "techRequires": [
+                "canEnterGMode"
+              ],
+              "otherRequires": [],
+              "note": [
+                "Ability to overload PLMs by having a Power Bomb explosion interact with an item, while being able to optimally place them to overload PLMs with as few Power Bombs as possible.",
+                "The number of PLMs spawned is highly dependent on the distance between the bomb and the item.",
+                "There is a special distance from the item in which two Power Bombs can fully overload PLMs - 16 tiles away horizontally or 12 tiles vertically away from the item.",
+                "This magic distance forms a rectangle around the item, which is approximately one tile thick.",
+                "Slightly outside this rectangle will not spawn any PLMs, slightly inside of it will require dozens of Power Bombs to overload them.",
+                "Without being able to place a Power Bomb within this special region, then the closer to the item, the more the PLMs are spawned - particularly when extremely close to it.",
+                "A Power Bomb placed one pixel from the item requires just two Power Bombs, while placing them two tiles away from the item will typically require 7-8 explosions.",
+                "This requires the item to be uncollected and Samus to be in Direct G-mode for visible and Chozo Ball items, but hidden items can be Power Bombed even if it is collected or in indirect G-mode."
+              ],
+              "devNote": "Note that this tech does not have any Power Bomb requirements - those are all included on the strat, because the number required varies significantly."
+            },
+            {
+              "id": 194,
+              "name": "canSamusEaterTeleport",
+              "techRequires": [
+                "canEnterGMode"
+              ],
+              "otherRequires": [],
+              "note": [
+                "Ability to use a Samus Eater to teleport when exiting G-mode, just before touching a door transition,",
+                "modifying where Samus is placed in the next room.",
+                "Exiting G-mode will teleport Samus to position where she touched the Samus Eater.",
+                "At the start of the door transition, Samus' X and Y pixel positions are reduced modulo 256 (the size of a screen),",
+                "so the relative position within the screen is all the matters (not the absolute position in the room).",
+                "The transition must be touched 2 frames after control is regained after releasing X-Ray.",
+                "A normalized method to do this is to position Samus slightly more than 1 pixel from the door (but less than $1.3 pixels away),",
+                "then hold forward toward the door while X-Ray is released.",
+                "Correct subpixels for this method can be obtained in the following way: 1) jump and press against a wall above,",
+                "2) jump and do a mid-air turnaround (making sure not to be in front of a wall when turning), which moves Samus back by half a pixel,",
+                "3) moonwalking back toward the door until 2 pixels away;",
+                "4) jump and do a turnaround mid-air toward the door.",
+                "Moonwalking moves back Samus in half-pixel increments, so in the absence of frame-perfect timing there is a 50% chance of ending in the correct position.",
+                "If Samus is 2 pixels away from the door after the final jump turnaround, then the position is correct;",
+                "if Samus is 1 pixel away from the door, then the position is incorrect, and the setup should be repeated."
               ]
             },
             {
               "id": 165,
               "name": "canDownwardGModeSetup",
               "techRequires": [
-                "canEnterRMode"
+                "canEnterGMode"
               ],
               "otherRequires": [],
               "note": [
                 "Ability to setup an R-mode or G-mode through a downward door or sand transition.",
-                "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
+                "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition."
+              ],
+              "detailNote": [
                 "There are three known ways to enter a downward transition where X-Ray is usable on entry: 1) Clip into the floor next to the transition, then move forward to touch the transition.",
                 "2) Freeze an enemy on the ground above and near the transition, typically with 1-2 pixels of air horizontally between the enemy and the transition,",
                 "run and fall over the doorframe and hit the opposite wall to wall ice clip Samus into the wall to force a stand up, which will expand her hitbox to touch the transition.",
                 "3) Crouch in quicksand and press forward to stand up to expand Samus' hitbox and touch the transition on the first frame the hitbox expands."
-              ]
+              ],
+              "devNote": "FIXME: This could be used for entering R-mode, with G-mode disabled. But for now, G-mode is more refined and easier to understand, so it would be somewhat odd to turn this on and not G-mode."
             },
             {
               "id": 166,
               "name": "canUpwardGModeSetup",
               "techRequires": [
-                "canEnterRMode",
+                "canEnterGMode",
                 "canTwoTileSqueeze"
               ],
               "otherRequires": [],
               "note": [
                 "Ability to setup an R-mode or G-mode through an upward door.",
                 "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
-                "This is typically done by standing or crouching on an enemy as a platform beneath the transition and pressing forward to activate the transition.",
+                "This is typically done by standing or crouching on an enemy as a platform beneath the transition and pressing forward to activate the transition."
+              ],
+              "detailNote": [
                 "Getting Samus onto the enemy without activating the transition can usually be done by spin jumping against the enemy and quickly releasing jump and forward once on top of it.",
                 "If the vertical space between the enemy and transition is 2 tiles or fewer, Samus needs to aim down before landing to prevent touching the transition as she lands.",
                 "it is also possible to get onto the enemy by jumping and aiming down with horizontal momentum while avoiding hitting the side of the enemy or the transition above.",
                 "This may also be done more easily with Spring Ball or a room geometry that makes it easy to midair morph directly onto the enemy.",
                 "Unmorphing when on top of the enemy will put Samus in a crouch, where a forward press will stand up and activate the transition.",
                 "If Samus is completely against the wall, an X-Ray turnaround or crouch is necessary to be able to activate the transition tiles with a forward press."
-              ]
+              ],
+              "devNote": "FIXME: This could be used for entering R-mode, with G-mode disabled. But for now, G-mode is more refined and easier to understand, so it would be somewhat odd to turn this on and not G-mode."
             }
           ]
         }


### PR DESCRIPTION
Of course, Github makes this simple change difficult to follow, so I'll describe the changes:

- Removed R-mode as a requirement from G-mode (no longer an extension)
- Split the tech description to fill a note and devNote for G-mode, upward setup, downward setup
- Move upward setup and downward setup to be inside the extension of g-mode, it now requires g-mode instead of r-mode, and added a FIXME devNote to them

I have more I want to do, but the changes were starting to look too messy, so I'll finish the rest later.