### PR TITLE
Crateria fixes

### DIFF
--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -162,7 +162,7 @@
     },
     {
       "id": "B",
-      "name": "Above SpeedBlocks with Temp Blue",
+      "name": "Above Speed Blocks with Temp Blue",
       "obstacleType": "abstract"
     },
     {
@@ -1336,6 +1336,7 @@
       "link": [2, 2],
       "name": "Leave with Runway, Frozen Boyon Bridge",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "canTrivialUseFrozenEnemies"
       ],
       "exitCondition": {
@@ -1440,6 +1441,7 @@
       "link": [2, 3],
       "name": "Frozen Boyon Runway",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "canTrivialUseFrozenEnemies",
         "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 128, "excessFrames": 6}}
@@ -1452,6 +1454,7 @@
       "link": [2, 3],
       "name": "Frozen Boyon Runway (Mid-Air Spark)",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "canTrivialUseFrozenEnemies",
         "h_shinechargeMaxRunway",
         "canMidairShinespark",
@@ -1471,6 +1474,7 @@
       "link": [2, 3],
       "name": "Frozen Boyon Runway (Speedy Jump Spark)",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "canTrivialUseFrozenEnemies",
         "h_shinechargeMaxRunway",
         "canSpeedyJump",
@@ -1489,8 +1493,9 @@
     {
       "id": 36,
       "link": [2, 3],
-      "name": "Frozen Boyon Runway (Fast Walljumps)",
+      "name": "Frozen Boyon Runway (Fast Wall Jumps)",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "canTrivialUseFrozenEnemies",
         "canShinechargeMovementComplex",
         "canFastWallJumpClimb",
@@ -1505,7 +1510,7 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": ["Quickly Walljump to conserve health on the shinespark."]
+      "note": ["Quickly wall jump to conserve health on the shinespark."]
     },
     {
       "id": 38,
@@ -1517,7 +1522,6 @@
         {"shinespark": {"frames": 128, "excessFrames": 6}},
         {"obstaclesCleared": ["A"]}
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -1285,7 +1285,7 @@
     {
       "id": 47,
       "link": [4, 1],
-      "name": "Blue Springball Jump",
+      "name": "Blue Spring Ball Jump",
       "requires": [
         "HiJump",
         "h_getBlueSpeedMaxRunway",
@@ -1293,11 +1293,12 @@
         "canLateralMidAirMorph",
         "canTrickySpringBallJump"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
         "From the right door, run and jump while on the dirt mound directly right of the ship.",
-        "Then SpringBall Jump to reach the Bomb blocks leading to the top left door."
+        "Then mid-air Spring Ball jump to pass through and destroy the Bomb blocks leading to the top left door."
       ]
     },
     {
@@ -2100,6 +2101,7 @@
         ]},
         "h_artificialMorphPowerBomb"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -2116,6 +2118,7 @@
         "h_artificialMorphLongIBJ",
         "ScrewAttack"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": "IBJ up to the top left of the room. Use X-Ray to cancel G-mode, then fall with Screw Attack to break the bomb blocks."
@@ -2128,6 +2131,7 @@
         "h_blueSuitGMode",
         "h_artificialMorphLongIBJ"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": "IBJ up to the top left of the room. Use X-Ray to cancel G-mode, then fall with a blue suit to break the bomb blocks."

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -376,7 +376,7 @@
         }
       },
       "requires": [
-        "h_artificialMorphBombs"
+        "h_artificialMorphPowerBomb"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -657,6 +657,7 @@
           {"acidFrames": 30}
         ]}
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -1021,6 +1022,7 @@
         {"notable": "Temporary Blue Chains"},
         "canChainTemporaryBlue"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -2002,7 +2002,6 @@
       "link": [9, 2],
       "name": "Beetom Stuck Moonfall",
       "requires": [
-        {"noBlueSuit": {}},
         {"notable": "Beetom Stuck Moonfall"},
         "canEnemyStuckMoonfall",
         "canTrickyUseFrozenEnemies",


### PR DESCRIPTION
I decided to try letting AI (gpt 5.6-sol medium) do a pass through the logic and see what errors it finds, and this is what turned up for Crateria. I wrote the PR by hand, based on the subset of the AI findings that I found to be correct. 

I don't think anything here was overly broken; mostly it's minor stuff that made some logic incomplete, for example:
- You could enter Landing Site from the left with G-mode artificial morph, break the bomb blocks with PBs, exit G-mode, refill at the Ship and return, which wouldn't have been logical before because we forgot to clear the obstacle for the bomb blocks. 
- You can moonfall clip down Green Pirates Shaft with a blue suit.
- You can temp blue chain through Gauntlet Entrance then spark out.

There were a few that potentially affect soundness:
- Gauntlet E-Tank logic thought you could use Bombs with G-mode artificial morph to fully break the left bomb wall (when you can only break the first half). I think it's not too impactful because to cross the room you still have to get through more bomb blocks, which I think would need Speed. So if I'm thinking of it right, it just comes down to needing to do a shorter shortcharge than expected.
- Climb Supers: We weren't checking that the Boyons are still alive when using them as a frozen runway. I'm not sure if it actually matters, but as more stuff gets added it can get difficult to be confident that it's ok. If you did an R-mode spark interrupt you may have needed to kill the Boyons for example, though with a blue suit there wouldn't be any point to the longer runway.

There also appears to be an issue with obstacle B in West Ocean but I'll let Kyle take a look at that separately.