### PR TITLE
Refine Bubble Mountain top-left to top-right jumps

### DIFF
--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -667,19 +667,33 @@
     {
       "id": 11,
       "link": [1, 7],
-      "name": "Open Door Full Runway Jump",
+      "name": "Jump Across",
       "requires": [
         {"doorUnlockedAtNode": 1},
-        {"or": [
-          "canTrickyJump",
-          {"and": [
-            "SpeedBooster",
-            "canCarefulJump"
-          ]}
-        ]},
+        "canTrickyJump",
         "canCameraManip"
       ],
       "note": "Kill King Cac by scrolling the camera, before attempting the jump."
+    },
+    {
+      "link": [1, 7],
+      "name": "Speedy Jump Across",
+      "requires": [
+        "SpeedBooster",
+        "canCarefulJump",
+        {"or": [
+          {"doorUnlockedAtNode": 1},
+          "canTrickyJump"
+        ]},
+        {"or": [
+          "canCameraManip",
+          {"and": [
+            "canNeutralDamageBoost",
+            {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
+          ]}
+        ]}
+      ],
+      "note": "King Cac can be killed by scrolling the camera before jumping across."
     },
     {
       "id": 12,
@@ -687,12 +701,16 @@
       "name": "Airball",
       "requires": [
         "canLateralMidAirMorph",
-        "canTrickyJump",
+        {"or": [
+          "canTrickyJump",
+          {"doorUnlockedAtNode": 1}
+        ]},
         {"or": [
           "canCameraManip",
           {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "note": "King Cac can be killed by scrolling the camera before jumping across."
     },
     {
       "id": 13,


### PR DESCRIPTION
- With Speed Booster, the jump is possible with the door locked. This could matter if you came in with a door lock bypass.
- With Speed Booster and the door unlocked, tanking a Cac hit (with `canNeutralDamageBoost`) seemed like a reasonable alternative to killing the Cac.
- Airball is significantly easier if the door can be unlocked, enough that the "canTrickyJump" requirement seems ok to drop in that case.

This was prompted by some of Sam's recent videos for this part of the room.
