### PR TITLE
Tourian fixes

### DIFF
--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -212,6 +212,7 @@
       "link": [1, 1],
       "name": "Leave With Temporary Blue",
       "requires": [
+        {"obstaclesCleared":["A"]},
         {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
       ],
       "exitCondition": {
@@ -225,6 +226,7 @@
       "link": [1, 1],
       "name": "Crystal Spark",
       "requires": [
+        {"obstaclesCleared":["A"]},
         {"canShineCharge": {"usedTiles": 15, "openEnd": 0}},
         "h_CrystalSpark"
       ],
@@ -423,6 +425,7 @@
       "link": [1, 2],
       "name": "Leave With Temporary Blue",
       "requires": [
+        {"obstaclesCleared":["A"]},
         {"getBlueSpeed": {"usedTiles": 14, "openEnd": 1}},
         "canChainTemporaryBlue",
         {"or": [
@@ -511,6 +514,9 @@
         "canBabyMetroidAvoid",
         "h_trickyToCarryFlashSuit"
       ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -534,6 +540,9 @@
         "canBabyMetroidAvoid",
         "h_trickyToCarryFlashSuit"
       ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": "Avoid the Baby Metroid by jumping over it many times in order to clear a path through the seaweed."
@@ -550,6 +559,9 @@
         "canInsaneJump",
         "h_trickyToCarryFlashSuit"
       ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -619,8 +631,16 @@
         }
       },
       "requires": [],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "devNote": [
+        "FIXME: Staying in the room is possible but may require complicated semi-blind movement:",
+        "the seaweed can be broken with grapple shots, and visibility of Samus (but not the terrain) can be gained by fixing the camera;",
+        "time is limited as the Baby will still grab Samus after the cutscene completes."
+      ]
     },
     {
       "id": 27,
@@ -634,7 +654,10 @@
       "requires": [],
       "bypassesDoorShell": "yes",
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "devNote": [
+        "There is no door shell here, but if there were, it would be skippable."
+      ]
     },
     {
       "id": 28,

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -2185,6 +2185,7 @@
       "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Metroid",
       "requires": [
+        {"obstaclesNotCleared": ["B"]},
         {"not": "f_KilledMetroidRoom1"},
         "canRiskPermanentLossOfAccess"
       ],

--- a/region/tourian/main/Seaweed Room.json
+++ b/region/tourian/main/Seaweed Room.json
@@ -656,7 +656,7 @@
       "name": "Leave Spinning (Space Jump, Door Open)",
       "requires": [
         "SpaceJump",
-        {"doorUnlockedAtNode": 3}
+        {"doorUnlockedAtNode": 2}
       ],
       "exitCondition": {
         "leaveSpinning": {


### PR DESCRIPTION
Nothing too significant here. Seaweed Room had a wrong node ID on a "doorUnlockedAtNode", which could put a longer-runway version of the leaveSpinning strat (with Space Jump) into logic when it's not possible.