### PR TITLE
Rinka Shaft: tighten some shinecharge frames

### DIFF
--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -435,7 +435,7 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 115},
+        {"shineChargeFrames": 110},
         "canWallJump",
         "canShinechargeMovementComplex"
       ],
@@ -457,7 +457,7 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 115},
+        {"shineChargeFrames": 110},
         "HiJump",
         "canShinechargeMovementComplex"
       ],
@@ -542,7 +542,7 @@
     {
       "id": 22,
       "link": [2, 1],
-      "name": "Come in Shinecharged, Leave With Spark (Platforming)",
+      "name": "Come in Shinecharged, Leave With Spark (Platforming, Close Spark)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -553,6 +553,50 @@
       ],
       "exitCondition": {
         "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharged, Leave With Spark (Platforming, Distant Spark)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 145},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 15, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in Shinecharged, Leave With Spark (Platforming, Distant Spark, Bottom Position)",
+      "entranceCondition": {
+        "comeInShinecharged": {}
+      },
+      "requires": [
+        {"shineChargeFrames": 135},
+        "canShinechargeMovementTricky",
+        {"shinespark": {"frames": 10, "excessFrames": 0}}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {
+          "position": "bottom"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1219,7 +1263,7 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 120},
+        {"shineChargeFrames": 115},
         "canWallJump",
         "canShinechargeMovementComplex"
       ],
@@ -1241,7 +1285,11 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 80},
+        {"shineChargeFrames": 75},
+        {"or": [
+          "canSpeedyJump",
+          {"shineChargeFrames": 5}
+        ]},
         "HiJump",
         "canWallJump",
         "canShinechargeMovementComplex",
@@ -1269,11 +1317,11 @@
         "canShinechargeMovementComplex",
         {"or": [
           {"and": [
-            {"shineChargeFrames": 110},
-            {"shinespark": {"frames": 10, "excessFrames": 0}}
+            {"shineChargeFrames": 105},
+            {"shinespark": {"frames": 11, "excessFrames": 0}}
           ]},
           {"and": [
-            {"shineChargeFrames": 85},
+            {"shineChargeFrames": 80},
             "canSpeedyJump",
             {"shinespark": {"frames": 7, "excessFrames": 0}}
           ]}
@@ -1297,10 +1345,10 @@
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 110},
+        {"shineChargeFrames": 95},
         "canWallJump",
         "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 6, "excessFrames": 0}}
+        {"shinespark": {"frames": 5, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}
@@ -1315,15 +1363,14 @@
     {
       "id": 54,
       "link": [3, 2],
-      "name": "Come in Shinecharged, Leave With Spark (HiJump Platforming)",
+      "name": "Come in Shinecharged, Leave With Spark (Platforming)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
       "requires": [
-        {"shineChargeFrames": 145},
-        "HiJump",
+        {"shineChargeFrames": 120},
         "canShinechargeMovementComplex",
-        {"shinespark": {"frames": 6, "excessFrames": 0}}
+        {"shinespark": {"frames": 13, "excessFrames": 0}}
       ],
       "exitCondition": {
         "leaveWithSpark": {}

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -1242,6 +1242,10 @@
       },
       "requires": [
         {"shineChargeFrames": 115},
+        {"or": [
+          "canSpeedyJump",
+         {"shineChargeFrames": 15} 
+        ]},
         "HiJump",
         "canShinechargeMovementComplex"
       ],


### PR DESCRIPTION
Noticed while going through some of Sam's videos: some of these strats had fairly loose shinecharge frames. And strat 54 was supposed to be bootless.