### PR TITLE
A couple more helpers for flash suits

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -748,6 +748,24 @@
           ]
         },
         {
+          "name": "h_complexToCarryFlashSuit",
+          "requires": [
+            {"or": [
+              {"noFlashSuit": {}},
+              "canComplexCarryFlashSuit"
+            ]}
+          ]
+        },
+        {
+          "name": "h_trickyToCarryFlashSuit",
+          "requires": [
+            {"or": [
+              {"noFlashSuit": {}},
+              "canTrickyCarryFlashSuit"
+            ]}
+          ]
+        },
+        {
           "name": "h_PlasmaHitbox",
           "requires": [
             "Plasma",

--- a/helpers.json
+++ b/helpers.json
@@ -773,6 +773,7 @@
               {"noFlashSuit": {}},
               "canTrickyCarryFlashSuit"
             ]}
+          ]
         },
         {
           "name": "h_PlasmaHitbox",

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -874,10 +874,7 @@
       "requires": [
         "canBombJumpWaterEscape",
         "canJumpIntoIBJ",
-        {"or": [
-          "canTrickyCarryFlashSuit",
-          {"noFlashSuit": {}}
-        ]}
+        "h_trickyToCarryFlashSuit"
       ],
       "flashSuitChecked": true,
       "note": "When the water is high, jump and place a Bomb on the descent just above the water, then very quickly crouch jump to hit the Bomb and IBJ.",

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -873,8 +873,7 @@
       "name": "Bomb Boost Water Escape Into IBJ",
       "requires": [
         "canBombJumpWaterEscape",
-        "canJumpIntoIBJ",
-        "h_trickyToCarryFlashSuit"
+        "canJumpIntoIBJ"
       ],
       "flashSuitChecked": true,
       "note": "When the water is high, jump and place a Bomb on the descent just above the water, then very quickly crouch jump to hit the Bomb and IBJ.",

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -1391,10 +1391,7 @@
               "HiJump",
               "Gravity"
             ]},
-            {"or": [
-              {"noFlashSuit": {}},
-              "canTrickyCarryFlashSuit"
-            ]}
+            "h_trickyToCarryFlashSuit"
           ]}
         ]}
       ],


### PR DESCRIPTION
We can use these to mark individual cases that are more difficult to carry a flash suit than reflected by their tech requirements alone.