### PR TITLE
Wrecked Ship fixes

### DIFF
--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -1094,7 +1094,7 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {
-          "direction": "left"
+          "direction": "right"
         }
       },
       "flashSuitChecked": true,

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -870,6 +870,7 @@
         {"haveBlueSuit": {}},
         "Morph"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -1142,6 +1143,7 @@
         {"haveBlueSuit": {}},
         "Morph"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -136,15 +136,15 @@
       },
       "requires": [
         "canLongChainTemporaryBlue",
-        "canXRayTurnaround",
-        {"electricityHits": 2}
+        "canXRayTurnaround"
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "It is possible to dodge the electricity."
     },
     {
       "id": 20,
@@ -186,7 +186,6 @@
       "requires": [
         "canLongChainTemporaryBlue",
         "canXRayTurnaround",
-        {"electricityHits": 2},
         {"or": [
           "Gravity",
           "HiJump",
@@ -199,7 +198,8 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": ["It is possible to dodge the electricity."]
     },
     {
       "id": 5,

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -1239,7 +1239,8 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "When the power is on, the floor has spikes (not thorns), and Samus will quickly lose i-frames."
+        "When the power is on, the floor has both thorns and spikes; normally Samus would interact only with the thorns,",
+        "but blue suit causes Samus to pass through the thorns without damage, resulting in contact with the spikes below."
       ]
     },
     {

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -872,6 +872,7 @@
         {"ammo": {"type": "Super", "count": 10}}
       ],
       "resetsObstacles": ["R-Mode"],
+      "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -909,6 +910,7 @@
           ]}
         ]}
       ],
+      "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [


### PR DESCRIPTION
Nothing too significant here. Mostly minor issues that could cause some logic incompleteness. Most significant one was in Attic, where a copy-paste error on the leaveWithTemporaryBlue strat through the down door meant logic didn't think you could leave facing right.

The AI suggested accounting for the possibility of power being off to avoid electricity hits in the temp blue chaining strats in Electric Death Room. But it's not actually too bad to just dodge them (considering these strats are already Insane level) so I just removed the `electricityHits` requirements.

Wrecked Ship E-Tank Room didn't accurately explain what was going on with the thorns vs. spikes so I clarified the note.
