### PR TITLE
Croc Speedway: tighten some heat frames

### DIFF
--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -175,6 +175,7 @@
             "FIXME: It is possible to stored fall speed clip through the door at 3 by using a fast run speed turnaround to slide down the stairs."
           ]
         },
+        {"id": 3},
         {"id": 4},
         {"id": 6},
         {"id": 8}
@@ -272,7 +273,7 @@
       "link": [1, 5],
       "name": "Base",
       "requires": [
-        {"heatFrames": 130}
+        {"heatFrames": 125}
       ],
       "flashSuitChecked": true
     },
@@ -634,6 +635,39 @@
       "devNote": "Some frames added to account for spike RNG."
     },
     {
+      "link": [2, 3],
+      "name": "Base",
+      "requires": [
+        "h_getBlueSpeedMaxRunway",
+        {"simpleHeatFrames": 300},
+        {"heatFrames": 90},
+        {"or": [
+          "Wave",
+          {"heatFrames": 30}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 4],
+      "name": "Base",
+      "requires": [
+        "h_getBlueSpeedMaxRunway",
+        {"simpleHeatFrames": 300},
+        {"heatFrames": 80},
+        {"or": [
+          "Wave",
+          {"heatFrames": 20}
+        ]}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "devNote": [
+        "FIXME: it can be possible to get through tankless without Wave, with enough arm pumping, or a cross-room runway."
+      ]
+    },
+    {
       "id": 75,
       "link": [2, 4],
       "name": "G-Mode Setup - Get Hit By Multiviola, Complex Manipulation",
@@ -676,7 +710,8 @@
       "name": "Base",
       "requires": [
         "h_getBlueSpeedMaxRunway",
-        {"heatFrames": 380}
+        {"simpleHeatFrames": 300},
+        {"heatFrames": 80}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
@@ -1463,7 +1498,7 @@
       "link": [5, 1],
       "name": "Base",
       "requires": [
-        {"heatFrames": 160}
+        {"heatFrames": 145}
       ],
       "unlocksDoors": [
         {
@@ -1512,10 +1547,15 @@
       "requires": [
         "canTrickyJump",
         {"or": [
-          "HiJump",
-          "canPreciseWalljump"
-        ]},
-        {"heatFrames": 140}
+          {"and": [
+            "HiJump",
+            {"heatFrames": 120}
+          ]},
+          {"and": [
+            "canPreciseWalljump",
+            {"heatFrames": 130}
+          ]}
+        ]}
       ],
       "unlocksDoors": [
         {
@@ -1627,10 +1667,10 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 70},
+        {"shineChargeFrames": 65},
         "HiJump",
         "canShinechargeMovementComplex",
-        {"heatFrames": 120},
+        {"heatFrames": 100},
         {"shinespark": {"frames": 18, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -1652,11 +1692,11 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 90},
+        {"shineChargeFrames": 80},
         "canWalljump",
         "canShinechargeMovementComplex",
-        {"heatFrames": 135},
-        {"shinespark": {"frames": 16, "excessFrames": 0}}
+        {"heatFrames": 120},
+        {"shinespark": {"frames": 17, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {
@@ -1679,7 +1719,7 @@
       "requires": [
         {"shineChargeFrames": 100},
         "canShinechargeMovementComplex",
-        {"heatFrames": 145},
+        {"heatFrames": 135},
         {"shinespark": {"frames": 16, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -2038,11 +2078,195 @@
     {
       "id": 42,
       "link": [5, 6],
-      "name": "Base",
+      "name": "Tank or Dodge Cacatacs",
       "requires": [
-        {"heatFrames": 215}
+        {"heatFrames": 180},
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+            {"heatFrames": 20}
+          ]}
+        ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Try to jump over the Cacatacs without taking damage.",
+        "With unlucky RNG, a spike hit may be unavoidable."
+      ]
+    },
+    {
+      "link": [5, 6],
+      "name": "Cross While Farming (1 Cacatac)",
+      "requires": [
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+            {"heatFrames": 20}
+          ]},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"heatFrames": 40}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Wave",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 85,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            {"ammo": {"type": "Missile", "count": 1}},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 90,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            {"resourceAvailable": [{"type": "Super", "count": 1}]},
+            {"heatFrames": 90}
+          ]},
+          {"and": [
+            "Plasma",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 90,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            "Spazer",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 95,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            "Grapple",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 100,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            "ScrewAttack",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 100,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"heatFramesWithEnergyDrops": {
+            "frames": 135,
+            "drops": [{"enemy": "Cacatac", "count": 1}]
+          }}
+        ]},
+        {"heatFrames": 95}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Kill a Cacatac and collect its drop along the way.",
+        "There will be a risk of a spike hit unless the Cacatac is safely killed from above."
+      ]
+    },
+    {
+      "link": [5, 6],
+      "name": "Cross While Farming (2 Cacatacs)",
+      "requires": [
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+            {"heatFrames": 20}
+          ]},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"heatFrames": 40}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Wave",
+            {"or": [
+              "Spazer",
+              "Plasma"
+            ]},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 105,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "Plasma",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 115,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "canUseGrapple",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 125,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "Wave",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 135,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            {"ammo": {"type": "Missile", "count": 2}},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 135,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "Spazer",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 145,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "ScrewAttack",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 175,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"heatFramesWithEnergyDrops": {
+            "frames": 205,
+            "drops": [{"enemy": "Cacatac", "count": 2}]
+          }}
+        ]},
+        {"heatFrames": 95}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Kill both Cacatacs and collect their drops along the way.",
+        "There will be a risk of a spike hit unless the first Cacatac is safely killed from above."
+      ]
+    },
+    {
+      "link": [5, 6],
+      "name": "Cross While Farming (2 Cacatacs, Power Bomb)",
+      "requires": [
+        "h_usePowerBomb",
+        {"heatFramesWithEnergyDrops": {
+          "frames": 180,
+          "drops": [{"enemy": "Cacatac", "count": 2}]
+        }},
+        {"heatFrames": 95}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Use a Power Bomb to safely kill both Cacatacs, and collect their drops along the way."
+      ]
     },
     {
       "id": 82,
@@ -2150,11 +2374,196 @@
     {
       "id": 48,
       "link": [6, 5],
-      "name": "Base",
+      "name": "Tank or Dodge Cacatacs",
       "requires": [
-        {"heatFrames": 300}
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            "canTrickyJump",
+            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+            {"heatFrames": 20}
+          ]},
+          {"and": [
+            {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}},
+            {"heatFrames": 20}
+          ]}
+        ]},
+        {"heatFrames": 170}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "note": [
+        "Try to jump over the Cacatacs without taking damage.",
+        "With unlucky RNG, a spike hit may be unavoidable."
+      ]
+    },
+    {
+      "link": [6, 5],
+      "name": "Cross While Farming (1 Cacatac)",
+      "requires": [
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+            {"heatFrames": 20}
+          ]},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"heatFrames": 40}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            {"ammo": {"type": "Missile", "count": 1}},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 90,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            {"resourceAvailable": [{"type": "Super", "count": 1}]},
+            {"heatFrames": 90}
+          ]},
+          {"and": [
+            "Plasma",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 90,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            "Grapple",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 105,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            "ScrewAttack",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 105,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            "Wave",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 105,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"and": [
+            "Spazer",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 105,
+              "drops": [{"enemy": "Cacatac", "count": 1}]
+            }}
+          ]},
+          {"heatFramesWithEnergyDrops": {
+            "frames": 120,
+            "drops": [{"enemy": "Cacatac", "count": 1}]
+          }}
+        ]},
+        {"heatFrames": 60}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Kill a Cacatac and collect its drop along the way.",
+        "There will be a risk of a spike hit unless the first Cacatac is safely killed from below."
+      ]
+    },
+    {
+      "link": [6, 5],
+      "name": "Cross While Farming (2 Cacatac)",
+      "requires": [
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+            {"heatFrames": 20}
+          ]},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"heatFrames": 40}
+          ]}
+        ]},
+        {"or": [
+          {"and": [
+            "Plasma",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 115,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            {"ammo": {"type": "Missile", "count": 1}},
+            {"heatFramesWithEnergyDrops": {
+              "frames": 135,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "Grapple",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 135,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "Wave",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 145,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "Spazer",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 145,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            "ScrewAttack",
+            {"heatFramesWithEnergyDrops": {
+              "frames": 165,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }}
+          ]},
+          {"and": [
+            {"heatFramesWithEnergyDrops": {
+              "frames": 195,
+              "drops": [{"enemy": "Cacatac", "count": 2}]
+            }},
+            {"or": [
+              "canBeVeryPatient",
+              {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+              {"heatFrames": 30}              
+            ]}
+          ]}
+        ]},
+        {"heatFrames": 65}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Kill both Cacatacs and collect their drops along the way.",
+        "There will be a risk of a spike hit unless the first Cacatac is safely killed from below."
+      ]
+    },
+    {
+      "link": [6, 5],
+      "name": "Cross While Farming (2 Cacatacs, Power Bomb)",
+      "requires": [
+        "h_usePowerBomb",
+        {"heatFramesWithEnergyDrops": {
+          "frames": 170,
+          "drops": [{"enemy": "Cacatac", "count": 2}]
+        }},
+        {"heatFrames": 65}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Use a Power Bomb to safely kill both Cacatacs from below, and collect their drops along the way."
+      ]
     },
     {
       "id": 49,


### PR DESCRIPTION
- In the top part of the shaft, some of the "Carry Shinecharge" heat & shinecharge frames were tighter than the Base ones. They are adjusted now to be consistent.
- The Base strat for traversing past the Cacatacs bottom-to-top was very loose. It is tightened here, and strats are also added for farming the Cacs along the way.
- The Base strat for running along the speedway left-to-right seemed like a good candidate for `simpleHeatFrames`. It could be added for right-to-left strats as well.
- I added strats that use the speedway to go from the left door directly to either of the bottom-right doors, because the heat frames can be reduced quite a bit compared to assuming you make a stop at the floating platform junction. With Wave it becomes fairly reasonable to get to either of these doors tankless.