### PR TITLE
Norfair East check flash suits pt. 7 (Upper Norfair Farm Room)

### DIFF
--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -114,7 +114,8 @@
           "length": 7,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -155,7 +156,8 @@
         ]}
       ],
       "resetsObstacles": ["A"],
-      "farmCycleDrops": [{"enemy": "Geruta", "count": 3}]
+      "farmCycleDrops": [{"enemy": "Geruta", "count": 3}],
+      "flashSuitChecked": true
     },
     {
       "id": 37,
@@ -171,7 +173,8 @@
       "farmCycleDrops": [
         {"enemy": "Metaree", "count": 2},
         {"enemy": "Geruta", "count": 3}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -221,7 +224,8 @@
           "requires": [{"heatFrames": 20}]
         }
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -248,7 +252,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -258,6 +263,7 @@
         {"obstaclesCleared": ["A"]},
         "h_heatProof"
       ],
+      "flashSuitChecked": true,
       "devNote": "There is no reason to logically run back through the room this way."
     },
     {
@@ -270,7 +276,8 @@
         {"simpleHeatFrames": 310},
         {"heatFrames": 40}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -313,6 +320,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": "Shoot from the middle of the second set of crumble blocks from the left."
     },
     {
@@ -329,6 +337,7 @@
         {"simpleHeatFrames": 240},
         {"heatFrames": 30}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a Crystal Flash after crossing 3 crumble block bridges,",
         "and a second Crystal Flash after crossing 3 more."
@@ -477,7 +486,8 @@
           "requires": [{"heatFrames": 20}]
         }
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -516,6 +526,7 @@
           "requires": [{"heatFrames": 20}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": "This can be used for collecting the item without needing to reset the room."
     },
     {
@@ -543,7 +554,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -598,6 +610,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": "Shoot while climbing the highest ramp for the shot to open the door."
     },
     {
@@ -612,6 +625,7 @@
         {"heatFrames": 335},
         {"shinespark": {"frames": 221}}
       ],
+      "flashSuitChecked": true,
       "note": "Align with the right side of a wall or door then turn around and shinespark in order to avoid colliding with a slope.",
       "devNote": [
         "There is enough time to visit 3 and return to 2 before performing this strat with the shinespark.",
@@ -633,6 +647,7 @@
         {"simpleHeatFrames": 280},
         {"heatFrames": 30}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a Crystal Flash after crossing 4 crumble block bridges,",
         "and a second Crystal Flash in the middle of the large ramp in the center of the room."
@@ -653,7 +668,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -665,7 +681,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -682,7 +699,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -699,7 +717,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -836,7 +855,8 @@
           "length": 8,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 40,
@@ -894,6 +914,7 @@
       ],
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Geruta", "count": 3}],
+      "flashSuitChecked": true,
       "devNote": "FIXME: The rising lava event may make it impossible to reset at 2."
     },
     {
@@ -923,7 +944,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 25}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -947,7 +969,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 25}
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/east/Speed Booster Room.json
+++ b/region/norfair/east/Speed Booster Room.json
@@ -62,7 +62,8 @@
           "length": 3.5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -78,8 +79,9 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        {"heatFrames": 80}
+        {"heatFrames": 65}
       ],
+      "flashSuitChecked": true,
       "devNote": "There is no G-Mode strat added here, as it would require immobile and indirect to have enough energy and would only save a few frames."
     },
     {
@@ -99,7 +101,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -124,7 +127,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -79,7 +79,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -103,6 +104,7 @@
           {"heatFrames": 40}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "If you have Speed Booster, unequip it to be able to run faster in the lava."
     },
     {
@@ -112,7 +114,8 @@
       "requires": [
         "Morph",
         {"heatFrames": 1050}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -134,6 +137,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spin-jump across both sets of lava, trying to minimize the time spent in lava.",
         "To get onto the first pillar, either use a wall jump off the pillar, or use the Tripper briefly as a platform by crouch jumping or down grabbing onto it."
@@ -152,6 +156,7 @@
         {"heatFrames": 760},
         {"lavaFrames": 60}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the Tripper to cross the first lava pit while avoiding all damage from the spikes and lava.",
         "If you do not have Morph, this is tricky but can be done by carefully timing a jump against the pillar and releasing the d-pad inputs, to land on the Tripper as early as possible.",
@@ -178,6 +183,7 @@
         {"heatFrames": 600},
         {"lavaFrames": 60}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform a bounceball to minimize lava damage.",
         "Move quickly to reach the second Tripper on its first cycle.",
@@ -200,6 +206,7 @@
         {"heatFrames": 600},
         {"lavaFrames": 70}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform a bounceball to minimize lava damage.",
         "Move quickly to reach the second Tripper on its first cycle.",
@@ -217,6 +224,7 @@
         {"heatFrames": 600},
         {"lavaFrames": 80}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Perform a bounceball to minimize lava damage.",
         "Move quickly to reach the second Tripper on its first cycle.",
@@ -300,6 +308,7 @@
         {"heatFrames": 300},
         {"lavaFrames": 70}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Ride the first Tripper, using Morph to avoid spike damage, then perform a Crystal Flash.",
         "The second Tripper will likely either be destroyed or in a bad pattern,",
@@ -323,6 +332,7 @@
           {"heatFrames": 40}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "If you have Speed Booster, unequip it to be able to run faster in the lava."
     },
     {
@@ -332,7 +342,8 @@
       "requires": [
         "Morph",
         {"heatFrames": 1050}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -354,6 +365,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spin-jump across both sets of lava, trying to minimize the time spent in lava.",
         "To get onto the first pillar, either use a wall jump off the pillar, or use the Tripper briefly as a platform by crouch jumping or down grabbing onto it."
@@ -375,6 +387,7 @@
         "Run to the left and jump directly onto the first pillar after the shutter.",
         "Spin jump across the remaining lava, trying to minimize the time spent in lava."
       ],
+      "flashSuitChecked": true,
       "devNote": "Wall jumps are not needed for this strat."
     },
     {
@@ -392,6 +405,7 @@
         "From the Tripper, run and jump directly onto the first pillar after the shutter.",
         "Spin jump across the remaining lava, trying to minimize the time spent in lava."
       ],
+      "flashSuitChecked": true,
       "devNote": "Wall jumps are not needed for this strat."
     },
     {
@@ -410,6 +424,7 @@
         {"heatFrames": 590},
         {"lavaFrames": 60}
       ],
+      "flashSuitChecked": true,
       "note": ["Perform a bounceball to minimize lava damage.", "Ride the second Tripper."]
     },
     {
@@ -428,6 +443,7 @@
         {"heatFrames": 590},
         {"lavaFrames": 70}
       ],
+      "flashSuitChecked": true,
       "note": ["Perform a bounceball to minimize lava damage.", "Ride the second Tripper."]
     },
     {
@@ -441,6 +457,7 @@
         {"heatFrames": 590},
         {"lavaFrames": 80}
       ],
+      "flashSuitChecked": true,
       "note": ["Perform a bounceball to minimize lava damage.", "Ride the second Tripper."]
     },
     {
@@ -454,6 +471,7 @@
         {"heatFrames": 300},
         {"lavaFrames": 70}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Ride the first Tripper, using Morph to avoid spike damage, then perform a Crystal Flash.",
         "The second Tripper will likely either be destroyed or in a bad pattern,",
@@ -559,7 +577,8 @@
       },
       "requires": [
         {"heatFrames": 45}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -571,7 +590,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -588,7 +608,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -605,7 +626,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -617,7 +639,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 21,

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -59,6 +59,9 @@
       "mapTileMask": [
         [2, 2],
         [1, 1]
+      ],
+      "note": [
+        "This represents being on the right side of the floating platform."
       ]
     },
     {
@@ -155,7 +158,8 @@
           "length": 12,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -248,7 +252,16 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Base",
+      "requires": [
+        {"heatFrames": 125}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -367,7 +380,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 57,
@@ -394,7 +408,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 75}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -433,7 +448,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 10,
@@ -445,7 +461,8 @@
           "length": 5,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -462,7 +479,8 @@
           "length": 11,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 54,
@@ -501,20 +519,22 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
       "link": [2, 5],
       "name": "Base",
       "requires": [
-        {"heatFrames": 120},
+        {"heatFrames": 100},
         {"or": [
           {"heatFrames": 30},
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 58,
@@ -536,6 +556,14 @@
       "flashSuitChecked": true,
       "note": "Kill the Gamets where Samus can grab the drops. Exit G-mode, then pause abuse to pick them up without dying.",
       "devNote": "Ice clipping through the shot blocks is not considered reasonable, as Samus can't use X-ray, kill any Gamets, or likely take a hit."
+    },
+    {
+      "link": [3, 1],
+      "name": "Base",
+      "requires": [
+        {"heatFrames": 125}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -654,7 +682,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 59,
@@ -685,7 +714,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -702,7 +732,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 19,
@@ -719,7 +750,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 20,
@@ -825,7 +857,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -837,7 +870,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -854,7 +888,8 @@
           "blockPositions": [[2, 18]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -871,7 +906,8 @@
           "blockPositions": [[2, 19]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -888,7 +924,8 @@
           "blockPositions": [[2, 28]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -905,7 +942,8 @@
           "blockPositions": [[2, 29]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -917,7 +955,8 @@
           "length": 12,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -934,7 +973,8 @@
       "name": "Base",
       "requires": [
         {"heatFrames": 75}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 31,
@@ -948,7 +988,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 10}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -973,7 +1014,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 33,
@@ -987,7 +1029,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 10}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 34,
@@ -1012,7 +1055,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 60,
@@ -1028,8 +1072,9 @@
       "link": [4, 5],
       "name": "Base",
       "requires": [
-        {"heatFrames": 35}
-      ]
+        {"heatFrames": 20}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 46,
@@ -1060,6 +1105,11 @@
       "requires": [
         {"heatFrames": 85},
         {"obstaclesCleared": ["A"]}
+      ],
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "devNote": [
+        "The unlocksDoors has no heatFrames since you could farm back up after unlocking."
       ]
     },
     {
@@ -1076,7 +1126,11 @@
           "openEnd": 1
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "devNote": [
+        "The unlocksDoors has no heatFrames since you could farm back up after unlocking."
+      ]
     },
     {
       "id": 47,
@@ -1117,12 +1171,21 @@
       "name": "Base",
       "requires": [
         {"or": [
-          "canWalljump",
-          "HiJump",
-          "SpaceJump"
-        ]},
-        {"heatFrames": 125}
-      ]
+          {"and": [
+            "canWalljump",
+            {"heatFrames": 85}
+          ]},
+          {"and": [
+            "HiJump",
+            {"heatFrames": 55}
+          ]},
+          {"and": [
+            "SpaceJump",
+            {"heatFrames": 110}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 39,
@@ -1130,7 +1193,7 @@
       "name": "Crouch Jump Down Grab",
       "requires": [
         "h_crouchJumpDownGrab",
-        {"heatFrames": 125}
+        {"heatFrames": 85}
       ],
       "flashSuitChecked": true
     },
@@ -1140,9 +1203,35 @@
       "name": "IBJ",
       "requires": [
         "canIBJ",
-        {"heatFrames": 850}
+        {"or": [
+          {"and": [
+            "h_runOverRespawningEnemies",
+            {"heatFrames": 680}
+          ]},
+          {"and": [
+            "canJumpIntoIBJ",
+            {"heatFrames": 200}
+          ]}
+        ]}
       ],
-      "note": "Kill a Gamet and don't pick up its drops, so that they won't spawn while performing the IBJ."
+      "flashSuitChecked": true,
+      "note": [
+        "If starting the IBJ from the ground, first kill a Gamet and don't pick up its drops,",
+        "so that they won't spawn while performing the IBJ."
+      ],
+      "devNote": [
+        "The helper h_runOverRespawningEnemies is not an exact match;",
+        "if a tech is ever added for leaving drops uncollected, we can use that."
+      ]
+    },
+    {
+      "link": [5, 4],
+      "name": "Unmorph Bomb Boost",
+      "requires": [
+        "canUnmorphBombBoost",
+        {"heatFrames": 160}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 41,
@@ -1150,8 +1239,9 @@
       "name": "Frozen Gamet",
       "requires": [
         "canUseFrozenEnemies",
-        {"heatFrames": 250}
-      ]
+        {"heatFrames": 220}
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 49,
@@ -1174,6 +1264,32 @@
       "requires": [
         "canSpringBallJumpMidAir",
         {"heatFrames": 120}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [5, 4],
+      "name": "Delayed Gamet Farm",
+      "requires": [
+        "canFarmWhileShooting",
+        {"or": [
+          "canWalljump",
+          {"and": [
+            "HiJump",
+            "canCameraManip",
+            "canInsaneJump"
+          ]},
+          "SpaceJump",
+          "h_crouchJumpDownGrab",
+          "canTrickySpringBallJump",
+          "canUnmorphBombBoost"
+        ]},
+        {"heatFrames": 35}
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Bring up the Gamets to the platform above, in order to delay farming them.",
+        "If not enough big energy drops spawn, go back down, farm up, and try again."
       ]
     },
     {
@@ -1184,7 +1300,8 @@
         {"heatFrames": 60},
         "Wave"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -1204,7 +1321,7 @@
       "requires": [
         {"notable": "Gate Glitch With Farming"},
         {"heatFrames": 300},
-        "canGateGlitch",
+        "h_gateGlitch",
         {"or": [
           {"ammo": {"type": "Missile", "count": 1}},
           {"ammo": {"type": "Super", "count": 1}}
@@ -1228,7 +1345,7 @@
             {"heatFrames": 0},
             "canPauseAbuse"
           ]},
-          {"heatFrames": 50}
+          {"heatFrames": 60}
         ]},
         {"partialRefill": {"type": "RegularEnergy", "limit": 50}}
       ],

--- a/region/norfair/east/Volcano Room.json
+++ b/region/norfair/east/Volcano Room.json
@@ -112,7 +112,8 @@
           "heated": false
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -165,6 +166,7 @@
           "requires": [{"lavaFrames": 60}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: A leaveWithRunway variation could be added, but it would require Speed Booster to be disabled,",
         "which would need new schema support in order to properly match entrance conditions in the next room."
@@ -212,7 +214,8 @@
           "types": ["powerbomb"],
           "requires": [{"lavaFrames": 150}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -259,6 +262,7 @@
           "requires": [{"lavaFrames": 150}]
         }
       ],
+      "flashSuitChecked": true,
       "devNote": "FIXME: a Gravity version of this could be added."
     },
     {
@@ -286,7 +290,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -317,12 +322,13 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
       "link": [2, 1],
-      "name": "SpaceJump",
+      "name": "Space Jump",
       "requires": [
         "Morph",
         "SpaceJump",
@@ -345,7 +351,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 14,
@@ -376,7 +383,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 15,
@@ -387,6 +395,7 @@
         "h_heatedCrystalFlash",
         {"heatFrames": 250}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "FIXME: by adding a junction here, we could account for more ways of entering the room;",
         "but a junction would complicate how the heated/unheated state of the room is tracked."
@@ -418,6 +427,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Move quickly (when X-Ray is not active) to climb the shaft before the Fune fireballs would reach Samus."
       ],
@@ -451,6 +461,7 @@
           "requires": [{"heatFrames": 50}]
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Move quickly (when X-Ray is not active) to climb the shaft before the Fune fireballs would reach Samus."
       ]
@@ -532,7 +543,8 @@
           "heated": true
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 9,

--- a/region/norfair/east/Wave Beam Room.json
+++ b/region/norfair/east/Wave Beam Room.json
@@ -62,7 +62,8 @@
           "length": 4,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -77,13 +78,15 @@
       "id": 3,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],


### PR DESCRIPTION
Upper Norfair Farming Room has some significant refinements:
- Added a "Delayed Gamet Farm" where you bring the Gamets up.
- Added Base strats to cross the top of the room (1 <-> 3). It this uses 125 heat frames compared to the currently expected amount of 150 by stopping on the floating platform (node 4).
- Added `canJumpIntoIBJ` and `canUnmorphBombBoost` variants for getting up.
- Tightened some other heat frames, splitting options out by movement item where they were lumped together before.