### PR TITLE
Norfair East check flash suits pt. 1 (Cathedral)

### DIFF
--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -109,7 +109,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -130,7 +131,8 @@
         {"cycleFrames": 300}
       ],
       "resetsObstacles": ["A"],
-      "farmCycleDrops": [{"enemy": "Skree", "count": 3}]
+      "farmCycleDrops": [{"enemy": "Skree", "count": 3}],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -144,7 +146,8 @@
           "canSpringBallJumpMidAir"
         ]},
         {"heatFrames": 350}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -154,6 +157,7 @@
         "canTrickyUseFrozenEnemies",
         {"heatFrames": 260}
       ],
+      "flashSuitChecked": true,
       "note": ["Freeze the middle Skree mid-air to use it as a platform."]
     },
     {
@@ -165,6 +169,7 @@
         "canTrickyJump",
         {"heatFrames": 220}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Shoot the Skree and shotblock from the door.",
         "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be."
@@ -179,6 +184,7 @@
         "canTrickyJump",
         {"heatFrames": 200}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Shoot the Skree and shotblock from the door.",
         "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be."
@@ -193,6 +199,7 @@
         "canTrickyJump",
         {"heatFrames": 240}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Shoot the Skree and shotblock from the door.",
         "While avoiding Skree projectiles, jump to the next bubble platform followed by jumping directly up where the shot block used to be,",
@@ -223,12 +230,16 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room with a Missile selected on auto-cancel, holding angle-up.",
         "Fire a Missile shot to kill the first Skree, then run right and immediately fire a beam shot to destroy the shot block.",
         "Run off the edge and down-grab onto the next platform.",
         "Run and jump directly up where the shot block used to be, moving quickly enough to dodge the Skree projectiles by going under them.",
         "Use a wall jump, HiJump, or a mid-air spring ball jump to make it up."
+      ],
+      "devNote": [
+        "FIXME: this can be done without a Missile (only Power Beam) with only about 5 more heat frames."
       ]
     },
     {
@@ -238,7 +249,8 @@
       "requires": [
         "canJumpIntoRespawningBlock",
         {"heatFrames": 625}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -256,6 +268,7 @@
         {"heatFrames": 300},
         {"shinespark": {"frames": 14, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "note": "Shoot diagonally to clear the Skree and shot block before jumping and sparking diagonally mid-air to the above area."
     },
     {
@@ -305,7 +318,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -340,7 +354,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -357,7 +372,8 @@
           "blockPositions": [[12, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -374,7 +390,8 @@
           "blockPositions": [[12, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -404,7 +421,8 @@
             {"enemyDamage": {"enemy": "Skree", "type": "contact", "hits": 1}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -428,6 +446,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": "Fall through the shot blocks and shoot around the Skree to open the door without falling into the lava to shinespark out of the room."
     },
     {
@@ -482,7 +501,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -494,7 +514,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -511,7 +532,8 @@
           "blockPositions": [[2, 18]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -528,7 +550,8 @@
           "blockPositions": [[2, 19]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -541,6 +564,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "The blocks respawn, so no need to split this in two runways.",
         "While waiting for respawn would take additional heat frames, the spawner makes that more or less inconsequential."
@@ -556,6 +580,7 @@
         {"heatFrames": 160}
       ],
       "resetsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "Destroy the shot block by standing on top of it, jumping, aiming down, and shooting at the moment that you land.",
         "This requires precision because the beam projectile will immediately despawn while off-camera.",
@@ -575,6 +600,7 @@
         ]},
         {"partialRefill": {"type": "Energy", "limit": 50}}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "The first farm is built into this strat to allow for the pause abuse.",
         "Leniency replaces the need for a tech to fire an accurate shot to hit the Gamets."
@@ -586,7 +612,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 50}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -602,6 +629,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": [
         "The blocks respawn, so no need to split this in two runways.",
         "While waiting for respawn would take additional heat frames, the spawner makes that more or less inconsequential."
@@ -631,7 +659,8 @@
         {"simpleCycleFrames": 90},
         {"cycleFrames": 20}
       ],
-      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}]
+      "farmCycleDrops": [{"enemy": "Gamet", "count": 5}],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -651,6 +680,7 @@
         {"cycleFrames": 100}
       ],
       "farmCycleDrops": [{"enemy": "Gamet", "count": 5}],
+      "flashSuitChecked": true,
       "note": "When off-camera, the Gamets still spawn but cannot be destroyed with beams or other projectiles."
     }
   ],

--- a/region/norfair/east/Bubble Mountain Save Room.json
+++ b/region/norfair/east/Bubble Mountain Save Room.json
@@ -61,7 +61,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -76,13 +77,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -342,7 +342,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -365,6 +366,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Place a Power Bomb on the bottom stair attached to the door in order to prevent killing the Sova, or free a Sova from the Morph maze with Bombs.",
         "If coming from below, be sure to lure the Sova to the bottom before placing a Power Bomb near the blocks in order to prevent killing it.",
@@ -380,7 +382,8 @@
         "leaveWithGrappleSwing": {
           "blocks": [{"position": [9, 2], "note": "Closest Grapple block to the door"}]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -427,7 +430,7 @@
     {
       "id": 6,
       "link": [1, 2],
-      "name": "Leave Shinecharged",
+      "name": "Come in Shinecharging, Leave Shinecharged",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
@@ -473,6 +476,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Use X-ray to cancel the shinecharge, in order to quickly destroy the Waver before taking a hit.",
         "Alternatively, run, jump, or slide off the edge, using a pause buffer to morph.",
@@ -522,6 +526,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Use X-ray to cancel the shinecharge, in order to quickly destroy the Waver before taking a hit.",
         "Alternatively, run, jump, or slide off the edge, using a pause buffer to morph.",
@@ -548,6 +553,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Use X-ray to cancel the shinecharge, in order to quickly destroy the Waver before taking a hit.",
         "Alternatively, run, jump, or slide off the edge, using a pause buffer to morph.",
@@ -578,6 +584,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Use X-ray to cancel the shinecharge, in order to quickly destroy the Waver before taking a hit.",
         "Alternatively, run, jump, or slide off the edge, using a pause buffer to morph.",
@@ -605,6 +612,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Destroy the Cac by touching it while in aim-down pose; enter a speedball for a moment, before unmorphing past the two half-tile dropoffs.",
         "Alternatively, if enough run speed is available, it is also an option to airball over the Cac."
@@ -617,6 +625,7 @@
       "requires": [
         "Grapple"
       ],
+      "flashSuitChecked": true,
       "note": "Kill King Cac by scrolling the camera before Grappling across."
     },
     {
@@ -635,6 +644,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "King Cac can be killed by scrolling the camera before jumping across."
     },
     {
@@ -662,7 +672,8 @@
             {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -674,6 +685,7 @@
         "canCameraManip"
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": "Kill King Cac by scrolling the camera, before attempting the jump."
     },
     {
@@ -695,6 +707,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "King Cac can be killed by scrolling the camera before jumping across."
     },
     {
@@ -712,6 +725,7 @@
           {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "King Cac can be killed by scrolling the camera before jumping across."
     },
     {
@@ -723,6 +737,7 @@
         "canHorizontalDamageBoost",
         {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": "Damage Boost off a Waver to cross the gap."
     },
     {
@@ -734,7 +749,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 42, "excessFrames": 22}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -784,6 +800,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Destroy the Cac by touching it while in aim-down pose; enter a speedball for a moment, before unmorphing past the two half-tile drops.",
         "Alternatively, if enough run speed is available, it is also an option to airball over the Cac."
@@ -807,6 +824,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": ["Destroy the Cac by bouncing on it with a controlled blue spring ball bounce."]
     },
     {
@@ -825,13 +843,15 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
       "link": [1, 9],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -856,6 +876,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies"
       ],
+      "flashSuitChecked": true,
       "note": "Freeze the Wavers on entry, as their initial pattern makes climbing much easier."
     },
     {
@@ -1132,7 +1153,8 @@
       },
       "requires": [
         "canPreciseGrappleJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 209,
@@ -1153,7 +1175,8 @@
       },
       "requires": [
         "canTrickyGrappleJump"
-      ]
+      ],
+      "flashSuitChecked": false
     },
     {
       "id": 212,
@@ -1612,7 +1635,8 @@
       },
       "requires": [
         "canTrickyJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -1631,7 +1655,8 @@
           "ScrewAttack",
           {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -1648,7 +1673,8 @@
         "canTrickySpringBallJump",
         "canNeutralDamageBoost",
         {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -1673,7 +1699,8 @@
             {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -1697,7 +1724,8 @@
             {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -1721,7 +1749,8 @@
             {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1735,7 +1764,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 22, "excessFrames": 2}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1773,7 +1803,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -1818,6 +1849,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": "The 2 in-room runway tiles are unusable, since at the minimal speed ($2.6) it is necessary to jump either through the transition or on the first frame after, to avoid bonking the ledge below the Cacatac."
     },
     {
@@ -1838,13 +1870,15 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 48,
       "link": [2, 9],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1906,7 +1940,8 @@
       "requires": [
         "canShinechargeMovementComplex",
         {"shinespark": {"frames": 20, "excessFrames": 2}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -1921,7 +1956,8 @@
       "requires": [
         "canShinechargeMovement",
         {"shinespark": {"frames": 39}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -1951,8 +1987,10 @@
         }
       },
       "requires": [
-        "canPreciseGrappleJump"
-      ]
+        "canPreciseGrappleJump",
+        "h_trickyToCarryFlashSuit"
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 211,
@@ -1973,7 +2011,8 @@
       },
       "requires": [
         "canTrickyGrappleJump"
-      ]
+      ],
+      "flashSuitChecked": false
     },
     {
       "id": 55,
@@ -2084,7 +2123,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 59,
@@ -2096,7 +2136,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 60,
@@ -2110,7 +2151,8 @@
           "length": 6,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 61,
@@ -2125,6 +2167,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Be sure to lure the Sova to the bottom before placing a Power Bomb near the blocks in order to prevent killing it.",
       "devNote": "This is only useful if the blocks are broken, but if they are not broken the longer runway can be used."
     },
@@ -2196,6 +2239,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Lay the Power Bomb low enough to kill the Sova.",
         "Descend during the Power Bomb explosion, to take advantage of the more lenient timing provided by the lag."
@@ -2212,7 +2256,8 @@
       },
       "requires": [
         "canMoonfall"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 181,
@@ -2234,6 +2279,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Lay the Power Bomb low enough to kill the Sova.",
         "Descend during the Power Bomb explosion, to take advantage of the more lenient timing provided by the lag."
@@ -2259,7 +2305,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 64,
@@ -2275,6 +2322,7 @@
         "canShinechargeMovementComplex",
         {"shinespark": {"frames": 26}}
       ],
+      "flashSuitChecked": true,
       "note": "Diagonal spark from the Save Room Door steps."
     },
     {
@@ -2311,13 +2359,15 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 66,
       "link": [3, 9],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 67,
@@ -2409,6 +2459,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": "The canBeVeryPatient requirement is for difficulty placement"
     },
     {
@@ -2465,6 +2516,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": "The canBeVeryPatient requirement is for difficulty placement"
     },
     {
@@ -2477,7 +2529,8 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 74,
@@ -2496,6 +2549,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Starting from the top of the room will require careful manipulation of the Sovas.",
         "If going through the Power Bomb blocks, place the Power Bomb on the lowest stair on the ledge above,",
@@ -2532,7 +2586,8 @@
         ]}
       ],
       "resetsObstacles": ["A"],
-      "farmCycleDrops": [{"enemy": "Sova", "count": 1}]
+      "farmCycleDrops": [{"enemy": "Sova", "count": 1}],
+      "flashSuitChecked": true
     },
     {
       "id": 76,
@@ -2607,7 +2662,8 @@
       "id": 79,
       "link": [4, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 204,
@@ -2623,6 +2679,7 @@
         "canFreeFallClip"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Use two frozen Sovas to moonfall and clip down past the door shell.",
         "One of the Sovas behind the bomb blocks will need to be released using a bomb or Power Bomb.",
@@ -2694,7 +2751,8 @@
           "direction": "right"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 82,
@@ -2708,7 +2766,8 @@
       "requires": [
         "canMoonfall"
       ],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 187,
@@ -2732,6 +2791,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": "The canBeVeryPatient requirement is for difficulty placement"
     },
     {
@@ -2756,13 +2816,15 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": "The canBeVeryPatient requirement is for difficulty placement"
     },
     {
       "id": 83,
       "link": [5, 4],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 84,
@@ -2808,15 +2870,6 @@
       "flashSuitChecked": true
     },
     {
-      "id": 86,
-      "link": [5, 5],
-      "name": "Leave Normally",
-      "requires": [],
-      "exitCondition": {
-        "leaveNormally": {}
-      }
-    },
-    {
       "id": 87,
       "link": [5, 5],
       "name": "Shinespark",
@@ -2827,6 +2880,7 @@
       "requires": [
         {"shinespark": {"frames": 12, "excessFrames": 12}}
       ],
+      "flashSuitChecked": true,
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
@@ -2859,6 +2913,7 @@
         ]}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": "It is possible to go through the Morph Maze with a single Power Bomb, placed low enough to not break A, but this isn't very useful."
     },
     {
@@ -2872,7 +2927,8 @@
           "h_useSpringBall",
           "canIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 91,
@@ -2916,7 +2972,8 @@
         "canMidairShinespark",
         "canShinechargeMovementComplex",
         {"shinespark": {"frames": 30, "excessFrames": 6}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 94,
@@ -2976,7 +3033,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 95,
@@ -2988,7 +3046,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 96,
@@ -3005,7 +3064,8 @@
           "blockPositions": [[2, 28]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 97,
@@ -3022,7 +3082,8 @@
           "blockPositions": [[2, 29]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 98,
@@ -3061,7 +3122,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 99,
@@ -3073,7 +3135,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 100,
@@ -3090,7 +3153,8 @@
           "blockPositions": [[2, 34]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 191,
@@ -3111,6 +3175,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Lay the Power Bomb low enough to kill the Sova.",
         "Descend during the Power Bomb explosion, to take advantage of the more lenient timing provided by the lag."
@@ -3136,7 +3201,8 @@
           "direction": "any"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 101,
@@ -3148,7 +3214,8 @@
           "length": 5,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 102,
@@ -3176,7 +3243,8 @@
       "id": 104,
       "link": [6, 7],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 105,
@@ -3264,7 +3332,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 109,
@@ -3308,7 +3377,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 110,
@@ -3343,12 +3413,13 @@
       "name": "Base",
       "requires": [
         "Grapple"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 112,
       "link": [7, 1],
-      "name": "Springball Bounce",
+      "name": "Spring Ball Bounce",
       "requires": [
         "canCarefulJump",
         "canSpringBallBounce",
@@ -3358,6 +3429,7 @@
           "canTrickyJump"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the full runway of the top-right door to jump to the ledge below the Cacatac and mockball on it.",
         "Either full jump from the left side of this platform, or do a small hop followed by a big jump to cross the gap.",
@@ -3374,6 +3446,7 @@
       "requires": [
         {"shinespark": {"frames": 41, "excessFrames": 2}}
       ],
+      "flashSuitChecked": true,
       "devNote": "Ending the spark earlier takes a hit from the Waver"
     },
     {
@@ -3412,6 +3485,7 @@
         "canCarefulJump",
         {"shinespark": {"frames": 30, "excessFrames": 6}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Dealing with spikes is up to luck.",
         "It is possible to shoot the Cacatac while jumping towards it."
@@ -3443,6 +3517,7 @@
           {"ammo": {"type": "Super", "count": 2}}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Kill the Cacatac and quickly jump over to its platform.",
         "Shoot towards the top-left door to open it, then follow the shot by jumping over the pit before initiating the shinespark."
@@ -3457,6 +3532,7 @@
         "canHorizontalDamageBoost",
         {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": "Damage Boost off a Waver to cross the gap."
     },
     {
@@ -3509,6 +3585,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "devNote": ["Speeds higher or lower than this can work but with greater difficulty."]
     },
     {
@@ -3530,7 +3607,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 119,
@@ -3590,7 +3668,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 120,
@@ -3602,7 +3681,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 121,
@@ -3619,7 +3699,8 @@
           "blockPositions": [[2, 28]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 122,
@@ -3636,7 +3717,8 @@
           "blockPositions": [[2, 29]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 123,
@@ -3675,7 +3757,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 124,
@@ -3687,7 +3770,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 125,
@@ -3704,7 +3788,8 @@
           "blockPositions": [[2, 34]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 198,
@@ -3725,6 +3810,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Lay the Power Bomb low enough to kill the Sova.",
         "Descend during the Power Bomb explosion, to take advantage of the more lenient timing provided by the lag."
@@ -3751,6 +3837,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Lay the Power Bomb low enough to kill the Sova.",
         "Descend during the Power Bomb explosion, to take advantage of the more lenient timing provided by the lag."
@@ -3760,7 +3847,8 @@
       "id": 126,
       "link": [7, 6],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 127,
@@ -3842,7 +3930,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 130,
@@ -3854,7 +3943,8 @@
           "length": 3.5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 131,
@@ -3875,6 +3965,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Place a Power Bomb on the bottom stair attached to the door in order to prevent killing the Sova, or free a Sova from the Morph maze with Bombs.",
         "If coming from below, be sure to lure the Sova to the bottom before placing a Power Bomb near the blocks in order to prevent killing it.",
@@ -3919,7 +4010,8 @@
       "farmCycleDrops": [
         {"enemy": "Cacatac", "count": 1},
         {"enemy": "Waver", "count": 1}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 133,
@@ -3956,7 +4048,8 @@
       "id": 136,
       "link": [7, 9],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 137,
@@ -4018,7 +4111,8 @@
           "SpaceJump",
           "canSpringBallJumpMidAir"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 213,
@@ -4034,6 +4128,7 @@
           "canJumpIntoIBJ"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": ["Either kill the Ripper, or dodge it by jumping into IBJ."]
     },
     {
@@ -4043,6 +4138,7 @@
       "requires": [
         "canTrickyUseFrozenEnemies"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump above the Ripper, and shoot down to freeze it as it moves below Samus.",
         "Alternatively, from below, freeze the Ripper as far to the right as possible, and spin jump to squeeze on top of it from the left."
@@ -4060,9 +4156,17 @@
         "h_shinechargeMaxRunway",
         "h_XModeSpikeHitLeniency",
         "h_XModeSpikeHitLeniency",
-        {"shinespark": {"frames": 6}}
+        {"shinespark": {"frames": 4, "excessFrames": 2}}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [8, 9],
+      "name": "Use Flash Suit",
+      "requires": [
+        {"useFlashSuit": {}},
+        {"shinespark": {"frames": 4, "excessFrames": 2}}
+      ]
     },
     {
       "id": 141,
@@ -4077,7 +4181,8 @@
             "canJumpIntoIBJ"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 142,
@@ -4086,7 +4191,8 @@
       "requires": [
         "HiJump",
         "canSpringBallJumpMidAir"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 143,
@@ -4094,7 +4200,8 @@
       "name": "Springwall",
       "requires": [
         "canSpringwall"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 144,
@@ -4104,6 +4211,7 @@
         "HiJump",
         "canPreciseWalljump"
       ],
+      "flashSuitChecked": true,
       "note": "This is the same size of ledge as WRITG."
     },
     {
@@ -4114,6 +4222,7 @@
         "canConsecutiveWalljump",
         "canInsaneWalljump"
       ],
+      "flashSuitChecked": true,
       "note": "This is the same size of ledge as WRITG."
     },
     {
@@ -4134,7 +4243,8 @@
             "canTrickyUseFrozenEnemies"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 147,
@@ -4158,6 +4268,7 @@
         "canTrickySpringBallJump",
         "canPreciseGrapple"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform a very tight Spring Ball jump from the Save room door runway, starting from either a crouch or spin jump,",
         "then use Grapple to barely reach the ceiling blocks."
@@ -4167,13 +4278,15 @@
       "id": 149,
       "link": [9, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 150,
       "link": [9, 3],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 151,
@@ -4185,7 +4298,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 152,
@@ -4193,7 +4307,8 @@
       "name": "Morph Maze",
       "requires": [
         "h_useMorphBombs"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 153,
@@ -4204,7 +4319,8 @@
           "SpaceJump",
           "canLongIBJ"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 154,
@@ -4215,6 +4331,7 @@
         "canCarefulJump",
         "canWalljump"
       ],
+      "flashSuitChecked": true,
       "note": "Starting from the platform near the door to the left, run and jump to the right wall and wall jump twice to get to the top."
     },
     {
@@ -4235,7 +4352,8 @@
             ]}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 156,
@@ -4245,7 +4363,8 @@
         "HiJump",
         "canTrickySpringBallJump"
       ],
-      "note": "Run and Jump into a Springball Jump from the Save Room runway."
+      "flashSuitChecked": true,
+      "note": "Run and Jump into a Spring Ball Jump from the Save Room runway."
     },
     {
       "id": 157,
@@ -4256,13 +4375,15 @@
         "canTrickyWalljump",
         "canConsecutiveWalljump"
       ],
+      "flashSuitChecked": true,
       "note": "A tricky, delayed walljump makes it possible to climb to top right in-room, with nothing."
     },
     {
       "id": 158,
       "link": [9, 8],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 159,
@@ -4291,7 +4412,8 @@
         ]}
       ],
       "resetsObstacles": ["A"],
-      "farmCycleDrops": [{"enemy": "Waver", "count": 2}]
+      "farmCycleDrops": [{"enemy": "Waver", "count": 2}],
+      "flashSuitChecked": true
     },
     {
       "id": 218,
@@ -4361,7 +4483,8 @@
         "h_useMorphBombs"
       ],
       "resetsObstacles": ["A"],
-      "farmCycleDrops": [{"enemy": "Sova", "count": 3}]
+      "farmCycleDrops": [{"enemy": "Sova", "count": 3}],
+      "flashSuitChecked": true
     },
     {
       "id": 219,
@@ -4391,7 +4514,8 @@
       "farmCycleDrops": [
         {"enemy": "Cacatac", "count": 1},
         {"enemy": "Waver", "count": 2}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 220,
@@ -4458,7 +4582,8 @@
       "farmCycleDrops": [
         {"enemy": "Ripper 2 (red)", "count": 1},
         {"enemy": "Waver", "count": 1}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 160,

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -152,7 +152,8 @@
           "length": 5,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -358,7 +359,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 150}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -500,7 +502,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -512,7 +515,8 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -663,6 +667,7 @@
           "drops": [{"enemy": "Sova", "count": 1}]
         }}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Manipulate the movement of the Sm. Dessgeegas by entering the room in a specific way.",
         "Multiple setups are possible:",
@@ -695,7 +700,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 150}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -742,6 +748,7 @@
         "h_bombThings",
         {"heatFrames": 450}
       ],
+      "flashSuitChecked": true,
       "note": "Only one bomb is needed after using a spinjump to get into the two tile tunnel."
     },
     {
@@ -751,7 +758,8 @@
       "requires": [
         "h_useSpringBall",
         {"heatFrames": 375}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -775,6 +783,7 @@
           {"heatFrames": 2700}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Either race the nearby Sova to the morph tunnel or wait for it to come back through the morph tunnel and use a Super to knock it off behind Samus.",
         "Alternatively, it is possible to wait for the global Sova to come around.",
@@ -806,14 +815,23 @@
             "HiJump",
             "SpeedBooster",
             "canCarefulJump",
-            {"heatFrames": 100}
+            {"heatFrames": 100},
+            {"or": [
+              {"noFlashSuit": {}},
+              {"and": [
+                "canTrickyCarryFlashSuit",
+                "canInsaneMidAirMorph"
+              ]},
+              {"heatFrames": 200}
+            ]}
           ]}
         ]},
         {"or": [
           "canHeroShot",
           {"heatFrames": 100}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -827,6 +845,7 @@
         {"heatFrames": 1100}
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Guide the morph tunnel Sova on top of the shot blocks by keeping it on camera.",
         "Move the camera away once it is on top of the shot blocks.  It will not move while off camera.",
@@ -845,6 +864,7 @@
         "canWalljump",
         {"heatFrames": 950}
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: It is possible but very precise to avoid the wall jump requirement here."
     },
     {
@@ -859,6 +879,7 @@
         {"enemyDamage": {"enemy": "Sova", "type": "contact", "hits": 1}},
         {"heatFrames": 1050}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a very well timed and precise walljump into morph to hit the global Sova so that the damage bonks Samus up to the door ledge.",
         "Aim for the lowest part of slope looking wall tile, where it does not look possible to make contact with a walljump, and fully delay the jump.",
@@ -899,7 +920,8 @@
         {"partialRefill": {"type": "Super", "limit": 4}},
         {"partialRefill": {"type": "Missile", "limit": 12}},
         {"partialRefill": {"type": "PowerBomb", "limit": 10}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -917,7 +939,8 @@
       "requires": [
         "Plasma",
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -926,7 +949,8 @@
       "requires": [
         "ScrewAttack",
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -938,7 +962,8 @@
           "explicitWeapons": ["Missile", "Super"]
         }},
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -950,7 +975,8 @@
           "Spazer"
         ]},
         {"heatFrames": 200}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -958,7 +984,8 @@
       "name": "Power Beam Kill",
       "requires": [
         {"heatFrames": 350}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -967,7 +994,8 @@
       "requires": [
         {"heatFrames": 150},
         {"enemyDamage": {"enemy": "Sm. Dessgeega", "type": "contact", "hits": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -976,7 +1004,8 @@
       "requires": [
         "canMockball",
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -987,6 +1016,7 @@
         {"heatFrames": 500},
         {"shinespark": {"frames": 22, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "note": "Jump and shoot the block, then quickly run away and back to charge the shinespark and shine through before the block respawns.",
       "devNote": ["FIXME: Some of the heatFrames should come after the shinespark"]
     },
@@ -1000,6 +1030,7 @@
         {"heatFrames": 250},
         {"shinespark": {"frames": 22, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "With plasma, it is possible to shoot the block from the ground and immediately shinespark.",
         "Other beams will disappear off-screen before Samus has moved up enough.",
@@ -1017,6 +1048,7 @@
         {"heatFrames": 250},
         {"shinespark": {"frames": 22, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "It is possible to shoot upwards from the ground then immediately as the shot is leaving the screen, press up and jump to shinespark without delay.",
         "A Charge shot can help, as it slows down the shot."
@@ -1029,8 +1061,13 @@
       "name": "Speedjump, Through the Shot Block",
       "requires": [
         "canTrickyDashJump",
-        {"heatFrames": 150}
+        {"heatFrames": 150},
+        {"or": [
+          {"noFlashSuit": {}},
+          {"heatFrames": 330}
+        ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "This is a precise strat which requires maximum run speed.",
         "Perform a spin jump right next to the left wall.",
@@ -1115,6 +1152,7 @@
         {"heatFrames": 380},
         {"shinespark": {"frames": 16, "excessFrames": 4}}
       ],
+      "flashSuitChecked": true,
       "devNote": ["FIXME: Some of the heatFrames should come after the shinespark"]
     },
     {
@@ -1131,6 +1169,7 @@
         ]},
         {"heatFrames": 150}
       ],
+      "flashSuitChecked": true,
       "note": [
         "This is a precise strat which requires maximum run speed.",
         "Jump when passing under the floating platform and barely avoid hitting the rightmost wall.",
@@ -1171,7 +1210,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -1188,7 +1228,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 0}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 42,
@@ -1205,7 +1246,8 @@
             {"heatFrames": 125}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -1239,16 +1281,18 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
       "link": [5, 2],
-      "name": "MidAir SpringBall",
+      "name": "Spring Ball Jump",
       "requires": [
         "canSpringBallJumpMidAir",
         {"heatFrames": 200}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1265,7 +1309,8 @@
             {"heatFrames": 510}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 46,
@@ -1282,7 +1327,8 @@
             {"heatFrames": 300}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -1386,7 +1432,8 @@
       "requires": [
         "canDodgeWhileShooting",
         {"heatFrames": 350}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 52,
@@ -1395,7 +1442,8 @@
       "requires": [
         {"heatFrames": 160},
         {"enemyDamage": {"enemy": "Sm. Dessgeega", "type": "contact", "hits": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -1404,7 +1452,8 @@
       "requires": [
         "Plasma",
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -1413,7 +1462,8 @@
       "requires": [
         "ScrewAttack",
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 55,
@@ -1425,7 +1475,8 @@
           "explicitWeapons": ["Missile", "Super"]
         }},
         {"heatFrames": 100}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 56,
@@ -1437,7 +1488,8 @@
           "Spazer"
         ]},
         {"heatFrames": 200}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 57,
@@ -1445,7 +1497,8 @@
       "name": "Power Beam Kill",
       "requires": [
         {"heatFrames": 350}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 68,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -61,13 +61,6 @@
       ]
     }
   ],
-  "obstacles": [
-    {
-      "id": "A",
-      "name": "Geruta Blocking the Missiles",
-      "obstacleType": "enemies"
-    }
-  ],
   "enemies": [
     {
       "id": "e1",
@@ -144,7 +137,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -196,7 +190,8 @@
       "requires": [
         {"heatFrames": 240},
         {"shinespark": {"frames": 57, "excessFrames": 0}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -223,6 +218,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "Lower run speeds can also work but may be more difficult or require more heat damage."
       ]
@@ -262,7 +258,6 @@
         {"heatFrames": 60},
         {"lavaFrames": 20}
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": "Exit G-mode then air ball into the lava to take fewer heat frames. Kill the Gerutas beforehand to make it easier to escape."
     },
@@ -272,7 +267,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 300}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -286,8 +282,9 @@
       },
       "requires": [
         "SpaceJump",
-        {"heatFrames": 200}
-      ]
+        {"heatFrames": 180}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -302,7 +299,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 140}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -310,9 +308,9 @@
       "name": "Tricky Platforming",
       "requires": [
         "canTrickyJump",
-        {"heatFrames": 220}
+        {"heatFrames": 200}
       ],
-      "devNote": "FIXME: Jumping fully over the platform, and killing the sova before landing on it is a little faster, with no movement items."
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -326,9 +324,33 @@
       },
       "requires": [
         "canTrickyJump",
-        {"heatFrames": 200}
+        {"or": [
+          {"heatFrames": 190},
+          {"and": [
+            {"heatFrames": 165},
+            {"or": [
+              "ScrewAttack",
+              "Wave",
+              "Spazer",
+              "Plasma",
+              {"ammo": {"type": "Missile", "count": 1}},
+              {"ammo": {"type": "Super", "count": 1}},
+              {"and": [
+                "Grapple",
+                {"heatFrames": 10}
+              ]}
+            ]}
+          ]}
+
+        ]}
       ],
-      "devNote": "FIXME: Jumping fully over the platform, and killing the sova before landing on it is a little faster, with no movement items."
+      "flashSuitChecked": true,
+      "note": [
+        "If a suitable weapon is available, jump over the first pillar and kill the Sova before landing on it."
+      ],
+      "devNote": [
+        "FIXME: farming the Sova would also be an option."
+      ]
     },
     {
       "id": 9,
@@ -345,6 +367,7 @@
         "canMockball",
         {"heatFrames": 180}
       ],
+      "flashSuitChecked": true,
       "note": "Upon room entry, jump and mockball on top of the first pillar."
     },
     {
@@ -364,7 +387,8 @@
         {"heatFrames": 225},
         {"shinespark": {"frames": 53, "excessFrames": 0}},
         {"heatFrames": 105}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -395,6 +419,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Carefully planned movement is needed to avoid damage from the Gerutas, and to avoid bonking on the overhangs."
       ]
@@ -432,7 +457,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -467,7 +493,8 @@
           "gentleDownTiles": 2,
           "startingDownTiles": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -521,7 +548,6 @@
         {"heatFrames": 60},
         {"lavaFrames": 20}
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "note": "Exit G-mode then air ball into the lava to take fewer heat frames. Kill the Gerutas beforehand to make it easier to escape."
     },
@@ -531,7 +557,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 250}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -554,26 +581,30 @@
           ]},
           {"heatFrames": 5}
         ]},
-        {"heatFrames": 220}
-      ]
+        {"heatFrames": 190}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        {"heatFrames": 200},
         {"or": [
-          {"lavaFrames": 50},
+          {"and": [
+            {"heatFrames": 150},
+            {"lavaFrames": 40}
+          ]},
           {"and": [
             "Gravity",
-            {"lavaFrames": 40}
+            {"heatFrames": 140},
+            {"lavaFrames": 30}
           ]}
-        ]},
-        {"or": [
-          {"enemyDamage": {"enemy": "Geruta", "type": "contact", "hits": 1}},
-          {"obstaclesCleared": ["A"]}
         ]}
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "This assumes that the Geruta closest to the item has already been killed."
       ]
     },
     {
@@ -585,8 +616,7 @@
           "Plasma",
           "ScrewAttack",
           {"ammo": {"type": "Super", "count": 1}},
-          {"enemyDamage": {"enemy": "Geruta", "type": "contact", "hits": 1}},
-          {"obstaclesCleared": ["A"]}
+          {"enemyDamage": {"enemy": "Geruta", "type": "contact", "hits": 1}}
         ]},
         {"heatFrames": 280}
       ],
@@ -595,7 +625,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -603,7 +634,7 @@
       "name": "Careful Jump",
       "requires": [
         "canCarefulJump",
-        {"heatFrames": 176}
+        {"heatFrames": 200}
       ],
       "unlocksDoors": [
         {
@@ -611,6 +642,7 @@
           "requires": [{"heatFrames": 25}]
         }
       ],
+      "flashSuitChecked": true,
       "note": "Build speed on the central platform and jump to the door."
     },
     {
@@ -630,7 +662,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -657,7 +690,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -705,24 +739,17 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
       "link": [4, 3],
-      "name": "Kill the Geruta",
+      "name": "Base",
       "requires": [
         "Morph",
-        {"heatFrames": 350},
+        {"heatFrames": 210},
         {"or": [
-          {"lavaFrames": 70},
-          {"and": [
-            "Gravity",
-            {"lavaFrames": 36}
-          ]}
-        ]},
-        {"or": [
-          {"obstaclesCleared": ["A"]},
           {"enemyKill": {
             "enemies": [["Geruta"]],
             "explicitWeapons": [
@@ -731,34 +758,37 @@
               "PowerBomb",
               "ScrewAttack",
               "Plasma",
-              "Ice+Spazer",
-              "Ice+Wave",
-              "Wave+Spazer",
-              "Charge+Wave",
-              "Charge+Spazer",
+              "Spazer",
+              "Wave",
               "PseudoScrew"
             ]
-          }}
-        ]}
-      ],
-      "clearsObstacles": ["A"]
-    },
-    {
-      "id": 25,
-      "link": [4, 3],
-      "name": "Tank the Geruta",
-      "requires": [
-        "Morph",
-        {"heatFrames": 350},
-        {"or": [
-          {"lavaFrames": 70},
+          }},
           {"and": [
-            "Gravity",
-            {"lavaFrames": 36}
+            "canDodgeWhileShooting",
+             {"heatFrames": 100}
+          ]},
+          {"and": [
+            {"enemyDamage": {"enemy": "Geruta", "type": "contact", "hits": 1}},
+            {"heatFrames": 200}
           ]}
         ]},
-        {"enemyDamage": {"enemy": "Geruta", "type": "contact", "hits": 1}}
-      ]
+        {"or": [
+          {"and": [
+            "canInsaneJump",
+            {"lavaFrames": 20}
+          ]},
+          {"and": [
+            {"lavaFrames": 70},
+            {"heatFrames": 50}
+          ]},
+          {"and": [
+            "Gravity",
+            {"lavaFrames": 40},
+            {"heatFrames": 20}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -790,7 +820,6 @@
           {"cycleFrames": 700}
         ]}
       ],
-      "resetsObstacles": ["A"],
       "farmCycleDrops": [
         {"enemy": "Sova", "count": 4},
         {"enemy": "Geruta", "count": 3}
@@ -804,7 +833,6 @@
       "requires": [
         "h_heatedCrystalFlash"
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true
     }
   ],


### PR DESCRIPTION
This includes significant updates to Cathedral heat frames. 

Initially I was looking at the right-to-left Cathedral traversal, to make sure killing the Sova worked with a flash suit (seems fine since you shoot it horizontally). Based on how precisely the strat modeled the extra 5 heat frames from not having a weapon, and based on the not-round-value of 176 used for the 4->1 heat frames, I gathered that this was intended to model a tankless traversal on Insane; however, the total energy used added up to 99, which wouldn't be enough to survive tankless (it would need to be 98).

The requirements here are tricky because node 4 is slightly nebulous, and because things can depend on which side you're coming from and exactly how the Gerutas happen to move. I took the opportunity to tighten things where I noticed they were loose. The tankless right-to-left traversal did seem reasonable for Insane, with 98 energy consumed. The 176 heat frames for 4->1 seemed impossibly tight (even accounting for node 4 being possibly anywhere on the two platforms it touches), but the 2->4 heat frames were loose so it worked out.

It looked to me like the Geruta obstacle "A" wasn't really useful: even with just Power Beam, it seemed better to kill the Geruta on the way down to the item rather than tank a hit from it, even accounting for the possibility that you may have Gravity (for enemy damage reduction) and that the item could be an ETank.