### PR TITLE
Norfair East check flash suits pt. 6 (Single Chamber)

### DIFF
--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -76,15 +76,6 @@
   ],
   "strats": [
     {
-      "id": 1,
-      "link": [1, 1],
-      "name": "Leave Normally",
-      "requires": [],
-      "exitCondition": {
-        "leaveNormally": {}
-      }
-    },
-    {
       "id": 2,
       "link": [1, 1],
       "name": "Shinespark",
@@ -95,6 +86,7 @@
       "requires": [
         {"shinespark": {"frames": 40, "excessFrames": 40}}
       ],
+      "flashSuitChecked": true,
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
@@ -117,7 +109,8 @@
       "farmCycleDrops": [
         {"enemy": "Geemer (grey)", "count": 4},
         {"enemy": "Red Space Pirate (standing)", "count": 3}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -144,7 +137,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Red Space Pirate (standing)", "count": 3}]
+      "farmCycleDrops": [{"enemy": "Red Space Pirate (standing)", "count": 3}],
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -178,7 +172,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Geemer (grey)", "count": 4}]
+      "farmCycleDrops": [{"enemy": "Geemer (grey)", "count": 4}],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -213,6 +208,7 @@
           "hits": 1
         }}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait for the pirates to step towards the wall then jump on their platform. Shoot them to momentarily prevent them from shooting lasers.",
         "This strat assumes getting hit once. Note that the Geemers do much less damage than the Pirates"
@@ -225,6 +221,7 @@
       "requires": [
         "canCarefulJump"
       ],
+      "flashSuitChecked": true,
       "note": "Wait for the pirates to step towards the wall then jump on their platform. Shoot them to momentarily prevent them from shooting lasers."
     },
     {
@@ -238,7 +235,8 @@
             ["Red Space Pirate (standing)", "Red Space Pirate (standing)"]
           ]
         }}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -251,13 +249,15 @@
       "requires": [
         {"shinespark": {"frames": 40, "excessFrames": 6}}
       ],
+      "flashSuitChecked": true,
       "note": "Enter on the either side of the doorway to make it to the top."
     },
     {
       "id": 9,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -292,7 +292,8 @@
       "requires": [
         "canMoonfall"
       ],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -304,7 +305,8 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -321,6 +323,7 @@
           "openEnd": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Knock a Geemer off with a Super then follow it back to the top. Grey Geemers can only be frozen with Plasma."
     },
     {
@@ -343,7 +346,8 @@
       "farmCycleDrops": [
         {"enemy": "Geemer (grey)", "count": 4},
         {"enemy": "Red Space Pirate (standing)", "count": 3}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -377,7 +381,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Geemer (grey)", "count": 4}]
+      "farmCycleDrops": [{"enemy": "Geemer (grey)", "count": 4}],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -404,7 +409,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Red Space Pirate (standing)", "count": 3}]
+      "farmCycleDrops": [{"enemy": "Red Space Pirate (standing)", "count": 3}],
+      "flashSuitChecked": true
     },
     {
       "id": 12,

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -86,7 +86,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -107,7 +108,8 @@
           {"cycleFrames": 360}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Sova", "count": 4}]
+      "farmCycleDrops": [{"enemy": "Sova", "count": 4}],
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -141,7 +143,8 @@
       "farmCycleDrops": [
         {"enemy": "Sova", "count": 5},
         {"enemy": "Dragon", "count": 4}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -165,7 +168,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Squeept", "count": 2}]
+      "farmCycleDrops": [{"enemy": "Squeept", "count": 2}],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -199,17 +203,18 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "SpaceJump",
+      "name": "Space Jump",
       "requires": [
         "SpaceJump",
         {"heatFrames": 460}
       ],
-      "note": "Building runspeed can speed up the room a noticable amount."
+      "flashSuitChecked": true,
+      "note": "Building run speed can speed up the room a noticable amount."
     },
     {
       "id": 5,
       "link": [1, 2],
-      "name": "SpaceJump with Run Speed",
+      "name": "Space Jump with Run Speed",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": "any",
@@ -220,6 +225,7 @@
         "SpaceJump",
         {"heatFrames": 370}
       ],
+      "flashSuitChecked": true,
       "note": "Building runspeed can speed up the room a noticable amount."
     },
     {
@@ -234,7 +240,8 @@
           ]},
           {"heatFrames": 660}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -251,7 +258,8 @@
         {"enemyDamage": {"enemy": "Sova", "type": "contact", "hits": 1}},
         {"enemyDamage": {"enemy": "Dragon", "type": "contact", "hits": 1}},
         {"heatFrames": 480}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -270,6 +278,7 @@
         "canSlowShortCharge",
         {"heatFrames": 350}
       ],
+      "flashSuitChecked": true,
       "note": "Jump between the first and second floating platforms, to speedball through the room.",
       "devNote": ["Some heat frames are implicit in the entrance condition."]
     },
@@ -290,6 +299,7 @@
         "canInsaneJump",
         {"heatFrames": 360}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump into the room with blue speed,",
         "and fall between the door ledge and the first floating platform, to speedball through the room."
@@ -310,6 +320,7 @@
         {"heatFrames": 210},
         {"shinespark": {"frames": 90, "excessFrames": 5}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spark in line with the top of the door.",
         "Sparking too low or too high will crash early."
@@ -348,6 +359,7 @@
         {"heatFrames": 195},
         {"shinespark": {"frames": 95, "excessFrames": 5}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spark in line with the top of the door.",
         "Sparking too low or too high will crash early."
@@ -378,7 +390,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -437,6 +450,7 @@
         "canBeVeryPatient",
         {"heatFrames": 390}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use controlled Spring Ball bounces to cross the whole room while avoiding all enemy damage.",
         "There is a significant chance of failure due to bad Squeept RNG."
@@ -445,16 +459,17 @@
     {
       "id": 12,
       "link": [2, 1],
-      "name": "SpaceJump",
+      "name": "Space Jump",
       "requires": [
         "SpaceJump",
         {"heatFrames": 450}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
       "link": [2, 1],
-      "name": "SpaceJump with Run Speed",
+      "name": "Space Jump with Run Speed",
       "entranceCondition": {
         "comeInRunning": {
           "speedBooster": "any",
@@ -464,7 +479,8 @@
       "requires": [
         "SpaceJump",
         {"heatFrames": 390}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -481,6 +497,7 @@
         {"heatFrames": 210},
         {"shinespark": {"frames": 90, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spark in line with the top of the door.",
         "Sparking too low or too high will crash early."
@@ -519,6 +536,7 @@
         {"heatFrames": 195},
         {"shinespark": {"frames": 95, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spark in line with the top of the door.",
         "Sparking too low or too high will crash early."
@@ -535,6 +553,7 @@
           {"heatFrames": 160}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "Build up run speed to travel farther when jumping."
     },
     {
@@ -553,7 +572,8 @@
         {"enemyDamage": {"enemy": "Sova", "type": "contact", "hits": 1}},
         {"heatFrames": 500},
         {"lavaFrames": 360}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -573,6 +593,7 @@
         {"heatFrames": 480},
         {"lavaFrames": 240}
       ],
+      "flashSuitChecked": true,
       "note": "Jump to the first long platform then use a the full platform to jump and mockball through the lava."
     },
     {
@@ -599,7 +620,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -612,7 +634,8 @@
       },
       "requires": [
         {"heatFrames": 50}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -624,7 +647,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -641,7 +665,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -658,7 +683,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -750,6 +776,7 @@
         "canBeVeryPatient",
         {"heatFrames": 390}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use controlled Spring Ball bounces to cross the whole room while avoiding all enemy damage.",
         "There is a significant chance of failure due to bad Squeept RNG."
@@ -765,7 +792,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -794,6 +822,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Sova", "count": 4}],
+      "flashSuitChecked": true,
       "devNote": "Add canTrickyJump for catching the Sovas on their first cycles."
     },
     {
@@ -832,7 +861,8 @@
       "farmCycleDrops": [
         {"enemy": "Sova", "count": 5},
         {"enemy": "Dragon", "count": 4}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -101,6 +101,32 @@
         [1, 0, 0, 0, 0, 0]
       ],
       "note": "Represents the platform where Samus will land after falling from the morph tunnel when arriving from Lower Norfair."
+    },
+    {
+      "id": 7,
+      "name": "Left Shaft - Middle Junction",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "mapTileMask": [
+        [1, 1, 1, 1, 1, 1],
+        [2, 0, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0]
+      ],
+      "note": "Represents the platform below the top right door of the left shaft."
+    },
+    {
+      "id": 8,
+      "name": "Left Shaft - Bottom Junction",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "mapTileMask": [
+        [1, 1, 1, 1, 1, 1],
+        [1, 0, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0, 0]
+      ],
+      "note": "Represents the platform below the middle right door of the left shaft."
     }
   ],
   "enemies": [
@@ -166,7 +192,8 @@
         {"id": 2},
         {"id": 3},
         {"id": 4},
-        {"id": 5}
+        {"id": 5},
+        {"id": 8}
       ]
     },
     {
@@ -176,7 +203,9 @@
         {"id": 2},
         {"id": 3},
         {"id": 4},
-        {"id": 5}
+        {"id": 5},
+        {"id": 7},
+        {"id": 8}
       ]
     },
     {
@@ -187,7 +216,8 @@
         {"id": 3},
         {"id": 4},
         {"id": 5},
-        {"id": 6}
+        {"id": 6},
+        {"id": 7}
       ]
     },
     {
@@ -203,7 +233,25 @@
       "to": [
         {"id": 1},
         {"id": 4},
-        {"id": 6}
+        {"id": 6},
+        {"id": 7}
+      ]
+    },
+    {
+      "from": 7,
+      "to": [
+        {"id": 3},
+        {"id": 4},
+        {"id": 6},
+        {"id": 8}
+      ]
+    },
+    {
+      "from": 8,
+      "to": [
+        {"id": 2},
+        {"id": 3},
+        {"id": 7}
       ]
     }
   ],
@@ -218,7 +266,8 @@
           "length": 8,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 97,
@@ -235,7 +284,8 @@
           {"cycleFrames": 30}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Multiviola", "count": 1}]
+      "farmCycleDrops": [{"enemy": "Multiviola", "count": 1}],
+      "flashSuitChecked": true
     },
     {
       "id": 61,
@@ -274,7 +324,8 @@
       "farmCycleDrops": [
         {"enemy": "Multiviola", "count": 1},
         {"enemy": "Alcoon", "count": 2}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -332,7 +383,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 77,
@@ -386,7 +438,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 78,
@@ -434,7 +487,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 67,
@@ -461,7 +515,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 79,
@@ -556,8 +611,9 @@
       "link": [1, 6],
       "name": "Base",
       "requires": [
-        {"heatFrames": 100}
-      ]
+        {"heatFrames": 80}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 68,
@@ -593,7 +649,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 82,
@@ -646,7 +703,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 104,
@@ -681,7 +739,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -698,7 +757,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -732,7 +792,8 @@
           "openEnd": 0,
           "gentleDownTiles": 4
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 98,
@@ -765,7 +826,8 @@
       "farmCycleDrops": [
         {"enemy": "Multiviola", "count": 1},
         {"enemy": "Alcoon", "count": 1}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -800,51 +862,6 @@
       "note": "Enter the room and crouch next to the closed door. After the Multiviola hits the door, open it and it will be on a trajectory to hit Samus the next pass."
     },
     {
-      "id": 13,
-      "link": [2, 3],
-      "name": "Base",
-      "requires": [
-        {"or": [
-          "canWalljump",
-          "HiJump",
-          "SpaceJump",
-          "h_crouchJumpDownGrab"
-        ]},
-        {"heatFrames": 280}
-      ]
-    },
-    {
-      "id": 14,
-      "link": [2, 3],
-      "name": "Leave with Runway",
-      "requires": [
-        {"or": [
-          "canWalljump",
-          "HiJump",
-          "SpaceJump",
-          "h_crouchJumpDownGrab"
-        ]},
-        {"heatFrames": 260}
-      ],
-      "exitCondition": {
-        "leaveWithRunway": {
-          "length": 4,
-          "openEnd": 1
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["missiles"],
-          "requires": [{"heatFrames": 50}]
-        },
-        {"types": ["super"], "requires": []},
-        {
-          "types": ["powerbomb"],
-          "requires": [{"heatFrames": 110}]
-        }
-      ]
-    },
-    {
       "id": 15,
       "link": [2, 3],
       "name": "Enter Shinecharging, Leave Sparking",
@@ -870,7 +887,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 16,
@@ -908,7 +926,9 @@
       "requires": [
         "canIBJ",
         {"heatFrames": 1200}
-      ]
+      ],
+      "flashSuitChecked": true,
+      "devNote": ["FIXME: refine these heat frames."]
     },
     {
       "id": 18,
@@ -918,6 +938,7 @@
         "canUseFrozenEnemies",
         {"heatFrames": 450}
       ],
+      "flashSuitChecked": true,
       "note": "Kill the Alcoon, then freeze the Multiviola to use as a platform."
     },
     {
@@ -954,7 +975,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 83,
@@ -1018,7 +1040,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 84,
@@ -1129,6 +1152,20 @@
       ]
     },
     {
+      "link": [2, 8],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"heatFrames": 100},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 95}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 71,
       "link": [3, 1],
       "name": "Come in Getting Blue Speed, Leave With Temporary Blue",
@@ -1163,6 +1200,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: This could be done with lower run speed, at the cost of more heat frames."
       ]
@@ -1218,7 +1256,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 105,
@@ -1253,7 +1292,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 106,
@@ -1270,7 +1310,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -1291,50 +1332,6 @@
         "Exit the previous room with Samus in a standing pose (while grappled).",
         "After teleporting, press right to release Grapple while staying standing (not being forced into a crouch).",
         "Then X-ray climb 1 screen to get up to the door transition, without needing to open the door."
-      ]
-    },
-    {
-      "id": 22,
-      "link": [3, 2],
-      "name": "Base",
-      "requires": [
-        {"heatFrames": 200}
-      ],
-      "unlocksDoors": [
-        {
-          "types": ["missiles"],
-          "requires": [{"heatFrames": 30}]
-        },
-        {
-          "types": ["powerbomb"],
-          "requires": [{"heatFrames": 10}]
-        }
-      ]
-    },
-    {
-      "id": 23,
-      "link": [3, 2],
-      "name": "Leave with Runway",
-      "requires": [
-        {"heatFrames": 140}
-      ],
-      "exitCondition": {
-        "leaveWithRunway": {
-          "length": 13,
-          "openEnd": 0,
-          "gentleDownTiles": 4
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["missiles"],
-          "requires": [{"heatFrames": 50}]
-        },
-        {"types": ["super"], "requires": []},
-        {
-          "types": ["powerbomb"],
-          "requires": [{"heatFrames": 30}]
-        }
       ]
     },
     {
@@ -1470,7 +1467,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 99,
@@ -1506,7 +1504,8 @@
       "farmCycleDrops": [
         {"enemy": "Multiviola", "count": 1},
         {"enemy": "Alcoon", "count": 1}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -1516,51 +1515,6 @@
         "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true
-    },
-    {
-      "id": 29,
-      "link": [3, 4],
-      "name": "Base",
-      "requires": [
-        {"or": [
-          "canWalljump",
-          "HiJump",
-          "SpaceJump",
-          "h_crouchJumpDownGrab"
-        ]},
-        {"heatFrames": 310}
-      ]
-    },
-    {
-      "id": 30,
-      "link": [3, 4],
-      "name": "Leave with Runway",
-      "requires": [
-        {"or": [
-          "canWalljump",
-          "HiJump",
-          "SpaceJump",
-          "h_crouchJumpDownGrab"
-        ]},
-        {"heatFrames": 290}
-      ],
-      "exitCondition": {
-        "leaveWithRunway": {
-          "length": 4,
-          "openEnd": 1
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["missiles"],
-          "requires": [{"heatFrames": 50}]
-        },
-        {"types": ["super"], "requires": []},
-        {
-          "types": ["powerbomb"],
-          "requires": [{"heatFrames": 110}]
-        }
-      ]
     },
     {
       "id": 31,
@@ -1620,7 +1574,9 @@
         "canIBJ",
         {"heatFrames": 1950}
       ],
-      "note": "Jump the Alcoon and kill the Multiviola, then IBJ."
+      "flashSuitChecked": true,
+      "note": "Jump the Alcoon and kill the Multiviola, then IBJ.",
+      "devNote": "FIXME: refine these heat frames."
     },
     {
       "id": 34,
@@ -1630,10 +1586,12 @@
         "canTrickyUseFrozenEnemies",
         {"heatFrames": 1300}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Wait for the Alcoon to walk off the edge. Use it and the Multiviola as platforms.",
         "Spawn the Alcoon, then run back to the right so it will not stop and fire projectiles."
-      ]
+      ],
+      "devNote": "FIXME: split this into 3->7 and 7->4 strats."
     },
     {
       "id": 73,
@@ -1670,6 +1628,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: This could be done with lower run speed, at the cost of more heat frames."
       ]
@@ -1783,6 +1742,43 @@
       ]
     },
     {
+      "link": [3, 7],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 120}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 110}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 150}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 155}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 180}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [3, 8],
+      "name": "Base",
+      "requires": [
+        {"heatFrames": 65}
+      ],
+      "flashSuitChecked": true
+    },
+    {
       "id": 35,
       "link": [4, 1],
       "name": "Enter Shinecharging, Leave Sparking",
@@ -1810,7 +1806,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 74,
@@ -1847,6 +1844,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: This could be done with lower run speed, at the cost of more heat frames."
       ]
@@ -1902,7 +1900,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -1914,7 +1913,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 107,
@@ -1931,7 +1931,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 38,
@@ -1979,7 +1980,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 93,
@@ -2002,49 +2004,6 @@
         "It is possible to kill a Multiviola by the door and pause abuse to grab its Energy drop on G-mode exit.",
         "It is important avoid touching the invisible fireballs the Alcoons place, and to prevent them from shooting too many fireballs, as they will eventually prevent drops from appearing.",
         "Either kill them or avoid them then kill the Multiviola near the door without too much delay."
-      ]
-    },
-    {
-      "id": 39,
-      "link": [4, 3],
-      "name": "Base",
-      "requires": [
-        {"heatFrames": 220}
-      ],
-      "unlocksDoors": [
-        {
-          "types": ["missiles"],
-          "requires": [{"heatFrames": 20}]
-        },
-        {
-          "types": ["powerbomb"],
-          "requires": [{"heatFrames": 10}]
-        }
-      ]
-    },
-    {
-      "id": 40,
-      "link": [4, 3],
-      "name": "Leave with Runway",
-      "requires": [
-        {"heatFrames": 200}
-      ],
-      "exitCondition": {
-        "leaveWithRunway": {
-          "length": 4,
-          "openEnd": 1
-        }
-      },
-      "unlocksDoors": [
-        {
-          "types": ["missiles"],
-          "requires": [{"heatFrames": 65}]
-        },
-        {"types": ["super"], "requires": []},
-        {
-          "types": ["powerbomb"],
-          "requires": [{"heatFrames": 30}]
-        }
       ]
     },
     {
@@ -2077,7 +2036,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 76,
@@ -2104,7 +2064,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 94,
@@ -2132,7 +2093,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 100,
@@ -2172,7 +2134,8 @@
       "farmCycleDrops": [
         {"enemy": "Multiviola", "count": 1},
         {"enemy": "Alcoon", "count": 2}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 101,
@@ -2191,6 +2154,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Multiviola", "count": 1}],
+      "flashSuitChecked": true,
       "note": "Jump and aim down two to three times to activate the Multiviola."
     },
     {
@@ -2314,13 +2278,29 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "canWalljump",
-          "HiJump",
-          "SpaceJump",
-          "h_crouchJumpDownGrab"
-        ]},
-        {"heatFrames": 200}
-      ]
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 130}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 115}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 150}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 155}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 180}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 45,
@@ -2330,7 +2310,9 @@
         "canIBJ",
         {"heatFrames": 750}
       ],
-      "note": "Kill the enemies, then IBJ."
+      "flashSuitChecked": true,
+      "note": "Kill the enemies, then IBJ.",
+      "devNote": "FIXME: Refine these heat frames."
     },
     {
       "id": 46,
@@ -2340,7 +2322,16 @@
         "canTrickyUseFrozenEnemies",
         {"heatFrames": 830}
       ],
+      "flashSuitChecked": true,
       "note": "Wait for the Alcoon to walk off the edge. Use it and the Multiviola as platforms."
+    },
+    {
+      "link": [4, 7],
+      "name": "Base",
+      "requires": [
+        {"heatFrames": 65}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -2353,7 +2344,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 108,
@@ -2438,7 +2430,8 @@
           "length": 4,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -2457,7 +2450,8 @@
         "Morph",
         "ScrewAttack",
         {"heatFrames": 600}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -2466,7 +2460,8 @@
       "requires": [
         "h_usePowerBomb",
         {"heatFrames": 660}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -2475,7 +2470,8 @@
       "requires": [
         "h_useMorphBombs",
         {"heatFrames": 730}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 102,
@@ -2485,7 +2481,8 @@
         {"heatFrames": 250},
         "h_heatedCrystalFlash",
         {"heatFrames": 380}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 103,
@@ -2506,7 +2503,8 @@
         ]},
         "h_heatedCrystalFlash",
         {"heatFrames": 250}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 55,
@@ -2514,15 +2512,42 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "canWalljump",
-          "HiJump",
-          "h_crouchJumpDownGrab",
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 100}
+          ]},
+          {"and": [
+            "canWalljump",
+            "ScrewAttack",
+            {"heatFrames": 85}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 95}
+          ]},
+          {"and": [
+            "HiJump",
+            "ScrewAttack",
+            {"heatFrames": 75}
+          ]},
+          {"and": [
+            "HiJump",
+            "Plasma",
+            {"heatFrames": 70}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 100}
+          ]},
           {"and": [
             "SpaceJump",
-            {"heatFrames": 40}
+            {"heatFrames": 115}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 120}
           ]}
-        ]},
-        {"heatFrames": 100}
+        ]}
       ],
       "unlocksDoors": [
         {
@@ -2533,19 +2558,50 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 70}]
         }
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "The heat frames account for bad scenarios of where the Multiviola may be (entering from node 4),",
+        "which is why Screw Attack can be helpful."
       ]
     },
     {
       "id": 56,
       "link": [6, 1],
-      "name": "Leave with Runway",
+      "name": "Leave With Runway",
       "requires": [
         {"or": [
-          "canWalljump",
-          "HiJump",
-          "h_crouchJumpDownGrab"
-        ]},
-        {"heatFrames": 60}
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 80}
+          ]},
+          {"and": [
+            "canWalljump",
+            "ScrewAttack",
+            {"heatFrames": 60}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 80}
+          ]},
+          {"and": [
+            "HiJump",
+            "ScrewAttack",
+            {"heatFrames": 60}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 80}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 80}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 90}
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -2563,7 +2619,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 70}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 57,
@@ -2573,7 +2630,9 @@
         "canIBJ",
         {"heatFrames": 1500}
       ],
-      "note": "Kill the enemies, then IBJ."
+      "flashSuitChecked": true,
+      "note": "Kill the enemies, then IBJ.",
+      "devNote": ["FIXME: Refine these heat frames."]
     },
     {
       "id": 58,
@@ -2582,14 +2641,29 @@
       "requires": [
         "canUseFrozenEnemies",
         {"heatFrames": 600}
-      ]
+      ],
+      "flashSuitChecked": true,
+      "devNote": ["FIXME: Refine these heat frames."]
     },
     {
       "id": 59,
       "link": [6, 4],
       "name": "Base",
       "requires": [
-        {"heatFrames": 150}
+        {"or": [
+          {"heatFrames": 130},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Alcoon"]],
+              "explicitWeapons": ["ScrewAttack", "Missile", "Super", "Wave+Plasma"]
+            }},
+            {"heatFrames": 125}
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"heatFrames": 125}
+          ]}
+        ]}
       ],
       "unlocksDoors": [
         {
@@ -2600,14 +2674,28 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 20}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 60,
       "link": [6, 4],
       "name": "Leave with Runway",
       "requires": [
-        {"heatFrames": 120}
+        {"or": [
+          {"heatFrames": 115},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Alcoon"]],
+              "explicitWeapons": ["ScrewAttack", "Missile", "Super", "Wave+Plasma"]
+            }},
+            {"heatFrames": 110}
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"heatFrames": 110}
+          ]}
+        ]}
       ],
       "exitCondition": {
         "leaveWithRunway": {
@@ -2625,10 +2713,439 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 20}]
         }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [6, 7],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"heatFrames": 145},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Alcoon"]],
+              "explicitWeapons": ["ScrewAttack", "Missile", "Super", "Wave+Plasma"]
+            }},
+            {"heatFrames": 140}
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"heatFrames": 140}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [7, 3],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"heatFrames": 130},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Alcoon"]],
+              "explicitWeapons": ["ScrewAttack", "Missile", "Super", "Wave+Plasma"]
+            }},
+            {"heatFrames": 125}
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"heatFrames": 125}
+          ]}
+        ]}
+      ],
+      "unlocksDoors": [
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 20}]
+        },
+        {
+          "types": ["powerbomb"],
+          "requires": [{"heatFrames": 10}]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "id": 40,
+      "link": [7, 3],
+      "name": "Leave with Runway",
+      "requires": [
+        {"or": [
+          {"heatFrames": 110},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Alcoon"]],
+              "explicitWeapons": ["ScrewAttack", "Missile", "Super", "Wave+Plasma"]
+            }},
+            {"heatFrames": 100}
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"heatFrames": 100}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 4,
+          "openEnd": 1
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 65}]
+        },
+        {"types": ["super"], "requires": []},
+        {
+          "types": ["powerbomb"],
+          "requires": [{"heatFrames": 30}]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [7, 4],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 75}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 60}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 110}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 95}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 120}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "id": 30,
+      "link": [7, 4],
+      "name": "Leave with Runway",
+      "requires": [
+        {"or": [
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 55}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 40}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 90}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 75}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 100}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 4,
+          "openEnd": 1
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 50}]
+        },
+        {"types": ["super"], "requires": []},
+        {
+          "types": ["powerbomb"],
+          "requires": [{"heatFrames": 110}]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [7, 6],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 150}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 110}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 270}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"enemyKill": {
+              "enemies": [["Multiviola"]],
+              "explicitWeapons": ["Missile", "Super", "Wave", "Plasma"]
+            }},
+            {"heatFrames": 200}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 205}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [7, 8],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"heatFrames": 160},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Multiviola", "Alcoon"]],
+              "explicitWeapons": ["ScrewAttack", "Wave+Plasma"]
+            }},
+            {"heatFrames": 145}
+          ]},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Multiviola"]],
+              "explicitWeapons": ["Missile", "Super", "Plasma"]
+            }},
+            {"heatFrames": 150}
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"heatFrames": 145}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "devNote": [
+        "This includes time to wait for the Multiviola to move out of the way (if it can't be quickly killed),",
+        "as will normally be a problem when entering through the upper doors (node 1 or 4)."
       ]
+    },
+    {
+      "link": [8, 2],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"heatFrames": 115},
+          {"and": [
+            {"enemyKill": {
+              "enemies": [["Alcoon"]],
+              "explicitWeapons": ["ScrewAttack", "Missile", "Super", "Wave+Plasma"]
+            }},
+            {"heatFrames": 110}
+          ]},
+          {"and": [
+            "h_PlasmaHitbox",
+            {"heatFrames": 110}
+          ]}
+        ]}
+      ],
+      "unlocksDoors": [
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 30}]
+        },
+        {
+          "types": ["powerbomb"],
+          "requires": [{"heatFrames": 10}]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "id": 23,
+      "link": [8, 2],
+      "name": "Leave with Runway",
+      "requires": [
+        {"heatFrames": 70}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 13,
+          "openEnd": 0,
+          "gentleDownTiles": 4
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 50}]
+        },
+        {"types": ["super"], "requires": []},
+        {
+          "types": ["powerbomb"],
+          "requires": [{"heatFrames": 30}]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [8, 3],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 85}
+          ]},
+          {"and": [
+            "canWalljump",
+            "ScrewAttack",
+            {"heatFrames": 65}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 75}
+          ]},
+          {"and": [
+            "HiJump",
+            "ScrewAttack",
+            {"heatFrames": 55}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 80}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 100}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 95}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "id": 14,
+      "link": [8, 3],
+      "name": "Leave With Runway",
+      "requires": [
+        {"or": [
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 65}
+          ]},
+          {"and": [
+            "canWalljump",
+            "ScrewAttack",
+            {"heatFrames": 45}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 55}
+          ]},
+          {"and": [
+            "HiJump",
+            "ScrewAttack",
+            {"heatFrames": 35}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 60}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 80}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 75}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithRunway": {
+          "length": 4,
+          "openEnd": 1
+        }
+      },
+      "unlocksDoors": [
+        {
+          "types": ["missiles"],
+          "requires": [{"heatFrames": 50}]
+        },
+        {"types": ["super"], "requires": []},
+        {
+          "types": ["powerbomb"],
+          "requires": [{"heatFrames": 110}]
+        }
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [8, 7],
+      "name": "Base",
+      "requires": [
+        {"or": [
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 160}
+          ]},
+          {"and": [
+            "canWalljump",
+            "ScrewAttack",
+            {"heatFrames": 140}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 135}
+          ]},
+          {"and": [
+            "HiJump",
+            "ScrewAttack",
+            {"heatFrames": 105}
+          ]},
+          {"and": [
+            "h_crouchJumpDownGrab",
+            {"heatFrames": 195}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 210}
+          ]},
+          {"and": [
+            "canSpringBallJumpMidAir",
+            {"heatFrames": 280}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],
   "nextStratId": 110,
-  "nextNotableId": 1
+  "nextNotableId": 1,
+  "devNote": [
+    "FIXME: Using a Power Bomb (e.g. for Crystal Flash) prevents using frozen enemies."
+  ]
 }


### PR DESCRIPTION
This is a fairly major overhaul of the left side of Single Chamber. Many of the heat frames were loose; a lot of the issue was the logic expected you to make a stop at each door while going up or down the shaft. To avoid this, the PR adds two new nodes 7 and 8, positioned like node 6, except one and two screens down, respectively. Also the logic didn't take into account differences between various movement options (e.g. wall jump vs. Space Jump vs. HiJump for going up) but it makes a big difference.

- For going from the top of the shaft to the bottom with nothing, the logic expected 670 heat frames total, now reduced to 500.
- Going from bottom to top with just wall jump, it was 890, now 510. With HiJump + Screw Attack it's now 385. So it can be done tankless whereas it would have expected 2 tanks before.

Even with the new nodes, there's some duplication but I don't know how to further improve it right now. The only thing I can think of is that we may eventually be able to combine the "leaveWithRunway" variants with the regular Base strats, if we rework the schema to allow treating exit conditions (and entrance conditions) like logical requirements, e.g. to be able to put them inside of an `or`. It's something that I've been thinking more about recently, because it could help with consolidating strats in many places.