### PR TITLE
Green Maridia check flash suits pt. 3 (West Sand Hall, etc.)

### DIFF
--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -180,7 +180,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -193,7 +194,8 @@
             {"position": [7, 3], "environment": "water", "note": "Crumbling Grapple block"}
           ]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -286,13 +288,15 @@
       "requires": [
         "h_navigateUnderwater"
       ],
+      "flashSuitChecked": true,
       "note": "Jump from door platform to door platform while avoiding the sand."
     },
     {
       "id": 7,
       "link": [1, 4],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -316,13 +320,24 @@
       "id": 9,
       "link": [2, 2],
       "name": "Leave with Runway",
-      "requires": [],
+      "requires": [
+        {"or": [
+          "Gravity",
+          "canPrepareForNextRoom"
+        ]}
+      ],
       "exitCondition": {
         "leaveWithRunway": {
           "length": 8,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true,
+      "devNote": [
+        "Resetting the room through this door puts you in East Pants Room, which is full of water.",
+        "So effectively there is only one chance to use the runway, unless Gravity is available;",
+        "otherwise the player must circle around through Pants Room again, which would be fairly slow."
+      ]
     },
     {
       "id": 10,
@@ -364,6 +379,7 @@
       "requires": [
         "h_navigateUnderwater"
       ],
+      "flashSuitChecked": true,
       "note": "Jump from door platform to door platform while avoiding the sand."
     },
     {
@@ -418,13 +434,15 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 17,
       "link": [3, 4],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -448,6 +466,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "It is easy enough to get out of the sand without tech, because the strats only require briefly entering it, but it is there as turning around at the wrong time will make Samus sink."
     },
     {
@@ -473,6 +492,7 @@
           "canTrickyDodgeEnemies"
         ]}
       ],
+      "flashSuitChecked": false,
       "note": [
         "Use the grapple block to initiate a Grapple Jump to climb up to the higher level and above the water line.",
         "Aiming the Grapple Jump to line up with the one tile hole is difficult and Samus is moving at high speeds.",
@@ -523,6 +543,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": "It is easy enough to get out of the sand without tech, because the strats only require briefly entering it, but it is there as turning around at the wrong time will make Samus sink."
     },
     {
@@ -533,7 +554,8 @@
         "Gravity",
         "Grapple",
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -546,6 +568,7 @@
         "canCarefulJump",
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Break the grapple block, then jump on the sand to get through the hole.",
         "Break spin before touching the sand, and then spinjump to get a good jump off of the sand.",
@@ -555,7 +578,7 @@
     {
       "id": 23,
       "link": [4, 5],
-      "name": "Gravity MidAir SpringBall Jump",
+      "name": "Gravity Mid-Air Spring Ball Jump",
       "requires": [
         "Gravity",
         "Grapple",
@@ -563,12 +586,13 @@
         "canTrickyJump",
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": "Break spin before touching the sand, and then spinjump to get a good jump off of the sand."
     },
     {
       "id": 24,
       "link": [4, 5],
-      "name": "SandJump into IBJ",
+      "name": "Sand Jump into IBJ",
       "requires": [
         "Gravity",
         "Grapple",
@@ -578,18 +602,20 @@
         "can4HighMidAirMorph",
         "canStationarySpinJump"
       ],
+      "flashSuitChecked": true,
       "note": "Break spin before touching the sand, and then spinjump to get a good jump off of the sand."
     },
     {
       "id": 25,
       "link": [4, 5],
-      "name": "SpringBall IBJ",
+      "name": "Spring Ball IBJ",
       "requires": [
         "Gravity",
         "Grapple",
         "h_useSpringBall",
         "canJumpIntoIBJ"
       ],
+      "flashSuitChecked": true,
       "note": "Springball can keep Samus out of the sand.  Place the first bomb right after Samus begins falling back towards the sand."
     },
     {
@@ -604,6 +630,7 @@
         "canStationarySpinJump",
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gets above the grapple block by doing a well-positioned and well-timed Gravity jump following a good jump off the sand.",
         "It is also possible to do this off of a wall jump on the side immediately followed by a gravity jump.",
@@ -614,7 +641,7 @@
     {
       "id": 27,
       "link": [4, 5],
-      "name": "Suitless MidAir SpringBall Jump with HiJump",
+      "name": "Suitless Mid-Air Spring Ball Jump with HiJump",
       "requires": [
         "Grapple",
         "canSuitlessMaridia",
@@ -623,6 +650,7 @@
         "canPlayInSand",
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Requires a mid-air SpringBall jump off the sand.",
         "Break spin before touching the sand, and then spinjump to get a good jump off of the sand.",
@@ -641,6 +669,7 @@
         "canFlatleyJump",
         "canSunkenTileWideWallClimb"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a flatley turnaround jump to get Samus inside the gap during a spinjump.",
         "Samus must jump from the left side platform."
@@ -656,6 +685,7 @@
         "canTrickyGrappleJump",
         "canMidairWiggle"
       ],
+      "flashSuitChecked": false,
       "note": [
         "Use the grapple block to initiate a Grapple Jump to climb up to the higher level.",
         "Aiming the Grapple Jump to line up with the one tile hole is difficult and Samus is moving at high speeds."
@@ -680,6 +710,7 @@
           "canResetFallSpeed"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Using movement tricks to reduce fall speed even slightly can avoid touching the sand.",
         "A Flatley style turnaround over the grapple block hole reduces fall speed some, but also needs a down back or a tiny jump."
@@ -700,6 +731,7 @@
           "h_pauseAbuseMinimalReserveRefill"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The swarm of Menus will attack Samus at the top of the room. Tank them or kill them with Screw or Pseudo Screw.",
       "devNote": "FIXME: 5->2 strats could be added, including x-ray climb and g-mode."
     },
@@ -717,6 +749,7 @@
           {"enemyDamage": {"enemy": "Menu", "type": "contact", "hits": 1}}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "The swarm of Menus will attack Samus at the top of the room. Tank them, carefully dodge them, or kill them with Screw or Pseudo Screw.",
       "devNote": "The Menus prevent a reliable IBJ."
     },
@@ -741,6 +774,7 @@
           "h_pauseAbuseMinimalReserveRefill"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Watch for the water level to start falling to time the jump to escape at its lowest point.",
         "Then use SpaceJump to splash on top of the water.",
@@ -761,6 +795,7 @@
         "canLongIBJ",
         "canDoubleBombJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait the water tide to reach its peak, then crouch jump into a spring ball jump into an IBJ.",
         "Perform the spring ball jump near max height.",
@@ -780,7 +815,8 @@
       "name": "Underwater Walljump Break Free",
       "requires": [
         "canUnderwaterWalljumpBreakFree"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -814,7 +850,8 @@
       "id": 35,
       "link": [5, 4],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -830,6 +867,7 @@
         {"cycleFrames": 1120}
       ],
       "farmCycleDrops": [{"enemy": "Menu", "count": 6}],
+      "flashSuitChecked": true,
       "devNote": ["FIXME: Many other options are possible for movement and weapons."]
     }
   ],

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -93,6 +93,7 @@
         "f_ShaktoolDoneDigging"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "devNote": "Entering the room with the flag 'f_ShaktoolDoneDigging' set means that the sand blocks and Power Bomb blocks will not spawn."
     },
     {
@@ -105,7 +106,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -124,6 +126,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $2.5"
     },
     {
@@ -229,7 +232,8 @@
         ]}
       ],
       "resetsObstacles": ["A", "B"],
-      "farmCycleDrops": [{"enemy": "Shaktool", "count": 1}]
+      "farmCycleDrops": [{"enemy": "Shaktool", "count": 1}],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -280,7 +284,8 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
-      "setsFlags": ["f_ShaktoolDoneDigging"]
+      "setsFlags": ["f_ShaktoolDoneDigging"],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -305,7 +310,8 @@
       "name": "Base",
       "requires": [
         {"obstaclesCleared": ["A", "B"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -317,6 +323,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "setsFlags": ["f_ShaktoolDoneDigging"],
+      "flashSuitChecked": true,
       "note": "Let the Snails (Yards) dig through the sand and follow them. They will not dig while off screen or while Samus is facing them, even while morphed."
     },
     {
@@ -396,6 +403,7 @@
       "requires": [
         "h_ShaktoolVanillaFlag"
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "With the vanilla game behavior, grapple teleporting here does not set the flag 'f_ShaktoolDoneDigging', as Samus does not spend a frame on the right side of the room."
       ]
@@ -413,6 +421,7 @@
         "h_ShaktoolSymmetricFlag"
       ],
       "setsFlags": ["f_ShaktoolDoneDigging"],
+      "flashSuitChecked": true,
       "devNote": [
         "Grapple teleporting crosses the room, so it will set the flag 'f_ShaktoolDoneDigging', assuming that the game is modified to treat the room symmetrically with how the flag gets set."
       ]
@@ -430,6 +439,7 @@
         "h_ShaktoolVanillaFlag"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "devNote": [
         "With the vanilla game behavior, grapple teleporting here does not set the flag 'f_ShaktoolDoneDigging', as Samus does not spend a frame on the right side of the room."
       ]
@@ -448,6 +458,7 @@
       ],
       "bypassesDoorShell": true,
       "setsFlags": ["f_ShaktoolDoneDigging"],
+      "flashSuitChecked": true,
       "devNote": [
         "Grapple teleporting crosses the room, so it will set the flag 'f_ShaktoolDoneDigging', assuming that the game is modified to treat the room symmetrically with how the flag gets set."
       ]
@@ -470,6 +481,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "devNote": [
         "With the vanilla game behavior, grapple teleporting here does not set the flag 'f_ShaktoolDoneDigging', as Samus does not spend a frame on the right side of the room."
       ]
@@ -493,6 +505,7 @@
       },
       "bypassesDoorShell": true,
       "setsFlags": ["f_ShaktoolDoneDigging"],
+      "flashSuitChecked": true,
       "devNote": [
         "Grapple teleporting crosses the room, so it will set the flag 'f_ShaktoolDoneDigging', assuming that the game is modified to treat the room symmetrically with how the flag gets set."
       ]
@@ -515,6 +528,7 @@
         }
       },
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "devNote": [
         "With the vanilla game behavior, grapple teleporting here does not set the flag 'f_ShaktoolDoneDigging', as Samus does not spend a frame on the right side of the room."
       ]
@@ -538,6 +552,7 @@
       },
       "bypassesDoorShell": true,
       "setsFlags": ["f_ShaktoolDoneDigging"],
+      "flashSuitChecked": true,
       "devNote": [
         "Grapple teleporting crosses the room, so it will set the flag 'f_ShaktoolDoneDigging', assuming that the game is modified to treat the room symmetrically with how the flag gets set."
       ]
@@ -553,6 +568,7 @@
         "f_ShaktoolDoneDigging"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "devNote": "Entering the room with the flag 'f_ShaktoolDoneDigging' set means that the sand blocks and Power Bomb blocks will not spawn."
     },
     {
@@ -567,6 +583,7 @@
         "Gravity"
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Bounce the snails around the room in order to destroy the sand blocks, opening up the runway.",
         "A snail can be made to bounce in 3 ways: shooting it off a wall or ceiling, kicking it on the ground, or touching it while it is already bouncing.",
@@ -593,6 +610,7 @@
         ]}
       ],
       "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
       "note": [
         "Bounce the snails around the room in order to destroy the sand blocks, opening up the runway.",
         "Without Gravity, this requires greater caution as the water will slow Samus down and increase the risk of taking damage from a snail.",
@@ -615,7 +633,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -634,6 +653,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $1.F"
     },
     {
@@ -712,7 +732,8 @@
         ]}
       ],
       "resetsObstacles": ["A", "B"],
-      "farmCycleDrops": [{"enemy": "Yard", "count": 2}]
+      "farmCycleDrops": [{"enemy": "Yard", "count": 2}],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -791,6 +812,7 @@
         "leaveNormally": {}
       },
       "setsFlags": ["f_ShaktoolDoneDigging"],
+      "flashSuitChecked": true,
       "note": [
         "In the vanilla game, if the flag is not already set, entering from the right door immediately sets the flag, though the room must be reset for it to take effect.",
         "Resetting the room also fixes the camera, which gets broken in this state."

--- a/region/maridia/inner-green/Spring Ball Room.json
+++ b/region/maridia/inner-green/Spring Ball Room.json
@@ -65,7 +65,8 @@
           "length": 7,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -84,7 +85,8 @@
         "Gravity",
         "h_bombThings",
         "h_additionalBomb"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -92,7 +94,8 @@
       "name": "Spring Ball",
       "requires": [
         "h_useSpringBall"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -170,6 +173,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "It may be necessary to turn off Gravity Suit in order have more time to jump and morph underwater."
     },
     {
@@ -180,7 +184,8 @@
         "canSuitlessMaridia",
         "HiJump",
         "canSpringBallJumpMidAir"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -191,6 +196,7 @@
         "canSpaceJumpWaterBounce",
         "can4HighMidAirMorph"
       ],
+      "flashSuitChecked": true,
       "note": "Space jump while partially submerged for more time to mid-air morph."
     },
     {
@@ -202,6 +208,7 @@
         "canUnderwaterBombIntoSpringBallJump",
         "canWallJumpInstantMorph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wall jump until Samus is just below the water line and then morph and place a Bomb",
         "Use the brief moment during the Bomb explosion that knocks Samus upwards to setup a Springball jump to jump out of the water."
@@ -223,6 +230,7 @@
         "can4HighMidAirMorph",
         "canSpaceJumpWaterBounce"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform a canSunkenTileWideWallClimb to get to the water surface, then use space jump at the water surface.",
         "Then either use space jump when the water is low then a spring ball jump to escape, or space jump when the water is high into a tight midair morph."

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -90,6 +90,7 @@
           "id": 2,
           "devNote": "This link is only for sparking and G-Mode. All other strats should go 1 -> 5 -> 4 -> 2."
         },
+        {"id": 4},
         {"id": 5}
       ]
     },
@@ -141,7 +142,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -160,8 +162,15 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        {"shinespark": {"frames": 99, "excessFrames": 5}}
-      ]
+        {"or": [
+          {"shinespark": {"frames": 99, "excessFrames": 5}},
+          {"and": [
+            "canSuitlessMaridia",
+            {"shinespark": {"frames": 99, "excessFrames": 14}}
+          ]}          
+        ]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -173,7 +182,8 @@
       "requires": [
         "Gravity",
         {"shinespark": {"frames": 77, "excessFrames": 4}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -189,7 +199,8 @@
         "Gravity",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 76, "excessFrames": 4}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -207,6 +218,7 @@
         {"shinespark": {"frames": 82, "excessFrames": 14}},
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": "Jump onto the platform, then hold angle-down to straight jump and move right, activating the spark when Samus is about one tile deep into the sandfall."
     },
     {
@@ -226,6 +238,7 @@
         "canTrickyDashJump",
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run into the room using exactly 20 tiles of runway (with closed ends) in the other room, or up to 6 pixels more (getting extra run speed exactly $4.4).",
         "Jump on the last possible frame, and aim down as Samus approaches the overhang, to avoid bonking it.",
@@ -255,6 +268,7 @@
         "canTrickyDashJump",
         "canLateralMidAirMorph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run into the room using exactly 20 tiles of runway (with an open end) in the other room, or up to 11 pixels more or 1 pixel less (getting extra run speed $4.5 or $4.6).",
         "Jump toward the end of the runway, quickly aim down, and then morph when close to the ceiling.",
@@ -267,6 +281,35 @@
         "there is a significant amount of vertical speed to lose, even though it may not appear that way because of how the sandfalls push Samus down.",
         "It is technically possible to make it across with a speed of $4.4, but it requires a last-frame jump and a tight morph, and it would be easier in that case to just spin jump across and not morph.",
         "Speeds in the range from $4.0 - $4.3 give a spike in jump speed, resulting in an early ceiling bonk."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInWithSpringBallBounce": {
+          "speedBooster": true,
+          "movementType": "controlled",
+          "adjacentMinTiles": 12,
+          "remoteAndLandingMinTiles": [[7, 1]]
+        }
+      },
+      "requires": [
+        "canTrickySpringBallBounce",
+        "canSpringFling"
+      ],
+      "note": [
+        "Enter the room with a normalized extra run speed of $2.0,",
+        "which can be obtained by gaining max run speed with Speedbooster unequipped;",
+        "Speedbooster must then be reequipped before the transition.",
+        "Use Spring Ball to jump within about the last half tile of runway,",
+        "hold jump, and Samus should bounce off the floating block before the first Evir.",
+        "After the bounce, perform a spring fling by unequipping and re-equipping Spring Ball,",
+        "to make it easier to reach the pillar at the right of the room."
+      ],
+      "detailNote": [
+        "If jumping or bouncing from further left of the entrance runway,",
+        "an additional spring fling can be used to ensure Samus makes the bounce on the first floating block."
       ]
     },
     {
@@ -307,12 +350,85 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 4],
+      "name": "Speedy Jump",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 9.4375,
+          "maxTiles": 12.4375,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canTrickyJump",
+        "canTrickyDodgeEnemies"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Run into the room using between 10 and 12 tiles of runway,",
+        "and jump at some point after the transition, to reach the center of the room."
+      ],
+      "detailNote": [
+        "Enter with extra run speed between $2.9 and $3.3.",
+        "Speeds in the center part of this range more lenient in the jump timing,",
+        "allowing the jump at any time after the transition;",
+        "higher speeds require jumping near the edge of the platform;",
+        "lower speeds require landing on the single-tile floating block after the first Evir."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Tricky Dash Jump Airball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 6.4375,
+          "speedBooster": true
+        }
+      },
+      "requires": [
+        "canTrickyDashJump",
+        "canLateralMidAirMorph",
+        "canTrickyDodgeEnemies"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Run into the room using between 10 and 12 tiles of runway,",
+        "and jump at some point after the transition, to reach the center of the room."
+      ],
+      "detailNote": [
+        "Enter with extra run speed between $2.9 and $3.3.",
+        "Speeds in the center part of this range more lenient in the jump timing,",
+        "allowing the jump at any time after the transition;",
+        "higher speeds require jumping near the edge of the platform;",
+        "lower speeds require landing on the single-tile floating block after the first Evir."
+      ]
+    },
+    {
+      "link": [1, 4],
+      "name": "Cross Room Space Jump",
+      "entranceCondition": {
+        "comeInSpaceJumping": {
+          "speedBooster": true,
+          "minTiles": 26
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneJump"
+      ],
+      "note": [
+        "Space Jump into the room with extra run speed at least $5.2.",
+        "Land on the floating block before the first Evir."
+      ]
+    },
+    {
       "id": 10,
       "link": [1, 5],
       "name": "Base",
       "requires": [
         "Gravity"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -324,6 +440,7 @@
         "canTrickySpringBallJump",
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": "Time the springball jump to be just before Samus enters the sand."
     },
     {
@@ -343,6 +460,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Time a bomb to hit Samus when she is morphed, 1 pixel into the sand, inside a sandfall, and moving horizontally.",
         "There is a setup using a Sand IBJ to rise up the sandfall from the floor and Sandfall Bounce with the correct timing.",
@@ -366,6 +484,7 @@
         "canTrickyJump",
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain momentum in the room to the left, then jump at the edge of the runway in order to land on the first pillar.",
         "Requires a runway of at least 2 tiles (with no open end) in the adjacent room.",
@@ -388,6 +507,7 @@
         "canPlayInSand",
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain momentum in the room to the left, then jump after entering this room in order to land on the first pillar. Ensure that Speed Booster is disabled."
       ],
@@ -408,6 +528,7 @@
         "canPlayInSand",
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled.",
         "With a short runway of 4 tiles (with an open end) in the adjacent room, it is required to jump as late as possible at the edge of the runway in this room.",
@@ -433,6 +554,7 @@
         "canTrickySpringBallJump",
         "canSpringFling"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Enter with at least 1 tile of run speed from an air room, with Speedbooster unequipped.",
         "Jump from near the end of the runway (though a jump from 1-2 tiles away from the end can still work).",
@@ -457,6 +579,7 @@
         "HiJump",
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain momentum in the room to the left, then jump in this room in order to land on the first pillar. Ensure that Speed Booster is disabled.",
         "Requires a runway of only approximately 0.5 tiles in the adjacent room.",
@@ -473,7 +596,22 @@
       "requires": [
         "canCrossRoomJumpIntoWater"
       ],
+      "flashSuitChecked": true,
       "note": "Bomb boost through the doorway. Get the bomb boost while as close to the door transition as possible in order to get to the first pillar."
+    },
+    {
+      "link": [1, 5],
+      "name": "Cross Room Space Jump",
+      "entranceCondition": {
+        "comeInSpaceJumping": {
+          "speedBooster": true,
+          "minTiles": 8
+        }
+      },
+      "requires": [],
+      "note": [
+        "Space Jump into the room with extra run speed at least $2.4."
+      ]
     },
     {
       "id": 60,
@@ -499,8 +637,20 @@
         "comeInWithSpark": {}
       },
       "requires": [
-        {"shinespark": {"frames": 99, "excessFrames": 5}}
-      ]
+        {"or": [
+          {"shinespark": {"frames": 99, "excessFrames": 5}},
+          {"and": [
+            {"shinespark": {"frames": 99, "excessFrames": 29}},
+            "canPlayInSand"
+          ]},
+          {"and": [
+            {"shinespark": {"frames": 99, "excessFrames": 38}},
+            "canPlayInSand",
+            "canTrickyJump"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -512,7 +662,8 @@
       "requires": [
         "Gravity",
         {"shinespark": {"frames": 78, "excessFrames": 4}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -528,7 +679,8 @@
         "Gravity",
         "canHorizontalShinespark",
         {"shinespark": {"frames": 76, "excessFrames": 4}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -546,6 +698,7 @@
         {"shinespark": {"frames": 86, "excessFrames": 39}},
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": "Jump across to the first pillar, then hold angle-down to straight jump and move left, activating the spark up to about two tiles deep into the sandfall."
     },
     {
@@ -572,7 +725,8 @@
           "blockPositions": [[7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -584,7 +738,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 65,
@@ -611,6 +766,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Evir", "count": 1}],
+      "flashSuitChecked": true,
       "note": [
         "Jump out 1 tile from the ledge and fire angle-down shots at the closest Evir,",
         "to quickly kill it before it descends too far.",
@@ -668,6 +824,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Evir", "count": 3}],
+      "flashSuitChecked": true,
       "note": [
         "The Evirs must be killed quickly before they descend too far.",
         "It can help to fire at the Evirs from a safe distance",
@@ -704,6 +861,7 @@
         {"cycleFrames": 1440}
       ],
       "farmCycleDrops": [{"enemy": "Evir", "count": 2}],
+      "flashSuitChecked": true,
       "note": [
         "The Evirs must be killed quickly before they descend too far.",
         "With only Spazer available for damage, this is particularly tight.",
@@ -758,7 +916,8 @@
       "requires": [
         "Gravity",
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -771,7 +930,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -785,7 +945,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -796,6 +957,7 @@
         "canTrickyJump",
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": "It is possible to cross this segment with nothing. Cancel spin before hitting the sand, then get a good jump off the sand in multiple places."
     },
     {
@@ -814,6 +976,7 @@
         "canPlayInSand",
         "canTrickyDashJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run into the room using between 11 and 12 tiles of runway in the other room (extra run speed between $2.D and $3.1).",
         "Jump somewhat soon after entering the room, and land on the pillar just past the last Evir.",
@@ -846,6 +1009,7 @@
         "canLateralMidAirMorph",
         "canPlayInSand"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run into the room with an exact amount of speed, by using 7.5 tiles of runway or up to 4 pixels more (getting extra run speed exactly $2.3).",
         "After entering the room, jump from the last tile or two of runway, perform a lateral mid-air morph, and land on the pillar just past the last Evir."
@@ -870,6 +1034,7 @@
         "canInsaneJump",
         "canDownGrab"
       ],
+      "flashSuitChecked": true,
       "note": [
         "In the other room, gain run speed using at least 36 tiles (extra run speed at least $6.4), and Space Jump low through the door.",
         "Land on the block just past the last Evir."
@@ -938,7 +1103,8 @@
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}},
           "h_pauseAbuseMinimalReserveRefill"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -954,6 +1120,7 @@
           "canInsaneJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Enter on the right side of the transition and move left to avoid damage.",
       "devNote": [
         "Entering from a non-sand room makes the suitless+hijumpless dodge only possible with a walljump.",
@@ -967,7 +1134,8 @@
       "requires": [
         "Gravity",
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -984,7 +1152,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -998,7 +1167,8 @@
           "canCarefulJump",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1019,6 +1189,7 @@
           "canTrickyDodgeEnemies"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform multiple stationary lateral mid-air morphs, while avoiding the Evir projectiles, to cross the room.",
         "It is necessary to start the jumps from the far side of the platforms in order to gain more horizontal momentum before entering the sand falls.",
@@ -1037,6 +1208,7 @@
         "canTrickyJump",
         "canTrickyUseFrozenEnemies"
       ],
+      "flashSuitChecked": true,
       "note": [
         "From the sand fall, quickly get onto the left platform to prevent the right side Evir from lowering too far.",
         "Freeze the right Evir, then jump on the sand to the right while shooting ice over the first Evir to also freeze the second.",
@@ -1062,7 +1234,8 @@
       "requires": [
         "Gravity",
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 48,
@@ -1084,7 +1257,8 @@
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1098,7 +1272,8 @@
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 50,
@@ -1117,6 +1292,7 @@
           "canTrickyDodgeEnemies"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The first Spring Ball jump is performed farther away from the sand tile so Samus can build up momentum and height before entering the sand fall.",
         "The second jump must be made from the right half of the solid tile (but not the rightmost pixels.)",
@@ -1136,6 +1312,7 @@
         "canTrickyJump",
         "canTrickyUseFrozenEnemies"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Freeze the Evir quickly before it descends and use it to get to the platforms.",
         "Getting a good jump while on the right side of the floating block can get Samus to the leftmost block.",
@@ -1169,6 +1346,7 @@
           "h_pauseAbuseMinimalReserveRefill"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the projectile from a fully submerged Evir to boost Samus into the sandfall, providing just enough height to make the first and hardest jump.",
         "Time the projectile to hit Samus when at the maximum height from a jump.",
@@ -1188,7 +1366,8 @@
           "canPlayInSand",
           "HiJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -1227,7 +1406,8 @@
       "requires": [
         "Gravity",
         "SpaceJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 56,
@@ -1244,7 +1424,8 @@
           "canTrickyJump",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 57,
@@ -1280,6 +1461,7 @@
         "canStationaryLateralMidAirMorph",
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform multiple stationary lateral mid-air morphs, while avoiding the Evir projectiles, to cross the room.",
         "It is necessary to start the jumps from the far side of the platforms in order to gain more horizontal momentum before entering the sand falls.",

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -614,6 +614,23 @@
       ]
     },
     {
+      "link": [1, 5],
+      "name": "Cross Room Space Jump into Airball",
+      "entranceCondition": {
+        "comeInSpaceJumping": {
+          "speedBooster": false,
+          "minTiles": 6.4375
+        }
+      },
+      "requires": [
+        "canLateralMidAirMorph",
+        "canTrickyJump"
+      ],
+      "note": [
+        "Space Jump into the room with max run speed without Speed Booster, then quickly airball after the transition."
+      ]
+    },
+    {
       "id": 60,
       "link": [1, 5],
       "name": "Use Flash Suit",


### PR DESCRIPTION
These remaining rooms seemed fairly straightforward. West Sand Hall was the only one with significant changes:
- Tightened shinespark excessFrames in the suitless comeInWithSpark strats.
- Added strats that use cross-room momentum to reach the center of the room from the left. A flash suit can then be used to reach the right door with much less energy than sparking across the whole room.
- Also added a cross-room space jump strat to reach the first pillar (node 5) from the left, which can be useful even without a flash suit.

For the Insane grapple jump strats in Pants Room, I didn't try to figure out how a flash suit affects the difficulty, because I couldn't manage to do the strat even when not carrying a flash suit :shrug: So I left that as `flashSuitChecked` false.