### PR TITLE
Brinstar fixes

### DIFF
--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -813,8 +813,7 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Sidehopper",
       "requires": [
-        "h_ZebesIsAwake",
-        {"obstaclesNotCleared": ["C"]}
+        "h_ZebesIsAwake"
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -1062,9 +1061,9 @@
             {"resourceCapacity": [{"type": "RegularEnergy", "count": 199}]},
             {"resourceCapacity": [{"type": "ReserveEnergy", "count": 199}]}
           ]}
-        ]}
+        ]},
+        {"obstaclesCleared": ["C"]}
       ],
-      "clearsObstacles": ["C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -1099,9 +1098,9 @@
             {"resourceCapacity": [{"type": "RegularEnergy", "count": 199}]},
             {"resourceCapacity": [{"type": "ReserveEnergy", "count": 199}]}
           ]}
-        ]}
+        ]},
+        {"obstaclesCleared": ["C"]}
       ],
-      "clearsObstacles": ["C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -813,7 +813,8 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Sidehopper",
       "requires": [
-        "h_ZebesIsAwake"
+        "h_ZebesIsAwake",
+        {"obstaclesNotCleared": ["C"]}
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
@@ -1061,9 +1062,9 @@
             {"resourceCapacity": [{"type": "RegularEnergy", "count": 199}]},
             {"resourceCapacity": [{"type": "ReserveEnergy", "count": 199}]}
           ]}
-        ]},
-        {"obstaclesCleared": ["C"]}
+        ]}
       ],
+      "clearsObstacles": ["C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -1098,9 +1099,9 @@
             {"resourceCapacity": [{"type": "RegularEnergy", "count": 199}]},
             {"resourceCapacity": [{"type": "ReserveEnergy", "count": 199}]}
           ]}
-        ]},
-        {"obstaclesCleared": ["C"]}
+        ]}
       ],
+      "clearsObstacles": ["C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -1192,6 +1193,7 @@
         ]},
         "h_bombThings"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -326,6 +326,7 @@
         {"haveBlueSuit": {}},
         "Morph"
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -444,6 +444,7 @@
         ]},
         "canXRayClimb"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -39,7 +39,12 @@
     {
       "id": "A",
       "name": "Beetoms Dead or Frozen",
-      "obstacleType": "enemies"
+      "obstacleType": "enemies",
+      "devNote": [
+        "FIXME: Lumping frozen and dead together is questionable,",
+        "because some strats require the Beetoms to be alive.",
+        "The frozen state might not need to be an obstacle."
+      ]
     }
   ],
   "enemies": [

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -5268,6 +5268,8 @@
         }
       },
       "requires": [
+        {"itemNotCollectedAtNode": 13},
+        "canRiskPermanentLossOfAccess",
         "Morph",
         {"blueSuitShinecharge": {}},
         {"or": [

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -5287,6 +5287,11 @@
       "blueSuitChecked": true,
       "note": [
         "Spark up the shaft, then shoot the Chozo ball to overload PLMs. Then go down, through the bomb blocks and tunnel, then exit G-mode."
+      ],
+      "devNote": [
+        "FIXME: Overloading PLMs requires the item to be not collected.",
+        "The apparent unsoundness has limited impact since you could X-ray climb instead.",
+        "There are many ways to get to the top aside from blue suit shinecharge."
       ]
     },
     {

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -5291,9 +5291,7 @@
         "Spark up the shaft, then shoot the Chozo ball to overload PLMs. Then go down, through the bomb blocks and tunnel, then exit G-mode."
       ],
       "devNote": [
-        "FIXME: Overloading PLMs requires the item to be not collected.",
-        "The apparent unsoundness has limited impact since you could X-ray climb instead.",
-        "There are many ways to get to the top aside from blue suit shinecharge."
+        "FIXME: There are many ways to get to the top aside from blue suit shinecharge."
       ]
     },
     {

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -704,6 +704,7 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [],
+      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -1411,6 +1412,7 @@
       "requires": [
         "canComplexGMode"
       ],
+      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -748,7 +748,8 @@
       "note": [
         "Kill Mini-Kraid after entry which will drop multiple Large Energy. If you're missing some Supers, quickly grab the four supers that drop",
         "so that the 5th drop can be Large Energy. Ceiling thorns, lingering Mini-Kraid Spikes, or Pirates can be used at-will to damage down.",
-        "Go back to the right side, full-speed into a shinecharge, then got shot by a pirate for Spark Interrupt."
+        "Go back to the right side, full-speed into a shinecharge, then use a Pirate laser for spark interrupt.",
+        "The Pirates can then be killed with the blue suit."
       ]
     },
     {

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -377,7 +377,6 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},        
         {"or": [
           {"noBlueSuit": {}},
           "canTrickyGMode"

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -296,6 +296,7 @@
       "link": [1, 1],
       "name": "Leave with Moondance",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},        
         {"noBlueSuit": {}},
         "canMoondance",
         "canCount",
@@ -320,6 +321,7 @@
       "link": [1, 1],
       "name": "Leave with Extended Moondance",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},        
         {"noBlueSuit": {}},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
@@ -375,6 +377,7 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},        
         {"or": [
           {"noBlueSuit": {}},
           "canTrickyGMode"

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -203,6 +203,7 @@
       "link": [1, 1],
       "name": "Kihunter Ice Moonfall Door Lock Skip",
       "requires": [
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -512,8 +513,9 @@
     {
       "id": 58,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By KiHunter",
+      "name": "G-Mode Setup - Get Hit By Kihunter",
       "requires": [
+        {"obstaclesNotCleared": ["C"]},
         {"enemyDamage": {"enemy": "Kihunter (green)", "type": "contact", "hits": 1}},
         {"noBlueSuit": {}},
         "canComplexGMode"
@@ -524,8 +526,8 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Quickly spinjump up into the tunnel to shoot the shotblocks before the KiHunter can swoop down.",
-        "Stand level with the tunnel and wait for the KiHunter to come down. Once it is in the tunnel, move to the wall to lure it down full.",
+        "Quickly spinjump up into the tunnel to shoot the shotblocks before the Kihunter can swoop down.",
+        "Stand level with the tunnel and wait for the Kihunter to come down. Once it is in the tunnel, move to the wall to lure it down full.",
         "Don't shoot the wings off it or it will spit projectiles at Samus. Instead take a contact hit when it is at the bottom and move towards to door to lure it along."
       ]
     },

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -203,7 +203,6 @@
       "link": [1, 1],
       "name": "Kihunter Ice Moonfall Door Lock Skip",
       "requires": [
-        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -515,7 +514,6 @@
       "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Kihunter",
       "requires": [
-        {"obstaclesNotCleared": ["C"]},
         {"enemyDamage": {"enemy": "Kihunter (green)", "type": "contact", "hits": 1}},
         {"noBlueSuit": {}},
         "canComplexGMode"

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2772,6 +2772,7 @@
       "requires": [
         {"notable": "Super Block Speedball"},
         "canPreciseSpaceJump",
+        {"ammo": {"type": "Super", "count": 1}},        
         "canInsaneJump",
         "canSpeedball"
       ],
@@ -3108,7 +3109,6 @@
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
-      "clearsObstacles": ["F"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/brinstar/pink/Mission Impossible Room.json
+++ b/region/brinstar/pink/Mission Impossible Room.json
@@ -372,7 +372,9 @@
       "id": 11,
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Sidehopper",
-      "requires": [],
+      "requires": [
+        {"obstaclesNotCleared": ["A"]}
+      ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -474,6 +474,7 @@
           ]}
         ]}
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/brinstar/red/Below Spazer.json
+++ b/region/brinstar/red/Below Spazer.json
@@ -271,7 +271,8 @@
           {"enemyKill": {
             "enemies": [["Cacatac"]],
             "explicitWeapons": ["Missile", "Super", "Wave", "Spazer", "Plasma"]
-          }}
+          }},
+          "canShinechargeMovementTricky"
         ]},
         {"shinespark": {"frames": 24, "excessFrames": 0}}
       ],
@@ -559,6 +560,14 @@
       },
       "requires": [
         "canShinechargeMovementComplex",
+        {"or": [
+          {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
+          {"enemyKill": {
+            "enemies": [["Cacatac"]],
+            "explicitWeapons": ["Missile", "Super", "Wave", "Spazer", "Plasma"]
+          }},
+          "canShinechargeMovementTricky"
+        ]},        
         {"shinespark": {"frames": 24, "excessFrames": 0}}
       ],
       "exitCondition": {
@@ -571,7 +580,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Kill the Cacatac, and reach the center of the room.",
+        "Kill or dodge the Cacatac, and reach the center of the room.",
         "Fire a shot and activate the shinespark wind-up.",
         "Wait until the shot hits the door before sparking."
       ]

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -590,6 +590,7 @@
           ]}
         ]}
       ],
+      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -642,6 +643,7 @@
           ]}
         ]}
       ],
+      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -203,12 +203,17 @@
   "obstacles": [
     {
       "id": "A",
-      "name": "Power Bomb Blocks and Beetom",
+      "name": "Power Bomb Blocks",
       "obstacleType": "inanimate"
     },
     {
       "id": "B",
       "name": "Top of Tower Rippers",
+      "obstacleType": "enemies"
+    },
+    {
+      "id": "C",
+      "name": "Beetom",
       "obstacleType": "enemies"
     }
   ],
@@ -294,13 +299,28 @@
           ]}
         ]}
       ],
-      "resetsObstacles": ["A", "B"],
+      "resetsObstacles": ["A", "B", "C"],
       "farmCycleDrops": [{"enemy": "Beetom", "count": 1}],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": [
         "Using a Power Bomb to farm the Beetom is only useful if Power Bomb drops are modified to give more than 1.",
         "FIXME: Other options for resetting the room at the top and bottom nodes are possible."
+      ]
+    },
+    {
+      "link": [1, 1],
+      "name": "Power Bomb Blocks Without Killing Beetom",
+      "requires": [
+        "h_usePowerBomb",
+        "canTrickyJump"
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Lay the Power Bomb mid-air, alongside the ledge below the Geega spawners.",
+        "Stay high enough to avoid activating the Beetom to hop during the explosion."
       ]
     },
     {
@@ -352,7 +372,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         "h_frozenEnemyRunway"
       ],
       "exitCondition": {
@@ -399,7 +419,7 @@
       "link": [1, 1],
       "name": "Leave with Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canMoondance",
         "canCount",
@@ -423,7 +443,7 @@
       "link": [1, 1],
       "name": "Door Frame Extended Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
@@ -482,7 +502,6 @@
         "canRModeSparkInterrupt"
       ],
       "unlocksDoors": [{"nodeId": 5, "types": ["ammo"], "requires": []}],
-      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -496,7 +515,7 @@
       "link": [1, 1],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}}
       ],
@@ -514,12 +533,18 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [
-        {"or": [
-          "h_usePowerBomb",
-          {"obstaclesCleared": ["A"]}
-        ]}
+        "h_usePowerBomb"
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Blocks Already Broken",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -528,9 +553,9 @@
       "link": [1, 2],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
-        "h_usePowerBomb",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
@@ -540,12 +565,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Either place a Power Bomb on the ledge with the Geega bug farms, to only break the top row of blocks and not kill the Beetom,",
-        "or move the Beetom to safety by shaking it off at a higher platform before breaking the Power Bomb blocks."
-      ],
-      "devNote": "Obstacle A cannot already be broken, because otherwise the Beetom will already be killed."
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -601,7 +621,7 @@
       "link": [1, 2],
       "name": "Frozen Beetom X-Ray Climb with Morph",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"notable": "Frozen Beetom X-Ray Climb with Morph"},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
@@ -630,7 +650,7 @@
       "link": [1, 2],
       "name": "Moondance Clip",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
@@ -640,7 +660,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Collect the Beetom and freeze it above and left of the Power Bomb Blocks in a way that Samus will be able to Moondance.",
+        "Collect the Beetom and freeze it above and left of the Power Bomb Blocks in a way that Samus will be able to moondance.",
         "Moondance until Samus falls through two tiles, then Moonfall again to sink through the solid blocks and reach the door."
       ]
     },
@@ -649,9 +669,9 @@
       "link": [1, 2],
       "name": "Leave with Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
-        "h_usePowerBomb",
         "canMoondance",
         "canCount",
         "canTrickyUseFrozenEnemies",
@@ -662,15 +682,11 @@
           "fallSpeedInTiles": 1
         }
       },
-      "unlocksDoors": [
-        {"types": ["missiles", "super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
-      ],
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Break the Power Bomb Blocks without killing the Beetom",
-        "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
+        "Freeze a Beetom at head height where Samus can spin jump into it and begin moondancing.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
       ]
     },
@@ -679,9 +695,9 @@
       "link": [1, 2],
       "name": "Leave with Extended Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
-        "h_usePowerBomb",
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
@@ -692,16 +708,12 @@
           "fallSpeedInTiles": 2
         }
       },
-      "unlocksDoors": [
-        {"types": ["missiles", "super"], "requires": []},
-        {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
-      ],
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Break the Power Bomb Blocks without killing the Beetom",
-        "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
-        "After 175 Moonfalls, reposition the Beetom to chest height.",
+        "Freeze a Beetom at head height where Samus can spin jump into it and begin moondancing.",
+        "After 175 moonfalls, reposition the Beetom to chest height.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
       ]
     },
@@ -710,7 +722,7 @@
       "link": [1, 2],
       "name": "Moondance Clip, G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canBeExtremelyPatient",
         "canExtendedMoondance",
@@ -726,7 +738,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Collect the Beetom and freeze it above and left of the Power Bomb Blocks in a way that Samus will be able to Moondance.",
+        "Collect the Beetom and freeze it above and left of the Power Bomb blocks in a way that Samus will be able to moondance.",
         "Moondance until Samus falls through two tiles, wait for the Beetom to thaw and attach to Samus,",
         "then Moonfall again to sink through the solid blocks and reach the door with the Beetom.",
         "Use the Beetom to perform a G-mode setup through the door."
@@ -737,7 +749,7 @@
       "link": [1, 2],
       "name": "Moondance Clip, Leave with Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canBeExtremelyPatient",
         "canExtendedMoondance",
@@ -753,7 +765,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Collect the Beetom and freeze it above and left of the Power Bomb Blocks in a way that Samus will be able to Moondance.",
+        "Collect the Beetom and freeze it above and left of the Power Bomb blocks in a way that Samus will be able to moondance.",
         "Moondance until Samus falls through two tiles, wait for the Beetom to thaw and attach to Samus,",
         "then Moonfall again to sink through the solid blocks and reach the door with the Beetom.",
         "Use the Beetom to perform another moondance to leave with stored fall speed."
@@ -764,7 +776,7 @@
       "link": [1, 2],
       "name": "Moondance Clip, Leave with Extended Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canBeExtremelyPatient",
         "canExtendedMoondance",
@@ -781,7 +793,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Collect the Beetom and freeze it above and left of the Power Bomb Blocks in a way that Samus will be able to Moondance.",
+        "Collect the Beetom and freeze it above and left of the Power Bomb Blocks in a way that Samus will be able to moondance.",
         "Moondance until Samus falls through two tiles, wait for the Beetom to thaw and attach to Samus,",
         "then Moonfall again to sink through the solid blocks and reach the door with the Beetom.",
         "Use the Beetom to perform another extended moondance to leave with stored fall speed."
@@ -792,7 +804,7 @@
       "link": [1, 3],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}}
       ],
@@ -832,7 +844,7 @@
       "link": [1, 3],
       "name": "Leave with Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canMoondance",
         "canCount",
@@ -869,7 +881,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
+        "Freeze a Beetom at head height where Samus can spin jump into it and begin moondancing.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
       ]
     },
@@ -878,7 +890,7 @@
       "link": [1, 3],
       "name": "Leave with Extended Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
@@ -925,7 +937,7 @@
       "link": [1, 4],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}}
       ],
@@ -965,7 +977,7 @@
       "link": [1, 4],
       "name": "Leave with Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canMoondance",
         "canCount",
@@ -1011,7 +1023,7 @@
       "link": [1, 4],
       "name": "Leave with Extended Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "canExtendedMoondance",
         "canTrickyUseFrozenEnemies",
@@ -1058,7 +1070,7 @@
       "link": [1, 5],
       "name": "Leave with Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         {"or": [
           "HiJump",
@@ -1079,7 +1091,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
+        "Freeze a Beetom at head height where Samus can spin jump into it and begin moondancing.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
       ]
     },
@@ -1088,7 +1100,7 @@
       "link": [1, 5],
       "name": "Leave with Extended Moondance",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         {"or": [
           "HiJump",
@@ -1109,7 +1121,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
+        "Freeze a Beetom at head height where Samus can spin jump into it and begin moondancing.",
         "After 175 Moonfalls, reposition the Beetom to chest height.",
         "If needed, the Beetom can be left at the door while Samus moves to the farm bugs."
       ]
@@ -1462,7 +1474,7 @@
       "link": [1, 9],
       "name": "Frozen Beetom Ice Climb",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"notable": "Frozen Beetom Ice Climb"},
         {"noBlueSuit": {}},
         "canTrickyUseFrozenEnemies",
@@ -1518,12 +1530,18 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [
-        {"or": [
-          "h_usePowerBomb",
-          {"obstaclesCleared": ["A"]}
-        ]}
+        "h_usePowerBomb"
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Blocks Already Broken",
+      "requires": [
+        {"obstaclesCleared": ["A"]}
+      ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -1612,7 +1630,7 @@
         {"cycleFrames": 300},
         "h_usePowerBomb"
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "resetsObstacles": ["B"],
       "farmCycleDrops": [{"enemy": "Beetom", "count": 1}],
       "flashSuitChecked": true,
@@ -1628,7 +1646,7 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -1652,7 +1670,7 @@
           "h_CrystalSpark"
         ]}
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": [
@@ -1673,7 +1691,7 @@
       "requires": [
         "h_artificialMorphPowerBomb"
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -1803,7 +1821,7 @@
         "canRModeSparkInterrupt"
       ],
       "unlocksDoors": [{"nodeId": 5, "types": ["ammo"], "requires": []}],
-      "clearsObstacles": ["B"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -1844,6 +1862,7 @@
         {"nodeId": 3, "types": ["ammo"], "requires": []},
         {"nodeId": 4, "types": ["ammo"], "requires": []}
       ],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -1874,7 +1893,7 @@
           "HiJump"
         ]}
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -1904,7 +1923,7 @@
           "HiJump"
         ]}
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -2480,7 +2499,7 @@
           "HiJump"
         ]}
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -2510,7 +2529,7 @@
           "HiJump"
         ]}
       ],
-      "clearsObstacles": ["A"],
+      "clearsObstacles": ["A", "C"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -3020,7 +3039,6 @@
         "canRModeSparkInterrupt"
       ],
       "unlocksDoors": [{"nodeId": 5, "types": ["ammo"], "requires": []}],
-      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -3107,7 +3125,7 @@
       "link": [5, 5],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
-        {"obstaclesNotCleared": ["A"]},
+        {"obstaclesNotCleared": ["C"]},
         {"noBlueSuit": {}},
         "HiJump",
         {"or": [
@@ -3250,7 +3268,7 @@
         {"noBlueSuit": {}},
         "canTrickyUseFrozenEnemies",
         "h_crouchJumpDownGrab",
-        {"obstaclesNotCleared": ["A"]}
+        {"obstaclesNotCleared": ["C"]}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -203,7 +203,7 @@
   "obstacles": [
     {
       "id": "A",
-      "name": "Power Bomb Blocks",
+      "name": "Power Bomb Blocks and Beetom",
       "obstacleType": "inanimate"
     },
     {
@@ -352,6 +352,7 @@
       "link": [1, 1],
       "name": "Leave With Runway - Frozen Beetom",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         "h_frozenEnemyRunway"
       ],
       "exitCondition": {
@@ -600,6 +601,7 @@
       "link": [1, 2],
       "name": "Frozen Beetom X-Ray Climb with Morph",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         {"notable": "Frozen Beetom X-Ray Climb with Morph"},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}},
@@ -1460,6 +1462,7 @@
       "link": [1, 9],
       "name": "Frozen Beetom Ice Climb",
       "requires": [
+        {"obstaclesNotCleared": ["A"]},
         {"notable": "Frozen Beetom Ice Climb"},
         {"noBlueSuit": {}},
         "canTrickyUseFrozenEnemies",


### PR DESCRIPTION
Continuing through a pass of AI review, a couple noteworthy soundness issues that are fixed here:
- Big Pink: there were a couple logical ways of clearing the Super block without Supers.
- Red Tower: if your only access is through the PB blocks, you would have to kill the Beetom but could logically still use it to Ice climb.

The theme continues that most of the errors found are obstacle-related. And there are some `obstaclesNotCleared` that we could maybe rationalize as not really needed, but it seems safer to put them in.