### PR TITLE
Rename canEnterGMode to canGMode

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1145,7 +1145,7 @@
         {
           "name": "h_heatedGMode",
           "requires": [
-            "canEnterGMode",
+            "canGMode",
             {"or": [
               "h_heatProof",
               "canHeatedGMode"
@@ -1155,7 +1155,7 @@
         {
           "name": "h_heatedGModePauseAbuse",
           "requires": [
-            "canEnterGMode",
+            "canGMode",
             "canPauseAbuse",
             {"or": [
               "h_heatProof",

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -1303,7 +1303,7 @@
       "link": [5, 2],
       "name": "G-Mode Morph Bomb the Crumble Block",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphIBJ",
         {"or": [
           "canConsecutiveWalljump",
@@ -1329,7 +1329,7 @@
       "link": [5, 2],
       "name": "G-Mode Morph Shoot the Ceiling Block Item",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "Morph",
         {"or": [
           "canConsecutiveWalljump",
@@ -1348,7 +1348,7 @@
       "name": "G-Mode Morph Power Bomb the Ceiling Block Item",
       "requires": [
         "canPowerBombItemOverloadPLMs",
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb",
         "h_artificialMorphMovement",
         {"or": [
@@ -1369,7 +1369,7 @@
       "link": [5, 4],
       "name": "G-Mode Morph",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -1378,7 +1378,7 @@
       "link": [5, 4],
       "name": "G-Mode Morph with Power Bomb",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
@@ -1390,7 +1390,7 @@
       "link": [6, 4],
       "name": "G-Mode Morph Touch the Item (Prepare to Remote Acquire)",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"itemNotCollectedAtNode": 4},
         "h_artificialMorphMovement"
       ],
@@ -1411,7 +1411,7 @@
       "link": [6, 5],
       "name": "Base",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     }

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -1460,7 +1460,7 @@
       "link": [5, 5],
       "name": "Power Bomb Blocks While in Artificial Morph from the Left",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"obstaclesCleared": ["D"]},
         "h_artificialMorphPowerBomb",
         {"or": [

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -5365,7 +5365,7 @@
       "link": [16, 1],
       "name": "G-Mode Up the Elevator",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "exitCondition": {
         "leaveWithGMode": {

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -3736,7 +3736,7 @@
       "link": [14, 4],
       "name": "Exit G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true
@@ -3746,7 +3746,7 @@
       "link": [14, 4],
       "name": "Leave with G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -3760,7 +3760,7 @@
       "link": [14, 4],
       "name": "G-Mode Morph, Power Bomb the Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B", "C"],
@@ -3772,7 +3772,7 @@
       "link": [15, 1],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "Morph",
           {"and": [
@@ -3800,7 +3800,7 @@
       "link": [15, 1],
       "name": "G-mode Morph Overload PLMs with Power Bombs and Spring Ball",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphSpringBallBombJump",
         "h_artificialMorphPowerBomb",
         "h_artificialMorphPowerBomb",
@@ -3826,7 +3826,7 @@
       "link": [15, 8],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphMovement"
       ]
     },
@@ -3835,7 +3835,7 @@
       "link": [15, 10],
       "name": "G-mode Morph with Bombs",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongIBJ",
         {"or": [
           "canTrickyDodgeEnemies",
@@ -3855,7 +3855,7 @@
       "link": [15, 10],
       "name": "G-mode Morph with HiJump Spring Fling",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "HiJump",
         "h_artificialMorphSpringFling",
         {"or": [
@@ -3875,7 +3875,7 @@
       "link": [15, 12],
       "name": "G-mode Morph Overload PLMs",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphMovement"
       ],
       "flashSuitChecked": true,
@@ -3886,7 +3886,7 @@
       "link": [15, 13],
       "name": "G-mode Morph Power Bomb the Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "canComplexGMode",
           "h_artificialMorphPowerBomb",
@@ -3906,7 +3906,7 @@
       "link": [15, 14],
       "name": "G-mode Overload PLMs with Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "canMidAirMorph"
       ],
       "flashSuitChecked": true,
@@ -3920,7 +3920,7 @@
       "link": [15, 14],
       "name": "G-mode Morph Overload PLMs with Bombs",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphIBJ",
         {"or": [
           "canTrickyDodgeEnemies",
@@ -3941,7 +3941,7 @@
       "link": [15, 14],
       "name": "G-mode Morph Overload PLMs with Spring Ball",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphSpringBall",
         "canCameraManip",
         {"or": [
@@ -3969,7 +3969,7 @@
       "link": [16, 1],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "Morph",
           "h_artificialMorphIBJ",
@@ -4001,7 +4001,7 @@
       "link": [16, 4],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphMovement",
         {"or": [
           "Morph",
@@ -4025,7 +4025,7 @@
       "link": [16, 8],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphMovement",
         {"or": [
           "Morph",
@@ -4048,7 +4048,7 @@
       "link": [16, 12],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphMovement",
         {"or": [
           "Morph",
@@ -4074,7 +4074,7 @@
       "link": [17, 1],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "Morph",
           "h_artificialMorphIBJ",
@@ -4128,7 +4128,7 @@
       "link": [17, 4],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "Morph",
           "h_artificialMorphIBJ",
@@ -4173,7 +4173,7 @@
       "link": [17, 4],
       "name": "G-mode Morph, Power Bomb the Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "Morph",
           "h_artificialMorphIBJ",
@@ -4219,7 +4219,7 @@
       "link": [17, 8],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphMovement"
       ],
       "collectsItems": [11],
@@ -4230,7 +4230,7 @@
       "link": [17, 12],
       "name": "G-mode Morph",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"itemNotCollectedAtNode": 11},
         "canRiskPermanentLossOfAccess"
       ],

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -405,7 +405,7 @@
       "link": [1, 1],
       "name": "Indirect G-Mode Damageless Kill",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"obstaclesCleared": ["C"]},
         "canTrickyDodgeEnemies",
         {"or": [

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -2321,7 +2321,7 @@
       "link": [7, 5],
       "name": "Exit G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true,
       "note": "Exit G-Mode near the door to pass the gate."
@@ -2331,7 +2331,7 @@
       "link": [7, 5],
       "name": "Exit G-Mode, Open Gate",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "canOffScreenMovement"
       ],
       "clearsObstacles": ["A"],

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -1843,7 +1843,7 @@
       "link": [8, 1],
       "name": "G-Mode Morph Power Bomb",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "h_artificialMorphLongIBJ",
           {"and": [
@@ -1864,7 +1864,7 @@
       "link": [8, 1],
       "name": "G-Mode Morph Screw Attack",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongIBJ",
         "ScrewAttack"
       ],
@@ -1876,7 +1876,7 @@
       "link": [8, 3],
       "name": "G-Mode Morph IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongIBJ"
       ],
       "flashSuitChecked": true
@@ -1886,7 +1886,7 @@
       "link": [8, 4],
       "name": "G-Mode Morph Power Bomb",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B"],
@@ -1898,7 +1898,7 @@
       "link": [8, 4],
       "name": "G-Mode Morph IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphIBJ"
       ],
       "flashSuitChecked": true,

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -3051,7 +3051,7 @@
       "link": [15, 16],
       "name": "G-mode Overload PLMs with Grapple",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "Grapple",
         "Morph"
       ],
@@ -3062,7 +3062,7 @@
       "link": [15, 16],
       "name": "G-mode Overload PLMs by Bombing Crumble Block with Space Jump",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_useMorphBombs",
         "SpaceJump",
         "canBeVeryPatient"
@@ -3075,7 +3075,7 @@
       "link": [15, 16],
       "name": "G-mode Overload PLMs by Bombing Crumble Block",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongIBJ",
         "h_artificialMorphCeilingBombJump"
       ],
@@ -3088,7 +3088,7 @@
       "link": [16, 14],
       "name": "G-Mode Through the Crumble Block",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           {"and": [
             "SpaceJump",

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -1760,7 +1760,7 @@
       "link": [10, 2],
       "name": "Exit G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -1769,7 +1769,7 @@
       "link": [10, 4],
       "name": "G-Mode Morph Pirate Kill",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphBombThings",
         "h_additionalBomb"
       ],
@@ -1780,7 +1780,7 @@
       "link": [10, 9],
       "name": "G-Mode Morph - Power Bomb to the Beetoms",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
@@ -1792,7 +1792,7 @@
       "link": [10, 9],
       "name": "G-Mode Morph - Overload PLMs to the Beetoms",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphBombs",
         {"or": [
           {"and": [

--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -1942,7 +1942,7 @@
       "link": [9, 2],
       "name": "G-Mode, Blind Temporary Blue and Speedball",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_heatProof",
         "canOffScreenMovement",
         {"getBlueSpeed": {"usedTiles": 20, "steepDownTiles": 4, "openEnd": 1}},

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -3155,7 +3155,7 @@
       "link": [10, 1],
       "name": "Overload PLMs - Bomb the Speed Blocks, To the Middle Left Door",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "Gravity",
         {"or": [
           "h_artificialMorphLongIBJ",
@@ -3169,7 +3169,7 @@
       "link": [10, 1],
       "name": "G-Mode Bomb the Block - Morphed Suitless Snail Climb",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphBombThings",
         "h_artificialMorphSpringBall",
         "canSnailClimb",
@@ -3185,7 +3185,7 @@
       "link": [10, 1],
       "name": "G-Mode Bomb the Block - Morphed Suitless Snail Climb, No Jump Assist",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphBombThings",
         "h_artificialMorphSpringBall",
         "canSnailClimb",
@@ -3203,7 +3203,7 @@
       "link": [10, 2],
       "name": "Break the Power Bomb Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
@@ -3215,7 +3215,7 @@
       "link": [10, 10],
       "name": "Power Bomb the Power Bomb Blocks - Break Later",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
@@ -3228,7 +3228,7 @@
       "link": [10, 11],
       "name": "G-Mode Morph, Overload PLMs - Bomb the Speed Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "Gravity",
         {"or": [
           "h_artificialMorphLongIBJ",
@@ -3242,7 +3242,7 @@
       "link": [10, 11],
       "name": "G-Mode, Overload PLMs - Bomb the Speed Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_useMorphBombs",
         {"or": [
           "canSnailClimb",
@@ -3258,7 +3258,7 @@
       "link": [10, 11],
       "name": "Overload PLMs - Morphed Suitless Snail Climb",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphBombs",
         "HiJump",
         "h_artificialMorphSpringBall",
@@ -3271,7 +3271,7 @@
       "link": [10, 11],
       "name": "Overload PLMs - Morphed Suitless Snail Climb, No Jump Assist",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphBombs",
         "h_artificialMorphSpringBall",
         "canSnailClimb",
@@ -3289,7 +3289,7 @@
       "link": [10, 12],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -3298,7 +3298,7 @@
       "link": [11, 1],
       "name": "G-Mode Overloaded PLMs Through the Bomb Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "canSnailClimb",
           {"and": [
@@ -3318,7 +3318,7 @@
       "link": [11, 7],
       "name": "G-Mode Overloaded PLMs Through the Speed Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "canSnailClimb",
         {"or": [
           "Gravity",
@@ -3340,7 +3340,7 @@
       "link": [11, 7],
       "name": "G-Mode Overloaded PLMs - Bootless UWJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "canSnailClimb",
         "canBootless2WideUWJ"
       ],
@@ -3408,7 +3408,7 @@
       "link": [12, 11],
       "name": "G-Mode Overload PLMs with Grapple",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "Grapple",
         "h_navigateUnderwater"
       ],
@@ -3583,7 +3583,7 @@
       "link": [13, 10],
       "name": "G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -3592,7 +3592,7 @@
       "link": [13, 13],
       "name": "Power Bomb the Power Bomb Blocks - Break Later",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -4318,7 +4318,7 @@
       "link": [5, 3],
       "name": "G-Mode Morph, Jump Assist",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "canOffScreenMovement",
         {"or": [
           "Gravity",
@@ -4337,7 +4337,7 @@
       "link": [5, 3],
       "name": "G-Mode, Blind Foosball",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "canOffScreenMovement",
         "canInsaneJump",
         "h_artificialMorphSpringBall"
@@ -4354,7 +4354,7 @@
       "link": [5, 4],
       "name": "G-Mode Morph, Long Blind IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "Gravity",
         "h_artificialMorphLongIBJ",
         "canOffScreenMovement"

--- a/region/maridia/inner-yellow/Maridia Elevator Room.json
+++ b/region/maridia/inner-yellow/Maridia Elevator Room.json
@@ -1395,7 +1395,7 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -1404,7 +1404,7 @@
       "link": [4, 3],
       "name": "Carry G-Mode Up the Elevator",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "exitCondition": {
         "leaveWithGMode": {

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -3930,7 +3930,7 @@
       "link": [5, 1],
       "name": "Exit G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -3939,7 +3939,7 @@
       "link": [5, 1],
       "name": "Carry G-Mode Morph Left",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "exitCondition": {
         "leaveWithGMode": {
@@ -3953,7 +3953,7 @@
       "link": [5, 4],
       "name": "Carry G-Mode Morph Right",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "exitCondition": {
         "leaveWithGMode": {

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -5432,7 +5432,7 @@
       "link": [13, 3],
       "name": "Exit G-Mode",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -5441,7 +5441,7 @@
       "link": [13, 4],
       "name": "G-Mode Morph Full Climb",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_navigateUnderwater",
         {"or": [
           {"and": [

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -5632,7 +5632,7 @@
       "link": [12, 6],
       "name": "Base",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true,
       "devNote": "This technically requires h_EverestMorphTunnelExpanded or going through the transition while in G-Mode, but that shouldn't cause a problem."
@@ -5642,7 +5642,7 @@
       "link": [12, 6],
       "name": "Carry G-Mode Morph Through the Tunnel",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "exitCondition": {
         "leaveWithGMode": {

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -442,7 +442,7 @@
       "link": [3, 4],
       "name": "G-Mode Morph Ceiling Bomb Jump",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongCeilingBombJump",
         "canBeVeryPatient",
         {"obstaclesCleared": ["A"]}

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -885,7 +885,7 @@
       "link": [3, 3],
       "name": "Exit G-Mode to Open Gate",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"obstaclesCleared": ["B"]}
       ],
       "clearsObstacles": ["A"],

--- a/region/norfair/crocomire/Indiana Jones Room.json
+++ b/region/norfair/crocomire/Indiana Jones Room.json
@@ -1601,7 +1601,7 @@
       "link": [6, 1],
       "name": "G-Mode Morph Spring Ball, IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphJumpIntoIBJ"
       ],
       "flashSuitChecked": true,
@@ -1612,7 +1612,7 @@
       "link": [6, 1],
       "name": "G-Mode Morph Long Diagonal Bomb Jump",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"notable": "G-Mode Morph Long Diagonal Bomb Jump"},
         "h_artificialMorphDiagonalBombJump",
         "h_artificialMorphLongIBJ"
@@ -1625,7 +1625,7 @@
       "link": [6, 1],
       "name": "G-Mode Morph Acid Dive IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "Gravity",
         "h_artificialMorphLongIBJ",
         "h_artificialMorphBombHorizontally",
@@ -1644,7 +1644,7 @@
       "link": [6, 2],
       "name": "Exit G-Mode (Right of Speed Blocks)",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -1683,7 +1683,7 @@
       "link": [6, 3],
       "name": "G-Mode Morph, IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongIBJ"
       ],
       "flashSuitChecked": true
@@ -1693,7 +1693,7 @@
       "link": [6, 5],
       "name": "Exit G-Mode (Left of Speed Blocks)",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -1702,7 +1702,7 @@
       "link": [6, 6],
       "name": "G-Mode Morph, Power Bomb the Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
@@ -1754,7 +1754,7 @@
       "link": [7, 6],
       "name": "G-Mode Morph",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -1763,7 +1763,7 @@
       "link": [7, 7],
       "name": "G-Mode Morph, Power Bomb the Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -1572,7 +1572,7 @@
       "link": [6, 1],
       "name": "G-Mode Morph IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "h_artificialMorphLongIBJ",
           {"and": [
@@ -1588,7 +1588,7 @@
       "link": [6, 4],
       "name": "G-Mode Morph IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         {"or": [
           "h_artificialMorphLongIBJ",
           "h_artificialMorphJumpIntoIBJ"

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -4409,7 +4409,7 @@
       "link": [10, 1],
       "name": "G-Mode Morph IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongIBJ",
         {"or": [
           "h_artificialMorphPowerBomb",
@@ -4430,7 +4430,7 @@
       "link": [10, 3],
       "name": "Base",
       "requires": [
-        "canEnterGMode"
+        "canGMode"
       ],
       "flashSuitChecked": true
     },
@@ -4439,7 +4439,7 @@
       "link": [10, 3],
       "name": "G-Mode Morph Power Bomb the Blocks",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["A"],
@@ -4450,7 +4450,7 @@
       "link": [10, 7],
       "name": "G-Mode Morph IBJ",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongIBJ",
         {"or": [
           "h_artificialMorphPowerBomb",

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -2181,7 +2181,7 @@
       "link": [7, 2],
       "name": "G-Mode, Heatproof, Fix Camera",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_heatProof",
         {"or": [
           "h_bombThings",

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -796,7 +796,7 @@
       "link": [2, 1],
       "name": "G-Mode Morph Ceiling Bomb Jump",
       "requires": [
-        "canEnterGMode",
+        "canGMode",
         "h_artificialMorphLongCeilingBombJump",
         "canBeVeryPatient",
         {"obstaclesCleared": ["A"]}

--- a/strats.md
+++ b/strats.md
@@ -1311,7 +1311,7 @@ A `comeInWithRMode` entrance condition indicates that Samus must obtain R-mode w
 A `comeInWithRMode` object does not have any properties.
 
 A `comeInWithRMode` entrance condition must match with a `leaveWithGModeSetup` entrance condition on the other side of the door. It comes with the following implicit requirements:
-- The tech requirement `canEnterRMode`.
+- The tech requirement `canRMode`.
 - The `XRayScope` item requirement.
 - A requirement to have at least 1 reserve energy.
 - A requirement to damage down to 0 energy, triggering reserves (causing the reserve energy to become zero and the regular energy to become what the reserve energy was).
@@ -1354,7 +1354,7 @@ A `comeInWithGMode` entrance condition must match with either a `leaveWithGModeS
 - If `mode` is "direct", then it can only match with a `leaveWithGModeSetup`. If `mode` is "indirect", then it can only match with a `leaveWithGMode`.
 
 When matching with a `leaveWithGModeSetup`, a `comeInWithGMode` has implicit requirements:
-- The tech requirement `canEnterGMode`.
+- The tech requirement `canGMode`.
 - The requirement `h_heatedGMode` if either the previous room or current room is heated.
 - The `XRayScope` item requirement.
 - A requirement to have at least 1 reserve energy.

--- a/tech.json
+++ b/tech.json
@@ -2483,7 +2483,7 @@
         },
         {
           "id": 161,
-          "name": "canEnterRMode",
+          "name": "canRMode",
           "techRequires": [
             "canUseEnemies"
           ],
@@ -2499,7 +2499,7 @@
         },
         {
           "id": 162,
-          "name": "canEnterGMode",
+          "name": "canGMode",
           "techRequires": [
             "canUseEnemies",
             "canPreciseReserveRefill"
@@ -2530,7 +2530,7 @@
               "id": 205,
               "name": "canComplexGMode",
               "techRequires": [
-                "canEnterGMode"
+                "canGMode"
               ],
               "otherRequires": [],
               "note": [
@@ -2564,7 +2564,7 @@
               "id": 198,
               "name": "canHeatedGMode",
               "techRequires": [
-                "canEnterGMode"
+                "canGMode"
               ],
               "otherRequires": [],
               "note": [
@@ -2573,13 +2573,14 @@
                 "With slightly too much Energy, Samus can take damage then use X-Ray until her i-frames expire to immediately be able to take damage again.",
                 "While G-mode provides heat protection (sometimes referred to as 'artificial Varia'), entering G-mode in a heated room is risky, as a fail will likely result in death if Samus had only 4 Reserve Energy.",
                 "Exiting G-mode while in a heated environment will remove Samus' artificial heat protection; luring and killing an enemy near the door to collect its drop with a pause abuse is possible."
-              ]
+              ],
+              "devNote": "FIXME: This could be used for entering R-mode, with G-mode disabled. But for now, G-mode is more refined and easier to understand, so it would be somewhat odd to turn this on and not G-mode."
             },
             {
               "id": 163,
-              "name": "canEnterGModeImmobile",
+              "name": "canGModeImmobile",
               "techRequires": [
-                "canEnterGMode"
+                "canGMode"
               ],
               "otherRequires": [],
               "note": [
@@ -2593,7 +2594,7 @@
               "id": 164,
               "name": "canArtificialMorph",
               "techRequires": [
-                "canEnterGMode"
+                "canGMode"
               ],
               "otherRequires": [],
               "note": [
@@ -2607,12 +2608,14 @@
               "id": 206,
               "name": "canPowerBombItemOverloadPLMs",
               "techRequires": [
-                "canEnterGMode"
+                "canGMode"
               ],
               "otherRequires": [],
               "note": [
                 "Ability to overload PLMs by having a Power Bomb explosion interact with an item, while being able to optimally place them to overload PLMs with as few Power Bombs as possible.",
-                "The number of PLMs spawned is highly dependent on the distance between the bomb and the item.",
+                "The number of PLMs spawned is highly dependent on the distance between the bomb and the item."
+              ],
+              "detailNote": [
                 "There is a special distance from the item in which two Power Bombs can fully overload PLMs - 16 tiles away horizontally or 12 tiles vertically away from the item.",
                 "This magic distance forms a rectangle around the item, which is approximately one tile thick.",
                 "Slightly outside this rectangle will not spawn any PLMs, slightly inside of it will require dozens of Power Bombs to overload them.",
@@ -2626,7 +2629,7 @@
               "id": 194,
               "name": "canSamusEaterTeleport",
               "techRequires": [
-                "canEnterGMode"
+                "canGMode"
               ],
               "otherRequires": [],
               "note": [
@@ -2635,7 +2638,9 @@
                 "Exiting G-mode will teleport Samus to position where she touched the Samus Eater.",
                 "At the start of the door transition, Samus' X and Y pixel positions are reduced modulo 256 (the size of a screen),",
                 "so the relative position within the screen is all the matters (not the absolute position in the room).",
-                "The transition must be touched 2 frames after control is regained after releasing X-Ray.",
+                "The transition must be touched exactly 2 frames after control is regained after releasing X-Ray."
+              ],
+              "detailNote": [
                 "A normalized method to do this is to position Samus slightly more than 1 pixel from the door (but less than $1.3 pixels away),",
                 "then hold forward toward the door while X-Ray is released.",
                 "Correct subpixels for this method can be obtained in the following way: 1) jump and press against a wall above,",
@@ -2646,49 +2651,44 @@
                 "If Samus is 2 pixels away from the door after the final jump turnaround, then the position is correct;",
                 "if Samus is 1 pixel away from the door, then the position is incorrect, and the setup should be repeated."
               ]
-            },
-            {
-              "id": 165,
-              "name": "canDownwardGModeSetup",
-              "techRequires": [
-                "canEnterGMode"
-              ],
-              "otherRequires": [],
-              "note": [
-                "Ability to setup an R-mode or G-mode through a downward door or sand transition.",
-                "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition."
-              ],
-              "detailNote": [
-                "There are three known ways to enter a downward transition where X-Ray is usable on entry: 1) Clip into the floor next to the transition, then move forward to touch the transition.",
-                "2) Freeze an enemy on the ground above and near the transition, typically with 1-2 pixels of air horizontally between the enemy and the transition,",
-                "run and fall over the doorframe and hit the opposite wall to wall ice clip Samus into the wall to force a stand up, which will expand her hitbox to touch the transition.",
-                "3) Crouch in quicksand and press forward to stand up to expand Samus' hitbox and touch the transition on the first frame the hitbox expands."
-              ],
-              "devNote": "FIXME: This could be used for entering R-mode, with G-mode disabled. But for now, G-mode is more refined and easier to understand, so it would be somewhat odd to turn this on and not G-mode."
-            },
-            {
-              "id": 166,
-              "name": "canUpwardGModeSetup",
-              "techRequires": [
-                "canEnterGMode",
-                "canTwoTileSqueeze"
-              ],
-              "otherRequires": [],
-              "note": [
-                "Ability to setup an R-mode or G-mode through an upward door.",
-                "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
-                "This is typically done by standing or crouching on an enemy as a platform beneath the transition and pressing forward to activate the transition."
-              ],
-              "detailNote": [
-                "Getting Samus onto the enemy without activating the transition can usually be done by spin jumping against the enemy and quickly releasing jump and forward once on top of it.",
-                "If the vertical space between the enemy and transition is 2 tiles or fewer, Samus needs to aim down before landing to prevent touching the transition as she lands.",
-                "it is also possible to get onto the enemy by jumping and aiming down with horizontal momentum while avoiding hitting the side of the enemy or the transition above.",
-                "This may also be done more easily with Spring Ball or a room geometry that makes it easy to midair morph directly onto the enemy.",
-                "Unmorphing when on top of the enemy will put Samus in a crouch, where a forward press will stand up and activate the transition.",
-                "If Samus is completely against the wall, an X-Ray turnaround or crouch is necessary to be able to activate the transition tiles with a forward press."
-              ],
-              "devNote": "FIXME: This could be used for entering R-mode, with G-mode disabled. But for now, G-mode is more refined and easier to understand, so it would be somewhat odd to turn this on and not G-mode."
             }
+          ]
+        },
+        {
+          "id": 165,
+          "name": "canDownwardGModeSetup",
+          "techRequires": [],
+          "otherRequires": [],
+          "note": [
+            "Ability to setup R-mode or G-mode through a downward door or sand transition.",
+            "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition."
+          ],
+          "detailNote": [
+            "There are three known ways to enter a downward transition where X-Ray is usable on entry: 1) Clip into the floor next to the transition, then move forward to touch the transition.",
+            "2) Freeze an enemy on the ground above and near the transition, typically with 1-2 pixels of air horizontally between the enemy and the transition,",
+            "run and fall over the doorframe and hit the opposite wall to wall ice clip Samus into the wall to force a stand up, which will expand her hitbox to touch the transition.",
+            "3) Crouch in quicksand and press forward to stand up to expand Samus' hitbox and touch the transition on the first frame the hitbox expands."
+          ]
+        },
+        {
+          "id": 166,
+          "name": "canUpwardGModeSetup",
+          "techRequires": [
+            "canTwoTileSqueeze"
+          ],
+          "otherRequires": [],
+          "note": [
+            "Ability to setup R-mode or G-mode through an upward door.",
+            "Samus needs to be in a standing or walking position with no vertical speed on the first frame in the next room, while taking damage through the transition.",
+            "This is typically done by standing or crouching on an enemy as a platform beneath the transition and pressing forward to activate the transition."
+          ],
+          "detailNote": [
+            "Getting Samus onto the enemy without activating the transition can usually be done by spin jumping against the enemy and quickly releasing jump and forward once on top of it.",
+            "If the vertical space between the enemy and transition is 2 tiles or fewer, Samus needs to aim down before landing to prevent touching the transition as she lands.",
+            "it is also possible to get onto the enemy by jumping and aiming down with horizontal momentum while avoiding hitting the side of the enemy or the transition above.",
+            "This may also be done more easily with Spring Ball or a room geometry that makes it easy to midair morph directly onto the enemy.",
+            "Unmorphing when on top of the enemy will put Samus in a crouch, where a forward press will stand up and activate the transition.",
+            "If Samus is completely against the wall, an X-Ray turnaround or crouch is necessary to be able to activate the transition tiles with a forward press."
           ]
         }
       ]


### PR DESCRIPTION
Also renamed `canRMode`, `canGModeImmobile`. These now match `canXMode`.

- Pulled out upward/downward setups to no longer require G or R mode. 
- Split a few more long g-mode descriptions to include detail notes