### PR TITLE
More leaveWithMockball (Maridia, Norfair, 3-room)

### DIFF
--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -555,6 +555,39 @@
       "note": "It takes 80 seconds for the global Zeela to make it over here. A Super could speed this up, but it's likely to just get the Zeela stuck."
     },
     {
+      "link": [2, 3],
+      "name": "Come in Running, Leave with Mockball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 7,
       "link": [2, 3],
       "name": "Come in Shinecharging, Leave Shinecharged",

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -399,6 +399,77 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 9,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "speedBooster": "any",
+          "unusableTiles": 0
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 9,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 13,
       "link": [1, 2],
       "name": "Come in Getting Blue Speed, Leave With Temporary Blue (Space Jump)",

--- a/region/brinstar/red/Skree Boost Room.json
+++ b/region/brinstar/red/Skree Boost Room.json
@@ -348,6 +348,77 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come in Jumping, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "minTiles": 5,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],      
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 13,
       "link": [2, 1],
       "name": "Base",

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -217,6 +217,53 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Leave with Mockball (Space Jump)",
+      "requires": [
+        "canPreciseSpaceJump",
+        {"obstaclesNotCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Leave with Controlled Spring Ball Bounce",
+      "requires": [
+        "canTrickySpringBallBounce",
+        {"obstaclesNotCleared": ["A"]}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "movementType": "controlled",
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 5,
       "link": [1, 2],
       "name": "Come in Shinecharging, Leave With Temporary Blue",

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -645,6 +645,77 @@
       "devNote": "Sparking in top position means the item will be avoided."
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 17,
       "link": [1, 2],
       "name": "Come in Shinecharging, Leave With Temporary Blue",

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -1417,6 +1417,43 @@
       "blueSuitChecked": true
     },
     {
+      "link": [3, 3],
+      "name": "Leave with Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 21,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 6,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [3, 3],
+      "name": "Leave with Temporary Blue",
+      "requires": [
+        {"canShineCharge": {
+          "usedTiles": 21,
+          "gentleUpTiles": 3,
+          "gentleDownTiles": 3,
+          "openEnd": 1
+        }},
+        "canChainTemporaryBlue"
+      ],
+      "exitCondition": {
+        "leaveWithTemporaryBlue": {}
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 34,
       "link": [3, 3],
       "name": "Crystal Flash",

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -760,6 +760,21 @@
       ]
     },
     {
+      "link": [4, 1],
+      "name": "Precise Space Jump",
+      "requires": [
+        "canDash",
+        "canPreciseSpaceJump",
+        "canTrickyDodgeEnemies",
+        {"heatFrames": 350}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Gain full run speed (without Speed Booster) and Space Jump through the lower part of the flames as they rise."
+      ]
+    },
+    {
       "id": 15,
       "link": [4, 1],
       "name": "Invulnerable Space Jump",
@@ -1021,6 +1036,38 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
+    {
+      "link": [4, 2],
+      "name": "Leave with Mockball (Space Jump)",
+      "requires": [
+        "h_heatedRemoteRunwayPreciseSpaceJump",
+        {"or": [
+          {"and": [
+            "h_speedDash",
+            {"heatFrames": 220}
+          ]},
+          {"heatFrames": 265}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 12,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },    
     {
       "id": 37,
       "link": [4, 2],

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -803,6 +803,33 @@
       "devNote": ["Max extra run speed $6.8."]
     },
     {
+      "link": [2, 2],
+      "name": "Leave with Mockball",
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 190},
+        "canHitbox",
+        "canTrickyDodgeEnemies"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 10,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: Add more variants, from node 3 (Pirates cleared), and through node 1."
+      ]
+    },
+    {
       "id": 16,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1604,6 +1604,28 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Leave with Mockball",
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 23,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -681,6 +681,39 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Leave with Mockball (Space Screw)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 1,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "h_heatedRemoteRunwayPreciseSpaceJump",
+        "ScrewAttack",
+        {"heatFrames": 320}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },    
+    {
       "id": 12,
       "link": [2, 1],
       "name": "Screw",
@@ -1529,6 +1562,44 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Mockball",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"or": [
+          {"and": [
+            "ScrewAttack",
+            {"heatFrames": 140}
+          ]},
+          {"and": [
+            "h_bombThings",
+            {"heatFrames": 205}
+          ]}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 2,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: Longer runway could be used, with more heat frames."
+      ]
     },
     {
       "id": 27,

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -434,6 +434,79 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Screw)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "h_heatedRemoteRunwayPreciseSpaceJump",
+        "ScrewAttack",
+        {"heatFrames": 240}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": [
+        "FIXME: other leaveWithMockball variants are possible, e.g. comeInSpinning or in-room acid run."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Screw)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "h_heatedRemoteRunwayPreciseSpaceJump",
+        "ScrewAttack",
+        {"heatFrames": 240}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "devNote": [
+        "FIXME: other leaveWithMockball variants are possible, e.g. comeInSpinning or in-room acid run."
+      ]
+    },
+    {
       "id": 49,
       "link": [1, 2],
       "name": "G-Mode",

--- a/region/lowernorfair/east/Ridley Tank Room.json
+++ b/region/lowernorfair/east/Ridley Tank Room.json
@@ -101,7 +101,7 @@
       "link": [1, 1],
       "name": "Leave with Mockball",
       "requires": [
-        "h_heatedRemoteRunway",
+        "canTrickyJump",
         {"heatFrames": 150}
       ],
       "exitCondition": {

--- a/region/lowernorfair/east/Ridley Tank Room.json
+++ b/region/lowernorfair/east/Ridley Tank Room.json
@@ -98,6 +98,28 @@
       "devNote": "Max extra run speed $2.B, or $2.C with Hi-Jump and a quick aim-down."
     },
     {
+      "link": [1, 1],
+      "name": "Leave with Mockball",
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 2,
       "link": [1, 2],
       "name": "Base",

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -481,6 +481,7 @@
       "name": "Leave with Mockball",
       "requires": [
         "h_heatedRemoteRunway",
+        "can4HighMidAirMorph",
         {"heatFrames": 210}
       ],
       "exitCondition": {

--- a/region/lowernorfair/east/Three Musketeers' Room.json
+++ b/region/lowernorfair/east/Three Musketeers' Room.json
@@ -477,6 +477,28 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Leave with Mockball",
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 210}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 17,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -583,6 +583,81 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 61,
       "link": [1, 2],
       "name": "Use Stored Spark",

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -137,6 +137,62 @@
       "devNote": "Max extra run speed $2.5"
     },
     {
+      "link": [1, 1],
+      "name": "Leave with Mockball",
+      "requires": [
+        {"obstaclesCleared": ["A", "B"]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 42,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        {"obstaclesCleared": ["A", "B"]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 42,
+            "openEnd": 2
+          },
+          "minExtraRunSpeed": "$6.2"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"obstaclesCleared": ["A", "B"]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 33,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 3,
       "link": [1, 1],
       "name": "Leave Shinecharged (Suitless)",
@@ -888,6 +944,62 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": "Max extra run speed $1.F"
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Mockball",
+      "requires": [
+        {"obstaclesCleared": ["B"]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 38,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [
+        {"obstaclesCleared": ["B"]}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 38,
+            "openEnd": 1
+          },
+          "minExtraRunSpeed": "$4.D"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        {"obstaclesCleared": ["B"]}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 27,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 25,

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -297,6 +297,79 @@
       ]
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 59,
       "link": [1, 2],
       "name": "Use Stored Spark",

--- a/region/maridia/inner-pink/Draygon Save Room.json
+++ b/region/maridia/inner-pink/Draygon Save Room.json
@@ -234,6 +234,190 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3.4375,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Enter with Samus already in a shooting pose, buffering an immediate shot on entry.",
+        "Jump over the save station."
+      ],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "note": [
+        "Enter with Samus already in a shooting pose, buffering an immediate shot on entry.",
+        "Space Jump through the middle of the save station."
+      ],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in with Side Platform Jump, Leave with Mockball",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 5.4375,
+              "speedBooster": "no",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Warehouse Energy Tank Room and Warehouse Entrance."
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Shaktool Room, Ridley Tank Room, Dust Torizo Room, and Halfie Climb Room."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Big Boy Room and Mickey Mouse Room."]
+            },
+            {
+              "minHeight": 4,
+              "maxHeight": 4,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Aqueduct."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "yes",
+              "obstructions": [[3, 2]],
+              "requires": [],
+              "note": ["This applies to Metal Pirates Room."]
+            }            
+          ]
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 10,
       "link": [1, 3],
       "name": "Base",

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -444,6 +444,81 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Jumping, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "minTiles": 5,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 17,
       "link": [2, 1],
       "name": "Base",

--- a/region/maridia/inner-yellow/Yoink Room.json
+++ b/region/maridia/inner-yellow/Yoink Room.json
@@ -656,6 +656,205 @@
       ]
     },
     {
+      "link": [1, 3],
+      "name": "Come in Jumping, Leave with Mockball (Speedy Jump)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "minTiles": 8,
+          "speedBooster": "yes"
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 3],
+      "name": "Come in Jumping, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "minTiles": 5,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneJump",
+        {"or": [
+          "Gravity",
+          "canInsaneMidAirMorph"
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 3],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 3],
+      "name": "Come in with Side Platform Jump, Leave with Mockball",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 5.4375,
+              "speedBooster": "no",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Warehouse Energy Tank Room and Warehouse Entrance."
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Shaktool Room, Ridley Tank Room, Dust Torizo Room, and Halfie Climb Room."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Big Boy Room and Mickey Mouse Room."]
+            },
+            {
+              "minHeight": 4,
+              "maxHeight": 4,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Aqueduct."]
+            },
+            {
+              "minHeight": 8,
+              "maxHeight": 8,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Screw Attack Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "yes",
+              "obstructions": [[3, 2]],
+              "requires": [],
+              "note": ["This applies to Metal Pirates Room."]
+            }            
+          ]
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 17,
       "link": [1, 3],
       "name": "Grapple Teleport Door Lock Skip",

--- a/region/maridia/outer/Maridia Tube.json
+++ b/region/maridia/outer/Maridia Tube.json
@@ -643,6 +643,71 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 3],
+      "name": "Come in Running, Leave with Mockball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
+      "link": [1, 3],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "Gravity",
+        "canPreciseSpaceJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 12,
       "link": [1, 4],
       "name": "Tricky Cross Room Jump",

--- a/region/norfair/crocomire/Grapple Tutorial Room 1.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 1.json
@@ -53,6 +53,25 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 1],
+      "name": "Leave with Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 1            
+          },
+          "landingRunway": {
+            "length": 10,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 2,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -424,6 +443,25 @@
         "leaveWithRunway": {
           "length": 9,
           "openEnd": 1
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Mockball",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 9,
+            "openEnd": 1            
+          },
+          "landingRunway": {
+            "length": 9,
+            "openEnd": 1
+          }
         }
       },
       "flashSuitChecked": true,

--- a/region/norfair/east/Frog Savestation.json
+++ b/region/norfair/east/Frog Savestation.json
@@ -234,6 +234,190 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3.4375,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Enter with Samus already in a shooting pose, buffering an immediate shot on entry.",
+        "Jump over the save station."
+      ],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "note": [
+        "Enter with Samus already in a shooting pose, buffering an immediate shot on entry.",
+        "Space Jump through the middle of the save station."
+      ],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in with Side Platform Jump, Leave with Mockball",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 5.4375,
+              "speedBooster": "no",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Warehouse Energy Tank Room and Warehouse Entrance."
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Shaktool Room, Ridley Tank Room, Dust Torizo Room, and Halfie Climb Room."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Big Boy Room and Mickey Mouse Room."]
+            },
+            {
+              "minHeight": 4,
+              "maxHeight": 4,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Aqueduct."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "yes",
+              "obstructions": [[3, 2]],
+              "requires": [],
+              "note": ["This applies to Metal Pirates Room."]
+            }            
+          ]
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 9,
       "link": [1, 3],
       "name": "Base",

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -364,6 +364,79 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 4],
+      "name": "Come in Running, Leave with Mockball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canInsaneJump",
+        {"heatFrames": 65}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 4],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        {"heatFrames": 70}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 51,
       "link": [1, 4],
       "name": "G-Mode Setup - Get Hit By Viola",

--- a/region/norfair/east/Lava Grapple Tunnel.json
+++ b/region/norfair/east/Lava Grapple Tunnel.json
@@ -403,6 +403,79 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        {"heatFrames": 330}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        {"heatFrames": 330}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 6,
       "link": [1, 2],
       "name": "Tank the Damage",

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -348,6 +348,91 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 2,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneJump",
+        {"or": [
+          "ScrewAttack",
+          "canPseudoScrew",
+          {"ammo": {"type": "Missile", "count": 1}},
+          {"ammo": {"type": "Super", "count": 1}}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneJump",
+        {"or": [
+          "ScrewAttack",
+          "canPseudoScrew",
+          {"ammo": {"type": "Missile", "count": 1}},
+          {"ammo": {"type": "Super", "count": 1}}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 28,
       "link": [1, 2],
       "name": "G-Mode",

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -364,7 +364,8 @@
           "canPseudoScrew",
           {"ammo": {"type": "Missile", "count": 1}},
           {"ammo": {"type": "Super", "count": 1}}
-        ]}
+        ]},
+        {"heatFrames": 240}
       ],
       "exitCondition": {
         "leaveWithMockball": {
@@ -404,10 +405,9 @@
         "canInsaneJump",
         {"or": [
           "ScrewAttack",
-          "canPseudoScrew",
-          {"ammo": {"type": "Missile", "count": 1}},
-          {"ammo": {"type": "Super", "count": 1}}
-        ]}
+          "canPseudoScrew"
+        ]},
+        {"heatFrames": 240}
       ],
       "exitCondition": {
         "leaveWithMockball": {

--- a/region/norfair/east/Nutella Refill.json
+++ b/region/norfair/east/Nutella Refill.json
@@ -238,6 +238,160 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Come in Running, Leave with Mockball",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Enter with Samus already in a shooting pose, buffering an immediate shot on entry."
+      ],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [1, 2],
+      "name": "Come in with Side Platform Jump, Leave with Mockball",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 5.4375,
+              "speedBooster": "no",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Warehouse Energy Tank Room and Warehouse Entrance."
+              ]
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": [
+                "This applies to Shaktool Room, Ridley Tank Room, Dust Torizo Room, and Halfie Climb Room."
+              ]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Big Boy Room and Mickey Mouse Room."]
+            },
+            {
+              "minHeight": 4,
+              "maxHeight": 4,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Aqueduct."]
+            },
+            {
+              "minHeight": 8,
+              "maxHeight": 8,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "note": ["This applies to Screw Attack Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 7.4375,
+              "speedBooster": "yes",
+              "obstructions": [[3, 2]],
+              "requires": [],
+              "note": ["This applies to Metal Pirates Room."]
+            }            
+          ]
+        }
+      },
+      "requires": [
+        "canInsaneJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },
+    {
       "id": 10,
       "link": [1, 3],
       "name": "Base",

--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -96,6 +96,53 @@
       ]
     },
     {
+      "link": [1, 1],
+      "name": "Leave with Mockball",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "Gravity",
+        {"disableEquipment": "SpeedBooster"},
+        "canOffScreenMovement",
+        {"lavaFrames": 80},
+        {"or": [
+          {"heatFrames": 400},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"heatFrames": 190}
+          ]},
+          {"and": [
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"heatFrames": 240}
+          ]}          
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "maxExtraRunSpeed": "$2.0"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Kill the Tripper or wait for it to move out of the way."
+      ],
+      "devNote": [
+        "The 'canOffScreenMovement' requirement is based on an assumption that the player may need to re-equip Speed Booster,",
+        "which involves doing the mockball while the screen is fading in or out."
+      ]
+    },
+    {
       "id": 42,
       "link": [1, 1],
       "name": "Come in Shinecharging, Crystal Spark",
@@ -1084,6 +1131,89 @@
         "Requires resetting the room to prevent bad cycles or the trippers already being killed during room traversal."
       ]
     },
+    {
+      "link": [2, 2],
+      "name": "Leave with Mockball (Before Tripper Arrives)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "Gravity",
+        {"disableEquipment": "SpeedBooster"},
+        {"lavaFrames": 70},
+        {"heatFrames": 160},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Move quickly to use the runway before the Tripper gets in the way."
+      ],
+      "devNote": [
+        "This is the specific length needed for the Ice Beam Gate Room mockball."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Mockball (Deal with Tripper)",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "Gravity",
+        {"disableEquipment": "SpeedBooster"},
+        "canOffScreenMovement",
+        {"lavaFrames": 80},
+        {"or": [
+          {"heatFrames": 400},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"heatFrames": 190}
+          ]},
+          {"and": [
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"heatFrames": 240}
+          ]}          
+        ]}
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 4,
+            "openEnd": 1
+          },
+          "maxExtraRunSpeed": "$2.0"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Kill the Tripper or wait for it to move out of the way."
+      ],
+      "devNote": [
+        "The 'canOffScreenMovement' requirement is based on an assumption that the player may need to re-equip Speed Booster,",
+        "which involves doing the mockball while the screen is fading in or out.",
+        "FIXME: More variants could be added that cross the room first."
+      ]
+    },    
     {
       "id": 21,
       "link": [2, 2],

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -620,6 +620,29 @@
       "blueSuitChecked": true
     },
     {
+      "name": "Leave with Mockball",
+      "link": [1, 6],
+      "requires": [
+        {"doorUnlockedAtNode": 1},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 14,
       "link": [1, 7],
       "name": "Carry Shinecharge (HiJump)",

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -939,7 +939,13 @@
         "canInsaneJump"
       ],
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": [
+        "If the landing in the other room is only a single tile wide (e.g. doorway only),",
+        "then the mockball must be optimized by aiming for the edge of the runway,",
+        "with a morph transition that starts relatively high in the air,",
+        "precisely timed to complete immediately after landing."
+      ]
     },
     {
       "link": [2, 8],

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -939,8 +939,23 @@
         "canInsaneJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 8],
+      "name": "More Insane Mockball",
+      "entranceCondition": {
+        "comeInWithMockball": {
+          "speedBooster": "any",
+          "adjacentMinTiles": 8.4375
+        }
+      },
+      "requires": [
+        "canInsaneMidAirMorph"
+      ],
+      "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "devNote": "Theoretically this can be done with 8 tiles (technically even 7.4375 tiles) but would require higher movement tech."
+      "devNote": "Theoretically this can be done with 7.4375 tiles but would require higher movement tech."
     },
     {
       "id": 74,

--- a/region/tourian/main/Tourian First Room.json
+++ b/region/tourian/main/Tourian First Room.json
@@ -295,6 +295,79 @@
       "blueSuitChecked": true
     },
     {
+      "link": [2, 3],
+      "name": "Come in Running, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInRunning": {
+          "minTiles": 3,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
+      "link": [2, 3],
+      "name": "Come in Spinning, Leave with Mockball (Space Jump)",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "minExtraRunSpeed": "$1.A",
+          "unusableTiles": 0,
+          "speedBooster": "any"
+        }
+      },
+      "requires": [
+        "canPreciseSpaceJump",
+        "canInsaneMidAirMorph"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
+        "when the schema allows it, represent the possible runways more generally."
+      ]
+    },    
+    {
       "id": 13,
       "link": [3, 1],
       "name": "Base",


### PR DESCRIPTION
In addition to covering more leaveWithMockball strats in Maridia/Norfair, I also did a pass of 3-room strats where you enter a room (e.g. a two-door Save room) running/spinning and then leave mockballing through an opposite door. The schema doesn't allow us to propagate the entry speed into the exit speed, but for now we can specialize to the case needed for the Ice Beam Gate Room mockball, which I think is the most significant application. 

Some of these strats are not possible to occur in Map Rando with Ice Beam Gate Room due to geometrically impossible room configurations, but I kept them anyway; some of them might have other applications, or if not, they probably will later when we extend them to general runway lengths.