### PR TITLE
Simplify underwater crouch jump helpers

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -697,21 +697,28 @@
           ]
         },
         {
-          "name": "h_underwaterCrouchJumpWithFlashSuit",
+          "name": "h_underwaterCrouchJump",
           "requires": [
             {"tech": "canCrouchJump"}
           ],
           "devNote": [
             "It is possible to crouch jump under water without losing a flash suit.",
             "Hold shoot to prevent using a flash suit while still getting the increased height of the crouch jump.",
-            "Alternatively, it is possible to crouch, jump, then quickly press down to prevent the use of the flash suit."
+            "Alternatively, it is possible to crouch, jump, then quickly press down (or have down already buffered) to prevent the use of the flash suit."
           ]
         },
         {
-          "name": "h_underwaterMaxHeightSpringBallJumpWithFlashSuit",
+          "name": "h_underwaterMaxHeightSpringBallJump",
           "requires": [
-            "h_underwaterCrouchJumpWithFlashSuit",
+            "h_underwaterCrouchJump",
             "canTrickySpringBallJump"
+          ]
+        },
+        {
+          "name": "h_underwaterCrouchJumpDownGrab",
+          "requires": [
+            "h_underwaterCrouchJump",
+            "canDownGrab"
           ]
         },
         {

--- a/helpers.json
+++ b/helpers.json
@@ -702,9 +702,10 @@
             {"tech": "canCrouchJump"}
           ],
           "devNote": [
-            "It is possible to crouch jump under water without losing a flash suit.",
-            "Hold shoot to prevent using a flash suit while still getting the increased height of the crouch jump.",
-            "Alternatively, it is possible to crouch, jump, then quickly press down (or have down already buffered) to prevent the use of the flash suit."
+            "Normally the tech 'canCrouchJump' comes with a requirement to not have a flash suit,",
+            "because a crouch jump would activate a shinespark, consuming the flash suit.",
+            "However, underwater it is possible to crouch jump without losing a flash suit (by holding shoot or down);",
+            "therefore this helper circumvents the `noFlashSuit` requirement of `canCrouchJump`."
           ]
         },
         {

--- a/helpers.json
+++ b/helpers.json
@@ -705,7 +705,9 @@
             "Normally the tech 'canCrouchJump' comes with a requirement to not have a flash suit,",
             "because a crouch jump would activate a shinespark, consuming the flash suit.",
             "However, underwater it is possible to crouch jump without losing a flash suit (by holding shoot or down);",
-            "therefore this helper circumvents the `noFlashSuit` requirement of `canCrouchJump`."
+            "therefore this helper circumvents the `noFlashSuit` requirement of `canCrouchJump`.",
+            "The knowledge of how to crouch jump underwater with a flash suit is part of the `canCarryFlashSuit` tech,",
+            "which is required as a tech dependency of all methods of gaining a flash suit."
           ]
         },
         {

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -1472,13 +1472,7 @@
         "canSuitlessMaridia",
         "canTrickyJump",
         "canNeutralDamageBoost",
-        {"or": [
-          "h_crouchJumpDownGrab",
-          {"and": [
-            "h_underwaterCrouchJumpWithFlashSuit",
-            "canDownGrab"
-          ]}
-        ]},
+        "h_underwaterCrouchJumpDownGrab",
         {"enemyDamage": {"enemy": "Skultera", "type": "contact", "hits": 1}}
       ],
       "flashSuitChecked": true,
@@ -1495,13 +1489,7 @@
       "name": "Use Flash Suit",
       "requires": [
         "canSuitlessMaridia",
-        {"or": [
-          "h_crouchJumpDownGrab",
-          {"and": [
-            "h_underwaterCrouchJumpWithFlashSuit",
-            "canDownGrab"
-          ]}
-        ]},
+        "h_underwaterCrouchJumpDownGrab",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 9, "excessFrames": 4}}
       ],

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -1162,10 +1162,7 @@
         "canSuitlessMaridia",
         "canPlayInSand",
         "canInsaneJump",
-        {"or": [
-          "canCrouchJump",
-          "h_underwaterCrouchJumpWithFlashSuit"
-        ]},
+        "h_underwaterCrouchJump",
         "canNeutralDamageBoost",
         {"or": [
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}},

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -415,11 +415,7 @@
           "HiJump",
           "canSpringBallJumpMidAir",
           "Gravity",
-          "h_crouchJumpDownGrab",
-          {"and": [
-            "h_underwaterCrouchJumpWithFlashSuit",
-            "canDownGrab"
-          ]}
+          "h_underwaterCrouchJumpDownGrab"
         ]},
         {"useFlashSuit": {}},
         {"or": [
@@ -528,13 +524,7 @@
         "canCeilingClip",
         "canUseFrozenEnemies",
         "canMorphTurnaround",
-        {"or": [
-          "h_crouchJumpDownGrab",
-          {"and": [
-            "h_underwaterCrouchJumpWithFlashSuit",
-            "canDownGrab"
-          ]}
-        ]},
+        "h_underwaterCrouchJumpDownGrab",
         {"or": [
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 1}}
@@ -560,13 +550,7 @@
         "canCeilingClip",
         "canUseFrozenEnemies",
         "canTrickyJump",
-        {"or": [
-          "h_crouchJumpDownGrab",
-          {"and": [
-            "h_underwaterCrouchJumpWithFlashSuit",
-            "canDownGrab"
-          ]}
-        ]}
+        "h_underwaterCrouchJumpDownGrab"
       ],
       "note": [
         "Use the middle section of pipes as a platform to reach the top level, above the Mochtroid.",

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -1936,10 +1936,7 @@
       "name": "Crouch Jump",
       "requires": [
         "canSuitlessMaridia",
-        {"or": [
-          "canCrouchJump",
-          "h_underwaterCrouchJumpWithFlashSuit"
-        ]}
+        "h_underwaterCrouchJump"
       ],
       "flashSuitChecked": true
     },
@@ -2008,10 +2005,7 @@
       "name": "Sciser Farm (1 Sciser, Fast Cycle)",
       "requires": [
         {"resetRoom": {"nodes": [3]}},
-        {"or": [
-          "canCrouchJump",
-          "h_underwaterCrouchJumpWithFlashSuit"
-        ]},
+        "h_underwaterCrouchJump",
         "canTrickyJump",
         {"or": [
           {"and": [

--- a/region/maridia/inner-pink/East Sand Pit.json
+++ b/region/maridia/inner-pink/East Sand Pit.json
@@ -557,10 +557,7 @@
       "link": [1, 5],
       "name": "Use Flash Suit",
       "requires": [
-        {"or": [
-          "canCrouchJump",
-          "h_underwaterCrouchJumpWithFlashSuit"
-        ]},
+        "h_underwaterCrouchJump",
         {"useFlashSuit": {}},
         {"or": [
           {"shinespark": {"frames": 13, "excessFrames": 3}},


### PR DESCRIPTION
The existing helper name `h_underwaterCrouchJumpWithFlashSuit` seems misleading because it suggests a requirement to have a flash suit, when all it means is that you *may* have a flash suit. It is defined as `{"tech": "canCrouchJump"}`, i.e. simply the crouch-jump tech without the `{"noFlashSuit": {}}` requirement that normally comes along with it. This seems to have led to some confusion where we are using redundant blocks like this:

```
{"or": [
  "canCrouchJump",
  "h_underwaterCrouchJumpWithFlashSuit"
]},
```

which expands to

```
{"or": [
  "canCrouchJump",
  {"tech": "canCrouchJump"}
]},
```

where it becomes clear that the first case of the `or` is unnecessary.

This PR proposes that we rename the helper to `h_underwaterCrouchJump` and replace blocks like this with simple uses of the helper. It also adds a `h_underwaterCrouchJumpDownGrab` and likewise replaces overly complicated blocks with simple uses of the helper.

This PR only addresses existing uses of the helper `h_underwaterCrouchJumpWithFlashSuit`. We will need to go through all the crouch jump uses, to classify them as underwater or not, but that can be done in a separate PR; I wanted to make sure first that everything is all right with the proposed helpers.