### PR TITLE
Crateria Central check flash suits

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -516,7 +516,7 @@ __Example:__
 
 __Additional considerations__
 
-* A `canShineCharge` object implicitly requires the Speed Booster. Energy requirements for the shinespark (if applicable) are specified separately using a `shinespark` object.
+* A `canShineCharge` object implicitly requires the Speed Booster. Energy requirements for the shinespark (if applicable) are specified separately using a `shinespark` object. A `canShineCharge` requirement causes a flash suit to be lost.
 
 #### getBlueSpeed object
 

--- a/region/crateria/central/230 Missile Room.json
+++ b/region/crateria/central/230 Missile Room.json
@@ -82,7 +82,8 @@
           "length": 10,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -97,13 +98,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Blue Brinstar Elevator Room.json
+++ b/region/crateria/central/Blue Brinstar Elevator Room.json
@@ -73,7 +73,8 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -88,7 +89,8 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -105,7 +105,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -124,6 +125,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $2.B with spin, or $2.C with a quick aim-down."]
     },
     {
@@ -141,6 +143,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $2.2 with spin, or $2.3 with a quick aim-down."]
     },
     {
@@ -155,6 +158,7 @@
           {"enemyDamage": {"enemy": "Bomb Torizo", "type": "contact", "hits": 3}}
         ]}
       ],
+      "flashSuitChecked": true,
       "setsFlags": ["f_DefeatedBombTorizo"]
     },
     {
@@ -183,7 +187,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -201,7 +206,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -220,7 +226,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -234,7 +241,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -250,7 +258,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -270,7 +279,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -291,7 +301,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -307,7 +318,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -326,19 +338,22 @@
         "f_ZebesSetAblaze"
       ],
       "setsFlags": ["f_AnimalsSaved"],
+      "flashSuitChecked": true,
       "devNote": "Technically this also requires opening the wall."
     },
     {
       "id": 12,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -251,7 +251,7 @@
           "blocks": [{"position": [9, 2], "note": "Closest Grapple block to door"}]
         }
       },
-      "flashSuitChecked": false
+      "flashSuitChecked": true
     },
     {
       "id": 2,

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -351,7 +351,10 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "Grapple",
+          {"and": [
+            "Grapple",
+            "h_midAirShootUp"
+          ]},
           "SpaceJump"
         ]}
       ],
@@ -1535,7 +1538,10 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "Grapple",
+          {"and": [
+            "Grapple",
+            "h_midAirShootUp"
+          ]},
           "SpaceJump"
         ]}
       ],

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -238,7 +238,8 @@
           "length": 6,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 75,
@@ -249,7 +250,8 @@
         "leaveWithGrappleSwing": {
           "blocks": [{"position": [9, 2], "note": "Closest Grapple block to door"}]
         }
-      }
+      },
+      "flashSuitChecked": false
     },
     {
       "id": 2,
@@ -352,7 +354,8 @@
           "Grapple",
           "SpaceJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -364,7 +367,8 @@
           "canUseIFrames",
           {"spikeHits": 1}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -375,7 +379,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 65, "excessFrames": 6}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -397,7 +402,8 @@
             {"shinespark": {"frames": 41, "excessFrames": 4}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 67,
@@ -414,7 +420,8 @@
       ],
       "note": [
         "Run, jump, and spark mid-air at a specific height to be able to down-grab onto the ledge."
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 68,
@@ -431,6 +438,7 @@
         "canDownGrab",
         {"shinespark": {"frames": 35, "excessFrames": 0}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "After gaining a shinecharge, run back to the door, then run right, jump, and spark mid-air at a specific height to be able to down-grab onto the ledge."
       ]
@@ -442,7 +450,8 @@
       "requires": [
         "canUseIFrames",
         "h_pauseAbuseMinimalReserveRefill"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -460,7 +469,8 @@
       "name": "Ceiling Bomb Jump Over Spikes",
       "requires": [
         "canLongCeilingBombJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -477,6 +487,7 @@
         "canLateralMidAirMorph",
         "canSpringFling"
       ],
+      "flashSuitChecked": true,
       "note": "Run and jump into an airball, pressing pause just as Samus hits the ceiling, in order to unequip Spring Ball to reset fall speed.",
       "devNote": "This can be done with 26 tiles of other-room runway, but it would probably require a higher movement tech."
     },
@@ -495,7 +506,8 @@
         "canTrickyJump",
         "canLateralMidAirMorph",
         "canSpringFling"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -722,7 +734,8 @@
       "requires": [
         "canSpeedball",
         "canBlueSpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -1032,6 +1045,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Samus will enter the room grappled to a spike block below.",
         "Release Grapple quickly after entering, then aim up and grapple onto a Grapple block on the ceiling to avoid taking spike damage."
@@ -1047,7 +1061,8 @@
           "length": 35,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -1061,7 +1076,8 @@
           "length": 45,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -1093,7 +1109,8 @@
           ]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 77,
@@ -1139,7 +1156,8 @@
         "canTrivialUseFrozenEnemies",
         "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 128, "excessFrames": 6}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 70,
@@ -1156,7 +1174,8 @@
             {"shinespark": {"frames": 113, "excessFrames": 6}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 71,
@@ -1173,7 +1192,8 @@
             {"shinespark": {"frames": 103, "excessFrames": 6}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -1192,6 +1212,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": ["Quickly Walljump to conserve health on the shinespark."]
     },
     {
@@ -1205,6 +1226,7 @@
         {"obstaclesCleared": ["A"]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
         "Use the remaining runway to gain speed to clear the pits with a single jump.",
@@ -1231,6 +1253,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
         "Use the remaining runway to gain speed to clear the pits with a single jump.",
@@ -1248,6 +1271,7 @@
         "ScrewAttack",
         {"shinespark": {"frames": 128, "excessFrames": 6}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
         "Use the remaining runway to gain speed to clear the pits with a single jump, using Screw Attack to avoid Boyon damage.",
@@ -1272,6 +1296,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Starting from the door, use a 1-tap shortcharge to gain a shinecharge running to the right.",
         "Use the remaining runway to gain speed to clear the pits with a single jump, using Screw Attack to avoid Boyon damage.",
@@ -1368,7 +1393,8 @@
       "name": "Boyons Cleared",
       "requires": [
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1376,7 +1402,8 @@
       "name": "Ice",
       "requires": [
         "Ice"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1399,6 +1426,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Intentionally take damage before attempting to jump through to avoid falling in the acid."
     },
     {
@@ -1413,6 +1441,7 @@
           "SpeedBooster"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Jump at the last tile to make it through all of the Boyons."
     },
     {
@@ -1422,6 +1451,7 @@
       "requires": [
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "devNote": "It's not really insane jump difficult, but that is where you think about needing to avoid the damage.  And failing the jump is still very punishing due to falling into the acid."
     },
     {
@@ -1461,7 +1491,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1484,6 +1515,7 @@
       "requires": [
         {"obstaclesCleared": ["B"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "The strat specific requirements are included when clearing the abstract obstacle."
     },
     {
@@ -1506,7 +1538,8 @@
           "Grapple",
           "SpaceJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -1518,7 +1551,8 @@
           "canUseIFrames",
           {"spikeHits": 1}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 74,
@@ -1527,7 +1561,8 @@
       "requires": [
         "canUseIFrames",
         "h_pauseAbuseMinimalReserveRefill"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -1553,7 +1588,8 @@
             "canWallJumpInstantMorph"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 56,
@@ -1561,7 +1597,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 57,
@@ -1578,7 +1615,8 @@
       "name": "Boyons Cleared",
       "requires": [
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 59,
@@ -1586,7 +1624,8 @@
       "name": "Ice",
       "requires": [
         "Ice"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 60,
@@ -1609,6 +1648,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Intentionally take damage before attempting to jump through to avoid falling in the acid."
     },
     {
@@ -1623,6 +1663,7 @@
           "SpeedBooster"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Jump at the last tile to make it through all of the Boyons."
     },
     {
@@ -1641,6 +1682,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "clearsObstacles": ["A"]
     },
     {
@@ -1650,6 +1692,7 @@
       "requires": [
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "devNote": "It's not really insane jump difficult, but that is where you think about needing to avoid the damage.  And failing the jump is still very punishing due to falling into the acid."
     },
     {
@@ -1706,7 +1749,8 @@
       ],
       "devNote": [
         "FIXME: The h_getBlueSpeedMaxRunway is to satisfy tests for now.",
-        "We should add a proper way to represent that the blue state carries over from the previous strat."
+        "We should add a proper way to represent that the blue state carries over from the previous strat.",
+        "FIXME: With Spring Ball it is possible to preserve a flash suit while both collecting the item and going down."
       ]
     },
     {
@@ -1714,6 +1758,7 @@
       "link": [6, 5],
       "name": "Base",
       "requires": [],
+      "flashSuitChecked": true,
       "devNote": "Samus is in a Speedball or BlueSuit state."
     }
   ],

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -298,7 +298,8 @@
         "leaveWithDoorFrameBelow": {
           "height": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -311,7 +312,8 @@
           "leftPosition": -2.5,
           "rightPosition": -0.5
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -324,7 +326,8 @@
           "leftPosition": 0.5,
           "rightPosition": 2.5
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -569,7 +572,8 @@
           "h_lavaProof",
           {"obstaclesNotCleared": ["B"]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 105,
@@ -580,6 +584,7 @@
       },
       "requires": [],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "devNote": "When Samus enters the room from the bottom left, lava starts to rise. In the escape it is acid instead."
     },
     {
@@ -592,7 +597,8 @@
           "length": 15,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -610,7 +616,8 @@
           "length": 29,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -630,7 +637,8 @@
           "openEnd": 0
         }
       },
-      "unlocksDoors": [{"nodeId": 5, "types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"nodeId": 5, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -660,7 +668,8 @@
         }
       },
       "requires": [],
-      "clearsObstacles": ["B"]
+      "clearsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -678,6 +687,7 @@
         {"shinespark": {"frames": 147}}
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Starting with a crouch, diagonal shinespark to the top to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -775,6 +785,7 @@
           "requires": [{"lavaFrames": 110}]
         }
       ],
+      "flashSuitChecked": true,
       "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -932,7 +943,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -944,7 +956,8 @@
       "requires": [
         {"shinespark": {"frames": 43, "excessFrames": 17}}
       ],
-      "clearsObstacles": ["A", "B"]
+      "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -957,7 +970,8 @@
         }
       },
       "requires": [],
-      "clearsObstacles": ["A", "B"]
+      "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -972,7 +986,8 @@
           ]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -988,6 +1003,7 @@
       },
       "requires": [],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "If needed, unmorph while passing through the blocks to break more than just the bottom one.",
       "devNote": [
         "If we had a comeInWithSpeedball entrance condition, it should be used instead.",
@@ -1005,7 +1021,8 @@
         }
       },
       "requires": [],
-      "clearsObstacles": ["A", "B"]
+      "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -1020,7 +1037,8 @@
         "canTrickyJump",
         "SpaceJump"
       ],
-      "clearsObstacles": ["A", "B"]
+      "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -1062,6 +1080,7 @@
         "f_ZebesSetAblaze"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "devNote": "These are destroyed on entry if Zebes is Ablaze."
     },
     {
@@ -1101,7 +1120,8 @@
           "length": 3,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1147,6 +1167,7 @@
         "comeInWithSuperSink": {}
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room with a super sink, in order to clip down through several screens and reach the door below."
       ]
@@ -1162,7 +1183,8 @@
           "h_lavaProof",
           {"obstaclesNotCleared": ["B"]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -1183,6 +1205,7 @@
         "canTrickyDashJump",
         "canSlowShortCharge"
       ],
+      "flashSuitChecked": true,
       "note": "Enter the room with a very specific run speed to jump from the door, and land a speedball perfectly in the tunnel to break the Bomb block.",
       "devNote": [
         "There is 1 unusable tile in this runway.",
@@ -1235,7 +1258,8 @@
       },
       "requires": [
         "canInsaneJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -1419,6 +1443,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "devNote": "It is sometimes possible to beat the lava, but it depends how you get here."
     },
     {
@@ -1446,7 +1471,8 @@
           "h_lavaProof",
           {"obstaclesNotCleared": ["B"]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 61,
@@ -1468,6 +1494,7 @@
         "canInsaneJump",
         "canBeExtremelyPatient"
       ],
+      "flashSuitChecked": true,
       "note": "Enter the room with a very specific run speed to jump from the door, squeeze by the ceiling, and land a speedball perfectly in the tunnel to break the Bomb block.",
       "devNote": [
         "There is 1 unusable tile in this runway.",
@@ -1520,7 +1547,8 @@
       },
       "requires": [
         "canInsaneJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 65,
@@ -1554,7 +1582,8 @@
       "requires": [
         {"shinespark": {"frames": 43, "excessFrames": 17}}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 67,
@@ -1567,7 +1596,8 @@
         }
       },
       "requires": [],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 68,
@@ -1586,7 +1616,8 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 69,
@@ -1607,7 +1638,8 @@
         "If we had a comeInWithSpeedball entrance condition, it should be used instead.",
         "This strat is for using a remote runway in the previous room to get the speedball;",
         "if the current runway were used then you could just run through with blue speed instead."
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 70,
@@ -1619,7 +1651,8 @@
         }
       },
       "requires": [],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 71,
@@ -1750,6 +1783,7 @@
         {"shinespark": {"frames": 147}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Starting with a crouch, diagonal shinespark to the top to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -1867,6 +1901,7 @@
         {"shinespark": {"frames": 147, "excessFrames": 124}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -1940,6 +1975,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "This is relatively tight when coming in from the bottom left and using a Power Bomb to break the wall.",
         "It wouldn't work if the door was Missile or Power Bomb locked."
@@ -1956,6 +1992,7 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
+      "flashSuitChecked": true,
       "exitCondition": {
         "leaveWithRunway": {
           "length": 29,
@@ -1981,19 +2018,22 @@
           "openEnd": 0
         }
       },
-      "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 87,
       "link": [5, 6],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 88,
       "link": [6, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 89,
@@ -2010,7 +2050,8 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 90,
@@ -2032,6 +2073,7 @@
         {"obstaclesNotCleared": ["B"]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": "These are destroyed on entry if Zebes is Ablaze."
     },
     {
@@ -2040,7 +2082,8 @@
       "name": "Base",
       "requires": [
         "h_bombThings"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 93,
@@ -2057,6 +2100,7 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Starting with a crouch, diagonal shinespark to the top to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -2084,6 +2128,7 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Manipulate the Pirates to the right wall while climbing the room.",
         "Kill all the Pirates while moonfalling down the right side.",
@@ -2101,6 +2146,7 @@
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 18, "excessFrames": 4}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Diagonal shinespark to break the bomb blocks to the morph tunnel on the right.",
         "Spark from the highest platform that is only one tile from the right wall (the morph tunnel will be off camera, but can be seen while jumping).",
@@ -2141,7 +2187,8 @@
       "name": "Base",
       "requires": [
         "h_bombThings"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 97,
@@ -2165,6 +2212,7 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right.",
         "A frozen Pirate can be used to stop the spark just above the bottom tunnel."
@@ -2189,6 +2237,7 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The bomb blocks can be broken by spinjumping with Screw attack and holding right, if moonfall makes Samus clip through the platform.",
         "Use the small blue platform 2nd from the top on the right side."
@@ -2216,6 +2265,7 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Diagonal shinespark to break the bomb blocks to the morph tunnel on the right.",
         "Spark from the lowest platform that is only one tile from the right wall (part of the bottom right door will be on screen).",
@@ -2280,7 +2330,8 @@
       "id": 102,
       "link": [6, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 103,
@@ -2324,6 +2375,7 @@
       ],
       "resetsObstacles": ["A", "B"],
       "farmCycleDrops": [{"enemy": "Grey Space Pirate (wall)", "count": 11}],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: Shinesparking can also be a viable option, in case it is patched to not cost energy."
       ]

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -2252,7 +2252,19 @@
         "Morph",
         {"useFlashSuit": {}},
         {"or": [
-          {"shinespark": {"frames": 135, "excessFrames": 124}},
+          {"and": [
+            {"disableEquipment": "HiJump"},
+            {"shinespark": {"frames": 127, "excessFrames": 124}}
+          ]},
+          {"and": [
+            "HiJump",
+            {"shinespark": {"frames": 130, "excessFrames": 129}}
+          ]},
+          {"and": [
+            "HiJump",
+            "canInsaneJump",
+            {"shinespark": {"frames": 126, "excessFrames": 124}}
+          ]},
           {"and": [
             {"shinespark": {"frames": 1, "excessFrames": 1}},
             "canTrickyUseFrozenEnemies",
@@ -2269,8 +2281,17 @@
       "note": [
         "Diagonal shinespark to break the bomb blocks to the morph tunnel on the right.",
         "Spark from the lowest platform that is only one tile from the right wall (part of the bottom right door will be on screen).",
-        "From this platform, the shinespark must be done from a crouch.",
+        "From this platform, the shinespark must be done from a crouch;",
+        "or, to save some energy, angle-down jump and spark at the peak of the jump (with Hi-Jump unequipped).",
         "It is possible to set up a frozen pirate on the right wall to stop the shinespark early."
+      ],
+      "detailNote": [
+        "If the positioning is ideal, Samus will bonk the platform at the top-right of the room, saving a bit of energy.",
+        "With Hi-Jump equipped, this is still possible (and with 1 less energy needed):",
+        "by sparking after bonking the platform and descending a few pixels (a 3-frame window);",
+        "or, more easily but requiring slightly more energy, by aiming down and sparking at the maximum height",
+        "(which will result in clipping through the platform at the top-right of the room",
+        "if the spark is not interrupted by running low on energy before that point)."
       ],
       "devNote": [
         "For the frozen pirate strat, it is assumed that Samus can farm the energy after the spark, resulting in no damaging shinespark frames.",

--- a/region/crateria/central/Crateria Map Room.json
+++ b/region/crateria/central/Crateria Map Room.json
@@ -60,7 +60,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -75,13 +76,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -69,7 +69,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -84,6 +85,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Wait for the Alcoon to walk off and reach the bottom of the slope.",
         "Dodge it's fireballs with Morph or Screw, or simply freeze it and wait while standing behind it.",
@@ -125,6 +127,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Alcoon", "count": 3}],
+      "flashSuitChecked": true,
       "note": [
         "The Alcoons have a 99.5% Power Bomb drop rate, after which they only drop small energy."
       ]
@@ -152,6 +155,7 @@
           }}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Duck under the first two Alcoon shots, or retreat back a platform to fight them with Power Beam.",
       "devNote": "All the Alcoons are assumed killed in each case."
     },
@@ -159,7 +163,8 @@
       "id": 6,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Crateria Save Room.json
+++ b/region/crateria/central/Crateria Save Room.json
@@ -60,7 +60,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -75,13 +76,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -63,7 +63,8 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -116,7 +117,8 @@
       "id": 5,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -165,7 +167,8 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -264,6 +267,7 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "devNote": [
         "Though there is no door shell here, this strat is included for completeness in case a randomizer adds a door shell where bypassing it could be useful."
       ]
@@ -283,7 +287,8 @@
           "blockPositions": [[12, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -300,13 +305,15 @@
           "blockPositions": [[12, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 17,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -355,7 +362,8 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -454,6 +462,7 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "devNote": [
         "Though there is no door shell here, this strat is included for completeness in case a randomizer adds a door shell where bypassing it could be useful."
       ]
@@ -473,7 +482,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -490,7 +500,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -502,7 +513,8 @@
           "length": 14,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 30,

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -63,7 +63,8 @@
           "length": 4,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -84,7 +85,8 @@
           "h_useSpringBall",
           "h_bombThings"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -111,6 +113,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": "Tight movement is needed to enter with a shinecharge, carry it through the morph tunnel, and spark out the right door in time.",
       "devNote": "There doesn't appear to be enough time to spark out in a 'top' position."
     },
@@ -134,6 +137,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "Higher speeds could work, up to at least about $4.4, but with greater difficulty."
       ]
@@ -157,6 +161,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Unmorph immediately after exiting the tunnel while still descending, to continue chaining temporary blue.",
         "The frame window for the unmorph depends on the alignment of Samus' bounces;",
@@ -174,7 +179,8 @@
       "name": "Base",
       "requires": [
         "h_bombThings"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -188,7 +194,8 @@
           }
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -210,6 +217,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "Higher speeds could work, up to at least about $4.4, but with greater difficulty."
       ]
@@ -242,7 +250,8 @@
       },
       "requires": [
         "canInsaneJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -276,6 +285,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Unmorph immediately after exiting the tunnel while still descending, to continue chaining temporary blue.",
         "The frame window for the unmorph depends on the alignment of Samus' bounces;",
@@ -312,7 +322,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -324,7 +335,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -341,7 +353,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -358,7 +371,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -370,7 +384,8 @@
           "length": 4,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 16,

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -90,7 +90,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -113,6 +114,7 @@
           "obstruction": [5, 2]
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Leaving with upward momentum is possible in three ways:",
         "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
@@ -157,7 +159,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -175,7 +178,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -194,7 +198,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -208,7 +213,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -257,7 +263,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Mellow", "count": 12}]
+      "farmCycleDrops": [{"enemy": "Mellow", "count": 12}],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -282,13 +289,15 @@
       "id": 11,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -300,7 +309,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -317,7 +327,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -334,7 +345,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -346,7 +358,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -369,6 +382,7 @@
           "obstruction": [3, 0]
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Leaving with upward momentum is possible in three ways:",
         "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
@@ -415,7 +429,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -433,7 +448,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -452,7 +468,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -466,7 +483,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 22,

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -309,7 +309,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -327,7 +328,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -346,7 +348,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -360,7 +363,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -380,6 +384,7 @@
           "maxExtraRunSpeed": "$5.A"
         }
       },
+      "flashSuitChecked": true,
       "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it into the next room."
     },
     {
@@ -404,6 +409,7 @@
           "maxExtraRunSpeed": "$5.A"
         }
       },
+      "flashSuitChecked": true,
       "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a mockball (or speedball) at the doorway."
     },
     {
@@ -429,6 +435,7 @@
           "movementType": "uncontrolled"
         }
       },
+      "flashSuitChecked": true,
       "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry it across the room into a spring ball bounce into the other room."
     },
     {
@@ -449,6 +456,7 @@
           "maxExtraRunSpeed": "$5.A"
         }
       },
+      "flashSuitChecked": true,
       "note": "Gain speed using the long runway at the top-right of room, and use Space Jump to carry into the other room.",
       "devNote": "This runway has some unusable tiles because the Space Jump descent will not work with too high speed."
     },
@@ -459,7 +467,8 @@
       "requires": [
         {"doorUnlockedAtNode": 1}
       ],
-      "clearsObstacles": ["C"]
+      "clearsObstacles": ["C"],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -554,6 +563,7 @@
         {"shinespark": {"frames": 154, "excessFrames": 37}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Shinespark through the top of the door to reach the breakable blocks.",
       "devNote": "With less Energy, Samus will drop to 5 and can get to 4 if she has SpeedBooster (she may not, i.e. elevator crystal flash)."
     },
@@ -595,6 +605,7 @@
         {"shinespark": {"frames": 154, "excessFrames": 107}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Shinespark through the top of the door to reach the breakable blocks.",
       "devNote": "With more Energy, Samus will spark to 4, but can freely access 5 from there."
     },
@@ -608,6 +619,7 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
+      "flashSuitChecked": true,
       "clearsObstacles": ["A"]
     },
     {
@@ -630,7 +642,8 @@
           "canLongChainTemporaryBlue"
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -644,7 +657,8 @@
       "requires": [
         "canTrickyJump"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -703,7 +717,8 @@
           "length": 45,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -762,7 +777,8 @@
       "id": 22,
       "link": [2, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -792,7 +808,8 @@
         "canHorizontalShinespark",
         {"shinespark": {"frames": 125, "excessFrames": 33}}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -815,6 +832,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true,
       "devNote": [
         "The Gauntlet Entrance door must be open, so the connecting room at 3 cannot be used.",
         "Unlocking the door is free since the obstacle C cleared means that any lock was already taken care of."
@@ -829,7 +847,8 @@
         "canCarefulJump",
         "ScrewAttack"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -845,6 +864,7 @@
         {"getBlueSpeed": {"usedTiles": 30, "openEnd": 2}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Use the runway near the top right door to jump towards the top left bomb blocks and break them using the blue speed from SpeedBooster.",
         "This can be done using the full runway, with a one-tap shortcharge, where the tap is at the top of the lowest slope, and the jump is at the top of the last slope.",
@@ -865,6 +885,7 @@
         {"getBlueSpeed": {"usedTiles": 30, "openEnd": 2}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Use the runway near the top right door to jump towards the top left bomb blocks and break them using the blue speed from SpeedBooster.",
         "This can be done using the full runway, with a one-tap shortcharge, where the tap is at the top of the lowest slope, and the jump is at the top of the last slope.",
@@ -921,6 +942,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true,
       "note": [
         "Gain speed using the long runway at the top-right of room, do a big jump across the room into a mockball or speedball, then use controlled bounces to make it through the top-left door."
       ],
@@ -980,7 +1002,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -997,7 +1020,8 @@
           "blockPositions": [[2, 34]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -1010,7 +1034,8 @@
           "openEnd": 1,
           "steepDownTiles": 9
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -1023,6 +1048,7 @@
       ],
       "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": ["never"]}],
       "clearsObstacles": ["C"],
+      "flashSuitChecked": true,
       "note": [
         "Open the Gauntlet Entrance door by shooting a charged Wave shot through the right wall to wrap around to hit the door.",
         "Near the top right door, move the right wall a bit off camera. Jump and shoot a charge shot diagonally into the floor just before landing while moving rightwards.",
@@ -1042,7 +1068,8 @@
       "id": 39,
       "link": [3, 4],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -1071,7 +1098,8 @@
         }},
         {"shinespark": {"frames": 125, "excessFrames": 33}}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -1093,6 +1121,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true,
       "devNote": [
         "Unlocking the door is free since the obstacle C cleared means that any lock was already taken care of."
       ]
@@ -1119,6 +1148,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Store the spark on the right side of the ledge.  Run left and do a big jump towards the gauntlet door and then midair spark at the right time.",
         "Do not jump to max height or Samus will run out of shinecharge frames, instead short the jump a little.",
@@ -1153,6 +1183,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true,
       "note": [
         "Store the spark on the right side of the ledge.  Run left and do a big jump towards the gauntlet door and then midair spark at the right time.",
         "Do not jump to max height or Samus will run out of shinecharge frames, instead short the jump a little.",
@@ -1176,6 +1207,7 @@
         }}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Use the lines in the background to determine the height of the breakable blocks.",
       "detailNote": [
         "It is also possible to do this from the top right door's runway.",
@@ -1196,6 +1228,7 @@
         {"getBlueSpeed": {"usedTiles": 38, "steepDownTiles": 3, "openEnd": 1}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Starting near the right runway, run through the bomb block passage, then jump right after exiting.",
         "Using HiJump and space jump, Samus is able to elevate enough to break through the bomb blocks blocking the Gauntlet entrance."
@@ -1211,6 +1244,7 @@
         "HiJump",
         "h_getBlueSpeedMaxRunway"
       ],
+      "flashSuitChecked": true,
       "note": [
         "From the right door, run and jump while on the dirt mound directly right of the ship.",
         "Then SpringBall Jump to reach the Bomb blocks leading to Gauntlet."
@@ -1226,7 +1260,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1243,7 +1278,8 @@
           "blockPositions": [[2, 34]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 50,
@@ -1325,7 +1361,8 @@
           "SpaceJump",
           "canLongIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -1339,7 +1376,8 @@
           "openEnd": 2
         }},
         {"shinespark": {"frames": 45, "excessFrames": 13}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 55,
@@ -1349,7 +1387,8 @@
         "SpeedBooster",
         "HiJump",
         "canTrickySpringBallJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 56,
@@ -1508,6 +1547,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "With SpeedBooster, climb the platforms to the ship, then run through the blocks.",
         "Without, the runway is not as long, but it's much longer than it takes to get max run speed."
@@ -1534,7 +1574,8 @@
       "id": 62,
       "link": [4, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 63,
@@ -1564,6 +1605,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Shinespark diagonally from the small hill left of the ship to break part way into the hidden bomb wall, then use Bombs or another means to continue to the left."
     },
     {
@@ -1611,7 +1653,8 @@
       "id": 67,
       "link": [5, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 68,
@@ -1637,7 +1680,8 @@
             {"shinespark": {"frames": 61, "excessFrames": 14}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 69,
@@ -1651,7 +1695,8 @@
           "HiJump",
           "canSpringBallJumpMidAir"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 70,
@@ -1664,7 +1709,8 @@
           {"obstaclesCleared": ["B"]}
         ]}
       ],
-      "clearsObstacles": ["B"]
+      "clearsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "id": 71,
@@ -1684,13 +1730,15 @@
       "requires": [
         {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
       ],
+      "flashSuitChecked": true,
       "devNote": "If the ship refill is somehow altered or removed, this needs to be updated here and on the G-mode strat from 1->4."
     },
     {
       "id": 73,
       "link": [5, 6],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 74,
@@ -1710,7 +1758,8 @@
             "canJumpIntoIBJ"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 75,
@@ -1722,7 +1771,8 @@
           "HiJump",
           "canConsecutiveWalljump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 76,
@@ -1738,7 +1788,8 @@
       "id": 77,
       "link": [6, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 78,
@@ -1756,7 +1807,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 79,
@@ -1781,6 +1833,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": "HiJump alone can only reach the lower bomb block."
     },
     {
@@ -1794,7 +1847,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 81,
@@ -1836,7 +1890,8 @@
       "id": 83,
       "link": [7, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 84,

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -380,7 +380,8 @@
           "steepUpTiles": 2,
           "steepDownTiles": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -396,7 +397,8 @@
           "steepUpTiles": 4,
           "steepDownTiles": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -419,7 +421,8 @@
           "steepDownTiles": 2
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -504,7 +507,8 @@
       "name": "Base",
       "requires": [
         "h_destroyBombWalls"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -516,6 +520,7 @@
       "requires": [
         {"shinespark": {"frames": 67, "excessFrames": 42}}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: A strat could be added coming in shinecharged, with 1 frame, 1 excess frame, and no horizontal spark needed."
     },
     {
@@ -530,7 +535,8 @@
           "steepDownTiles": 2
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -555,7 +561,8 @@
           }}
         ]}
       ],
-      "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -601,7 +608,8 @@
           "blockPositions": [[12, 12], [12, 13]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 138,
@@ -616,6 +624,7 @@
       "requires": [
         "canLongXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Fall into the first Samus Eater in Hellway or Alpha Power Bomb Room.",
         "After teleporting and passing through the transition, X-Ray climb 2 screens to reach the space behind the bomb blocks at the top of the room.",
@@ -635,7 +644,8 @@
           "length": 3,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -804,7 +814,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -829,6 +840,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Moonfall to become stuck in the ground, then moonfall again to clip fully through the floor."
     },
     {
@@ -871,6 +883,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "If entering the transition too deeply, Samus may end up stuck slightly inside the Bomb blocks and the floor.",
         "This can be avoided by tapping up to retract Grapple (pulling Samus left and down), holding left while releasing Grapple, then jumping to clip up through the floor.",
@@ -891,6 +904,7 @@
         "canLongXRayClimb",
         "canBePatient"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Fall into the first Samus Eater in Hellway or Alpha Power Bomb Room.",
         "After teleporting and passing through the transition, X-Ray climb 3 screens to reach the space behind the bomb blocks at the top of the room.",
@@ -1001,7 +1015,8 @@
           "openEnd": 1,
           "steepUpTiles": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -1018,6 +1033,7 @@
           "steepUpTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "There is a Geemer just below the door that only moves while on camera."
     },
     {
@@ -1158,7 +1174,8 @@
       "id": 36,
       "link": [3, 8],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -1186,7 +1203,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -1198,7 +1216,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -1215,7 +1234,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -1232,7 +1252,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -1312,7 +1333,8 @@
           "openEnd": 0,
           "steepUpTiles": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1375,7 +1397,8 @@
       "id": 48,
       "link": [4, 8],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1411,7 +1434,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -1423,7 +1447,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 52,
@@ -1440,7 +1465,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -1457,7 +1483,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -1534,7 +1561,8 @@
           "openEnd": 0,
           "steepDownTiles": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 141,
@@ -1544,7 +1572,8 @@
         "ScrewAttack",
         {"cycleFrames": 180}
       ],
-      "farmCycleDrops": [{"enemy": "Ripper", "count": 1}]
+      "farmCycleDrops": [{"enemy": "Ripper", "count": 1}],
+      "flashSuitChecked": true
     },
     {
       "id": 57,
@@ -1605,7 +1634,8 @@
       "name": "Base",
       "requires": [
         "h_bombThings"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 61,
@@ -1620,6 +1650,7 @@
           "canConsecutiveWalljump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Wall jump up and midair morph to get out without needing to break the bomb blocks to the right."
     },
     {
@@ -1630,7 +1661,8 @@
         "canMidAirMorph",
         "canCarefulJump",
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 63,
@@ -1640,6 +1672,7 @@
         "canTrickySpringBallJump",
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run and spin jump into a spring ball jump, starting from the floating platform."
       ]
@@ -1653,6 +1686,7 @@
         "canMidAirMorph",
         "canTrickyDashJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "The wall above can be used to align to a good starting position for the running jump."
       ]
@@ -1677,6 +1711,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait 3 minutes for a global Geemer to waddle over, or shoot a Super 20 to 30 seconds after entering the room to knock it off the ceiling and save a lot of time.",
         "Freeze the Geemer as it turns onto the middle slope of the left wall to escape - it helps to freeze the geemer from below.",
@@ -1846,6 +1881,7 @@
       "requires": [
         "canLongXRayClimb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump into the second Samus Eater in the ceiling of Hellway.",
         "After teleporting and passing through the transition, X-Ray climb about 2 screens to reach the top of the room.",
@@ -1879,7 +1915,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 73,
@@ -1891,7 +1928,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 74,
@@ -1908,7 +1946,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 75,
@@ -1925,7 +1964,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 76,
@@ -2159,7 +2199,8 @@
           "openEnd": 1,
           "steepUpTiles": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 82,
@@ -2180,6 +2221,7 @@
           "steepUpTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Wait 2 minutes for a global Geemer, or use a Super to grab a closer one."
     },
     {
@@ -2241,7 +2283,8 @@
       "id": 86,
       "link": [6, 8],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 87,
@@ -2415,15 +2458,6 @@
       "flashSuitChecked": true
     },
     {
-      "id": 92,
-      "link": [7, 7],
-      "name": "Leave Normally",
-      "requires": [],
-      "exitCondition": {
-        "leaveNormally": {}
-      }
-    },
-    {
       "id": 93,
       "link": [7, 7],
       "name": "Shinespark",
@@ -2434,6 +2468,7 @@
       "requires": [
         {"shinespark": {"frames": 3, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
@@ -2448,6 +2483,7 @@
         "canTrickyUseFrozenEnemies"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Use a Super to bring a Geemer down to the bottom floating platform.",
         "Freeze this Geemer along with a Geemer on the floor and use them to perform an enemy-stuck moonfall.",
@@ -2467,6 +2503,7 @@
         "canFreeFallClip"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Freeze a Geemer on the right of the overhang just below the door to Final Missile Bombway.",
         "Freeze a second Geemer on the top left of its platform and setup a moonfall between them.",
@@ -2520,7 +2557,8 @@
       "id": 98,
       "link": [7, 8],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 99,
@@ -2528,7 +2566,8 @@
       "name": "Base",
       "requires": [
         "h_destroyBombWalls"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 100,
@@ -2557,6 +2596,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Break the bomb wall while blue, or spark diagonally next to it.",
       "devNote": "It is possible to come in the top right door, charge a spark, use a bounce ball, or blue space jump, but this is a bit easier anyway."
     },
@@ -2584,6 +2624,7 @@
         "leaveWithSpark": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Break the bomb wall while blue, or spark diagonally next to it. Open the door then charge the spark again and spark through the wall and door.",
       "devNote": "The canCarefulJump or 2 spark frames could be reduced by having the door already open, but that's probably not worth modeling."
     },
@@ -2602,7 +2643,8 @@
           "steepDownTiles": 2
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 103,
@@ -2625,7 +2667,8 @@
           "steepDownTiles": 2
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 104,
@@ -2674,7 +2717,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 107,
@@ -2702,7 +2746,8 @@
       "id": 108,
       "link": [8, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 109,
@@ -2729,7 +2774,8 @@
       "id": 110,
       "link": [8, 4],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 111,
@@ -2795,7 +2841,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 121,
@@ -2822,6 +2869,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Unmorph a few tiles above the ground, and hold right to land on the platform aligning Samus with the top of the doorway.",
         "If needed, shoot the door open while falling, and hold jump to buffer the shinespark activation as soon as Samus lands."
@@ -2850,6 +2898,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform a soft unmorph and run toward the door (shooting it open if needed).",
         "If needing to spark out the bottom of the doorway, then stop on a dime at the bottom of the runway before activating the spark;",
@@ -2873,13 +2922,15 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 115,
       "link": [8, 6],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 116,
@@ -2906,7 +2957,8 @@
       "id": 117,
       "link": [8, 7],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 118,
@@ -2993,6 +3045,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Geemer (blue)", "count": 11}],
+      "flashSuitChecked": true,
       "devNote": [
         "A two-way farming strat could be added, e.g. if it is possible to reset the room at both the top-right and the bottom."
       ]

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -180,7 +180,8 @@
           "length": 8,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -192,7 +193,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -208,7 +210,8 @@
       "id": 4,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -240,7 +243,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -351,7 +355,8 @@
       "id": 13,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -383,7 +388,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -400,7 +406,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -417,7 +424,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -429,7 +437,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -446,7 +455,8 @@
       "farmCycleDrops": [
         {"enemy": "Grey Space Pirate (standing)", "count": 8},
         {"enemy": "Grey Space Pirate (wall)", "count": 2}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -466,6 +476,7 @@
         {"enemy": "Grey Space Pirate (standing)", "count": 4},
         {"enemy": "Grey Space Pirate (wall)", "count": 1}
       ],
+      "flashSuitChecked": true,
       "note": "This strat is slower but only requires one of the two doors to be unlocked."
     },
     {
@@ -630,7 +641,8 @@
           "blockPositions": [[2, 18], [2, 19], [2, 28], [2, 29]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -641,7 +653,8 @@
           {"obstaclesCleared": ["A"]},
           "h_destroyBombWalls"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -78,7 +78,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -94,6 +95,7 @@
           "minExtraRunSpeed": "$1.5"
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Leaving with lower speed (e.g. $1.2) is possible with SpeedBooster equipped; not sure if this matters for anything though."
     },
     {
@@ -112,7 +114,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -132,6 +135,7 @@
           "movementType": "uncontrolled"
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "One tile of landing runway is unusable; it could be used with a shorter remoteRunway, but there's no application yet."
       ]
@@ -148,7 +152,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -185,7 +190,8 @@
       "farmCycleDrops": [
         {"enemy": "Reo", "count": 1},
         {"enemy": "Mellow", "count": 3}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -210,7 +216,8 @@
       "id": 9,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -235,7 +242,8 @@
       "id": 11,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -266,7 +274,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -283,7 +292,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -300,7 +310,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -312,7 +323,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -327,7 +339,8 @@
           },
           "minExtraRunSpeed": "$1.5"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -345,7 +358,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -364,7 +378,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -378,7 +393,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 21,

--- a/strats.md
+++ b/strats.md
@@ -821,7 +821,7 @@ The length should not include any tiles that Samus skips over through the transi
 A `comeInShinecharging` must match with a corresponding `leaveWithRunway` condition on the other side of the door. 
 
 A `comeInShinecharging` object also includes implicit requirements for actions to be performed in the previous room, which are effectively prepended to the start of the current strat's `requires` (or equivalently but more properly, onto the end of the `requires` of the `leaveWithRunway` strat in the other room):
-- A `canShinecharge` requirement is included based on the combined runway length. This includes a `SpeedBooster` item requirement as well as a check that the combined runway length is long enough that charging a shinespark is possible.
+- A `canShinecharge` requirement is included based on the combined runway length. This includes a `SpeedBooster` item requirement as well as a check that the combined runway length is long enough that charging a shinespark is possible. It also includes a requirement that a flash suit is lost.
 - If the previous room is heated, then `heatFrames` are included based on the time spent running in that room.
 - If the current room is heated, then `heatFrames` are included based on the time spent running in this room.
 - If the previous door environment is water, then `Gravity` is required.
@@ -1082,7 +1082,7 @@ A `comeInWithTemporaryBlue` entrance condition indicates that Samus must come in
 
 A `comeInWithTemporaryBlue` entrance condition must match with one of the following exit conditions on the other side of the door: `leaveWithTemporaryBlue`, `leaveWithRunway`:
 
-- To match with a `leaveWithTemporaryBlue`, its `direction` properties must equal that of `comeInWithTemporaryBlue`, unless one of them is unspecified or "any". It has an implicit tech requirement of `canTemporaryBlue`. 
+- To match with a `leaveWithTemporaryBlue`, its `direction` properties must equal that of `comeInWithTemporaryBlue`, unless one of them is unspecified or "any". It has an implicit tech requirement of `canTemporaryBlue`, including the loss of a flash suit. 
 - A match with `leaveWithRunway` comes with implicit requirements:
   - The tech `canTemporaryBlue`.
   - A `canShinecharge` requirement based on the runway length (including the `SpeedBooster` item requirement).

--- a/tech.json
+++ b/tech.json
@@ -750,6 +750,9 @@
                 "The window for morphing and jumping is much more lenient with HiJump.",
                 "This is most often a series of crouch jumps, but it is possible to stand and spinjump on each Grapple Jump."
               ],
+              "devNote": [
+                "FIXME: Preserving a flash suit while grapple jumping is possible but difficult."
+              ],
               "extensionTechs": [
                 {
                   "id": 195,


### PR DESCRIPTION
I was happy to confirm that the requirements related to flash suit already seem nicely set up in the tech/helpers, so almost all strats can just be marked `"flashSuitChecked": true`. Some possible exceptions that I'm trying to watch out for:
- Strats involving Grapple. These can sometimes need the "h_midAirShootUp" helper. Grapple jump/fling strats I'm just putting `"flashSuitChecked": false` on for now because I think they could use a closer look. The tech `canGrappleJump` currently has a `noFlashSuit` requirement but that should possibly be refined later.
- Strats involving tight mid-air morphs from a stand. Without Hi-Jump, even `canJumpIntoIBJ` can be a bit tricky though I'm assuming not enough to justify adding the Insane-level `canTrickyCarryFlashSuit` as a requirement (PR #2259 puts a `canComplexCarryFlashSuit` requirement on it). For jump morphs in a 4-high space like West Sand Pit, I would think that would probably be `canTrickyCarryFlashSuit`, but there don't seem to be any jumps like that in Crateria.