### PR TITLE
Early Supers right-side G-mode setup from right

### DIFF
--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -872,6 +872,32 @@
     },
     {
       "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit By Waver (Come in Jumping, Mockball)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        "can4HighMidAirMorph",
+        "canMockball",
+        "canComplexGMode"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "note": [
+        "Jump into the room and mockball to get under the first shutter, to break the crumble blocks to the left.",
+        "Stop before passing under the second shutter.",
+        "Breaking these crumble blocks is the only way for the Wavers to reach the door.",
+        "After the crumbles are broken, shoot the ceiling block and wait by the door for the Waver to come."
+      ]
+    },
+    {
+      "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Waver (Come in Space Jumping)",
       "entranceCondition": {
         "comeInSpaceJumping": {

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -488,9 +488,6 @@
         "This assumes that Samus comes from the left with Speed, a mockball, or a crouch gate clip.",
         "After the crumbles are broken, shoot the ceiling block and wait by the door for the Waver to come.",
         "Note that if Samus takes more than 35 seconds after entering the room, before shooting the ceiling, the Waver will not come down."
-      ],
-      "devNote": [
-        "FIXME: It is possible to come in from the right and get under the gate to break the crumbles."
       ]
     },
     {
@@ -848,6 +845,70 @@
         "h_CrystalFlash"
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit By Waver (Come in Jumping)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": false,
+          "minTiles": 4
+        }
+      },
+      "requires": [
+        "canCrouchGateClip",
+        "canComplexGMode"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "note": [
+        "Jump into the room and aim down to get under the first shutter, then break the crumble blocks to the left.",
+        "This is the only way for the Wavers to reach the door.",
+        "After the crumbles are broken, shoot the ceiling block and wait by the door for the Waver to come."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit By Waver (Come in With Side Platform)",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 2,
+              "minTiles": 4,
+              "speedBooster": false,
+              "obstructions": [[1, 0]],
+              "note": ["Skree Boost Room and Butterfly Room are minimal-runway examples that this applies to."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 5,
+              "speedBooster": false,
+              "obstructions": [[1, 0]],
+              "note": ["Bomb Torizo Room is a minimal-runway example that this applies to."]
+            }
+          ]
+        }
+      },
+      "requires": [
+        "canCrouchGateClip",
+        "canComplexGMode"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "note": [
+        "Jump into the room and aim down to get under the first shutter, then break the crumble blocks to the left.",
+        "This is the only way for the Wavers to reach the door.",
+        "After the crumbles are broken, shoot the ceiling block and wait by the door for the Waver to come."
+      ]
     },
     {
       "id": 31,

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -872,6 +872,30 @@
     },
     {
       "link": [2, 2],
+      "name": "G-Mode Setup - Get Hit By Waver (Come in Space Jumping)",
+      "entranceCondition": {
+        "comeInSpaceJumping": {
+          "speedBooster": false,
+          "minTiles": 4
+        }
+      },
+      "requires": [
+        "canCrouchGateClip",
+        "canComplexGMode"
+      ],
+      "exitCondition": {
+        "leaveWithGModeSetup": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "note": [
+        "Space Jump into the room and aim down to get under the first shutter, then break the crumble blocks to the left.",
+        "This is the only way for the Wavers to reach the door.",
+        "After the crumbles are broken, shoot the ceiling block and wait by the door for the Waver to come."
+      ]
+    },
+    {
+      "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Waver (Come in With Side Platform)",
       "entranceCondition": {
         "comeInWithSidePlatform": {


### PR DESCRIPTION
This came up in Eddie's latest shuffler.

The right-side entry has the advantage that you don't risk a softlock, and you only have to get under a single shutter instead of two. And it could be logically important in case the left door is locked.

Video by Sam: https://videos.maprando.com/video/7579