### PR TITLE
grapple gate glitch flashsuit checked

### DIFF
--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -1214,6 +1214,7 @@
         "canTrickyJump"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Build up some run speed and then extend the Grapple Beam through the Blue Gate, while jumping, to open it from the wrong side."
       ]


### PR DESCRIPTION
Grapple Gate Glitch keeps flashsuit.

Am I understanding correctly that all the listed requirements for the tech don't "kill" the flashsuit (at least I think they don't? But that's mostly just guessing on my part, to be honest) and therefore the procedure is just to add the "checkedFlashSuit": true part and it's done?
