### PR TITLE
Norfair East check flash suits pt. 4 (Lava Farm Tunnel)

### DIFF
--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -165,7 +165,8 @@
           "length": 1,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 46,
@@ -184,6 +185,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $3.9"
     },
     {
@@ -214,7 +216,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -293,7 +296,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 90}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -309,6 +313,7 @@
         {"heatFrames": 200},
         {"lavaFrames": 60}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain a specifc amount of speed by running from a standstill, starting slightly more than 3 tiles from the edge of the Ridley statue jaw.",
         "Jump on the last possible frame (second-to-last frame may also work, depending on subpixels).",
@@ -332,7 +337,8 @@
       "requires": [
         {"heatFrames": 60}
       ],
-      "note": []
+      "note": [],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -344,7 +350,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -361,7 +368,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -378,7 +386,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -584,7 +593,8 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -616,7 +626,8 @@
           ]}
         ]}
       ],
-      "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
+      "flashSuitChecked": true,
+      "note": "Samus will be slowed by lava if Speed Booster is equipped, even with Gravity."
     },
     {
       "id": 14,
@@ -642,6 +653,7 @@
         {"lavaFrames": 155},
         {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Store the shinespark on the last possible pixels of runway.",
         "Quickly drop to the nearby namihe and damage boost using its flame.",
@@ -664,13 +676,14 @@
         {"gravitylessLavaFrames": 392},
         {"heatFrames": 515}
       ],
+      "flashSuitChecked": true,
       "note": [
-        "BounceBall into the Lava, Unmorphing with good timing to sink faster and drift effeciently towards the bottom right Namihe.",
-        "Walljump at about eye height (4 pixel window) to gain enough height to reach the center portion of ceiling.",
-        "While rising, wiggle to shrink Samus' hitbox.  Some walljump positions will not need to wiggle, when walljumping far away from the Namihe.",
+        "Bounceball into the Lava, unmorphing with good timing to sink faster and drift efficiently towards the bottom right Namihe.",
+        "Wall jump at about eye height (4 pixel window) to gain enough height to reach the center portion of ceiling.",
+        "While rising, wiggle to shrink Samus' hitbox.  Some walljump positions will not need to wiggle, when wall jumping far away from the Namihe.",
         "Jumping, from the wall, around the next lowest overhang is very precise and taking any extra time to position will increase the amount of lava damage being taken.",
-        "It may help to disable HiJump for this part.",
-        "Then Walljump again to exit the Lava and reach the left ledge."
+        "It may help to disable Hi-Jump for this part.",
+        "Then wall jump again to exit the lava and reach the left ledge."
       ]
     },
     {
@@ -687,6 +700,7 @@
         {"heatFrames": 365},
         {"lavaFrames": 305}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Build up a little run speed and do a small jump into the lava.",
         "Morph before reaching the lava, Bounce, and Unmorph shortly after sink slightly before floating down to the stairs."
@@ -712,6 +726,7 @@
         {"heatFrames": 330},
         {"lavaFrames": 290}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump into the door frame so that Samus is falling when entering this room.",
         "Morph before reaching the lava and Bounce down to the bottom."
@@ -738,7 +753,8 @@
           ]}
         ]}
       ],
-      "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
+      "flashSuitChecked": true,
+      "note": "Samus will be slowed by lava if Speed Booster is equipped, even with Gravity."
     },
     {
       "id": 19,
@@ -751,7 +767,8 @@
         ]},
         {"heatFrames": 330},
         {"lavaFrames": 270}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -767,6 +784,7 @@
         {"heatFrames": 260},
         {"lavaFrames": 200}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Build up a little run speed and do a small jump into the lava.",
         "Morph before reaching the lava, Bounce, and Unmorph shortly after sink slightly before floating down to the stairs."
@@ -792,6 +810,7 @@
         {"heatFrames": 230},
         {"lavaFrames": 190}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump into the door frame so that Samus is falling when entering this room.",
         "Morph before reaching the lava, Bounce, and Unmorph shortly after sink slightly before floating down to the stairs."
@@ -810,7 +829,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 10}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -872,7 +892,8 @@
             {"lavaFrames": 20}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -887,9 +908,10 @@
         {"heatFrames": 270},
         {"gravitylessLavaFrames": 240}
       ],
+      "flashSuitChecked": true,
       "note": [
-        "Walljump off of the lower half of the Upper-Left Namihe to cross to the right side wall.",
-        "Continue Walljumping up from there, waiting for the above flame to pass if it is in the way."
+        "Wall jump off of the lower half of the upper-left Namihe to cross to the right side wall.",
+        "Continue wall jumping up from there, waiting for the above flame to pass if it is in the way."
       ]
     },
     {
@@ -908,9 +930,10 @@
         {"heatFrames": 195},
         {"lavaFrames": 180}
       ],
+      "flashSuitChecked": true,
       "note": [
-        "Walljump off of the Upper-Left Namihe and then Spring Ball jump up and out of the Lava.",
-        "Delay the pause until in position to perform the Spring Ball jump because Lava physics will reduce Samus' horizontal momentum.",
+        "Wall jump off of the upper-left Namihe and then Spring Ball jump up and out of the lava.",
+        "Delay the pause until in position to perform the Spring Ball jump because lava physics will reduce Samus' horizontal momentum.",
         "It may help to also delay the Morph."
       ],
       "devNote": [
@@ -932,6 +955,7 @@
         {"heatFrames": 270},
         {"gravitylessLavaFrames": 240}
       ],
+      "flashSuitChecked": true,
       "note": "Double springball jump out of a walljump starting from the top of the left wall Namihe."
     },
     {
@@ -952,8 +976,9 @@
         {"gravitylessLavaFrames": 480},
         {"enemyDamage": {"enemy": "Namihe", "type": "kago", "hits": 2}}
       ],
+      "flashSuitChecked": true,
       "note": [
-        "Enter the Bottom-Left Namihe by Kagoing inside of it.",
+        "Enter the bottom-left Namihe by kagoing inside of it.",
         "Wait for a second hit to gain i-frames and then very quickly walljump up the spikes and across to the right side wall."
       ]
     },
@@ -995,6 +1020,7 @@
           ]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Begin on top of the lower left Namihe",
         "Jump into a double IBJ with such timing that Samus passes above the fired flame and such a way that there is no horizontal speed.",
@@ -1035,6 +1061,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
     },
     {
@@ -1066,6 +1093,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
     },
     {
@@ -1121,6 +1149,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity.",
       "devNote": [
         "Varia no etanks is barely possible with vanilla Varia.",
@@ -1140,6 +1169,7 @@
         {"gravitylessLavaFrames": 230},
         {"lavaFrames": 20}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gravity jump from below the Lowest-Right Namihe.",
         "Walljump using the right side wall to reach the top of the lava, avoiding the Namihe fireball.",
@@ -1162,6 +1192,7 @@
         {"gravitylessLavaFrames": 125},
         {"lavaFrames": 20}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gravity jump from below the Lowest-Right Namihe.",
         "A crouch jump or walljump can help exit the lava in one jump, but are not required."
@@ -1183,6 +1214,7 @@
         {"gravitylessLavaFrames": 500},
         {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the bottom-most right-side Namihe to generate a flame and walk with it to the bottom-most left Namihe head.",
         "Use a turnaround animation as Samus is hit by the flame to cancel out knockback frames.",
@@ -1207,6 +1239,7 @@
         {"heatFrames": 375},
         {"gravitylessLavaFrames": 300}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the bottom-most right-side Namihe to generate a flame and walk with it to the bottommost left Namihe head.",
         "Pause and use a turnaround animation as Samus is hit by the flame to cancel out knockback frames.",
@@ -1224,6 +1257,7 @@
         {"heatFrames": 255},
         {"gravitylessLavaFrames": 225}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Double Spring Ball Jump from below the lowest-right Namihe.",
         "Double Spring Ball Jumps are easier in Lava than in Water."
@@ -1241,6 +1275,7 @@
         {"lavaFrames": 100},
         {"gravitylessLavaFrames": 200}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gravity jump from two platforms below the lowest-right Namihe.",
         "Double Spring Ball Jump out of the lava without HiJump."
@@ -1265,6 +1300,7 @@
         {"heatFrames": 1040},
         {"lavaFrames": 1020}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Align with the above platform and scroll the camera left by walking into the left side of the bottom-most tiles.",
         "Freeze both left side Namihes and begin bomb jumping"
@@ -1293,6 +1329,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Samus will be slowed by lava if SpeedBooster is equipped, even with Gravity."
     },
     {

--- a/region/norfair/east/Lava Farm Tunnel.json
+++ b/region/norfair/east/Lava Farm Tunnel.json
@@ -122,7 +122,8 @@
           "length": 14,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 1,
@@ -163,6 +164,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Space Jump, Spring Ball, to carry blue speed across the room;",
         "alternatively, use a long series of temporary blue chains."
@@ -229,6 +231,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Space Jump, Spring Ball, to carry blue speed across the room;",
         "alternatively, use a long series of temporary blue chains."
@@ -286,8 +289,9 @@
       "link": [1, 4],
       "name": "Base",
       "requires": [
-        {"heatFrames": 70}
-      ]
+        {"heatFrames": 60}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 48,
@@ -348,6 +352,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use Space Jump, Spring Ball, to carry blue speed across the room;",
         "alternatively, use a long series of temporary blue chains."
@@ -364,7 +369,8 @@
       },
       "requires": [
         {"heatFrames": 50}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -376,7 +382,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -393,7 +400,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -410,7 +418,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -422,7 +431,8 @@
           "length": 14,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -439,7 +449,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 80}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -597,7 +608,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -613,7 +625,8 @@
           "rightPosition": 2
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -641,6 +654,7 @@
           "requires": [{"heatFrames": 110}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "This includes time to moonwalk back against the right door, without shooting it open.",
         "An additional tile could be used by opening the right door but there is not yet any known application."
@@ -677,6 +691,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain the shinecharge below the right edge of the door above to avoid bringing the Dragon on-camera."
       ]
@@ -708,7 +723,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 52,
@@ -746,8 +762,9 @@
       "link": [2, 4],
       "name": "Base",
       "requires": [
-        {"heatFrames": 210}
-      ]
+        {"heatFrames": 180}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -775,7 +792,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 55}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -833,7 +851,8 @@
         "leaveWithDoorFrameBelow": {
           "height": 2
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -848,7 +867,8 @@
           "leftPosition": -2.5,
           "rightPosition": 2.5
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -864,12 +884,13 @@
           "rightPosition": 6
         }
       },
+      "flashSuitChecked": true,
       "devNote": "An additional tile could be used by opening the right door but there is not yet any known application."
     },
     {
       "id": 29,
       "link": [3, 3],
-      "name": "G-Mode Setup - Frozen Gammets",
+      "name": "G-Mode Setup - Frozen Gamets",
       "requires": [
         "h_heatProof",
         "canUpwardGModeSetup",
@@ -884,8 +905,8 @@
       },
       "flashSuitChecked": true,
       "note": [
-        "Freeze the stack of Gammets together a few times to try and raise them as high as possible.",
-        "Run with them to the door and freeze the top two such that Samus can stand on the lower and take damage from the higher Gammet when it unfreezes."
+        "Freeze the stack of Gamets together a few times to try and raise them as high as possible.",
+        "Run with them to the door and freeze the top two such that Samus can stand on the lower and take damage from the higher Gamet when it unfreezes."
       ],
       "detailNote": "It is possible to jump onto the Gamet without Morph, as long as it is not too high."
     },
@@ -976,8 +997,9 @@
       "link": [3, 4],
       "name": "Base",
       "requires": [
-        {"heatFrames": 210}
-      ]
+        {"heatFrames": 175}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 50,
@@ -1005,8 +1027,9 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        {"heatFrames": 80}
-      ]
+        {"heatFrames": 75}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -1021,7 +1044,8 @@
           "openEnd": 1
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1041,9 +1065,10 @@
       "link": [4, 2],
       "name": "Base",
       "requires": [
-        {"heatFrames": 210}
+        {"heatFrames": 205}
       ],
-      "unlocksDoors": [{"types": ["missiles"], "requires": []}]
+      "unlocksDoors": [{"types": ["missiles"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -1068,7 +1093,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -1092,7 +1118,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 210}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -1116,7 +1143,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -1142,7 +1170,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 41,

--- a/region/norfair/east/Lava Grapple Tunnel.json
+++ b/region/norfair/east/Lava Grapple Tunnel.json
@@ -72,7 +72,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -85,7 +86,8 @@
         "leaveWithGrappleSwing": {
           "blocks": [{"position": [9, 2], "note": "Closest Grapple block to the left door"}]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -132,7 +134,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 390}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -147,7 +150,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 350}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 52,
@@ -162,7 +166,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 330}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -177,7 +182,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 310}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -192,7 +198,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 285}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -207,7 +214,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 250}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 55,
@@ -222,7 +230,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 225}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 56,
@@ -237,7 +246,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 195}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 57,
@@ -252,7 +262,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 175}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 58,
@@ -267,7 +278,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 145}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 59,
@@ -282,7 +294,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 120}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -292,7 +305,8 @@
         {"heatFrames": 820},
         {"lavaFrames": 150},
         {"spikeHits": 7}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -300,12 +314,13 @@
       "name": "Suitless Damage Boosts (Left to Right)",
       "requires": [
         {"notable": "Suitless Damage Boosts"},
-        {"heatFrames": 520},
-        {"lavaFrames": 80},
+        {"heatFrames": 460},
+        {"lavaFrames": 60},
         {"spikeHits": 3},
         "canUseIFrames",
         "canHorizontalDamageBoost"
       ],
+      "flashSuitChecked": true,
       "note": "Damage boosts can be used to save energy - delay the damage boost from the spikes slightly in order to rise above the lava before moving."
     },
     {
@@ -315,18 +330,25 @@
       "requires": [
         "Gravity",
         {"disableEquipment": "SpeedBooster"},
-        {"heatFrames": 350},
-        {"lavaFrames": 100},
+        {"heatFrames": 330},
+        {"lavaFrames": 90},
         {"spikeHits": 2},
         {"or": [
           "canUseIFrames",
           {"and": [
             {"spikeHits": 2},
             {"heatFrames": 50}
-          ]},
-          "canHorizontalDamageBoost"
+          ]}
+        ]},
+        {"or": [
+          "canHorizontalDamageBoost",
+          {"and": [
+            {"heatFrames": 20},
+            {"lavaFrames": 20}
+          ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Speedbooster significantly reduces your jump speed in lava and should be turned off."
     },
     {
@@ -346,7 +368,8 @@
         {"spikeHits": 2},
         {"heatFrames": 350},
         {"lavaFrames": 20}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -367,6 +390,7 @@
         {"heatFrames": 240},
         {"lavaFrames": 10}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Uses a runway of at least 14 tiles in the adjacent room.",
         "Disable SpeedBooster after jumping so that the lava will not take away all of Samus' momentum."
@@ -391,6 +415,7 @@
         {"heatFrames": 350},
         {"lavaFrames": 32}
       ],
+      "flashSuitChecked": true,
       "note": "It may help to perform the first jump with HiJump disabled."
     },
     {
@@ -413,6 +438,7 @@
         {"heatFrames": 311},
         {"lavaFrames": 22}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Uses a runway of at least 8 tiles in the adjacent room.",
         "It will help to perform the first jump with HiJump disabled.",
@@ -439,6 +465,7 @@
         {"heatFrames": 200},
         {"lavaFrames": 11}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Uses a runway of at least 21 tiles in the adjacent room.",
         "It will help to perform the first jump with HiJump disabled.",
@@ -456,7 +483,8 @@
       "requires": [
         {"shinespark": {"frames": 80, "excessFrames": 4}},
         {"heatFrames": 210}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -482,7 +510,8 @@
             {"heatFrames": 300}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -514,6 +543,7 @@
           "requires": [{"heatFrames": 90}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "The minimum speed $1.A is arbitrary; lower speeds could work with larger heatFrames.",
         "FIXME: set up a mechanism to automate heat frames required in cases like this."
@@ -541,6 +571,7 @@
         {"lavaFrames": 15},
         {"heatFrames": 580}
       ],
+      "flashSuitChecked": true,
       "note": [
         "While crossing the Spiky Lava, land on frozen Yapping Maws to reduce the number of spike hits needed.",
         "Damage boost towards then freeze the Leftmost enemy as it extends.",
@@ -558,6 +589,7 @@
         "canLongCeilingBombJump",
         "canResetFallSpeed"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Samus can ceiling bomb jump up gentle slopes.",
         "Going down gentle slopes is also possible but harder, instead an unmorph to reset fall speed is recommended here."
@@ -707,7 +739,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 390}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 60,
@@ -722,7 +755,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 350}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 61,
@@ -737,7 +771,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 330}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 62,
@@ -752,7 +787,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 310}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -767,7 +803,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 285}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 63,
@@ -782,7 +819,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 250}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 64,
@@ -797,7 +835,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 225}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 65,
@@ -812,7 +851,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 195}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 66,
@@ -827,7 +867,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 175}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 67,
@@ -842,7 +883,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 145}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 68,
@@ -857,7 +899,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 120}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -867,7 +910,8 @@
         {"heatFrames": 820},
         {"lavaFrames": 150},
         {"spikeHits": 7}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -875,12 +919,13 @@
       "name": "Suitless Damage Boosts (Right to Left)",
       "requires": [
         {"notable": "Suitless Damage Boosts"},
-        {"heatFrames": 520},
-        {"lavaFrames": 80},
+        {"heatFrames": 460},
+        {"lavaFrames": 60},
         {"spikeHits": 3},
         "canUseIFrames",
         "canHorizontalDamageBoost"
       ],
+      "flashSuitChecked": true,
       "note": "Damage boosts can be used to save energy - delay the damage boost from the spikes slightly in order to rise above the lava before moving."
     },
     {
@@ -890,18 +935,25 @@
       "requires": [
         "Gravity",
         {"disableEquipment": "SpeedBooster"},
-        {"heatFrames": 350},
-        {"lavaFrames": 100},
+        {"heatFrames": 330},
+        {"lavaFrames": 90},
         {"spikeHits": 2},
         {"or": [
           "canUseIFrames",
           {"and": [
             {"spikeHits": 2},
             {"heatFrames": 50}
-          ]},
-          "canHorizontalDamageBoost"
+          ]}
+        ]},
+        {"or": [
+          "canHorizontalDamageBoost",
+          {"and": [
+            {"heatFrames": 20},
+            {"lavaFrames": 20}
+          ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Speedbooster significantly reduces your jump speed in lava and should be turned off."
     },
     {
@@ -920,7 +972,8 @@
         {"spikeHits": 2},
         {"heatFrames": 350},
         {"lavaFrames": 20}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -941,6 +994,7 @@
         {"heatFrames": 240},
         {"lavaFrames": 10}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Uses a runway of at least 14 tiles in the adjacent room.",
         "Disable SpeedBooster after jumping so that the lava will not take away all of Samus' momentum."
@@ -965,6 +1019,7 @@
         {"heatFrames": 350},
         {"lavaFrames": 32}
       ],
+      "flashSuitChecked": true,
       "note": "It may help to perform the first jump with HiJump disabled."
     },
     {
@@ -987,6 +1042,7 @@
         {"heatFrames": 311},
         {"lavaFrames": 22}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Uses a runway of at least 8 tiles in the adjacent room.",
         "It will help to perform the first jump with HiJump disabled.",
@@ -1013,6 +1069,7 @@
         {"heatFrames": 200},
         {"lavaFrames": 11}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Uses a runway of at least 21 tiles in the adjacent room.",
         "It will help to perform the first jump with HiJump disabled.",
@@ -1030,7 +1087,8 @@
       "requires": [
         {"shinespark": {"frames": 80, "excessFrames": 4}},
         {"heatFrames": 210}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -1056,7 +1114,8 @@
             {"heatFrames": 300}
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -1080,6 +1139,7 @@
         {"lavaFrames": 15},
         {"heatFrames": 580}
       ],
+      "flashSuitChecked": true,
       "note": [
         "While crossing the Spiky Lava, land on frozen Yapping Maws to reduce the number of spike hits needed.",
         "Morph and unmorph while above the rightmost Yapping Maw to land on it just above the lava line.",
@@ -1118,6 +1178,7 @@
           "requires": [{"heatFrames": 90}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "The minimum speed $1.A is arbitrary; lower speeds could work with larger heatFrames.",
         "FIXME: set up a mechanism to automate heat frames required in cases like this."
@@ -1134,7 +1195,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -1146,7 +1208,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -1163,7 +1226,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -1180,7 +1244,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -1191,6 +1256,7 @@
         "canLongCeilingBombJump",
         "canResetFallSpeed"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Samus can ceiling bomb jump up gentle slopes.",
         "Going down gentle slopes is also possible but harder, instead an unmorph to reset fall speed is recommended here."
@@ -1314,7 +1380,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -1327,7 +1394,8 @@
         "leaveWithGrappleSwing": {
           "blocks": [{"position": [6, 2], "note": "Closest Grapple block to the right door"}]
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 36,


### PR DESCRIPTION
This tightens heat frames in Lava Farm Tunnel, by assuming a tighter pause abuse where you fall into the lava for your initial drops; this makes it so that in Insane you can now logically make it from the farm to either of the right doors and back tankless. Tightened a few heat/lava frames in Lava Grapple Tunnel as well.