### PR TITLE
Tourian check flash suits

### DIFF
--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -86,6 +86,7 @@
       },
       "requires": [],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "The Baby Metroid is not active when entering from the left side of the room."
     },
     {
@@ -100,7 +101,8 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -119,6 +121,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $3.1"]
     },
     {
@@ -150,7 +153,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -170,7 +174,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -191,7 +196,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -207,7 +213,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -218,7 +225,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -264,7 +272,8 @@
       "name": "Base",
       "requires": [
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -280,6 +289,7 @@
         "leaveWithSpark": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Gain a shinecharge by running right-to-left on the leftmost runway.",
         "Then run toward the right, jumping twice before sparking mid-air."
@@ -301,7 +311,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -324,7 +335,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -348,7 +360,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -371,7 +384,8 @@
           "movementType": "controlled"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -389,7 +403,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -407,7 +422,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -416,6 +432,7 @@
       "requires": [
         {"resourceAtMost": [{"type": "RegularEnergy", "count": 1}]}
       ],
+      "flashSuitChecked": true,
       "clearsObstacles": ["A"]
     },
     {
@@ -424,7 +441,8 @@
       "name": "Baby Inactive",
       "requires": [
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -441,8 +459,10 @@
         "HiJump",
         "SpeedBooster",
         "canTrickyJump",
-        "canBabyMetroidAvoid"
+        "canBabyMetroidAvoid",
+        "h_trickyToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump over the Baby Metroid to avoid getting grabbed.",
         "Use Wave plus a Wide Beam to clear much of the seaweed with each shot.",
@@ -460,8 +480,10 @@
         "canMidAirMorph",
         "HiJump",
         "canTrickyJump",
-        "canBabyMetroidAvoid"
+        "canBabyMetroidAvoid",
+        "h_trickyToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": "Avoid the Baby Metroid by jumping over it many times in order to clear a path through the seaweed."
     },
     {
@@ -472,8 +494,10 @@
         {"notable": "Baby Skip With Nothing"},
         {"obstaclesNotCleared": ["A"]},
         "canBabyMetroidAvoid",
-        "canInsaneJump"
+        "canInsaneJump",
+        "h_trickyToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Avoid the Baby Metroid with no items at all.",
         "Jump over it many times in order to clear a path through the seaweed.",
@@ -507,6 +531,7 @@
           "movementType": "uncontrolled"
         }
       },
+      "flashSuitChecked": true,
       "unlocksDoors": [{"types": ["ammo"], "requires": []}]
     },
     {
@@ -525,7 +550,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -536,7 +562,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -548,7 +575,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -565,7 +593,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -582,7 +611,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -594,7 +624,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -611,6 +642,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $2.5 with spin, or $2.6 with a quick aim-down."]
     },
     {
@@ -625,7 +657,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -643,7 +676,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -662,7 +696,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -676,7 +711,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 35,

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -77,7 +77,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -94,6 +95,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Avoid backing into the corner;",
         "instead press against it and turn around, to put Samus into a better position."
@@ -126,7 +128,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -144,7 +147,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -163,7 +167,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -177,7 +182,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -188,7 +194,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -203,13 +210,15 @@
       "id": 9,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -221,7 +230,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -238,7 +248,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -255,7 +266,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -267,7 +279,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -284,6 +297,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Avoid backing into the corner;",
         "instead press against it and turn around, to put Samus into a better position."
@@ -316,7 +330,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -334,7 +349,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -353,7 +369,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -367,7 +384,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -378,7 +396,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/tourian/main/Lower Tourian Save Room.json
+++ b/region/tourian/main/Lower Tourian Save Room.json
@@ -60,7 +60,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -75,13 +76,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -117,7 +117,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -132,6 +133,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Stand a bit more than a tile away from the ledge and wait for the Rinka to start moving.",
         "Freeze the Rinka at the correct height while maintainig a half-tile gap between the Rinka and the runway to extend it as much as possible."
@@ -166,6 +168,7 @@
           "obstruction": [3, 0]
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "It is best to start 4 or 5 pixels from the end of the runway;",
         "equivalently, start at the end of the runway and use arm pumps to advance 4 or 5 pixels while running."
@@ -209,7 +212,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -233,7 +237,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -258,7 +263,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -278,7 +284,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -296,6 +303,7 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
+      "flashSuitChecked": true,
       "note": "If it not possible to freeze or kill the Metroids, then move quickly enough that they get stuck off-camera to the right, and gain the shinecharge in a position where Samus can angle up and shoot the Rinka while waiting for the shinecharge timer to run out."
     },
     {
@@ -327,6 +335,7 @@
         {"metroidFrames": 330}
       ],
       "setsFlags": ["f_KilledMetroidRoom1"],
+      "flashSuitChecked": true,
       "note": [
         "Place Power Bombs to kill the Metroids.",
         "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
@@ -351,6 +360,7 @@
         ]}
       ],
       "setsFlags": ["f_KilledMetroidRoom1"],
+      "flashSuitChecked": true,
       "note": [
         "Group all of the Metroids by hitting the first Rinka with a Power Bomb.",
         "Once grouped, use two more Power Bombs to finish them off."
@@ -444,7 +454,8 @@
           "explicitWeapons": ["Super", "Missile"]
         }}
       ],
-      "setsFlags": ["f_KilledMetroidRoom1"]
+      "setsFlags": ["f_KilledMetroidRoom1"],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -459,6 +470,7 @@
         "canMidairShinespark",
         {"shinespark": {"frames": 112, "excessFrames": 16}}
       ],
+      "flashSuitChecked": true,
       "note": "Spark through the top of the door to avoid the platforms.",
       "devNote": "FIXME: Add strats that come in charged and spark to save energy."
     },
@@ -487,7 +499,8 @@
             {"shinespark": {"frames": 75, "excessFrames": 16}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -502,6 +515,7 @@
           "canDodgeWhileShooting"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Align with the wall below the door while facing left.",
         "Hold dash, turn around, start running and arm pump once.",
@@ -526,6 +540,7 @@
           {"metroidFrames": 130}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Use the full runway to gain blue speed and enough speed to reach the far platform."
     },
     {
@@ -542,7 +557,8 @@
           "canMetroidAvoid",
           {"metroidFrames": 270}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -551,7 +567,8 @@
       "requires": [
         "canBlueSpaceJump",
         {"getBlueSpeed": {"usedTiles": 31, "openEnd": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -567,6 +584,7 @@
         "canBlueSpaceJump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Jump Immediately upon entry, or before the transition.",
       "devNote": "There is 1 unusable tile in this runway."
     },
@@ -583,6 +601,7 @@
           {"metroidFrames": 200}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "At max run speed without SpeedBooster, you can bounce on both platforms and avoid all acid.",
         "Jump from the center of the rightmost X in the background.",
@@ -606,6 +625,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Freeze the middle Metroid as soon as it comes on screen to use as a platform to cross over the acid.",
         "If no Metroids are alive, the far left Rinka can be used instead, at a high angle.",
@@ -627,6 +647,7 @@
           "canMetroidAvoid"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Aim the leftmost Rinka to travel horizontally across the top of the room and use it to damage boost between the two floating platforms.",
         "Killing the Rinka will normalize it's respawn timer, which may help in setting up the correct angle.",
@@ -668,7 +689,8 @@
           "canMetroidAvoid",
           {"metroidFrames": 150}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 60,
@@ -694,6 +716,7 @@
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "SpinJump often to reduce the amount of time spent in the acid."
     },
     {
@@ -714,6 +737,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump from the left platform and mid air morph to bounce through the lava quickly.",
         "This is only useful when morphing before reaching the ceiling."
@@ -744,6 +768,7 @@
           "canCeilingBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Bomb Jump between the two floating platforms."
     },
     {
@@ -804,6 +829,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "Requires preopening the door, so this is more difficult than a normal MetroidAvoid.",
         "FIXME: Blue speed can be used to protect against metroid damage, in the canTrickyDodgeEnemies case;",
@@ -841,6 +867,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "It is possible to open the door with ammo and mockball out in one motion.",
         "But the timing makes it harder than crossing the room multiple times."
@@ -877,7 +904,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -911,6 +939,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: It is possible to open the door and leave with a controlled bounce in one motion.",
         "But then avoiding damage becomes unreliable."
@@ -941,7 +970,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -954,7 +984,8 @@
           "explicitWeapons": ["Super", "Missile"]
         }}
       ],
-      "setsFlags": ["f_KilledMetroidRoom1"]
+      "setsFlags": ["f_KilledMetroidRoom1"],
+      "flashSuitChecked": true
     },
     {
       "id": 63,
@@ -970,7 +1001,8 @@
           "canMetroidAvoid",
           {"metroidFrames": 420}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 64,
@@ -1001,7 +1033,8 @@
             "Gravity"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 65,
@@ -1020,6 +1053,7 @@
           {"metroidFrames": 270}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "At max non-speed run speed, Spring Ball bounce on both platforms and avoid all acid.",
         "Land on the right side of the first platform to avoid the second Metroid.",
@@ -1035,6 +1069,7 @@
         "canTrickyJump",
         "canCameraManip"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the lower Rinka as a platform to setup the angle for the top Rinka.",
         "Then use the frozen Rinka to cross the acid.",
@@ -1072,6 +1107,7 @@
           {"acidFrames": 27}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Aim the ceiling Rinka to travel horizontally across the top of the room and use it to damage boost between the two floating platforms.",
         "Killing the lower Rinka shortly before killing the higher Rinka will synchronize their respawn timers so that Samus can jump when the lower Rinka reappears in order to get a good angle on the higher Rinka.",
@@ -1134,6 +1170,7 @@
           {"acidFrames": 27}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "1) Jump from the acid to the floating platform.",
         "2) Deal with the Metroid.",
@@ -1161,7 +1198,8 @@
           ]},
           {"metroidFrames": 670}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 70,
@@ -1171,7 +1209,8 @@
         "canBlueSpaceJump",
         {"getBlueSpeed": {"usedTiles": 22, "openEnd": 1}},
         {"metroidFrames": 67}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 71,
@@ -1195,7 +1234,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 72,
@@ -1208,6 +1248,7 @@
           "canDiagonalBombJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Bomb Jump between the two floating platforms."
     },
     {
@@ -1284,6 +1325,7 @@
         "canMidairShinespark",
         {"shinespark": {"frames": 112, "excessFrames": 35}}
       ],
+      "flashSuitChecked": true,
       "note": "Spark through the top of the door to avoid the platforms.",
       "devNote": "FIXME: Add strats that come in charged and spark to save energy."
     },
@@ -1301,6 +1343,7 @@
         "canBlueSpaceJump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Jump Immediately upon entry, or before the transition.",
       "devNote": "There is 1 unusable tile in this runway."
     },
@@ -1329,7 +1372,8 @@
           "blockPositions": [[7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -1341,7 +1385,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -1358,7 +1403,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -1375,7 +1421,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -1387,7 +1434,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -1409,6 +1457,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Use a frozen Metroid or a Rinka from the left to extend the length of the runway.",
         "Luring a Rinka is easiest with Morph - While morphed, barely move the bottom Rinka spawner on camera in order to have it shoot at a usable angle.",
@@ -1443,6 +1492,7 @@
           "obstruction": [3, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Max extra run speed $4.7.",
         "Using almost the full runway (between 3 and 6 pixels from the edge), the momentum conserving turnaround has a 2-frame window for the jump,",
@@ -1486,7 +1536,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -1510,7 +1561,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -1535,7 +1587,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -1555,7 +1608,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -1572,7 +1626,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -1599,6 +1654,7 @@
         {"metroidFrames": 170}
       ],
       "setsFlags": ["f_KilledMetroidRoom1"],
+      "flashSuitChecked": true,
       "note": [
         "Place Power Bombs to kill the Metroids.",
         "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
@@ -1618,6 +1674,7 @@
         "canMetroidAvoid"
       ],
       "setsFlags": ["f_KilledMetroidRoom1"],
+      "flashSuitChecked": true,
       "note": [
         "Group all of the Metroids by hitting the first Rinka with a Power Bomb.",
         "Once grouped, use two more Power Bombs to finish them off."

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -97,7 +97,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -112,6 +113,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Kill or lure and freeze the Metroids at the bottom of the room.",
         "It may be easiest to stand on a frozen Rinka from the top left spawner to position a freeze of the other Rinka.",
@@ -136,7 +138,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -160,7 +163,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -185,7 +189,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -236,7 +241,8 @@
       "name": "Already Cleared",
       "requires": [
         "f_KilledMetroidRoom2"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -249,7 +255,8 @@
           "explicitWeapons": ["Super", "Missile"]
         }}
       ],
-      "setsFlags": ["f_KilledMetroidRoom2"]
+      "setsFlags": ["f_KilledMetroidRoom2"],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -262,7 +269,8 @@
         }},
         {"metroidFrames": 96}
       ],
-      "setsFlags": ["f_KilledMetroidRoom2"]
+      "setsFlags": ["f_KilledMetroidRoom2"],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -279,6 +287,7 @@
         ]}
       ],
       "setsFlags": ["f_KilledMetroidRoom2"],
+      "flashSuitChecked": true,
       "note": "An easy way is once Samus is on the top platform, jump and aim down to lower the camera, then place 3 PBs."
     },
     {
@@ -287,7 +296,8 @@
       "name": "Ice Evade",
       "requires": [
         "Ice"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -300,6 +310,7 @@
           "canPseudoScrew"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use ScrewAttack or a PseudoScrew to prevent Metroids from attaching to Samus."
       ]
@@ -310,7 +321,8 @@
       "name": "Harder Evade",
       "requires": [
         "canMetroidAvoid"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -318,7 +330,8 @@
       "name": "Tank the Damage",
       "requires": [
         {"metroidFrames": 80}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -376,7 +389,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -464,6 +478,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas.",
       "devNote": "Doing this with Metroids alive is technically possible but seems really bad."
     },
@@ -473,7 +488,8 @@
       "name": "Already Cleared",
       "requires": [
         "f_KilledMetroidRoom2"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -486,7 +502,8 @@
           "explicitWeapons": ["Super", "Missile"]
         }}
       ],
-      "setsFlags": ["f_KilledMetroidRoom2"]
+      "setsFlags": ["f_KilledMetroidRoom2"],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -499,7 +516,8 @@
         }},
         {"metroidFrames": 400}
       ],
-      "setsFlags": ["f_KilledMetroidRoom2"]
+      "setsFlags": ["f_KilledMetroidRoom2"],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -514,6 +532,7 @@
         "canMetroidAvoid"
       ],
       "setsFlags": ["f_KilledMetroidRoom2"],
+      "flashSuitChecked": true,
       "note": "Kill the two Metroids with Power Bombs while avoiding damage."
     },
     {
@@ -524,6 +543,7 @@
         "Ice",
         "canDodgeWhileShooting"
       ],
+      "flashSuitChecked": true,
       "note": "Shoot the Metroids on entry, shooting one horizontally and the other diagonally."
     },
     {
@@ -543,6 +563,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Use ScrewAttack or a PseudoScrew to prevent Metroids from attaching to Samus."
     },
     {
@@ -553,6 +574,7 @@
         {"notable": "Bottom Door Metroid Avoid"},
         "canMetroidAvoid"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Buffer a spinjump towards the door to jump over the top metroid and land on the middle platform.",
         "Metroids can be knocked with Beam shots to clear a path."
@@ -564,7 +586,8 @@
       "name": "Tank the Damage",
       "requires": [
         {"metroidFrames": 180}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -675,6 +698,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Not pressing dash will make the platforming easier, unless HiJump is also equipped."
       ],
@@ -1080,6 +1104,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas."
     },
     {
@@ -1102,6 +1127,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "devNote": "FIXME: Is it worth adding a method with avoiding the Metroids?"
     },
     {
@@ -1117,6 +1143,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Kill or lure and freeze the Metroids at the top of the room.",
         "It may be easiest to stand on a frozen Rinka from the left spawner to position a freeze of the other Rinka.",
@@ -1146,6 +1173,7 @@
           "obstruction": [3, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Max extra run speed $2.6",
         "This strat is included for completeness, though it apparently doesn't have any applications."
@@ -1169,7 +1197,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -1194,6 +1223,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "devNote": "There is 1 unusable landing tile here; at low speeds (earlier jump) it could be used but wouldn't serve a purpose."
     },
     {
@@ -1219,7 +1249,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1239,7 +1270,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 50,

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -94,7 +94,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -109,6 +110,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "One simple setup to position a Rinka is to crouch a couple tiles away from the bottom right spawner.",
         "This will also prevent the left two Rinka spawners to activate, as they will be off camera.",
@@ -150,7 +152,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -174,7 +177,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -192,7 +196,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -220,7 +225,8 @@
           },
           "minExtraRunSpeed": "$1.2"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -239,7 +245,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -268,7 +275,8 @@
           "minExtraRunSpeed": "$1.A",
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -282,7 +290,8 @@
             "openEnd": 2
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -305,7 +314,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -325,7 +335,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -435,7 +446,8 @@
       "name": "Already Cleared",
       "requires": [
         "f_KilledMetroidRoom3"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -448,7 +460,8 @@
           "explicitWeapons": ["Super", "Missile"]
         }}
       ],
-      "setsFlags": ["f_KilledMetroidRoom3"]
+      "setsFlags": ["f_KilledMetroidRoom3"],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -466,6 +479,7 @@
         {"metroidFrames": 300}
       ],
       "setsFlags": ["f_KilledMetroidRoom3"],
+      "flashSuitChecked": true,
       "note": [
         "Place Power Bombs to kill the Metroids.",
         "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
@@ -488,6 +502,7 @@
         ]}
       ],
       "setsFlags": ["f_KilledMetroidRoom3"],
+      "flashSuitChecked": true,
       "note": [
         "Group the Metroids by hitting the first Rinka with a Power Bomb.",
         "Quickly moving to the right as the Power Bomb explodes may help as that area is more open with no Rinkas.",
@@ -508,7 +523,8 @@
           ]},
           "Morph"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -527,6 +543,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use ScrewAttack or a PseudoScrew to prevent Metroids from attaching to Samus.",
         "These abilities may also be used to temporarily prevent damage from Metroids if they do attach."
@@ -542,7 +559,8 @@
           "canTrickyJump",
           "canMockball"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -558,6 +576,7 @@
         "canBlueSpaceJump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Jump Immediately upon entry, or before the transition.",
       "devNote": "There is 1 unusable tile in this runway."
     },
@@ -567,7 +586,8 @@
       "name": "Tank the Damage",
       "requires": [
         {"metroidFrames": 670}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -579,6 +599,7 @@
       "requires": [
         {"shinespark": {"frames": 112, "excessFrames": 6}}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: Add strats that come in charged and spark to save energy."
     },
     {
@@ -587,7 +608,8 @@
       "name": "Already Cleared",
       "requires": [
         "f_KilledMetroidRoom3"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -600,6 +622,7 @@
           "explicitWeapons": ["Super", "Missile"]
         }}
       ],
+      "flashSuitChecked": true,
       "setsFlags": ["f_KilledMetroidRoom3"]
     },
     {
@@ -618,6 +641,7 @@
         {"metroidFrames": 200}
       ],
       "setsFlags": ["f_KilledMetroidRoom3"],
+      "flashSuitChecked": true,
       "note": [
         "Place Power Bombs to kill the Metroids.",
         "By hitting the first Rinka, all of the Metroids (on a similar vertical height to the Power Bomb) will be damaged."
@@ -644,6 +668,7 @@
         ]}
       ],
       "setsFlags": ["f_KilledMetroidRoom3"],
+      "flashSuitChecked": true,
       "note": [
         "Group the Metroids by hitting the first Rinka with a Power Bomb.",
         "Then Kill all three Metroids with Power Bombs while avoiding damage."
@@ -663,7 +688,8 @@
           ]},
           "Morph"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 31,
@@ -682,6 +708,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use ScrewAttack or a PseudoScrew to prevent Metroids from attaching to Samus.",
         "These abilities may also be used to temporarily prevent damage from Metroids if they do attach."
@@ -697,7 +724,8 @@
           "canTrickyJump",
           "canMockball"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -713,6 +741,7 @@
         "canBlueSpaceJump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "devNote": "There is 1 unusable tile in this runway."
     },
     {
@@ -721,7 +750,8 @@
       "name": "Tank the Damage",
       "requires": [
         {"metroidFrames": 600}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -733,6 +763,7 @@
       "requires": [
         {"shinespark": {"frames": 112, "excessFrames": 23}}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: Add strats that come in charged and spark to save energy."
     },
     {
@@ -745,7 +776,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -762,7 +794,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -779,7 +812,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -791,7 +825,8 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -822,7 +857,8 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -851,7 +887,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -875,7 +912,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -904,7 +942,8 @@
           },
           "movementType": "controlled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -926,7 +965,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -955,7 +995,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 46,

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -97,7 +97,8 @@
           "length": 10,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -112,6 +113,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Kill or lure and freeze the Metroid down lower in the room off camera.",
         "One simple setup to position a Rinka is to stand or crouch a couple tiles away from the edge of the runway and freeze the Rinka from the right spawner.",
@@ -230,7 +232,8 @@
       "name": "Already Cleared",
       "requires": [
         "f_KilledMetroidRoom4"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -247,7 +250,8 @@
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
       ],
-      "setsFlags": ["f_KilledMetroidRoom4"]
+      "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -260,7 +264,8 @@
         }},
         {"metroidFrames": 200}
       ],
-      "setsFlags": ["f_KilledMetroidRoom4"]
+      "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -273,7 +278,8 @@
         }},
         "canDodgeWhileShooting"
       ],
-      "setsFlags": ["f_KilledMetroidRoom4"]
+      "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -314,7 +320,8 @@
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -324,6 +331,7 @@
         "canMetroidAvoid",
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": "Run under the top Metroid then roll beneath the second and third."
     },
     {
@@ -335,6 +343,7 @@
         "canMetroidAvoid",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Avoid all of the Rinkas and Metroids with no equipment and taking no damage.",
         "One way to do this is to bait the top Rinkas to fire upwards, and then carefully spinjump around each corner as the Metroid below passes by."
@@ -347,6 +356,7 @@
       "requires": [
         {"metroidFrames": 240}
       ],
+      "flashSuitChecked": true,
       "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage."
     },
     {
@@ -371,6 +381,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas.",
         "Use spring ball to bounce through the 3-tile-high portion."
@@ -385,7 +396,8 @@
       "name": "Already Cleared",
       "requires": [
         "f_KilledMetroidRoom4"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -403,7 +415,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -430,7 +443,8 @@
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
       ],
-      "setsFlags": ["f_KilledMetroidRoom4"]
+      "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -451,6 +465,7 @@
         ]}
       ],
       "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true,
       "note": [
         "Climb to the middle section and kill all three Metroids while taking damage.",
         "Or use a tricky jump morph into the bottom left corner of room to kill all three Metroids from the bottom section."
@@ -472,6 +487,7 @@
         ]}
       ],
       "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true,
       "note": "Move to the middle section after the first Metroid has died to kill the remaining two."
     },
     {
@@ -487,6 +503,7 @@
         "canMetroidAvoid"
       ],
       "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true,
       "note": [
         "Take out the lower two Metroids with Power Bombs while avoiding damage.",
         "Then Kill the remaining one with three more Power Bombs."
@@ -510,6 +527,7 @@
         ]}
       ],
       "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true,
       "note": [
         "Move to the left side of the lowest section and jump morph before placing the Power Bomb to kill all three Metroids.",
         "Then Kill all three Metroids with Power Bombs while avoiding damage."
@@ -525,6 +543,7 @@
         "canDodgeWhileShooting",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Avoid all of the Rinkas and Metroids with no equipment and taking no damage.",
         "Begin by shooting the bottom Metroid hold it in place, and wait right below the first ledge.",
@@ -540,17 +559,9 @@
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
         {"metroidFrames": 256}
       ],
+      "flashSuitChecked": true,
       "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage.",
       "devNote": "Avoiding Rinkas is more difficult than getting hit, so it is not important to know to want to get hit."
-    },
-    {
-      "id": 26,
-      "link": [2, 2],
-      "name": "Leave Normally",
-      "requires": [],
-      "exitCondition": {
-        "leaveNormally": {}
-      }
     },
     {
       "id": 27,
@@ -564,6 +575,7 @@
         "f_KilledMetroidRoom4",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark.",
         "This requires the Metroids to be killed, because otherwise Samus will be grabbed on entry, and the other 2->1 strats won't work."
@@ -578,6 +590,7 @@
         "canEnemyStuckMoonfall"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Use two frozen Rinkas to clip down past the door shell.",
         "Time the Rinkas to be at correct heights by killing both, starting with the higher Rinka.",

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -266,7 +266,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -283,6 +284,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Max extra run speed $0.B.",
         "This strat is included for completeness, though it apparently doesn't have any applications."
@@ -327,6 +329,7 @@
         {"notable": "Reverse Mother Brain"},
         "f_MotherBrainGlassBroken"
       ],
+      "flashSuitChecked": true,
       "note": [
         "When the glass is broken, touching Mother Brain from the left will instantly transport Samus to the right.",
         "This gives Samus i-frames and knockback but does not cause damage."
@@ -343,7 +346,8 @@
       },
       "requires": [
         "h_bypassMotherBrainRoom"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -356,6 +360,7 @@
         "canTrickyUseFrozenEnemies",
         "canCrystalFlash"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Freeze all 3 Rinkas at close to the same time, ",
         "then quickly jump into the morph nook at the top-left of Mother Brain,",
@@ -463,6 +468,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Carefully dodge the Rinkas, or take a hit, while carefully avoiding falling off, then use the i-frames to use the runway."
     },
     {
@@ -474,8 +480,10 @@
         {"or": [
           "canDodgeWhileShooting",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
-        ]}
+        ]},
+        "h_complexToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "setsFlags": ["f_KilledZebetites1"]
     },
     {
@@ -521,7 +529,8 @@
         {"or": [
           "canTrickyDodgeEnemies",
           {"enemyDamage": {"enemy": "Mother Brain 1", "type": "turret", "hits": 1}}
-        ]}
+        ]},
+        "h_complexToCarryFlashSuit"
       ],
       "note": [
         "Glitch through the Mother Brain Zebetites by using a frozen Rinka and i-frames.",
@@ -559,6 +568,7 @@
         {"shinespark": {"frames": 4}},
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Shinespark diagonally into the lower Rinka Spawner while holding down, spamming jump, then pressing forward,",
         "in order to glitch through the first Mother Brain Zebetites during Samus' i-frames.",
@@ -619,7 +629,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -631,6 +642,7 @@
         "h_partiallyBreakMotherBrainGlass"
       ],
       "setsFlags": ["f_MotherBrainGlassBroken"],
+      "flashSuitChecked": true,
       "devNote": [
         "Requires 18 ammo to fully break the glass, which will remain broken if Samus leaves.",
         "Or, it takes 6 ammo to partially break the glass, and then 3000 damage is required to kill Mother Brain 1, but the glass also needs to be broken.",
@@ -657,7 +669,8 @@
           ]},
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 3}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -680,7 +693,8 @@
           ]},
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -726,7 +740,8 @@
           ]},
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -756,7 +771,8 @@
           ]},
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 2}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -776,7 +792,8 @@
           "canDodgeWhileShooting",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -804,7 +821,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -812,7 +830,8 @@
       "name": "Base",
       "requires": [
         "f_DefeatedMotherBrain"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -828,6 +847,7 @@
         {"ammoDrain": {"type": "PowerBomb", "count": 300}}
       ],
       "setsFlags": ["f_ZebesSetAblaze", "f_DefeatedMotherBrain"],
+      "flashSuitChecked": true,
       "note": "The fight also brings Samus down below 100 energy, but then it fills her up"
     },
     {
@@ -896,7 +916,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -910,9 +931,11 @@
             "canInsaneJump"
           ]},
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
-        ]}
+        ]},
+        "h_complexToCarryFlashSuit"
       ],
-      "setsFlags": ["f_KilledZebetites2"]
+      "setsFlags": ["f_KilledZebetites2"],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -941,7 +964,8 @@
           ]}
         ]},
         {"enemyDamage": {"enemy": "Mother Brain 1", "type": "turret", "hits": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -970,7 +994,8 @@
           ]}
         ]},
         {"enemyDamage": {"enemy": "Mother Brain 1", "type": "turret", "hits": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -984,9 +1009,11 @@
             "canTrickyJump"
           ]},
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
-        ]}
+        ]},
+        "h_complexToCarryFlashSuit"
       ],
-      "setsFlags": ["f_KilledZebetites3"]
+      "setsFlags": ["f_KilledZebetites3"],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -998,7 +1025,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -1026,7 +1054,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -1038,7 +1067,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -1046,9 +1076,11 @@
       "name": "Destroy Fourth Zebetite",
       "requires": [
         "h_openZebetites",
-        {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
+        {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
+        "h_complexToCarryFlashSuit"
       ],
-      "setsFlags": ["f_KilledZebetites4"]
+      "setsFlags": ["f_KilledZebetites4"],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1067,6 +1099,7 @@
         {"ammo": {"type": "Missile", "count": 18}}
       ],
       "setsFlags": ["f_MotherBrainGlassBroken"],
+      "flashSuitChecked": true,
       "note": [
         "To be able to break the glass and leave out the left side, Samus must be at a specific horizontal X pixel position ($63).",
         "Therefore, the Crystal Flash should have been performed at this position;",
@@ -1096,6 +1129,7 @@
         "canWallIceClip",
         {"spikeHits": 1}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform a moondance while killing the Rinkas, carefully avoiding being hit by them.",
         "After 176 moonfalls, Samus will clip down into the tank.",

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -101,7 +101,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 59,
@@ -121,6 +122,7 @@
           "obstruction": [2, 2]
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "Max extra run speed $1.1.",
         "This strat is included for completeness, though it apparently doesn't have any applications."
@@ -138,7 +140,8 @@
             "openEnd": 2
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -156,7 +159,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -175,7 +179,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -189,7 +194,8 @@
             "openEnd": 2
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -220,7 +226,8 @@
       "id": 8,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -266,7 +273,8 @@
       "id": 11,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -488,7 +496,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -521,7 +530,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -536,6 +546,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "One simple setup to position a Rinka is to stand a few pixels away from the right edge of the floating platform in front of the door.",
         "The lower right Rinka spawner will spawn a Rinka at a good angle.",
@@ -567,7 +578,8 @@
       "id": 27,
       "link": [2, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -629,7 +641,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 31,
@@ -778,13 +791,15 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas."
     },
     {
       "id": 37,
       "link": [3, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -935,7 +950,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1200,6 +1216,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Use X-ray immediately after shinecharging, in order to be able to dodge the Rinkas."
     },
     {
@@ -1212,7 +1229,8 @@
           "length": 13,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 57,

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -90,6 +90,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "If coming from below, carefully get up on the left side of the room without breaking the runway blocks."
     },
     {
@@ -109,6 +110,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "There is one unusable remote runway tile here, in order to allow space to reasonably perform the mockball."
       ]
@@ -131,6 +133,7 @@
           "movementType": "uncontrolled"
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "There is one unusable remote runway tile here, in order to allow space to reasonably perform the bounce."
       ]
@@ -202,6 +205,7 @@
         "leaveWithSpark": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
       "note": "Use Wave to clear the seaweed quickly."
     },
     {
@@ -214,7 +218,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -231,7 +236,8 @@
           "blockPositions": [[2, 28]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -248,7 +254,8 @@
           "blockPositions": [[2, 29]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -268,6 +275,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
     },
     {
@@ -289,13 +297,15 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
     },
     {
       "id": 13,
       "link": [1, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -368,6 +378,7 @@
         "leaveWithSpark": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
       "note": "Clear the seaweed one block at a time, with just barely enough time remaining to spark out the door."
     },
     {
@@ -426,6 +437,7 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
+      "flashSuitChecked": true,
       "note": "Carefully clear a path through the seaweed in order to chain temporary blue up or down the room."
     },
     {
@@ -438,13 +450,15 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 21,
       "link": [2, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -490,6 +504,7 @@
         "leaveShinecharged": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
       "note": [
         "Gain a shinecharge while entering the room.",
         "Shoot three times to break the lower two rows of seaweed.",
@@ -629,7 +644,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -647,7 +663,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -666,7 +683,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -687,7 +705,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -705,13 +724,15 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 31,
       "link": [3, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -744,7 +765,8 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 50,
@@ -764,7 +786,8 @@
       ],
       "exitCondition": {
         "leaveShinecharged": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -786,7 +809,8 @@
         "leaveWithSpark": {
           "position": "bottom"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 52,
@@ -808,7 +832,8 @@
         "leaveWithSpark": {
           "position": "top"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -895,7 +920,8 @@
       "id": 36,
       "link": [3, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 55,
@@ -918,7 +944,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 56,
@@ -942,6 +969,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": ["Squeeze underneath the seaweed, then clear a path to the door from below."]
     },
     {
@@ -1071,7 +1099,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -1088,7 +1117,8 @@
           "blockPositions": [[2, 28]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -1105,7 +1135,8 @@
           "blockPositions": [[2, 29]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -1117,7 +1148,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1134,6 +1166,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $0.F"
     }
   ],

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -80,7 +80,8 @@
           "length": 21,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -179,7 +180,8 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -193,13 +195,15 @@
       "requires": [
         "canMoonfall"
       ],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 5,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -253,16 +257,8 @@
         "leaveWithTemporaryBlue": {
           "direction": "left"
         }
-      }
-    },
-    {
-      "id": 8,
-      "link": [2, 2],
-      "name": "Leave Normally",
-      "requires": [],
-      "exitCondition": {
-        "leaveNormally": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -275,6 +271,7 @@
       "requires": [
         {"shinespark": {"frames": 4, "excessFrames": 4}}
       ],
+      "flashSuitChecked": true,
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     }
   ],

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -96,7 +96,8 @@
         "leaveWithDoorFrameBelow": {
           "height": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -109,7 +110,8 @@
           "leftPosition": -2.5,
           "rightPosition": 2.5
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -218,7 +220,8 @@
       "id": 6,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -254,7 +257,8 @@
       "id": 8,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -352,7 +356,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -369,6 +374,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $0.F"]
     },
     {
@@ -389,6 +395,7 @@
           "minExtraRunSpeed": "$0.E"
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the floating platform near the bottom-left of the room."
     },
     {
@@ -409,6 +416,7 @@
           "movementType": "uncontrolled"
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the floating platform near the bottom-left of the room."
     },
     {
@@ -424,6 +432,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the floating platform near the bottom-left of the room."
     },
     {

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -102,7 +102,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -131,6 +132,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the lower runway."
     },
     {
@@ -150,6 +152,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the lower runway."
     },
     {
@@ -170,6 +173,7 @@
           "movementType": "uncontrolled"
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the upper runway."
     },
     {
@@ -185,6 +189,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the upper runway."
     },
     {
@@ -197,7 +202,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -238,6 +244,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Kill the Pirates fast enough that they won't attack, or shoot them from below with Wave.",
       "devNote": "These requirements are to kill all of the pirates, but another strat is needed to cross the room to get to the top half."
     },
@@ -277,6 +284,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Safely kill the first pirate, then run from or roll under the remaining pirate lasers.",
         "The Pirates will also not shoot if they come on screen while Samus is crouched."
@@ -296,7 +304,8 @@
           "canIBJ",
           "canSpringBallJumpMidAir"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -335,6 +344,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Safely kill the first pirate, then walk through the rest while taking damage or by using Plasma Beam.",
         "It is possible to get through the lower three pirates with a single hit while using i-frames to prevent a second hit.",
@@ -350,6 +360,7 @@
         "h_getBlueSpeedMaxRunway"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Safely kill the first pirate, then run into the rest with blue speed.",
         "A speedy jump can reach the top platform to save Energy over shinesparking."
@@ -483,7 +494,8 @@
       "name": "Pirates Already Dead",
       "requires": [
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -514,6 +526,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run through the pirates while taking damage or by using Plasma Beam.",
         "It is possible to get through the lower three pirates with a single hit while using i-frames to prevent a second hit.",
@@ -541,6 +554,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Fall through the speed blocks from above with Temporary Blue, or kill the pirates from above with speed echoes."
     },
     {
@@ -553,7 +567,8 @@
           "openEnd": 0
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -566,7 +581,8 @@
       },
       "requires": [
         "canMoonfall"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -576,6 +592,7 @@
         "comeInWithSuperSink": {}
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": ["Enter the room with a super sink, to clip down past the Speed blocks."]
     },
     {
@@ -588,7 +605,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -605,7 +623,8 @@
           "blockPositions": [[2, 28]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -622,7 +641,8 @@
           "blockPositions": [[2, 29]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -634,7 +654,8 @@
           "length": 5,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -672,6 +693,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Run from or Roll under the pirate lasers.",
         "The Pirates will also not shoot if they come on screen while Samus is crouched."
@@ -704,6 +726,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Kill the Pirates fast enough that they won't attack, or shoot them from above with Wave.",
       "devNote": [
         "Technically it's not possible to kill the bottom Pirates while staying at node 2 (not dropping down);",
@@ -743,7 +766,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 31,
@@ -764,7 +788,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -780,7 +805,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -795,6 +821,7 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Gain temporary blue with a shinecharge; then do a tight lateral mid-air morph to jump past the speed blocks.",
         "Alernatively, start the temporary blue chain by doing a running jump over them rather than doing a shinecharge."

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -167,7 +167,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -184,6 +185,7 @@
           "obstruction": [5, 4]
         }
       },
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $1.8."]
     },
     {
@@ -198,7 +200,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -216,7 +219,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -235,7 +239,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -287,8 +292,10 @@
             ],
             "explicitWeapons": ["Missile", "Super", "PowerBomb", "Wave", "Spazer", "Plasma", "ScrewAttack"]
           }}
-        ]}
+        ]},
+        "h_midAirShootUp"
       ],
+      "flashSuitChecked": true,
       "note": ["Go up safely by killing the Pirates."]
     },
     {
@@ -308,7 +315,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -331,7 +339,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -354,8 +363,10 @@
             "hits": 4
           }},
           "canInsaneJump"
-        ]}
+        ]},
+        "h_trickyToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Freeze the Pirates and use them as platforms to climb the room.",
         "Sometimes the Pirates may decide to climb the wrong way; patience may be required to wait for them to come back.",
@@ -398,7 +409,11 @@
       "requires": [
         "canTrickyGrappleJump"
       ],
-      "devNote": ["FIXME: Setups from other rooms are possible but with greater difficulty."]
+      "flashSuitChecked": false,
+      "devNote": [
+        "FIXME: Setups from other rooms are possible but with greater difficulty.",
+        "Carrying a flash suit might be possible in some cases, with great difficulty."
+      ]
     },
     {
       "id": 9,
@@ -456,7 +471,8 @@
           "blockPositions": [[12, 12], [12, 13]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -531,7 +547,8 @@
           "length": 26,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -594,7 +611,8 @@
           "length": 26,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -611,7 +629,8 @@
             "hits": 1
           }}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -624,6 +643,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "devNote": [
         "There are 19 unusable tiles in this runway.",
         "It is not worthwhile to Shinespark into the room, because that would require more energy than the Pirates would deal."
@@ -654,7 +674,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -670,6 +691,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Screw Attack to avoid Space Pirate attacks while climbing the central shaft.",
         "The Screw Attack effect is not active when Samus is preparing to Walljump."
@@ -692,6 +714,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Pseudo Screw to avoid Space Pirate attacks while climbing the central shaft.",
         "The Screw Attack effect is not active when Samus is preparing to Walljump."
@@ -712,6 +735,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Navigate the room in reverse by killing or distracting the right side pirates and manipulating or dodging the left side pirates during the shaft climb.",
         "The acid starts rising when Samus is at the bottom of the long climb.",
@@ -744,6 +768,7 @@
         }
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "After reaching the top, fall down the right side to land on the platform below the door, taking a dip in acid before jumping into the door."
@@ -779,6 +804,7 @@
         }
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -816,6 +842,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -849,6 +876,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -902,6 +930,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Climbing the shaft with Space Jump is slower than other methods, so it is necessary to move quickly in order to minimize acid damage.",
         "With each Space Jump, release jump early rather than doing a full-height jump, in order to be able to Space Jump again more quickly.",
@@ -931,6 +960,7 @@
         "canMidairShinespark",
         {"shinespark": {"frames": 76, "excessFrames": 6}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain a shinecharge by running right-to-left at the bottom of the room.",
         "Move quickly to minimize damage from the acid, which will begin rising as soon as you reach the bottom of the room.",
@@ -951,6 +981,7 @@
         {"shinespark": {"frames": 83, "excessFrames": 2}}
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Gain a shinecharge by running right-to-left at the bottom of the room, performing a stutter just before the acid reaches Samus' feet.",
         "Use spin jumps to minimize damage from the acid, and spark diagonally (to the left) mid-air to make it up the shaft."
@@ -975,6 +1006,7 @@
         ]}
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": "Clear the right side Space Pirates and then race the rising acid by bomb jumping."
     },
     {
@@ -989,7 +1021,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -1039,7 +1072,8 @@
           }}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -1062,13 +1096,15 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
       "link": [4, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -293,7 +293,7 @@
             "explicitWeapons": ["Missile", "Super", "PowerBomb", "Wave", "Spazer", "Plasma", "ScrewAttack"]
           }}
         ]},
-        "h_midAirShootUp"
+        "h_complexToCarryFlashSuit"
       ],
       "flashSuitChecked": true,
       "note": ["Go up safely by killing the Pirates."]

--- a/region/tourian/main/Tourian Eye Door Room.json
+++ b/region/tourian/main/Tourian Eye Door Room.json
@@ -63,7 +63,8 @@
           "length": 8,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -78,13 +79,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -96,7 +99,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -113,7 +117,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -130,7 +135,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -142,7 +148,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -158,7 +165,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -178,7 +186,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -199,7 +208,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -220,7 +230,8 @@
           },
           "movementType": "controlled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -236,7 +247,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/tourian/main/Tourian First Room.json
+++ b/region/tourian/main/Tourian First Room.json
@@ -134,7 +134,8 @@
       "id": 2,
       "link": [1, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -204,7 +205,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -219,7 +221,8 @@
       "id": 8,
       "link": [2, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -301,13 +304,15 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
       "link": [3, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -363,7 +368,8 @@
       "id": 17,
       "link": [3, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -445,7 +451,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -458,7 +465,7 @@
           "openEnd": 1
         }
       },
-      "devNote": "FIXME: Is it possible to leave charged through the elevator."
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -474,7 +481,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -492,7 +500,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -511,7 +520,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -525,7 +535,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/tourian/main/Tourian Hopper Room.json
+++ b/region/tourian/main/Tourian Hopper Room.json
@@ -81,7 +81,8 @@
         "leaveWithDoorFrameBelow": {
           "height": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -95,6 +96,7 @@
           "rightPosition": 1.5
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Additional platforms could be added, but they don't yet appear to have applications."
     },
     {
@@ -206,6 +208,7 @@
           ]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Enter through the far left side of the door.",
         "Wait for the top hopper to move right to start running.",
@@ -237,6 +240,7 @@
           ]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Try to scroll the camera to the right to keep the left Hopper off-camera for longer.",
         "Wait for the top hopper to move right to start running.",
@@ -266,6 +270,7 @@
           ]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait for the top hopper to move right, then jump through the left hopper.",
         "The left hopper may be harder to dodge if the camera is scrolled to the left."
@@ -278,7 +283,8 @@
       "requires": [
         {"obstaclesCleared": ["A"]}
       ],
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -294,6 +300,7 @@
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Kill the top hopper quickly; the left hopper is more random.",
         "To be safe, plan to retreat right while attacking.",
@@ -326,6 +333,7 @@
           ]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait for the left hopper to move right so it does not follow Samus as i-frames run out.",
         "A damage boost using the top hopper also moves through the room fast enough to be safe."
@@ -426,8 +434,10 @@
         {"notable": "Screw Attack Jumps"},
         "canPrepareForNextRoom",
         "ScrewAttack",
-        "canTrickyJump"
+        "canTrickyJump",
+        "h_complexToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spin jump into the room with Screw Attack, holding left through the transition to land near the door.",
         "Do a turn-around spin jump to the right, bonking the ceiling and overhang and then falling straight down.",
@@ -445,7 +455,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 43, "excessFrames": 19}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -458,7 +469,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 32, "excessFrames": 8}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -471,8 +483,10 @@
         {"notable": "Roll Under Hoppers"},
         "Morph",
         "canPrepareForNextRoom",
-        "canTrickyDodgeEnemies"
+        "canTrickyDodgeEnemies",
+        "h_complexToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Time Samus' movement carefully to roll underneath a Tourian Hopper and also race it to the far door.",
         "Enter the room morphed and let the hoppers jump against the wall a couple of times.",
@@ -492,8 +506,10 @@
       "requires": [
         {"notable": "Squeeze Under Hoppers"},
         "canPrepareForNextRoom",
-        "canTwoTileSqueeze"
+        "canTwoTileSqueeze",
+        "h_complexToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use at least 4 tiles of runway to gain speed, running through the transition.",
         "Hold down during and after the transition in order to aim down and squeeze under the Hopper.",
@@ -506,7 +522,8 @@
       "name": "Sidehoppers Already Killed",
       "requires": [
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -524,6 +541,7 @@
         "canCameraManip"
       ],
       "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room while morphed and let the hoppers jump against the wall a couple of times.",
         "Between hops, unmorph and shoot the lower hopper.",
@@ -535,16 +553,20 @@
       "link": [2, 1],
       "name": "Take Another Hit",
       "requires": [
-        {"enemyDamage": {"enemy": "Blue Sidehopper", "type": "contact", "hits": 1}}
-      ]
+        {"enemyDamage": {"enemy": "Blue Sidehopper", "type": "contact", "hits": 1}},
+        "h_complexToCarryFlashSuit"
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
       "link": [2, 1],
       "name": "Avoid Another Hit",
       "requires": [
-        "canCarefulJump"
-      ]
+        "canCarefulJump",
+        "h_complexToCarryFlashSuit"
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -561,8 +583,10 @@
         {"or": [
           "SpaceJump",
           "canCarefulJump"
-        ]}
+        ]},
+        "h_complexToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": "Jump far enough to land on the first floor pillar.",
       "devNote": "This is not the level of precision that would call for canBlueSpaceJump."
     },
@@ -625,7 +649,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -648,6 +673,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "This is used to fulfill the requirement on exiting the previous room.",
         "FIXME: The hopper hit can be avoided depending on the entry speed and canPrepareForNextRoom."
@@ -669,7 +695,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -687,6 +714,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room morphed to avoid a hopper hit on entry.",
         "Roll under the bottom hopper to lead it to the right, and then roll back to reach the door safely."
@@ -708,6 +736,7 @@
         }}
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Enter the room morphed to avoid a hopper hit on entry."
     },
     {
@@ -726,6 +755,7 @@
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room in ball mode and let the hoppers jump against the wall a couple of times.",
         "Between hops, unmorph and shoot the lower hopper."
@@ -746,6 +776,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": "FIXME: An alternative strat may be possible where the enemies are lured off-camera to the right instead of killed."
     },
     {
@@ -775,6 +806,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $2.B."]
     },
     {
@@ -800,6 +832,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $2.4."]
     },
     {
@@ -817,7 +850,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -838,7 +872,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -860,7 +895,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -878,6 +914,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "For higher speed, use the farther-away runway in the middle of the room."
     },
     {

--- a/region/tourian/main/Tourian Recharge Room.json
+++ b/region/tourian/main/Tourian Recharge Room.json
@@ -79,19 +79,22 @@
           "length": 2,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -99,7 +102,8 @@
       "name": "Refill",
       "requires": [
         "h_useMissileRefillStation"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -119,13 +123,15 @@
       "id": 6,
       "link": [2, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
       "link": [3, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -133,7 +139,8 @@
       "name": "Refill",
       "requires": [
         "h_useEnergyRefillStation"
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/tourian/main/Upper Tourian Save Room.json
+++ b/region/tourian/main/Upper Tourian Save Room.json
@@ -60,7 +60,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -75,13 +76,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/strats.md
+++ b/strats.md
@@ -347,7 +347,11 @@ The `leaveSpaceJumping` object has the following properties:
 - _maxExtraRunSpeed_: The maximum extra run speed (as a hexadecimal string) with which it is possible to leave with this condition. There is already an implicit speed limit based on the length of the remote runway (see the [full run speed table](#full-run-speed-table)), and for leaving with blue speed there is a different implicit limit based on a combination of runway length and shortcharging skill (see the [blue run speed table](#blue-run-speed-table)); so this property only needs to be specified as an additional constraint in case something else prevents Samus from reaching the door transition (in the needed positions) at high speeds.
 - _blue_: This takes one of three possible values, "yes", "no", or "any", indicating whether this strat can be used for leaving with blue speed, without blue speed, or either. The default is "any".
 
-A `leaveSpaceJumping` condition implicitly includes the `SpaceJump` item requirement. If it is used for blue speed in the next room, then it also implicitly includes a `canShinecharge` requirement (including the `SpeedBooster` item) and the `canBlueSpaceJump` tech requirement. Heat frames are not included and would have to described explicitly in the strat "requires".
+A `leaveSpaceJumping` condition comes with implicit requirements:
+- The `SpaceJump` item requirement.
+- A `h_trickyToCarryFlashSuit` requirement, because being 1 frame late on the doorway Space Jump results in loss of a flash suit.
+- If used for blue speed in the next room, a `getBlueSpeed` requirement (including the `SpeedBooster` item) and the `canBlueSpaceJump` tech requirement. 
+- Heat frames are not included and would have to described explicitly in the strat "requires".
 
 #### Example
 ```json
@@ -769,7 +773,10 @@ A `comeInSpaceJumping` entrance condition indicates that Samus must come in with
 * _minTiles_: The minimum horizontal speed that will satisfy the condition, measured in effective runway tiles with dash held on the remote runway.
 * _maxTiles_: The maximum horizontal speed that will satisfy the condition, measured in effective runway tiles with dash held on the remote runway.
 
-A `comeInSpaceJumping` entrance condition must match with a `leaveSpaceJumping` on the other side of the door. To match, the `blue` property of `leaveSpaceJumping` must be "no" or "any". This comes with an implicit `SpaceJump` item requirement.
+A `comeInSpaceJumping` entrance condition must match with a `leaveSpaceJumping` on the other side of the door. To match, the `blue` property of `leaveSpaceJumping` must be "no" or "any". This comes with implicit requirements:
+
+- The `SpaceJump` item requirement.
+- A `h_trickyToCarryFlashSuit` requirement, because being 1 frame late on the doorway Space Jump results in loss of a flash suit.
 
 ```json
 {
@@ -796,6 +803,7 @@ A `comeInBlueSpaceJumping` entrance condition indicates that Samus must come in 
 A `comeInBlueSpaceJumping` entrance condition must match with a `leaveSpaceJumping` on the other side of the door, with the following requirements:
   - The `blue` property of the matching `leaveSpaceJumping` must be "yes" or "any".
   - `SpeedBooster` and `SpaceJump` item requirements.
+  - A `h_trickyToCarryFlashSuit` requirement, because being 1 frame late on the doorway Space Jump results in loss of a flash suit.
   - There must exist a possible value of extra run speed satisfying any applicable constraints, including any `minExtraRunSpeed` or `maxExtraRunSpeed` properties in the entrance condition and/or exit condition, along with implicit constraints based on shortcharge skill and the effective runway length of the `remoteRunway` in the exit condition (see the [blue run speed table](#blue-run-speed-table)).
 
 ```json


### PR DESCRIPTION
Rooms with an interesting flash suit interaction :
- Big Boy Room: flash suit makes it hard to break the top seaweed while baby skipping counter-clockwise. Doing it clockwise should be an option. Using a Power Bomb can be another alternative (saw this on your stream yesterday @osse101 ). I'm not good enough at baby skipping to estimate how these variations would impact difficulty, so I just put `h_trickyToCarryFlashSuit` to be safe. It can be adjusted if there is a case that would be ok with just `complex`.
- Mother Brain Room: Destroying the Zebs or doing Ice Zeb Skip are both a bit awkward, seemed like `complex` level.
- Tourian Escape Room 4: Freezing the Pirates while climbing the left side is tricky. Killing them also seemed non-trivial (complex level).
- Tourian Hopper Room: going left-to-right, opening the door can be awkward if the Hoppers are still chasing you. Regardless of the entry strat (Morph roll, Screw, Squeeze under, or Tank damage) it always seemed possible to get the Hoppers stuck off-camera if moving cleanly/quickly enough; or if the Hoppers do follow, there can still be enough time to shoot it open. But it affects the difficulty enough that it seemed worth putting `h_complexToCarryFlashSuit` on all the left-to-right strats that have the Hoppers alive.

This also updates the docs to say that `leaveSpaceJumping` comes with an implicit `h_trickyToCarryFlashSuit` requirement. In my testing I saw that the case that you lose the flash suit is if you are exactly 1 frame late on the Space Jump, and it still happens even if you are holding forward. Since some applications may require a last-frame jump, this did seem like high risk since being off by 1 frame will make you lose it. It could probably be refined by putting this requirement in the room with the entrance condition (comeInSpaceJumping), only in cases needing a very late/low jump; but for now it seemed safest to just put it everywhere. Of course, `leaveSpinning` strats (even ones involving Space Jump) won't be affected, since those don't require a low jump.