### PR TITLE
Tourian Hopper left-to-right spin jump squeeze

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -641,6 +641,7 @@
           "name": "h_heatedRemoteRunwaySpaceJump",
           "requires": [
             "canTrickyJump",
+            "SpaceJump",
             {"or": [
               "h_heatProof",
               "canPreciseSpaceJump"
@@ -660,6 +661,7 @@
         {
           "name": "h_heatedRemoteRunwaySpringBall",
           "requires": [
+            "h_useSpringBall",
             {"or": [
               "h_heatProof",
               "canTrickySpringBallBounce"

--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -350,6 +350,25 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": -4,
+          "runway": {
+            "length": 19,
+            "openEnd": 2
+          },
+          "obstruction": [8, -4]
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": ["Max extra run speed $3.E with spin, or $3.F with an aim-down."]      
+    },
+    {
       "id": 12,
       "link": [1, 2],
       "name": "Leave Space Jumping",
@@ -889,6 +908,25 @@
         "Max extra run speed $3.3 with spin, or $3.4 with a quick aim-down.",
         "This would not be logically valid for gaining blue speed, so we have to be sure it can't be used that way."
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Tank Spike Hit, Leave Spinning",
+      "requires": [
+        "Gravity",
+        {"spikeHits": 1},
+        "canTrickyJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 12,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 32,

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -2172,6 +2172,24 @@
       "blueSuitChecked": true
     },
     {
+      "link": [6, 6],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 1,
+          "runway": {
+            "length": 19,
+            "openEnd": 0
+          },
+          "obstruction": [6, -1]
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": ["Max extra run speed $3.C."]
+    },
+    {
       "id": 50,
       "link": [6, 6],
       "name": "Leave Spinning",

--- a/region/brinstar/pink/Mission Impossible Room.json
+++ b/region/brinstar/pink/Mission Impossible Room.json
@@ -195,6 +195,27 @@
       "devNote": "Two spike hits are expected per attempt (with any additional leniency hits being multiplied by this amount)."
     },
     {
+      "link": [1, 1],
+      "name": "Leave With Side Platform",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        {"obstaclesNotCleared": ["B"]}        
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 2,
+          "runway": {
+            "length": 16,
+            "openEnd": 0
+          },
+          "obstruction": [13, 2]
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": ["Max extra run speed $3.A."]
+    },
+    {
       "id": 5,
       "link": [1, 1],
       "name": "Leave Spinning (Space Jump)",

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -371,8 +371,10 @@
     {
       "id": 12,
       "link": [2, 2],
-      "name": "Leave Spinning",
-      "requires": [],
+      "name": "Leave Spinning (Speed Booster)",
+      "requires": [
+        "h_speedJump"
+      ],
       "exitCondition": {
         "leaveSpinning": {
           "remoteRunway": {
@@ -382,6 +384,23 @@
             "steepDownTiles": 4
           },
           "minExtraRunSpeed": "$3.E"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning (Space Jump)",
+      "requires": [
+        "SpaceJump"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          }
         }
       },
       "flashSuitChecked": true,

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -830,6 +830,71 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Spring Ball Bounce",
+      "requires": [
+        "h_heatedRemoteRunwaySpringBall",
+        {"heatFrames": 190},
+        "canHitbox",
+        "canTrickyDodgeEnemies"
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 10,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },    
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 190},
+        "canHitbox",
+        "canTrickyDodgeEnemies"
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 10,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "h_heatedRemoteRunwayPreciseSpaceJump",
+        {"heatFrames": 190},
+        "canHitbox",
+        "canTrickyDodgeEnemies"
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 10,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 16,
       "link": [2, 2],
       "name": "Crystal Flash",

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1606,6 +1606,9 @@
     {
       "link": [2, 2],
       "name": "Leave with Mockball",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
       "requires": [
         "h_heatedRemoteRunway",
         {"heatFrames": 150}
@@ -1622,6 +1625,78 @@
           }
         }
       },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave with Spring Ball Bounce",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 155}
+      ],
+      "exitCondition": {
+        "leaveWithSpringBallBounce": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 2
+          },
+          "landingRunway": {
+            "length": 1,
+            "openEnd": 1
+          },
+          "movementType": "uncontrolled"
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Spinning",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 7,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Leave Space Jumping",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_heatedRemoteRunwaySpaceJump",
+        {"heatFrames": 160}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 4,
+            "openEnd": 1
+          }
+        }
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },

--- a/region/lowernorfair/east/Ridley Tank Room.json
+++ b/region/lowernorfair/east/Ridley Tank Room.json
@@ -120,6 +120,42 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 1],
+      "name": "Leave Spinning",
+      "requires": [
+        "h_heatedRemoteRunway",
+        {"heatFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveSpinning": {
+          "remoteRunway": {
+            "length": 8,
+            "openEnd": 2
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Leave Space Jumping",
+      "requires": [
+        "h_heatedRemoteRunwaySpaceJump",
+        {"heatFrames": 150}
+      ],
+      "exitCondition": {
+        "leaveSpaceJumping": {
+          "remoteRunway": {
+            "length": 5,
+            "openEnd": 1
+          }
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 2,
       "link": [1, 2],
       "name": "Base",

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -525,6 +525,26 @@
       "blueSuitChecked": true
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [
+        "Gravity",
+        "f_DefeatedBotwoon"
+      ],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": 3,
+          "runway": {
+            "length": 16,
+            "openEnd": 0
+          },
+          "obstruction": [13, 2]
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 15,
       "link": [2, 2],
       "name": "Leave Shinecharged",

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -783,23 +783,6 @@
       "blueSuitChecked": true
     },
     {
-      "link": [2, 2],
-      "name": "Leave With Side Platform",
-      "requires": [],
-      "exitCondition": {
-        "leaveWithSidePlatform": {
-          "height": -3,
-          "runway": {
-            "length": 45,
-            "openEnd": 1
-          },
-          "obstruction": [5, -3]
-        }
-      },
-      "flashSuitChecked": true,
-      "blueSuitChecked": true
-    },
-    {
       "id": 27,
       "link": [2, 2],
       "name": "Fight Pirates Slowly",

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -783,6 +783,23 @@
       "blueSuitChecked": true
     },
     {
+      "link": [2, 2],
+      "name": "Leave With Side Platform",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithSidePlatform": {
+          "height": -3,
+          "runway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "obstruction": [5, -3]
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 27,
       "link": [2, 2],
       "name": "Fight Pirates Slowly",

--- a/region/tourian/main/Tourian Hopper Room.json
+++ b/region/tourian/main/Tourian Hopper Room.json
@@ -636,14 +636,6 @@
               "speedBooster": "yes",
               "obstructions": [[13, 2]],
               "note": ["This applies to Botwoon's Room."]  
-            },
-            {
-              "minHeight": -3,
-              "maxHeight": -3,
-              "minTiles": 45,
-              "speedBooster": "yes",
-              "obstructions": [[5, -3]],
-              "note": ["This applies to Tourian Escape Room 3."]
             }
           ]
         }

--- a/region/tourian/main/Tourian Hopper Room.json
+++ b/region/tourian/main/Tourian Hopper Room.json
@@ -554,6 +554,109 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Come in Spinning, Squeeze Under Hoppers",
+      "entranceCondition": {
+        "comeInSpinning": {
+          "speedBooster": "any",
+          "unusableTiles": 0,
+          "minExtraRunSpeed": "$2.0"
+        }
+      },
+      "requires": [
+        {"notable": "Squeeze Under Hoppers"},
+        "canInsaneJump",
+        "h_complexToCarryFlashSuit"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Gain as much speed as possible, using a remote runway to spin jump precisely through the transition.",
+        "Samus needs to be low enough to fit under the first Hopper,",
+        "but high enough (and low enough fall speed) to make the required horizontal distance before landing, to be clear of the Hopper."
+      ],
+      "detailNote": [
+        "If Samus hits the transition relatively high, aiming down through the transition can help to squeeze under the Hopper.",
+        "If Samus hits the transition relatively low, do not aim down; remaining in spin helps Samus cover the horizontal distance."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Come in With Side Platform Jump, Squeeze Under Hoppers",
+      "entranceCondition": {
+        "comeInWithSidePlatform": {
+          "platforms": [
+            {
+              "minHeight": -4,
+              "maxHeight": -4,
+              "minTiles": 19,
+              "speedBooster": "yes",
+              "obstructions": [[8, -4]],
+              "note": "This applies to Blue Brinstar Boulder Room."
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 9.4375,
+              "speedBooster": "any",
+              "obstructions": [[2, 0]],
+              "note": "This applies to Early Supers Room."
+            },
+            {
+              "minHeight": 1,
+              "maxHeight": 1,
+              "minTiles": 18.4375,
+              "speedBooster": "yes",
+              "obstructions": [[6, -1]],
+              "note": "This applies to Big Pink."
+            },
+            {
+              "minHeight": 2,
+              "maxHeight": 2,
+              "minTiles": 15.4375,
+              "speedBooster": "yes",
+              "obstructions": [[13, 2]],
+              "note": "This applies to Mission Impossible Room."
+            },
+            {
+              "minHeight": 8,
+              "maxHeight": 8,
+              "minTiles": 7.4375,
+              "speedBooster": "any",
+              "obstructions": [[1, 0]],
+              "requires": [
+                "HiJump"
+              ],
+              "note": ["This applies to Screw Attack Room."]
+            },
+            {
+              "minHeight": 3,
+              "maxHeight": 3,
+              "minTiles": 15.4375,
+              "speedBooster": "yes",
+              "obstructions": [[13, 2]],
+              "note": ["This applies to Botwoon's Room."]  
+            },
+            {
+              "minHeight": -3,
+              "maxHeight": -3,
+              "minTiles": 45,
+              "speedBooster": "yes",
+              "obstructions": [[5, -3]],
+              "note": ["This applies to Tourian Escape Room 3."]
+            }
+          ]
+        }
+      },
+      "requires": [
+        {"notable": "Squeeze Under Hoppers"},
+        "canInsaneJump",
+        "h_complexToCarryFlashSuit"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 39,
       "link": [2, 1],
       "name": "Sidehoppers Already Killed",
@@ -789,6 +892,32 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": "Enter the room morphed to avoid a hopper hit on entry."
+    },
+    {
+      "link": [2, 2],
+      "name": "Sidehopper Tricky Dodge Enter and Exit",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "canTrickyDodgeEnemies",
+        "canInsaneJump",
+        "h_trickyToCarryFlashSuit"
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
+      "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Enter with a spin jump, ideally as low and with as much fall speed as possible, and hold left against the wall.",
+        "After landing, shoot up to open the door, then jump straight up and hold left to exit."
+      ],
+      "devNote": [
+        "This can be logically useful to respawn the Super block in Mission Impossible Room,",
+        "or the shot block in Mickey Mouse Room."
+      ]
     },
     {
       "id": 40,

--- a/strats.md
+++ b/strats.md
@@ -94,7 +94,7 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveWithGMode_: This indicates that Samus can carry G-mode into the next room (where it will become indirect G-mode).
 - _leaveWithDoorFrameBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump.
 - _leaveWithPlatformBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping from a platform below, possibly with run speed.
-- _leaveWithSidePlatform_: This indicates that Samus can go through this horizontal door with upward momentum by jumping from a platform near the doorway but not attached to it.
+- _leaveWithSidePlatform_: This indicates that Samus can go through this horizontal door by jumping from a platform near the doorway but not attached to it.
 - _leaveWithGrappleSwing_: This indicates that Samus can leave through this door by swinging using Grapple, carrying momentum and the ability to grapple jump in the next room.
 - _leaveWithGrappleJump_: This indicates that Samus can go up through this door by grapple jumping, with no horizontal momentum.
 - _leaveWithGrappleTeleport_: This indicates that Samus can leave through this door while grappling, which can enable a teleport in the next room.
@@ -491,7 +491,7 @@ In a heated room, heat frames must be explicitly included in the strat `requires
 
 ### Leave With Side Platform
 
-A `leaveWithSidePlatform` exit condition represents that that Samus can leave through this door by jumping from a platform to the side, carrying upward momentum into the next room. This applies to horizontal door transitions with a platform below the doorway, close enough to it that Samus can jump through the door without bonking on the ceiling. A `leaveWithSidePlatform` exit condition can satisfy a `comeInWithSidePlatform` entrance condition in the next room.
+A `leaveWithSidePlatform` exit condition represents that that Samus can leave through this door by jumping from a platform to the side. This is typically used for carrying upward momentum into the next room, applying to horizontal door transitions with a platform below the doorway, close enough to it that Samus can jump through the door without bonking on the ceiling. It can also apply to runways with other kinds of unique uses that depend on their specific geometry (e.g. not covered by more general exit conditions such as `leaveSpinning`). A `leaveWithSidePlatform` exit condition can satisfy a `comeInWithSidePlatform` entrance condition in the next room.
 
 A `leaveWithSidePlatform` object has the following properties:
 
@@ -671,7 +671,7 @@ In all strats with an `entranceCondition`, the `from` node of the strat must be 
 - _comeInWithWallJumpBelow_: This indicates that Samus must come up through this vertical door with momentum by wall-jumping in the door frame below.
 - _comeInWithSpaceJumpBelow_: This indicates that Samus must come up through this vertical door with momentum by using Space Jump in the door frame below.
 - _comeInWithPlatformBelow_: This indicates that Samus must come up through this vertical door with momentum by jumping from a platform below, possibly with run speed.
-- _comeInWithSidePlatform_: This indicates that Samus must jump through this horizontal door with upward momentum, by jumping from a platform to the side of the doorway (but not attached to it) in the other room.
+- _comeInWithSidePlatform_: This indicates that Samus must jump through this horizontal door, by jumping from a platform to the side of the doorway (but not attached to it) in the other room.
 - _comeInWithGrappleSwing_: This indicates that Samus swing into the room using Grapple, giving momentum and possibly the ability to grapple jump.
 - _comeInWithGrappleJump_: This indicates that Samus must come into the room by grapple jumping vertically through this door, with no horizontal momentum.
 - _comeInWithGrappleTeleport_: This indicates that Samus must come into the room while grappling, teleporting Samus to a position in this room corresponding to the location of the (grapple) block in the other room.
@@ -1534,7 +1534,7 @@ __Example:__
 
 ### Come In With Side Platform
 
-A `comeInWithSidePlatform` entrance condition indicates that Samus must jump through this horizontal door with upward momentum, by jumping from a platform to the side of the doorway (but not attached to it) in the other room. It has one property:
+A `comeInWithSidePlatform` entrance condition indicates that Samus must jump through this horizontal door, by jumping from a platform to the side of the doorway (but not attached to it) in the other room. It has one property:
 
 * _platforms_: An array of objects, each describing a type of platform geometry that can satisfy this condition.
   - _minTiles_: Minimum length of platform runway in the other room, measured in tiles (including unusable tiles).


### PR DESCRIPTION
- Adds comeInSpinning and comeInWithSidePlatform strats for avoiding Tourian Hopper damage left-to-right.
- Adds many leaveWithSidePlatform strats to match with the new Tourian Hopper strat (for cases with unusual geometry, not already covered by leaveSpinning).
- Updates docs for leaveWithSidePlatform/comeInWithSidePlatform to reflect the new intent, that these are for requirements on neighboring-room remote runway geometry, no longer necessarily requiring preserving upward momentum. In this way it becomes more parallel with leaveWithPlatformBelow/comeInWithPlatformBelow.
- Adds/updates a few other remote-runway strats where I noticed them lacking.
- Adds item requirements to "h_heatedRemoteRunwaySpaceJump" and "h_heatedRemoteRunwaySpringBall" helpers. It may have been already covered by strat-specific requirements but seems safer this way.
