### PR TITLE
Crocomire Norfair check flash suits

### DIFF
--- a/region/norfair/crocomire/Cosine Room.json
+++ b/region/norfair/crocomire/Cosine Room.json
@@ -83,7 +83,8 @@
           "steepUpTiles": 2,
           "steepDownTiles": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -130,7 +131,8 @@
         "ScrewAttack",
         {"cycleFrames": 255}
       ],
-      "farmCycleDrops": [{"enemy": "Metaree", "count": 2}]
+      "farmCycleDrops": [{"enemy": "Metaree", "count": 2}],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -212,7 +214,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -235,7 +238,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -255,7 +259,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}]
+      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -843,7 +843,8 @@
           {"ammo": {"type": "Missile", "count": 2}},
           {"ammo": {"type": "Super", "count": 2}}
         ]},
-        {"resourceCapacity": [{"type": "Missile", "count": 5}]}
+        {"resourceCapacity": [{"type": "Missile", "count": 5}]},
+        "h_complexToCarryFlashSuit"
       ],
       "setsFlags": ["f_DefeatedCrocomire"],
       "flashSuitChecked": true,

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -140,12 +140,13 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
       "link": [1, 1],
-      "name": "Leave ShineCharged, Croc Alive",
+      "name": "Leave Shinecharged, Croc Alive",
       "requires": [
         "h_CrocomireCameraFix",
         {"canShineCharge": {"usedTiles": 14, "openEnd": 1}},
@@ -204,7 +205,8 @@
       "name": "Base",
       "requires": [
         "f_DefeatedCrocomire"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -215,7 +217,8 @@
         "leaveWithDoorFrameBelow": {
           "height": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -230,7 +233,8 @@
           "leftPosition": -38.5,
           "rightPosition": 41.5
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -243,7 +247,8 @@
           "leftPosition": -21,
           "rightPosition": 11.5
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -329,7 +334,8 @@
         "comeInNormally": {},
         "comesThroughToilet": "any"
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -347,9 +353,13 @@
       "requires": [
         {"or": [
           "SpaceJump",
-          "Grapple"
+          {"and": [
+            "Grapple",
+            "h_midAirShootUp"
+          ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -358,7 +368,8 @@
       "requires": [
         "Gravity",
         {"acidFrames": 40}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -370,7 +381,8 @@
           "canWalljump",
           {"acidFrames": 15}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -379,7 +391,8 @@
       "requires": [
         "HiJump",
         {"acidFrames": 75}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -390,7 +403,8 @@
         "canTrickyJump",
         "can4HighMidAirMorph",
         {"acidFrames": 55}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 48,
@@ -435,7 +449,8 @@
       "requires": [
         "canLongCeilingBombJump",
         "canBePatient"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -447,6 +462,7 @@
         "canBeVeryPatient",
         {"obstaclesCleared": ["A"]}
       ],
+      "flashSuitChecked": true,
       "note": "Touch the item while remaining in artificial morph. Ceiling bomb jump back to the left, then use x-ray to cancel g-mode and obtain the item.",
       "devNote": "This strat alone would only require canBePatient, but it is only possible after Ceiling Bomb Jumping there, so it would be a combined 4 minutes."
     },
@@ -456,7 +472,8 @@
       "name": "Base",
       "requires": [
         "f_DefeatedCrocomire"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -471,7 +488,8 @@
           "canWalljump",
           "canSpringBallJumpMidAir"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -578,7 +596,8 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -588,9 +607,13 @@
         "f_DefeatedCrocomire",
         {"or": [
           "SpaceJump",
-          "Grapple"
+          {"and": [
+            "Grapple",
+            "h_midAirShootUp"
+          ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -604,7 +627,8 @@
           "canWalljump",
           {"acidFrames": 10}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -614,7 +638,8 @@
         "f_DefeatedCrocomire",
         "canWalljump",
         {"acidFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -625,7 +650,8 @@
         "canLateralMidAirMorph",
         "canWalljump",
         {"acidFrames": 35}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -637,7 +663,8 @@
         "can4HighMidAirMorph",
         "canTrickySpringBallJump",
         {"acidFrames": 25}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -654,7 +681,8 @@
             {"shinespark": {"frames": 5}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -666,6 +694,7 @@
         "canTrickyJump",
         "canWalljump"
       ],
+      "flashSuitChecked": true,
       "note": "With a precise enough jump, it's possible to avoid acid damage without a shinespark."
     },
     {
@@ -678,6 +707,8 @@
         "canInsaneJump",
         "canLateralMidAirMorph"
       ],
+      "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": "With a precise enough jump and a quick airball, it's possible to avoid acid damage without a shinespark or wall jump."
     },
     {
@@ -691,6 +722,7 @@
         "canInsaneJump"
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Use a Bomb or Power Bomb to boost Samus up onto the ledge.",
         "It helps to time the acid cycle to be high when making the final jump."
@@ -721,7 +753,8 @@
         "f_DefeatedCrocomire",
         "canLongCeilingBombJump",
         "canBePatient"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -734,7 +767,8 @@
           {"enemyDamage": {"enemy": "Crocomire", "type": "contact", "hits": 5}}
         ]}
       ],
-      "setsFlags": ["f_DefeatedCrocomire"]
+      "setsFlags": ["f_DefeatedCrocomire"],
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -748,6 +782,7 @@
         ]}
       ],
       "setsFlags": ["f_DefeatedCrocomire"],
+      "flashSuitChecked": true,
       "devNote": "Some farming will still be useful, but without dodging efficiently, many of the drops will be energy."
     },
     {
@@ -764,6 +799,7 @@
         {"resourceCapacity": [{"type": "Missile", "count": 10}]}
       ],
       "setsFlags": ["f_DefeatedCrocomire"],
+      "flashSuitChecked": true,
       "note": "Farming requires somewhat careful dodging in order to minimize energy drops.",
       "devNote": [
         "Crocomire does not have a farming phase until he has been hit twice.",
@@ -786,6 +822,7 @@
         ]}
       ],
       "setsFlags": ["f_DefeatedCrocomire"],
+      "flashSuitChecked": true,
       "note": [
         "The hitbox on Croc's mouth may cause direct hits to miss, so jumping and shooting Supers horizontally is recommended.",
         "While Crocomire's farmables may drop Supers, the rate is too low to rely on.",
@@ -809,6 +846,7 @@
         {"resourceCapacity": [{"type": "Missile", "count": 5}]}
       ],
       "setsFlags": ["f_DefeatedCrocomire"],
+      "flashSuitChecked": true,
       "note": [
         "This can be a very long fight if Crocomire is stingy with the farming phases.",
         "Farming requires careful dodging in order to minimize energy drops. Delay grabbing all of the drops until necessary to reduce the chance of running out of ammo."

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -110,7 +110,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -127,6 +128,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $0.8"
     },
     {
@@ -138,7 +140,8 @@
         "leaveWithGrappleSwing": {
           "blocks": [{"position": [8, 3], "note": "Closest Grapple block to the door"}]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -153,7 +156,8 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -178,7 +182,8 @@
           "requires": [{"shineChargeFrames": 5}]
         },
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -207,7 +212,8 @@
           "SpaceJump",
           "canLongIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -221,7 +227,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 40}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -258,7 +265,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -283,7 +291,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -307,7 +316,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -410,7 +420,8 @@
           "length": 10,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -439,7 +450,8 @@
       "id": 18,
       "link": [2, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -455,7 +467,8 @@
         {"shineChargeFrames": 5},
         "canShinechargeMovementComplex"
       ],
-      "endsWithShineCharge": true
+      "endsWithShineCharge": true,
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -468,7 +481,8 @@
           "h_crouchJumpDownGrab",
           "canSpringBallJumpMidAir"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -480,10 +494,31 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "devNote": [
         "This gets to the top left of the room without walljump or crouch jump.",
         "Avoiding a crouch jump could be useful for preserving a flash suit.",
         "FIXME: When we have a way to represent grapple teleporting with a shinecharge, that can also be useful here."
+      ]
+    },
+    {
+      "link": [2, 4],
+      "name": "Tricky Grapple Jump",
+      "entranceCondition": {
+        "comeInWithGrappleSwing": {
+          "blocks": [
+            {"position": [13, 5], "environment": "water", "note": "Mt. Everest"},
+            {"position": [7, 3], "note": "The Precious Room"}
+          ]
+        }
+      },
+      "requires": [
+        "canTrickyGrappleJump"
+      ],
+      "wallJumpAvoid": true,
+      "devNote": [
+        "This is only useful as a way to preserve a flash suit without Hi-Jump or wall jump.",
+        "FIXME: This can be possible from other rooms, with greater difficulty."
       ]
     },
     {
@@ -494,13 +529,15 @@
       "requires": [
         {"shineChargeFrames": 35},
         {"shinespark": {"frames": 40}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
       "link": [3, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -517,7 +554,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -528,7 +566,8 @@
           "Grapple",
           "canPreciseWalljump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -538,6 +577,7 @@
         "HiJump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Run and jump from the second-highest platform on the left."
     },
     {
@@ -547,6 +587,7 @@
       "requires": [
         "canTrickySpringBallJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Starting from the second-highest platform on the left, run and jump into a mid-air Spring Ball jump.",
         "It helps but is not required to then unmorph to reset fall speed."
@@ -561,6 +602,7 @@
         "canTrickyJump",
         "canLateralMidAirMorph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "With SpeedBooster equipped, run from the top left platform and jump into an airball to reach the top right platform.",
         "It helps but is not required to moonwalk against the wall to maximize the available runway."

--- a/region/norfair/crocomire/Grapple Tutorial Room 1.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 1.json
@@ -64,7 +64,8 @@
           "length": 10,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -79,7 +80,8 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -108,6 +110,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Build some run speed to jump to the opposite runway to open the door before shinesparking."
       ]
@@ -133,6 +136,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run into the room, using part of the runway to gain a shinecharge.",
         "Use the remaining runway to gain speed to jump across the room and leave with a shinecharge."
@@ -155,7 +159,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -175,7 +180,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -196,13 +202,15 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -231,6 +239,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Build some run speed to jump to the opposite runway to open the door before shinesparking."
       ]
@@ -256,6 +265,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run into the room, using part of the runway to gain a shinecharge.",
         "Use the remaining runway to gain speed to jump across the room and leave with a shinecharge."
@@ -278,7 +288,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -298,7 +309,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -319,7 +331,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -331,7 +344,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -348,7 +362,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -365,7 +380,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -377,7 +393,8 @@
           "length": 9,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/crocomire/Grapple Tutorial Room 2.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 2.json
@@ -78,7 +78,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -99,7 +100,8 @@
           "canLongIBJ",
           "canJumpIntoIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -110,8 +112,10 @@
         {"or": [
           "HiJump",
           "canWalljump"
-        ]}
-      ]
+        ]},
+        "h_midAirShootUp"
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -123,7 +127,8 @@
           "canPreciseWalljump",
           "SpeedBooster"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -131,7 +136,8 @@
       "name": "SpringBall Jump",
       "requires": [
         "canSpringBallJumpMidAir"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -191,7 +197,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -217,7 +224,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -242,7 +250,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -250,7 +259,8 @@
       "name": "Bomb Boost",
       "requires": [
         "canWallJumpBombBoost"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -301,17 +311,21 @@
         }
       },
       "requires": [
-        "canTrickyGrappleJump"
+        "canTrickyGrappleJump",
+        {"noFlashSuit": {}}
       ],
+      "flashSuitChecked": true,
       "devNote": [
-        "FIXME: Other setup rooms such as Moat are theoretically possible but seem unreasonably difficult?"
+        "FIXME: Other setup rooms such as Moat are theoretically possible but seem unreasonably difficult?",
+        "FIXME: Carrying a flash suit can be possible in some cases, though very difficult."
       ]
     },
     {
       "id": 10,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -336,6 +350,7 @@
         "leaveShinecharged": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: A Super door could still be unlocked as part of this strat, but Wave/Grapple would no longer help;",
         "there doesn't seem to be a way to model that interaction without making a separate strat."
@@ -361,7 +376,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -373,7 +389,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -390,6 +407,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $1.5"
     },
     {
@@ -401,7 +419,8 @@
         "leaveWithGrappleSwing": {
           "blocks": [{"position": [6, 4], "note": "Closest Grapple block to the door"}]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 12,

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -134,7 +134,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -156,6 +157,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure the Gamets up out of the water. It may be helpful to freeze them on the ascent to prevent them from separating and moving horizontally.",
         "Positioning is much easier with Morph; simply morph on the runway before they start separating.",
@@ -170,7 +172,8 @@
         {"simpleCycleFrames": 100},
         {"cycleFrames": 20}
       ],
-      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}]
+      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -238,6 +241,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Lure the Geemers up out of the water. It may be helpful to freeze them on the ascent to prevent them from separating and moving horizontally.",
         "At the top, position a Gamet flush with the central runway. Positioning is much easier with Morph; simply morph on the runway before they start separating.",
@@ -354,7 +358,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 56, "excessFrames": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -369,7 +374,8 @@
       "requires": [
         "canHorizontalShinespark",
         {"shinespark": {"frames": 54, "excessFrames": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -379,6 +385,7 @@
         {"notable": "Frozen Gamet Bridge"},
         "canTrickyUseFrozenEnemies"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Lead a Gamet up through the water and freeze it to cross the first moat.",
         "Freeze the Gamet before it starts moving left.",
@@ -396,6 +403,7 @@
         "canHorizontalDamageBoost",
         {"enemyDamage": {"enemy": "Gamet", "type": "contact", "hits": 2}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "1- Stand near the farm point, on the edge of where you make Gamets spawn.",
         "2- Wait for the water position to be high.",
@@ -421,6 +429,7 @@
         "canMockball",
         "canSpringBallBounce"
       ],
+      "flashSuitChecked": true,
       "note": [
         "With at least 6 tiles of run speed, jump over the first moat and MockBall into a regular springball jump over the second moat.",
         "Aim down before reaching the ceiling to increase the jump distance."
@@ -441,6 +450,7 @@
         "canMockball",
         "canSpringBallBounce"
       ],
+      "flashSuitChecked": true,
       "note": [
         "With around four tiles of run speed, jump over the first moat and MockBall into a regular springball jump over the second moat.",
         "SpeedBooster makes the jump possible with a shorter runway, but the trajectory is less predictable."
@@ -461,6 +471,7 @@
         "canMockball",
         "canSpringBallBounce"
       ],
+      "flashSuitChecked": true,
       "note": [
         "With at least two tiles of run speed, jump over the first moat by maximizing the jump distance and then MockBall into a regular springball to jump over the second moat."
       ]
@@ -514,6 +525,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "It is possible to use one set of the Grapple blocks in G-Mode. Generally the second moat is harder to cross so the logic is only allowing it there.",
         "FIXME: It may be possible to cross the whole room with Grapple in G-Mode, but it would be very hard."
@@ -533,7 +545,8 @@
           "canUseFrozenEnemies",
           "canGravityJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -546,7 +559,8 @@
           "canWalljump",
           "canLateralMidAirMorph"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -564,7 +578,8 @@
           "canWalljump",
           "canLateralMidAirMorph"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -583,7 +598,8 @@
           "canWalljump",
           "canLateralMidAirMorph"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -597,7 +613,8 @@
       },
       "requires": [
         "canCarefulJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -614,6 +631,7 @@
         ]},
         {"enemyDamage": {"enemy": "Gamet", "type": "contact", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "1- Stand near the farm point, on the edge of where you make Gamets spawn.",
         "2- Wait for the water position to be high.",
@@ -632,6 +650,7 @@
         "HiJump",
         "h_maxHeightSpringBallJump"
       ],
+      "flashSuitChecked": true,
       "note": "Wait for the water to be rising and perform a max height SpringBall Jump."
     },
     {
@@ -641,6 +660,7 @@
       "requires": [
         "canUnderwaterWalljumpBreakFree"
       ],
+      "flashSuitChecked": true,
       "note": "This may be easier by starting with a flatley jump from the lowest ledge.",
       "devNote": "This is likely never useful unless the Gamets are gone or Samus can't take a hit from them for some reason."
     },
@@ -726,7 +746,8 @@
           ]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -737,7 +758,8 @@
           "blockPositions": [[5, 3], [7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -749,7 +771,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -766,7 +789,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -783,7 +807,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -815,7 +840,8 @@
           "length": 4,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 31,
@@ -829,7 +855,8 @@
           "length": 7,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -878,7 +905,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -899,7 +927,8 @@
       "name": "Base",
       "requires": [
         {"obstaclesCleared": ["A"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -920,7 +949,8 @@
           ]}
         ]}
       ],
-      "resetsObstacles": ["B"]
+      "resetsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -943,13 +973,15 @@
         ]}
       ],
       "resetsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Kill either the leftmost puyo or jump into the right side of the water and fight all the puyos."
     },
     {
       "id": 42,
       "link": [4, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -983,7 +1015,8 @@
           ]},
           "canPreciseGrapple"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1004,7 +1037,8 @@
             "SpeedBooster"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1021,6 +1055,7 @@
           "Plasma"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Either freeze the Puyos immediately on the stairs, or at the highest part of their jump to barely jump up to the ledge with HiJump."
     },
     {
@@ -1038,6 +1073,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run and jump at the very edge of the center platform.",
         "Wait for the water level to begin lowering to walljump on the far edge.",
@@ -1047,13 +1083,14 @@
     {
       "id": 47,
       "link": [4, 3],
-      "name": "SpringFling",
+      "name": "Spring Fling",
       "requires": [
         "canCarefulJump",
         "canLateralMidAirMorph",
         "canSpringFling",
         "SpeedBooster"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 48,
@@ -1064,6 +1101,7 @@
         "canTrickyJump",
         "h_doubleSpringBallJumpWithHiJump"
       ],
+      "flashSuitChecked": true,
       "note": "Jump when the water level is at its lowest."
     },
     {

--- a/region/norfair/crocomire/Indiana Jones Room.json
+++ b/region/norfair/crocomire/Indiana Jones Room.json
@@ -1296,7 +1296,8 @@
       "requires": [
         {"notable": "Indiana Jones Grapple"},
         "canUseEnemies",
-        "canPreciseGrapple"
+        "canPreciseGrapple",
+        "h_midAirShootUp"
       ],
       "flashSuitChecked": true,
       "note": "Involves grappling off several Ripper 2."

--- a/region/norfair/crocomire/Indiana Jones Room.json
+++ b/region/norfair/crocomire/Indiana Jones Room.json
@@ -194,7 +194,8 @@
           "length": 10,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -212,7 +213,8 @@
       "requires": [
         {"doorUnlockedAtNode": 1}
       ],
-      "clearsObstacles": ["E"]
+      "clearsObstacles": ["E"],
+      "flashSuitChecked": true
     },
     {
       "id": 88,
@@ -234,7 +236,8 @@
         "ScrewAttack"
       ],
       "resetsObstacles": ["A", "B", "E"],
-      "farmCycleDrops": [{"enemy": "Ripper 2 (green)", "count": 4}]
+      "farmCycleDrops": [{"enemy": "Ripper 2 (green)", "count": 4}],
+      "flashSuitChecked": true
     },
     {
       "id": 117,
@@ -244,11 +247,13 @@
         "canUseEnemies",
         {"enemyDamage": {"enemy": "Ripper 2 (green)", "type": "contact", "hits": 2}},
         "Morph",
-        "SpringBall"
+        "SpringBall",
+        "h_trickyToCarryFlashSuit"
       ],
       "exitCondition": {
         "leaveWithSuperSink": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Swing counter-clockwise around the left-most Ripper closely (pressing up to retract Grapple),",
         "positioned as far left as possible while avoiding getting caught on the stalactite.",
@@ -276,7 +281,8 @@
         "canPreciseSpaceJump"
       ],
       "clearsObstacles": ["B"],
-      "note": "The blocks can be broken if you can generate a blue suit using the previous room's runway, and carry it to the blocks by slowing floating down with Space Jump."
+      "flashSuitChecked": true,
+      "note": "The blocks can be broken if you can generate blue speed using the previous room's runway, and carry it to the blocks by slowing floating down with Space Jump."
     },
     {
       "id": 4,
@@ -284,7 +290,8 @@
       "name": "Base",
       "requires": [
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -300,12 +307,13 @@
         "canWalljump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Jump with enough run speed to reach the wall below the Missile Item Location."
     },
     {
       "id": 6,
       "link": [1, 3],
-      "name": "Left-Side Enter with Shinespark",
+      "name": "Shinespark (Come in Shinecharged, Bootless)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -323,7 +331,7 @@
     {
       "id": 7,
       "link": [1, 3],
-      "name": "Left-Side Shinespark",
+      "name": "Shinespark (Come in Shinecharging, Bootless)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 9,
@@ -337,12 +345,13 @@
         "canMidairShinespark",
         {"shinespark": {"frames": 78}}
       ],
+      "flashSuitChecked": true,
       "note": "Takes three walljumps, and must shinespark at the apex."
     },
     {
       "id": 8,
       "link": [1, 3],
-      "name": "Left-Side Enter with Shinespark and HiJump",
+      "name": "Shinespark (Come in Shinecharged, HiJump)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -366,7 +375,7 @@
     {
       "id": 9,
       "link": [1, 3],
-      "name": "Left-Side HiJump Shinespark",
+      "name": "Shinespark (Come in Shinecharging, HiJump)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 9,
@@ -386,12 +395,13 @@
         "canMidairShinespark",
         {"shinespark": {"frames": 60}}
       ],
+      "flashSuitChecked": true,
       "note": "Walljump or build run speed using the full runway to jump high enough for the shinespark."
     },
     {
       "id": 10,
       "link": [1, 3],
-      "name": "Left Side Diagonal Shinespark",
+      "name": "Diagonal Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -416,15 +426,18 @@
       "requires": [
         {"notable": "Indiana Jones Grapple"},
         "canUseEnemies",
-        "canPreciseGrapple"
+        "canPreciseGrapple",
+        "h_midAirShootUp"
       ],
+      "flashSuitChecked": true,
       "note": "Grapple off several Ripper 2."
     },
     {
       "id": 12,
       "link": [1, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 89,
@@ -545,6 +558,7 @@
         ]},
         {"shinespark": {"frames": 85}}
       ],
+      "flashSuitChecked": true,
       "note": "Fire off the shinespark at the apex of two consecutive walljumps."
     },
     {
@@ -559,6 +573,7 @@
         {"shinespark": {"frames": 52}},
         "canDownGrab"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Charge a spark to the right, then come back, run and jump, and do a horizontal spark at the apex.",
         "If needed, down-grab onto the ledge."
@@ -575,6 +590,7 @@
         {"canShineCharge": {"usedTiles": 23, "gentleDownTiles": 6, "openEnd": 1}},
         {"shinespark": {"frames": 26}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Charge a spark to the right a specific distance of about 6 tiles past the broken Speed blocks.",
         "Then turn around, run and jump, and activate a diagonal spark as late as possible.",
@@ -595,7 +611,8 @@
             "canTrickySpringBallJump"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -608,7 +625,8 @@
           "HiJump"
         ]},
         {"obstaclesCleared": ["A", "B"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 80,
@@ -624,7 +642,8 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true
     },
     {
       "id": 81,
@@ -641,7 +660,8 @@
           "position": "bottom"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true
     },
     {
       "id": 82,
@@ -657,7 +677,8 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true
     },
     {
       "id": 83,
@@ -673,6 +694,7 @@
         "leaveWithSpark": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": [], "useImplicitRequires": false}],
+      "flashSuitChecked": true,
       "note": [
         "Store a shinecharge and start running below the left side of the vertical door, to set up the jump in a way that shinesparking at the apex of the jump approximately aligns with the top of the far door."
       ]
@@ -684,7 +706,8 @@
       "requires": [
         "h_usePowerBomb"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -694,7 +717,8 @@
         "h_getBlueSpeedMaxRunway",
         {"obstaclesCleared": ["A"]}
       ],
-      "clearsObstacles": ["B"]
+      "clearsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -704,6 +728,7 @@
         {"getBlueSpeed": {"usedTiles": 17, "openEnd": 0}}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Commonly known as a stutter-3, this is also doable as a 4-tap."
     },
     {
@@ -785,6 +810,7 @@
       ],
       "resetsObstacles": ["A", "B", "E"],
       "farmCycleDrops": [{"enemy": "Mella", "count": 5}],
+      "flashSuitChecked": true,
       "note": "Shoot the Mellas when they first begin to come on screen, and they will not move."
     },
     {
@@ -845,7 +871,8 @@
         "leaveWithDoorFrameBelow": {
           "height": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 31,
@@ -858,7 +885,8 @@
           "leftPosition": -1,
           "rightPosition": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -874,6 +902,7 @@
           "rightPosition": -1.5
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "With HiJump this can be used coming up Main Street, the bottom left of Mt. Everest, and The Beach.",
         "We could add other Power Bomb block platforms too (e.g. the lower ones, and on the right side), but they don't yet appear to have any application."
@@ -892,7 +921,8 @@
           "leftPosition": -23,
           "rightPosition": 22
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -909,6 +939,7 @@
           "rightPosition": -7
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "The tile next to the Power Bomb blocks is not counted as part of the jumpway, since using it would cause Samus to bonk.",
         "A tricky jump is required because of the difficulty of avoiding the Power Bomb blocks and still reaching the door."
@@ -928,6 +959,7 @@
           "rightPosition": 22
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "This strat is for avoiding the canTrickyJump requirement when jumping left-to-right, if the Power Bomb blocks can be destroyed.",
         "It also makes it possible to gain more speed by running a few tiles further, which is needed for certain strats."
@@ -1050,12 +1082,13 @@
           ]}
         ]},
         {"shinespark": {"frames": 40}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 40,
       "link": [2, 3],
-      "name": "Speedjump",
+      "name": "Speedy Jump",
       "requires": [
         {"obstaclesCleared": ["B"]},
         "SpeedBooster",
@@ -1064,6 +1097,24 @@
           "canSpringBallJumpMidAir",
           "canWalljump"
         ]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Tricky Dash Jump with HiJump",
+      "requires": [
+        {"obstaclesCleared": ["A", "B"]},
+        "SpeedBooster",
+        "HiJump",
+        "canTrickyDashJump"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Start running from about 1 to 2 tiles right of the door, and jump at the top of the ramp."
+      ],
+      "detailNote": [
+        "This needs extra run speed between $6.C and $6.F."
       ]
     },
     {
@@ -1075,7 +1126,8 @@
           "Morph",
           {"obstaclesCleared": ["B"]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -1246,13 +1298,15 @@
         "canUseEnemies",
         "canPreciseGrapple"
       ],
+      "flashSuitChecked": true,
       "note": "Involves grappling off several Ripper 2."
     },
     {
       "id": 49,
       "link": [3, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 50,
@@ -1260,7 +1314,8 @@
       "name": "Base",
       "requires": [
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -1268,7 +1323,8 @@
       "name": "Jump into IBJ",
       "requires": [
         "canJumpIntoIBJ"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 52,
@@ -1277,7 +1333,8 @@
       "requires": [
         "HiJump",
         "canSpringBallJumpMidAir"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -1289,6 +1346,7 @@
         "canWalljump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Run on the moving platform (Kamer)."
     },
     {
@@ -1297,7 +1355,8 @@
       "name": "Tricky Spring Wall",
       "requires": [
         "h_trickySpringwall"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 84,
@@ -1333,6 +1392,7 @@
           "Morph"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Lure a Mella from the right by breaking the speed blocks or using Morph.",
         "Then you need to manipulate it to go high enough to be used as a stepping stone once frozen."
@@ -1402,7 +1462,8 @@
           "Morph",
           {"obstaclesCleared": ["B"]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 58,
@@ -1412,13 +1473,14 @@
         {"notable": "Acid Shinespark"},
         "Gravity",
         "canSuitlessLavaDive",
+        "h_shinechargeMaxRunway",
         "canShinechargeMovement",
         "canHorizontalShinespark",
-        "h_shinechargeMaxRunway",
         {"acidFrames": 140},
         {"shinespark": {"frames": 35}}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": "Gravity makes it possible to charge a spark in the acid in order to break the speed blocks."
     },
     {
@@ -1446,7 +1508,7 @@
         {"getBlueSpeed": {"usedTiles": 12, "gentleDownTiles": 6, "openEnd": 1}}
       ],
       "clearsObstacles": ["B"],
-      "note": "Commonly known as a stutter-3, this is also doable as a 4-tap."
+      "flashSuitChecked": true
     },
     {
       "id": 59,
@@ -1457,17 +1519,19 @@
           "SpaceJump",
           "canLongIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 60,
       "link": [5, 3],
-      "name": "Speedjump SpringBall",
+      "name": "Speedy Jump Spring Ball Jump",
       "requires": [
         "HiJump",
         "canTrickyDashJump",
         "canTrickySpringBallJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 61,
@@ -1480,6 +1544,7 @@
         "canPreciseWalljump",
         "can3HighWallMidAirMorph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "A particularly precise springwall.",
         "Aim the walljump at the bottom of the second sloped wall fixture, where it looks like you cant jump off of.",
@@ -1507,6 +1572,7 @@
           "canSpringBallJumpMidAir"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Lure a Mella from the right by breaking the speed blocks or using Morph.",
         "Then you need to manipulate it to go high enough to be used as a stepping stone once frozen."
@@ -1524,7 +1590,10 @@
           "canWalljump",
           "HiJump",
           "canSpringBallJumpMidAir",
-          "canBeVeryPatient"
+          {"and": [
+            "canBeVeryPatient",
+            {"noFlashSuit": {}}
+          ]}
         ]},
         {"or": [
           "canTrickyDodgeEnemies",
@@ -1535,6 +1604,7 @@
           "Morph"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Lure a Mella from the right by breaking the speed blocks or using Morph.",
         "Then manipulate it to go high enough to be used as a stepping stone once frozen.",

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -150,7 +150,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -172,6 +173,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure the Gamets up; it may be helpful to freeze them on the ascent to prevent them from separating and moving horizontally.",
         "Freeze a Gamet at the correct height, and then use it as a platform to reach the door.",
@@ -212,6 +214,7 @@
         "leaveShinecharged": {}
       },
       "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run right-to-left to gain a shinecharge, then use between 1 and 2 tiles of remaining runway to gain speed to reach the top-left with a wall jump."
@@ -238,6 +241,7 @@
           "position": "bottom"
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run left-to-right to gain a shinecharge, then run back to the left to gain speed to reach the top-left."
@@ -265,6 +269,7 @@
           "position": "bottom"
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run left-to-right to gain a shinecharge, then run back to the left to gain speed to reach the top-left with a wall jump.",
@@ -336,7 +341,16 @@
       "id": 8,
       "link": [1, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Ripper Grapple",
+      "requires": [
+        "Grapple"
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -347,7 +361,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 43, "excessFrames": 8}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -410,16 +425,8 @@
       "requires": [
         {"shinespark": {"frames": 25, "excessFrames": 5}}
       ],
+      "flashSuitChecked": true,
       "note": "Enter on the far right side of the doorway to reach the ledge above."
-    },
-    {
-      "id": 11,
-      "link": [2, 2],
-      "name": "Leave Normally",
-      "requires": [],
-      "exitCondition": {
-        "leaveNormally": {}
-      }
     },
     {
       "id": 12,
@@ -462,6 +469,7 @@
         "canTrickyUseFrozenEnemies"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Stand next to the Gamet farm on the left side.",
         "Freeze the Gamets and destroy the second and third Gamet from the top.",
@@ -482,6 +490,7 @@
       "requires": [
         {"shinespark": {"frames": 15, "excessFrames": 15}}
       ],
+      "flashSuitChecked": true,
       "note": "Enter on the left side of the doorway to reduce the amount of energy used.",
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
@@ -489,7 +498,8 @@
       "id": 15,
       "link": [2, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -535,7 +545,8 @@
           "canLongIBJ",
           "canJumpIntoIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -543,8 +554,10 @@
       "name": "Ripper Grapple",
       "requires": [
         "canUseEnemies",
-        "Grapple"
+        "Grapple",
+        "h_midAirShootUp"
       ],
+      "flashSuitChecked": true,
       "note": "Involves grappling off a Ripper 2."
     },
     {
@@ -554,6 +567,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies"
       ],
+      "flashSuitChecked": true,
       "note": "Use the moving platform (Kamer) to elevate the Gamets and then freeze them."
     },
     {
@@ -564,6 +578,7 @@
         "HiJump",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Run on the moving platform (Kamer)."
     },
     {
@@ -575,6 +590,7 @@
         "canTrickyDashJump",
         "canWalljump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Doesn't require opening the bottom right door. Just using the available space and jumping late enough.",
         "It does require killing the Gamets and leaving the drops there so they don't kill your momentum."
@@ -588,6 +604,7 @@
         "canTrickyJump",
         "canTrickySpringBallJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run on the the moving platform into a midair spring ball jump as far horizontal as possible.",
         "Unmorph or spring fling to reset fall speed can help."
@@ -618,12 +635,13 @@
         ]},
         {"shinespark": {"frames": 25, "excessFrames": 5}}
       ],
-      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 59,
       "link": [3, 1],
-      "name": "Damage Boost",
+      "name": "Gamet Damage Boost",
       "requires": [
         {"notable": "Damage Boost"},
         "canTrickyJump",
@@ -634,6 +652,7 @@
         "canHorizontalDamageBoost",
         {"enemyDamage": {"enemy": "Gamet", "type": "contact", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the moving platform (Kamer) to elevate the Gamets, then damage boost off of them to get to the top left.",
         "Alternatively, it is possible to wall jump off of the right overhang and damage boost from the ceiling Ripper, but it is likely more difficult."
@@ -659,6 +678,7 @@
         "leaveShinecharged": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run left-to-right to gain a shinecharge, then run left and jump (just underneath the Kamer) to the top-left ledge without needing to wall jump."
@@ -687,7 +707,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 25}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -706,6 +727,7 @@
         "canDodgeWhileShooting",
         {"shinespark": {"frames": 25, "excessFrames": 5}}
       ],
+      "flashSuitChecked": true,
       "note": "Kill the Gamets with Wave Beam when entering the room."
     },
     {
@@ -773,7 +795,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -790,7 +813,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -807,7 +831,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -833,7 +858,8 @@
       "id": 61,
       "link": [3, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 62,
@@ -868,6 +894,7 @@
         {"nodeId": 3, "types": ["ammo"], "requires": []},
         {"types": ["ammo"], "requires": []}
       ],
+      "flashSuitChecked": true,
       "note": ["Leave Gamet drops uncollected to prevent them from respawning."]
     },
     {
@@ -881,7 +908,8 @@
           "openEnd": 0,
           "gentleUpTiles": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 78,
@@ -898,6 +926,7 @@
           "gentleDownTiles": 2
         }
       },
+      "flashSuitChecked": true,
       "note": "Involves leaving some drops hanging after killing the Gamets so they don't respawn."
     },
     {
@@ -908,7 +937,8 @@
         {"simpleCycleFrames": 90},
         {"cycleFrames": 20}
       ],
-      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}]
+      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -931,7 +961,8 @@
           "canWalljump",
           "canSpringBallJumpMidAir"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 66,
@@ -939,8 +970,10 @@
       "name": "Ripper Grapple",
       "requires": [
         "canUseEnemies",
-        "Grapple"
+        "Grapple",
+        "h_midAirShootUp"
       ],
+      "flashSuitChecked": true,
       "note": "Involves grappling off a Ripper 2."
     },
     {
@@ -950,6 +983,7 @@
       "requires": [
         "canUseFrozenEnemies"
       ],
+      "flashSuitChecked": true,
       "note": "Use the moving platform (Kamer) to elevate the Gamets and then freeze them."
     },
     {
@@ -1005,6 +1039,24 @@
       "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}]
     },
     {
+      "link": [3, 4],
+      "name": "Gamet Damage Boost",
+      "requires": [
+        {"notable": "Damage Boost"},
+        "canTrickyJump",
+        "canHorizontalDamageBoost",
+        {"enemyDamage": {"enemy": "Gamet", "type": "contact", "hits": 1}}
+      ],
+      "wallJumpAvoid": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Use the moving platform (Kamer) to elevate the Gamets, then damage boost off of the top one to get to the top right."
+      ],
+      "detailNote": [
+        "This is only useful as a way of carrying a flash suit, if wall jump cannot be used."
+      ]
+    },
+    {
       "id": 71,
       "link": [3, 4],
       "name": "Leave Shinecharged (HiJump)",
@@ -1053,6 +1105,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run left-to-right to gain a shinecharge.",
@@ -1072,7 +1125,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 25}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -1091,6 +1145,7 @@
         "canDodgeWhileShooting",
         {"shinespark": {"frames": 25}}
       ],
+      "flashSuitChecked": true,
       "note": "Kill the Gamets with Wave Beam when entering the room."
     },
     {
@@ -1143,7 +1198,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -1192,7 +1248,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -1262,6 +1319,36 @@
       "flashSuitChecked": true
     },
     {
+      "link": [4, 1],
+      "name": "Ripper Grapple",
+      "requires": [
+        "Grapple"
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [4, 1],
+      "name": "Ripper Damage Boost",
+      "requires": [
+        {"notable": "Damage Boost"},
+        "canTrickyJump",
+        "canHorizontalDamageBoost",
+        {"enemyDamage": {"enemy": "Ripper 2 (green)", "type": "contact", "hits": 1}}
+      ],
+      "wallJumpAvoid": true,
+      "flashSuitChecked": true,
+      "note": [
+        "Damage boost off the Ripper to reach the top-left of the room."
+      ],
+      "detailNote": [
+        "This is a faster but likely more difficult alternative to using a Gamet to damage boost."
+      ],
+      "devNote": [
+        "This can be uniquely useful if carrying a flash suit, if wall jump cannot be used,",
+        "since damage boosting off a Gamet would not be possible in that scenario."
+      ]
+    },
+    {
       "id": 40,
       "link": [4, 1],
       "name": "Come In With Spark",
@@ -1270,7 +1357,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 43, "excessFrames": 8}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -1318,7 +1406,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1335,7 +1424,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1352,7 +1442,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 46,
@@ -1379,7 +1470,8 @@
       "id": 50,
       "link": [4, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -1391,7 +1483,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 48,
@@ -1412,6 +1505,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Lure the Gamets up; it may be helpful to freeze them on the ascent to prevent them from separating and moving horizontally.",
         "At the top, freeze a Gamet while there is a half-tile gap between it and the runway in order to extend it as much as possible.",
@@ -1438,6 +1532,7 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run left-to-right to gain a shinecharge.",
@@ -1468,6 +1563,7 @@
           "position": "bottom"
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run left-to-right to gain a shinecharge.",
@@ -1494,6 +1590,7 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Leave Gamet drops uncollected to prevent them from respawning.",
         "Run left-to-right to gain a shinecharge.",
@@ -1517,7 +1614,8 @@
             }
           ]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 49,

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -1333,6 +1333,7 @@
       "requires": [
         {"notable": "Damage Boost"},
         "canTrickyJump",
+        "canTrickyDodgeEnemies",
         "canHorizontalDamageBoost",
         {"enemyDamage": {"enemy": "Ripper 2 (green)", "type": "contact", "hits": 1}}
       ],

--- a/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
+++ b/region/norfair/crocomire/Post Crocomire Power Bomb Room.json
@@ -62,7 +62,8 @@
           "length": 5,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -96,16 +97,18 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        {"heatFrames": 100}
-      ]
+        {"heatFrames": 40}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        {"heatFrames": 65}
-      ]
+        {"heatFrames": 70}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -130,7 +133,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/crocomire/Post Crocomire Save Room.json
+++ b/region/norfair/crocomire/Post Crocomire Save Room.json
@@ -61,7 +61,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -76,13 +77,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -141,7 +141,8 @@
           "length": 10,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -163,13 +164,15 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off a Viola and follow it to this door."
     },
     {
       "id": 3,
       "link": [1, 4],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -268,15 +271,6 @@
       ]
     },
     {
-      "id": 6,
-      "link": [2, 2],
-      "name": "Leave Normally",
-      "requires": [],
-      "exitCondition": {
-        "leaveNormally": {}
-      }
-    },
-    {
       "id": 7,
       "link": [2, 2],
       "name": "Shinespark",
@@ -287,6 +281,7 @@
       "requires": [
         {"shinespark": {"frames": 2, "excessFrames": 2}}
       ],
+      "flashSuitChecked": true,
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
@@ -324,7 +319,8 @@
       "id": 9,
       "link": [2, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -423,7 +419,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -440,7 +437,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -463,7 +461,8 @@
       "id": 15,
       "link": [3, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -522,7 +521,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -538,6 +538,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Use a Super to knock off a Viola and follow it to this door."
     },
     {
@@ -578,7 +579,8 @@
           {"cycleFrames": 60}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Viola", "count": 4}]
+      "farmCycleDrops": [{"enemy": "Viola", "count": 4}],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -612,12 +614,13 @@
           "SpaceJump",
           "canLongIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
       "link": [3, 4],
-      "name": "Shinespark",
+      "name": "Shinespark (Come in Shinecharging)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -626,12 +629,13 @@
       },
       "requires": [
         {"shinespark": {"frames": 58, "excessFrames": 2}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
       "link": [3, 4],
-      "name": "Enter with Shinespark",
+      "name": "Shinespark (Come in Shinecharged)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -650,6 +654,7 @@
         {"ammo": {"type": "Super", "count": 1}},
         "canBePatient"
       ],
+      "flashSuitChecked": true,
       "note": "Knock a Viola off of the middle platforms and ride it up the right wall by freezing it with Ice Beam."
     },
     {
@@ -699,6 +704,7 @@
         ]}
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Use a Super to knock a Viola off of the middle platforms and ride it up the right wall by freezing it.",
         "Once it reaches the top door, use another Super to knock it off again, and freeze it mid-air.",
@@ -787,8 +793,10 @@
         }
       },
       "requires": [
-        "canPreciseGrappleJump"
-      ]
+        "canPreciseGrappleJump",
+        {"noFlashSuit": {}}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -808,8 +816,10 @@
         }
       },
       "requires": [
-        "canTrickyGrappleJump"
+        "canTrickyGrappleJump",
+        {"noFlashSuit": {}}
       ],
+      "flashSuitChecked": true,
       "devNote": ["This appears not to be possible from Climb Supers Room?"]
     },
     {
@@ -821,13 +831,15 @@
           "blockPositions": [[7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 31,
       "link": [4, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -876,7 +888,8 @@
       "id": 32,
       "link": [4, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -896,7 +909,8 @@
         "leaveWithDoorFrameBelow": {
           "height": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 35,
@@ -909,7 +923,8 @@
           "leftPosition": -7,
           "rightPosition": 3.5
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 36,


### PR DESCRIPTION
- Post Croc Farm Room had the most interesting changes: using the Ripper to grapple across from top-left to top-right is always possible with a flash suit, but using it to get up from the bottom of the room requires "h_midAirShootUp". With a flash suit, damage boosting off the Ripper becomes logically significant, because you may not be able to use the Gamets. Boosting off a Gamet to the top-right also becomes a useful option.
- Heat frames in Post Croc Power Bomb Room seemed way off, so I updated them.
- Added a grapple jump strat in Grapple Beam Room which is only useful for carrying a flash suit.
- Added a "Tricky Dash Jump with Hi-Jump" strat in Indiana Jones Room to directly reach the item from the bottom-right with PB blocks cleared. It mostly only makes a difference logically if carrying a flash suit, since otherwise you could just shinespark, farming Mellas for energy.