### PR TITLE
Increase leaveSpaceJumping runway in Below Spazer top

### DIFF
--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -1022,8 +1022,8 @@
       "exitCondition": {
         "leaveSpaceJumping": {
           "remoteRunway": {
-            "length": 6,
-            "openEnd": 1
+            "length": 7,
+            "openEnd": 0
           }
         }
       },


### PR DESCRIPTION
This is only a half-tile more, but it can be significant because it means you can get tricky dash jump speed.