### PR TITLE
fix 2 minor typos

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -3,7 +3,7 @@
   "helperCategories": [
     {
       "name": "Randomizer Dependent",
-      "description": "Common parameters than may be changed based on the randomizer implementation or settings.",
+      "description": "Common parameters that may be changed based on the randomizer implementation or settings.",
       "helpers": [
         {
           "name": "h_heatProof",

--- a/tech.json
+++ b/tech.json
@@ -2809,7 +2809,7 @@
                 "modifying where Samus is placed in the next room.",
                 "Exiting G-mode will teleport Samus to position where she touched the Samus Eater.",
                 "At the start of the door transition, Samus' X and Y pixel positions are reduced modulo 256 (the size of a screen),",
-                "so the relative position within the screen is all the matters (not the absolute position in the room).",
+                "so the relative position within the screen is all that matters (not the absolute position in the room).",
                 "The transition must be touched exactly 2 frames after control is regained after releasing X-Ray."
               ],
               "detailNote": [


### PR DESCRIPTION
- **add Zeb Ice Clip SBA to Big Pink**
- **some fixes for Zeb Ice Clip SBA**
- **additional fixes for Zeb Ice Clip SBA**
- **minor fixes to Big Pink**
- **Fixes to strats in my plando**
- **add link**
- **feedback update**
- **Direct G-mode open blue gates**
- **Apply suggestions from code review**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **Misc G-mode setups**
- **Second pass at upward G-mode setups**
- **Small misc changes**
- **Indirect upward G-mode, more Everest strats**
- **fix errors**
- **fix more errors**
- **rename strat**
- **add regain mobility fixes**
- **Downward G-mode setup, wall ice clip method**
- **A few cross-room spring ball bounce strats**
- **Downward G-Mode setups, sand transitions**
- **add unlock door requirement**
- **Refine some canUnderwaterBombIntoSpringBallJump notes**
- **Room renames**
- **second batch of room renames**
- **third batch of room renames**
- **feedback update**
- **shorten to Cosine Room**
- **shortened name Green Brinstar Save Room**
- **NobodyNada suggested names: 230 Missile, No Snakes, Spiky Snakes**
- **feedback update**
- **feedback update**
- **feedback update**
- **Yoink Room, Lava Grapple Tunnel, Lava Farm Tunnel**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **Some heated spring ball bounces**
- **Refine Seaweed Room shinecharges**
- **More WS ETank speedy jump strats**
- **add 3->1 power beam strats**
- **feedback updates**
- **Wrecked Ship G-Mode: Second Pass**
- **feedback updates**
- **fix errors**
- **adjustments based on feedback/polls**
- **Bootless two-wall UWJ**
- **single wall note**
- **A couple more moonfall clips**
- **feedback update**
- **Some more X-mode strats & refinements**
- **fix errors**
- **Add Basement Workrobot Kago**
- **Fireflea escape shinespark**
- **Update region/lowernorfair/east/Lower Norfair Fireflea Room.json**
- **Acid Statue cross-room strats to cross acid**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **Ceiling clips using a flash suit**
- **fix link**
- **Metroid 3**
- **G-Mode Metroid Rooms: Second Pass**
- **Tourian G-Mode: Second Pass**
- **Rest of Crateria farms**
- **feedback updates**
- **feedback update**
- **feedback update**
- **remove unnecessary strat**
- **Update region/wreckedship/main/Sponge Bath.json**
- **feedback update**
- **Rest of Blue Brinstar farms**
- **Apply suggestions from code review**
- **feedback updates**
- **Update region/brinstar/blue/Morph Ball Room.json**
- **feedback updates**
- **remaining feedback updates**
- **Green Brinstar farms**
- **Refine Volcano Room**
- **Reverse Mother Brain notable**
- **Below Spazer CWJ jump shot speedball**
- **Pink Brinstar farms**
- **feedback updates**
- **Update region/norfair/east/Volcano Room.json**
- **feedback updates**
- **add L->R tankless spacejump strat**
- **add canInsaneJump req**
- **Apply suggestions from code review**
- **tighten waterway cycleFrames a bit**
- **Red Brinstar farms**
- **G-Mode, Yellow Green Maridia: Second Pass**
- **fix duplicate id**
- **Zeb farm in early supers**
- **tighten right-side tunnel leaveShinecharged**
- **Warehouse Brinstar farms**
- **update note on warehouse e-tank farm**
- **simpleHeatFrames and simpleCycleFrames**
- **restore leaveShinecharged strats**
- **Aqueduct G-Mode: Second Pass**
- **tighten frames with Gravity+ScrewAttack**
- **feedback updates**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **Add way to break PB blocks too, Add node to reduce duplication**
- **add missing link**
- **add canLongXRayClimb tech**
- **botwoon etank**
- **Croc Area Farms**
- **Apply suggestions from code review**
- **stronger dodge requirements for Mini-Kraid and Kihunters**
- **add note about spin-jump entry**
- **add simpleCycleFrames**
- **add simpleCycleFrames to applicable farms**
- **Restrict position of Kraid Eye Door hero shot spark**
- **Update region/norfair/crocomire/Post Crocomire Farming Room.json**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **Some West Maridia farms**
- **Fix some issues with auto-formatting**
- **add Boyon Gate Hall double Zebbo farm**
- **Plowerhouse tricky dodge and cross while farming strats**
- **More Bowling Alley X-Ray climbs**
- **add canShinesparkSlopeClip tech, x-mode variant, update canShinesparkDeepStuck note**
- **tighten Tricky Dodge to 310 frames**
- **Pink Maridia**
- **fix error**
- **feedback update**
- **Fish Tank farms**
- **East Cac Alley, G-Mode: Second Pass**
- **UN West Farms (#2141)**
- **Refine Crumble Shaft strats**
- **add extra Medium lenience for left-side walljumps**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2148)**
- **Acid Statue shinespark slope clip X-Ray climb**
- **Moat CWJ bomb boost**
- **feedback updates**
- **fix test**
- **G-Mode Fixes from Bobbob's List**
- **fix error**
- **Main Street farms**
- **finish resolving conflicts**
- **Lava Dive pause abuse**
- **Halfie Climb temp blue updates based on Sam videos**
- **Post Croc Shaft superless moonfall option**
- **Refine Rising Tide speedball**
- **Green Hill Zone more leaveShinecharged**
- **Refine Moat temp blue**
- **add dodge option for Pants Room grapple jump**
- **Aqueduct damageless snail stuck moonfall**
- **Climb frozen pirate behemoth spark**
- **LN G-Mode: Second Pass**
- **fix missing shinecharge req**
- **add Ice+HiJump strat**
- **feedback updates**
- **Apply suggestions from code review**
- **small tweak to note**
- **feedback update**
- **Apply suggestions from code review**
- **feedback update**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2165)**
- **Behemoth spark while farming**
- **tighten shinespark frames a bit**
- **feedback update**
- **replace canStaggeredWalljump and canDelayedWalljump with canTrickyWalljump**
- **remove canPreciseWalljump reqs redundant with canTrickyWalljump**
- **Difficulty adjustments**
- **fix conflict**
- **Croc's Lair G-Mode: Second Pass**
- **Indiana Jones G-Mode Restructure**
- **delete node**
- **Update Crumble Shaft.json**
- **Red Fish Room farms**
- **Refine X-Ray dboost strats (#2164)**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2171)**
- **Restructure Indiana Jones G-Mode Again**
- **add missing links**
- **add more missing links**
- **Fix Wasteland traversal missing a Power Bomb**
- **Upper Norfair West G-Mode: Second Pass**
- **fix error**
- **Update Remaining Old Room Names (#2172)**
- **Everest farms**
- **Pink Maridia farms part 1: Aqueduct, etc.**
- **add missing zebes awake req to new Behemoth spark strat**
- **Add notable req for Plasma Spark Room precise down grab**
- **Botwoon E-tank ledge Zoa farm**
- **fix big pink temp blue runway length**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2181)**
- **downgrade Plasma Spark precise crouch jump**
- **add crouch jump notable for Watering Hole**
- **Feedback and a couple more in HiJump ETank**
- **remove duplicate strat id**
- **feedback updates**
- **feedback updates**
- **add pause menu cycle frames**
- **add canMidairWiggle req**
- **second try at canMidairWiggle option**
- **More East Sand Hall notables**
- **Apply suggestions from code review**
- **fix hijump etank**
- **Plasma Room damage-avoiding pseudo screw**
- **Construction Zone ice moonfall clip**
- **crab hole**
- **UN East farms part 1 (#2183)**
- **UN East Farms Part 2 (#2187)**
- **most of west maridia**
- **Update region/maridia/inner-green/East Sand Hall.json**
- **feedback update**
- **Pink Maridia farms part 2: Botwoon Hallway, etc.**
- **finish outer maridia**
- **Botwoon E-Tank Room: add left-side suitless leaveShinecharged**
- **Update region/maridia/inner-pink/Botwoon Energy Tank Room.json**
- **Super sinks**
- **Add missing Morph+SpringBall req to Indiana Jones setup**
- **Update region/maridia/outer/Maridia Tube.json**
- **feedback update**
- **some notes/docs cleanup**
- **feedback updates**
- **add FIXME about water entry**
- **Worst Room X-mode temporary blue & refinements**
- **Update region/lowernorfair/east/The Worst Room In The Game.json**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2194)**
- **feedback update: Grapple/beam variants**
- **Upper Norfair East G-mode: part 1**
- **feedback updates**
- **Rest of Pink Maridia farms**
- **Upper Norfair Heated G-mode: part 2**
- **C, WS, blue/green/pink B**
- **Add canPowerBombItemOverloadPLMs**
- **More UN East Farms**
- **Add canComplexGMode, use throughout Brinsar**
- **add more details to tech, move very deep stuck**
- **Apply suggestions from code review**
- **feedback update**
- **Cathedral Entrance right-to-left**
- **Add CF strat at node 5**
- **add notable, hero shot requirement**
- **Screw Attack Room canBombAboveIBJ and other refinements**
- **fixme on x-ray climb heat frames**
- **Amphitheatre CF strats and a few other refinements**
- **Remove multiviola farm**
- **add missing reqs for 4->3 IBJ**
- **feedback update**
- **feedback - fix error**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2205)**
- **Remaining UNEast Farms (#2204)**
- **More heated Crystal Flash strats (#2206)**
- **Yellow Maridia farms part 1: Butterfly Room, etc.**
- **feedback updates**
- **LN EAST FARMS 1**
- **Add canComplexGMode to WS**
- **Add canComplexGMode to Tourian**
- **Swiss Cheese Room menu farms**
- **Add canComplexGMode to Crateria**
- **Update mama turtle stutter shinecharge to the top**
- **add missing screw option in landing site**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2213)**
- **Add canComplexGMode to LN**
- **Plasma Room and Plasma Spark Room farms**
- **Rest of Yellow Maridia farms**
- **Update region/maridia/inner-yellow/Plasma Spark Room.json**
- **More requirements/notes in Swiss Cheese room**
- **feedback update - apply feedback to older regions too**
- **Plasma Tutorial farm: add notes and more lenience**
- **Yoink Room right door frame farm**
- **Add Yapping Maw obstacles in Yoink Room**
- **Remaining LN East Farms (#2217)**
- **feedback update**
- **Add canComplexGMode to Green and Yellow Maridia**
- **Update description of canTrickyGMode**
- **Add canComplexGMode to Pink Maridia**
- **Add canComplexGMode to West Maridia**
- **Green Maridia farms part 1: Sand Halls**
- **Add canComplexGMode to Crocomire and West Norfair**
- **add crouch jump option**
- **Add canComplexGMode to Upper Norfair East**
- **Apply suggestions from code review**
- **feedback update**
- **Cosine remove fixme for impossible strat**
- **feedback updates**
- **LN West Farms (#2218)**
- **Lonely Crab Room farm**
- **Add canComplexGMode to setups (B, C, T, WS)**
- **Shaktool Room farms**
- **Add canComplexGMode to setups (Maridia)**
- **Pants Room farms**
- **add missing link**
- **Add canComplexGMode to setups (Norfair)**
- **fix errors**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2230)**
- **more feedback updates**
- **Climb Supers speed keep lenience**
- **Wrecked Ship Farms (#2231)**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2233)**
- **Fix kihunter enemy names (#2234)**
- **Caterpillar spike boost**
- **last_enemy not clearing (#2236)**
- **Remove R-mode Req from G-mode**
- **Rename canEnterGMode to canGMode**
- **Red Firefleas IBJ into HBJ, remove X-ray room references**
- **Refine Bubble Mountain top-left to top-right jumps**
- **Early Supers right-side G-mode setup from right**
- **add space jump variant**
- **Red Tower x-ray climbs**
- **Apply suggestions from code review**
- **Gmode setup spike boost**
- **GMode setup with morph**
- **refine diagonal bomb jump strats**
- **add wallJumpAvoid tag**
- **add mockball variant**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2244)**
- **fix Cac spike damage type**
- **Maridia Elevator ripper dodge IBJ**
- **add Ripper hit lenience**
- **add Space jump options, canTrickyDodgeEnemies reqs**
- **Small Changes**
- **Crocomire's Room Hi-Jump bomb acid escape**
- **Ice Beam Gate speedy crouch gate clip**
- **remove obsolete FIXME**
- **Bubble Mountain Frozen Waver Platforms**
- **Update Fast Pillars Setup Room.json**
- **add arm pump crouch gate clip**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter (#2252)**
- **Crateria Central check flash suits**
- **add missing reqs in Climb Supers**
- **Ridley Room shinespark**
- **Crateria East check flash suits**
- **Blue Brinstar check flash suits**
- **Crateria West check flash suits**
- **revert unneeded/irrelevant change to canGateGlitch**
- **Add can(Complex)CarryFlashSuit, but don't add uses**
- **revert change to canBombJumpWaterEscape requirements**
- **mark Leave With Grapple Swing checked**
- **mark Leave With Grapple Swing checked**
- **feedback update: Climb behemoth spark**
- **Update tech.json**
- **Crumble Shaft: adjust mapTileMask**
- **feedback update**
- **Main uses of canComplexCarryFlashSuit**
- **reqs for h_midAirShootUp and canGrappleJump**
- **add detailNote for canPreciseGrappleJump**
- **remove canGrappleJump circular dependencies**
- **Simplify underwater crouch jump helpers**
- **update devNote**
- **second pass at updating devNote**
- **Update helpers.json**
- **A couple more helpers for flash suits**
- **remove req from boulder bomb jump water escape**
- **fix syntax error from merge**
- **feedback updates**
- **feedback updates**
- **add h_midAirShootUp option**
- **fix error**
- **Refine flash suits and crouch jumps**
- **Tourian check flash suits**
- **Wrecked Ship check flash suits**
- **Crocomire Norfair check flash suits**
- **Update region/tourian/main/Tourian Escape Room 4.json**
- **feedback update**
- **Refine flash suits and max height spring ball**
- **Norfair West check flash suits (and some heat frames)**
- **Update region/norfair/crocomire/Indiana Jones Room.json**
- **feedback updates**
- **Fix to Ice Beam Snake Room**
- **feedback update**
- **West Maridia check flash suits**
- **Pit Room obstacle cleared fixes**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **add missing Morph requirements in Behemoth spark strats**
- **add missing resetRoom requirement on homing geemer farm**
- **miscellaneous grapple teleport updates**
- **Pink Maridia check flash suits part 1**
- **fix error**
- **add grapple teleport door escape strats**
- **checked that grapple gate glitch keeps flashsuit**
- **Croc Speedway: tighten some heat frames**
- **feedback updates**
- **Hard Boss Updates**
- **Pink Brinstar check flash suits**
- **Apply suggestions from code review**
- **feedback updates**
- **Update strats.md**
- **feedback updates**
- **Update region/norfair/crocomire/Crocomire's Room.json**
- **feedback update**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **add missing requirements in Rinka Shaft shinecharges**
- **Update region/tourian/main/Rinka Shaft.json**
- **Rest of Pink Maridia check flash suits**
- **feedback update**
- **kraid flash except etank and kihunter room**
- **finish flash suit checked kraid brinstar**
- **Update region/maridia/inner-pink/Halfie Climb Room.json**
- **feedback updates**
- **partial feedback update**
- **Red Brinstar check flash suits**
- **Yellow Maridia check flash suits**
- **feedback update**
- **Run Strat ID, Tech ID, and Notable ID Generator & Autoformatter**
- **feedback update**
- **feedback update, split strat, add note**
- **Green Maridia check flash suits pt. 1 (#2288)**
- **Green Maridia check flash suits pt. 3 (West Sand Hall, etc.) (#2290)**
- **Green Maridia check flash suits pt. 2 (Oasis) (#2289)**
- **fix 2 minor typos**
