### PR TITLE
Crocomire Speedway: 99 energy crumble jump reverse spark

### DIFF
--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -1172,7 +1172,13 @@
           {"shinespark": {"frames": 87, "excessFrames": 10}},
           {"and": [
             "h_heatProof",
-            "canControlShinesparkEnd",
+            {"or": [
+              "canControlShinesparkEnd",
+              {"and": [
+                "canCrumbleJump",
+                {"resourceAtMost": [{"type": "RegularEnergy", "count": 99}]}
+              ]}
+            ]},
             {"shinespark": {"frames": 87, "excessFrames": 44}}
           ]}
         ]},
@@ -1197,7 +1203,8 @@
         "Spark left through the speed blocks, then run to the right and back to get speed to go through the rest.",
         "If performing the spark with low energy, there is a risk of ending the spark above the spikes or in front of the Pirate;",
         "to be safe, assuming Samus has heat protection and begins sparking about 3 tiles from the Speed blocks, start with between 72 and 87 energy or at least 105 energy;",
-        "with a buffered crumble jump to the right, up to 93 energy can work."
+        "with a buffered crumble jump to the right, up to 93 energy can work.",
+        "With 99 energy, start from the right door and use a buffered crumble jump right."
       ],
       "devNote": ["FIXME: This should be split into 3->9 and 9->2 strats."]
     },
@@ -1528,7 +1535,13 @@
           {"shinespark": {"frames": 84, "excessFrames": 10}},
           {"and": [
             "h_heatProof",
-            "canControlShinesparkEnd",
+            {"or": [
+              "canControlShinesparkEnd",
+              {"and": [
+                "canCrumbleJump",
+                {"resourceAtMost": [{"type": "RegularEnergy", "count": 99}]}
+              ]}
+            ]},
             {"shinespark": {"frames": 84, "excessFrames": 45}}
           ]}
         ]},
@@ -1553,7 +1566,8 @@
         "Spark left through the speed blocks, then run to the right and back to get speed to go through the rest.",
         "If performing the spark with low energy, there is a risk of ending the spark above the spikes or in front of the Pirate;",
         "to be safe, assuming Samus has heat protection, begin the shinespark at the Speed blocks with between 68 and 84 energy, or at least 101 energy;",
-        "with a buffered crumble jump to the right, up to 89 energy can work."
+        "with a buffered crumble jump to the right, up to 89 energy can work.",
+        "With 99 energy, start from the right door and use a buffered crumble jump right."
       ]
     },
     {


### PR DESCRIPTION
Croc Reverse Spark with 99 energy is easier than Expert+

https://videos.maprando.com/video/10974
https://videos.maprando.com/video/10976

Initial stab at bringing this down out of Expert+, but after a lot of discussion w/ @kjbranch we'll try instead splitting out new strats / new notable: #2963

https://discord.com/channels/1053421401354285129/1053436236628496454/1541859636175699998