### PR TITLE
Add canRiskPLA to blue brinstar etank overload plms with item.

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -1760,7 +1760,6 @@
       ],
       "devNote": [
         "This will force Samus to pick up the item, so it can only be done once.",
-        "itemNotCollectedAtNode implicitly includes canRiskPermanentLossOfAccess.",
         "Spring Ball is required, because Morph, Bombs, or a Power Bomb will allow other strats to be used instead."
       ]
     },

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -1731,6 +1731,7 @@
       "requires": [
         "canGMode",
         {"itemNotCollectedAtNode": 4},
+        "canRiskPermanentLossOfAccess",
         "h_artificialMorphSpringBall",
         {"or": [
           "canConsecutiveWallJump",


### PR DESCRIPTION
This was mentioned in logic a few weeks ago and I recently had it come up in a seed today (on desolate with no item there anyway, but that seems like a separate issue).