### PR TITLE
Main Hall cross with Crystal Flash strats

### DIFF
--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -174,13 +174,49 @@
     {
       "id": 5,
       "link": [1, 4],
-      "name": "TrickyJumps",
+      "name": "Tricky Jumps",
       "requires": [
         "h_navigateHeatRooms",
         "canTrickyJump",
         {"heatFrames": 570}
       ],
       "note": "Take the platforms two at a time by building some run speed for each jump on a one tile runway."
+    },
+    {
+      "link": [1, 4],
+      "name": "Tricky Jumps with Crystal Flash",
+      "requires": [
+        "canTrickyJump",
+        {"or": [
+          {"and": [
+            {"heatFrames": 95},
+            "h_heatedCrystalFlash",
+            "canTrickyDodgeEnemies",
+            {"heatFrames": 475}
+          ]},
+          {"and": [
+            {"heatFrames": 175},
+            "h_heatedCrystalFlash",
+            "canTrickyDodgeEnemies",
+            {"heatFrames": 395}
+          ]},
+          {"and": [
+            {"heatFrames": 240},
+            "h_heatedCrystalFlash",
+            "canTrickyDodgeEnemies",
+            {"heatFrames": 330}
+          ]},
+          {"and": [
+            {"heatFrames": 310},
+            "h_heatedCrystalFlash",
+            {"heatFrames": 260}
+          ]}
+        ]}
+      ],
+      "note": [
+        "The Crystal Flash can be done on any of the floating blocks or single-tile-wide pillars that don't have a Hibashi.",
+        "The safest place to do it is on the last single-tile-wide pillar."
+      ]
     },
     {
       "id": 6,
@@ -352,6 +388,15 @@
       ]
     },
     {
+      "link": [2, 4],
+      "name": "Cross with Crystal Flash",
+      "requires": [
+        {"heatFrames": 180},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 180}
+      ]
+    },
+    {
       "id": 34,
       "link": [2, 4],
       "name": "G-Mode, Up the Elevator",
@@ -496,6 +541,17 @@
         {"heatFrames": 500}
       ],
       "note": "Take the platforms two at a time by building some run speed for each jump on a one tile runway."
+    },
+    {
+      "link": [4, 1],
+      "name": "Tricky Jumps with Crystal Flash",
+      "requires": [
+        "canTrickyJump",
+        {"heatFrames": 135},
+        "h_heatedCrystalFlash",
+        {"heatFrames": 350}
+      ],
+      "note": "The Crystal Flash can be done safely on the leftmost 2-tile-wide platform."
     },
     {
       "id": 20,


### PR DESCRIPTION
Main Hall is one of the rooms that I skipped earlier when adding "Cross with Crystal Flash" strats. I saw some videos from Sam here which gave the motivation to add them.

With recent changes to the randomizer, we can now have multiple Crystal Flash options within the same strat and it can choose the best one, so I took advantage of that for the 1->4 strat.

Videos for all of these are on the video site.