### PR TITLE
Tighten Lava Grapple Tunnel grapple heat frames

### DIFF
--- a/region/norfair/east/Lava Grapple Tunnel.json
+++ b/region/norfair/east/Lava Grapple Tunnel.json
@@ -102,8 +102,17 @@
       "name": "Grapple",
       "requires": [
         "Grapple",
-        {"heatFrames": 320}
+        {"heatFrames": 320},
+        {"or": [
+          {"noFlashSuit": {}},
+          {"and": [
+            "canMidAirMorph",
+            "canComplexCarryFlashSuit",
+            {"heatFrames": 130}
+          ]}
+        ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "To optimize the Grapple swings for minimal heat damage,",
         "1) hold forward and angle-up the entire time,",
@@ -668,8 +677,17 @@
       "name": "Grapple",
       "requires": [
         "Grapple",
-        {"heatFrames": 320}
+        {"heatFrames": 320},
+        {"or": [
+          {"noFlashSuit": {}},
+          {"and": [
+            "canMidAirMorph",
+            "canComplexCarryFlashSuit",
+            {"heatFrames": 130}
+          ]}
+        ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "To optimize the Grapple swings for minimal heat damage,",
         "1) hold forward and angle-up the entire time,",

--- a/region/norfair/east/Lava Grapple Tunnel.json
+++ b/region/norfair/east/Lava Grapple Tunnel.json
@@ -102,7 +102,18 @@
       "name": "Grapple",
       "requires": [
         "Grapple",
-        {"heatFrames": 450}
+        {"heatFrames": 320}
+      ],
+      "note": [
+        "To optimize the Grapple swings for minimal heat damage,",
+        "1) hold forward and angle-up the entire time,",
+        "2) press down to extend Grapple immediately after each Grapple attachment,",
+        "3) release Grapple soon after Samus swings past vertical,",
+        "4) re-press Grapple as quickly as possible after release."
+      ],
+      "detailNote": [
+        "If there is no runway (or only 1 tile) to gain momentum from the neighboring room,",
+        "it is faster to begin grappling as quickly as possible, rather than doing a big jump."
       ]
     },
     {
@@ -657,7 +668,18 @@
       "name": "Grapple",
       "requires": [
         "Grapple",
-        {"heatFrames": 450}
+        {"heatFrames": 320}
+      ],
+      "note": [
+        "To optimize the Grapple swings for minimal heat damage,",
+        "1) hold forward and angle-up the entire time,",
+        "2) press down to extend Grapple immediately after each Grapple attachment,",
+        "3) release Grapple soon after Samus swings past vertical,",
+        "4) re-press Grapple as quickly as possible after release."
+      ],
+      "detailNote": [
+        "If there is no runway (or only 1 tile) to gain momentum from the neighboring room,",
+        "it is faster to begin grappling as quickly as possible, rather than doing a big jump."
       ]
     },
     {


### PR DESCRIPTION
Looked into this after noticing a video by Sam that showed you could traverse Lava Grapple Tunnel tankless with Grapple. It took a while to get the hang of how to optimize the swings, but it seems not too bad.

With the new amount of heat frames, crossing tankless would be in Expert logic. I think this may be ok, but if it's not then we could add some extra heat frames in an `or` with `canInsaneJump` or something. 

Videos for this are on the video site.