### PR TITLE
leaveWithDamage initial migration

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -506,12 +506,14 @@
     {
       "id": 15,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -959,7 +959,7 @@
     {
       "id": 35,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geemer - Broken Crumble Blocks",
+      "name": "Get Hit By Geemer - Broken Crumble Blocks",
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
@@ -973,7 +973,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -982,7 +984,7 @@
     {
       "id": 36,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geemer - Broken Power Bomb Blocks",
+      "name": "Get Hit By Geemer - Broken Power Bomb Blocks",
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
@@ -1000,7 +1002,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1009,13 +1013,15 @@
     {
       "id": 37,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geemer - Blocks Already Broken",
+      "name": "Get Hit By Geemer - Blocks Already Broken",
       "requires": [
         "h_ZebesIsAwake",
         {"obstaclesCleared": ["A", "B"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/blue/Construction Zone.json
+++ b/region/brinstar/blue/Construction Zone.json
@@ -174,12 +174,14 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -600,12 +602,14 @@
     {
       "id": 24,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -990,13 +994,15 @@
     {
       "id": 38,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "Morph",
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -811,12 +811,14 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sidehopper",
+      "name": "Get Hit By Sidehopper",
       "requires": [
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sidehopper"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -139,10 +139,12 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -660,13 +662,16 @@
     {
       "id": 25,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zeela or Sidehopper",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "The small Sidehopper can also be used."
     },
     {
       "id": 26,

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -260,10 +260,12 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -548,7 +550,7 @@
     {
       "id": 17,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"or": [
@@ -575,7 +577,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1120,7 +1124,7 @@
     {
       "id": 48,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Waver (Come in Jumping)",
+      "name": "Get Hit By Waver (Come in Jumping)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "no",
@@ -1132,7 +1136,9 @@
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1146,7 +1152,7 @@
     {
       "id": 49,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Waver (Come in Jumping, Mockball)",
+      "name": "Get Hit By Waver (Come in Jumping, Mockball)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -1159,7 +1165,9 @@
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1174,7 +1182,7 @@
     {
       "id": 50,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Waver (Come in Space Jumping)",
+      "name": "Get Hit By Waver (Come in Space Jumping)",
       "entranceCondition": {
         "comeInSpaceJumping": {
           "speedBooster": "no",
@@ -1186,7 +1194,9 @@
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1200,7 +1210,7 @@
     {
       "id": 51,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Waver (Come in With Side Platform)",
+      "name": "Get Hit By Waver (Come in With Side Platform)",
       "entranceCondition": {
         "comeInWithSidePlatform": {
           "platforms": [
@@ -1230,7 +1240,9 @@
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -389,13 +389,14 @@
     {
       "id": 125,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         "canComplexGMode",
         {"obstaclesCleared": ["C"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -698,13 +699,14 @@
     {
       "id": 128,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         "canComplexGMode",
         {"obstaclesCleared": ["C"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -1058,7 +1060,7 @@
           "canWallJump",
           "HiJump",
           "SpaceJump",
-          {"and":[
+          {"and": [
             "canTrickyDodgeEnemies",
             {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
           ]}
@@ -1072,7 +1074,7 @@
         "Stand on the frozen enemy and freeze the second Beetom at the peak of Samus' jump; in position to ice clip.",
         "The Beetoms can be frozen against the wall where they will unfreeze without falling, so Samus may leave and farm energy."
       ],
-      "detailNote":[
+      "detailNote": [
         "A hero shot through the spike tunnel helps with refreezing the bottom beetom to at least keep both enemies separated.",
         "Climbing onto the positioned Beetom requires some hitbox manipulation.",
         "Spinjump from the ledge and press into the Beetom to gain the needed height to climb on top.",
@@ -1559,7 +1561,7 @@
     {
       "id": 79,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit By Zebbo",
       "requires": [
         "Morph",
         {"or": [
@@ -1568,7 +1570,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -2373,7 +2377,7 @@
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note":  [
+      "note": [
         "After entering from the right, wait by the door until the first Beetom hops onto the nearby pipe.",
         "Freeze the Beetom on the left side of the pipe, morph, and hold left against it until a Zebbo spawns and boosts Samus onto it.",
         "The Zebbo should move right the correct height; unmorph is freeze it."
@@ -2488,7 +2492,7 @@
     {
       "id": 80,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit By Zebbo",
       "requires": [
         {"or": [
           "canTrickyDodgeEnemies",
@@ -2497,7 +2501,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -333,12 +333,13 @@
     {
       "id": 12,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         "h_complexToCarryBlueSuit"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -1086,12 +1087,13 @@
     {
       "id": 49,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         "h_complexToCarryBlueSuit"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -527,7 +527,7 @@
     {
       "id": 5,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [
         {"or": [
           "canBePatient",
@@ -535,7 +535,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -586,7 +588,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "id": 7,
       "link": [2, 3],
@@ -1106,10 +1108,12 @@
     {
       "id": 30,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2047,7 +2051,7 @@
     {
       "id": 73,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [
         {"or": [
           "canBePatient",
@@ -2055,7 +2059,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2799,10 +2805,12 @@
     {
       "id": 106,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -3599,10 +3607,12 @@
     {
       "id": 143,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -3984,10 +3994,12 @@
     {
       "id": 161,
       "link": [7, 7],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -4433,10 +4445,12 @@
     {
       "id": 181,
       "link": [8, 8],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -6136,7 +6150,7 @@
     {
       "id": 295,
       "link": [14, 9],
-      "name": "G-mode Setup - Bottom Ice Clip, Zeela Lure",
+      "name": "Bottom Ice Clip, Zeela Lure",
       "requires": [
         {"notable": "Bottom Ice Clip"},
         {"obstaclesCleared": ["B"]},
@@ -6153,7 +6167,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -6175,7 +6191,7 @@
     {
       "id": 296,
       "link": [14, 10],
-      "name": "G-mode Setup - Bottom Ice Clip, Zeela Lure",
+      "name": "Bottom Ice Clip, Zeela Lure",
       "requires": [
         {"notable": "Bottom Ice Clip"},
         {"obstaclesCleared": ["B"]},
@@ -6198,7 +6214,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -1843,10 +1843,12 @@
     {
       "id": 66,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Sidehopper",
+      "name": "Get Hit By Sidehopper",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sm. Sidehopper"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -297,12 +297,14 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [
         "canBeVeryPatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -771,12 +773,14 @@
     {
       "id": 29,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [
         "canBePatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -300,10 +300,12 @@
     {
       "id": 9,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Kihunter",
+      "name": "Get Hit By Kihunter",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Kihunter (green)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -137,10 +137,12 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -966,7 +968,7 @@
     {
       "id": 30,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [
         {"or": [
           "canTrickyUseFrozenEnemies",
@@ -974,7 +976,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1340,7 +1344,7 @@
         "leaveWithMockball": {
           "remoteRunway": {
             "length": 5,
-            "openEnd": 1            
+            "openEnd": 1
           },
           "landingRunway": {
             "length": 3,
@@ -1395,7 +1399,7 @@
     {
       "id": 43,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [
         {"or": [
           "canTrickyUseFrozenEnemies",
@@ -1403,7 +1407,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -494,7 +494,7 @@
     {
       "id": 9,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Kraid's Talons",
+      "name": "Get Hit By Kraid's Talons",
       "requires": [
         {"not": "f_DefeatedKraid"},
         "canRiskPermanentLossOfAccess",
@@ -505,7 +505,10 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Kraid",
+          "attack": "talon"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -284,7 +284,7 @@
           {"and": [
             {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 8}},
             "canTrickyDodgeEnemies"
-          ]}          
+          ]}
         ]}
       ],
       "exitCondition": {
@@ -317,7 +317,7 @@
           {"and": [
             {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 8}},
             "canTrickyDodgeEnemies"
-          ]}          
+          ]}
         ]}
       ],
       "exitCondition": {
@@ -413,7 +413,7 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"or": [
           {"noBlueSuit": {}},
@@ -421,7 +421,8 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -512,14 +512,16 @@
     {
       "id": 58,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By KiHunter",
+      "name": "Get Hit By KiHunter",
       "requires": [
         {"enemyDamage": {"enemy": "Kihunter (green)", "type": "contact", "hits": 1}},
         {"noBlueSuit": {}},
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Kihunter (green)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -167,10 +167,12 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -400,10 +402,12 @@
     {
       "id": 14,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -787,14 +791,16 @@
     {
       "id": 32,
       "link": [3, 3],
-      "name": "G-Mode Setup - Frozen Zeela",
+      "name": "Frozen Zeela",
       "requires": [
         "canUpwardGModeSetup",
         "canTrickyUseFrozenEnemies",
         {"obstaclesCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -478,7 +478,7 @@
     {
       "id": 2,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [
         {"or": [
           "h_bombThings",
@@ -486,7 +486,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -973,10 +975,12 @@
     {
       "id": 17,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1256,13 +1260,15 @@
     {
       "id": 24,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [
         "canComplexGMode",
         "canTrickyUseFrozenEnemies"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1619,7 +1625,7 @@
     {
       "id": 32,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [
         "canComplexGMode",
         "canTrickyUseFrozenEnemies",
@@ -1639,7 +1645,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2281,10 +2289,12 @@
     {
       "id": 55,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2987,13 +2997,15 @@
     {
       "id": 145,
       "link": [8, 8],
-      "name": "G-Mode Setup - Get Hit By Reo",
+      "name": "Get Hit By Reo",
       "requires": [
         "canComplexGMode",
         "Morph"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Reo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -4191,14 +4203,16 @@
     {
       "id": 146,
       "link": [13, 5],
-      "name": "G-Mode Setup - Get Hit By Reo",
+      "name": "Get Hit By Reo",
       "requires": [
         "canTrickyGMode",
         "h_preciseIceClip",
         {"notable": "Reo Ice Clip Without Morph and X-Ray"}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Reo"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -287,10 +287,12 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeela",
+      "name": "Get Hit By Zeela",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1465,9 +1467,9 @@
     {
       "id": 55,
       "link": [3, 2],
-      "name": "G-Mode Setup - Lure the Zeela Down Below",
+      "name": "Lure the Zeela Down Below",
       "requires": [
-        {"notable": "G-Mode Setup - Lure the Zeela Down Below"},
+        {"notable": "Lure the Zeela Down Below"},
         "canComplexGMode",
         "canBePatient",
         {"or": [
@@ -1483,7 +1485,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1567,7 +1571,7 @@
     {
       "id": 59,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zeela or Reo",
+      "name": "Get Hit By Zeela",
       "requires": [
         {"or": [
           "h_getBlueSpeedMaxRunway",
@@ -1577,10 +1581,13 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeela"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "A Reo can also be used."
     },
     {
       "id": 67,
@@ -1632,7 +1639,7 @@
     },
     {
       "id": 4,
-      "name": "G-Mode Setup - Lure the Zeela Down Below",
+      "name": "Lure the Zeela Down Below",
       "note": [
         "Using Speed Booster, run through and break the bomb wall to free the global Zeela.",
         "Break the speed blocks just before the Zeela gets to them in order for it to go down to the bottom half of the room.",

--- a/region/brinstar/pink/Mission Impossible Room.json
+++ b/region/brinstar/pink/Mission Impossible Room.json
@@ -392,10 +392,12 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sidehopper",
+      "name": "Get Hit By Sidehopper",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sidehopper"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -752,7 +752,7 @@
     {
       "id": 18,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Hopper (Jump Entry)",
+      "name": "Get Hit By Sidehopper (Jump Entry)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "any",
@@ -761,7 +761,9 @@
       },
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sidehopper"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
@@ -776,12 +778,14 @@
     {
       "id": 19,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Hopper",
+      "name": "Get Hit By Sidehopper",
       "requires": [
         {"obstaclesNotCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sidehopper"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -258,10 +258,12 @@
     {
       "id": 10,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -404,10 +406,12 @@
     {
       "id": 17,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/pink/Spore Spawn Super Room.json
+++ b/region/brinstar/pink/Spore Spawn Super Room.json
@@ -133,7 +133,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
-        {
+    {
       "link": [1, 1],
       "name": "Come in Shinecharged, Gain Flash Suit (Slopespark)",
       "entranceCondition": {
@@ -169,10 +169,12 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -437,10 +437,12 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zero",
+      "name": "Get Hit By Zero",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -549,12 +549,14 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sidehopper",
+      "name": "Get Hit By Sidehopper",
       "requires": [
         {"obstaclesNotCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sidehopper"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -271,7 +271,7 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zero",
+      "name": "Get Hit By Zero",
       "requires": [
         "canBeVeryPatient",
         "Morph",
@@ -285,7 +285,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -298,7 +300,7 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zero (Zero Damage Boost Up)",
+      "name": "Get Hit By Zero (Zero Damage Boost Up)",
       "requires": [
         "canBeVeryPatient",
         "h_midAirMorphDamageBoost",
@@ -307,7 +309,9 @@
         {"enemyDamage": {"enemy": "Zero", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
@@ -326,7 +330,7 @@
     {
       "id": 104,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zero (Cacatac Damage Boost Up)",
+      "name": "Get Hit By Zero (Cacatac Damage Boost Up)",
       "requires": [
         "canBeVeryPatient",
         "Morph",
@@ -336,7 +340,9 @@
         {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
@@ -905,7 +911,7 @@
     {
       "id": 28,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zero",
+      "name": "Get Hit By Zero",
       "requires": [
         {"or": [
           {"and": [
@@ -927,7 +933,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -942,7 +950,7 @@
     {
       "id": 29,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zero (Zero Damage Boost Up)",
+      "name": "Get Hit By Zero (Zero Damage Boost Up)",
       "requires": [
         "canBeVeryPatient",
         "h_midAirMorphDamageBoost",
@@ -951,7 +959,9 @@
         {"enemyDamage": {"enemy": "Zero", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
@@ -970,7 +980,7 @@
     {
       "id": 105,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zero (Cacatac Damage Boost Up)",
+      "name": "Get Hit By Zero (Cacatac Damage Boost Up)",
       "requires": [
         "canBeVeryPatient",
         "Morph",
@@ -980,7 +990,9 @@
         {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
@@ -1724,10 +1736,12 @@
     {
       "id": 56,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zero",
+      "name": "Get Hit By Zero",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2275,7 +2289,7 @@
     {
       "id": 80,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Zero",
+      "name": "Get Hit By Zero",
       "requires": [
         {"or": [
           "HiJump",
@@ -2287,7 +2301,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2296,7 +2312,7 @@
     {
       "id": 81,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Zero (Zero Damage Boost Up to the Door)",
+      "name": "Get Hit By Zero (Zero Damage Boost Up to the Door)",
       "requires": [
         "h_midAirMorphDamageBoost",
         "canTrickyJump",
@@ -2304,7 +2320,9 @@
         {"enemyDamage": {"enemy": "Zero", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
@@ -2319,7 +2337,7 @@
     {
       "id": 107,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Zero (Cacatac Damage Boost Up to the Door)",
+      "name": "Get Hit By Zero (Cacatac Damage Boost Up to the Door)",
       "requires": [
         "canNeutralDamageBoost",
         "canTrickyDodgeEnemies",
@@ -2327,7 +2345,9 @@
         {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
@@ -2674,7 +2694,7 @@
     {
       "id": 90,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Zero",
+      "name": "Get Hit By Zero",
       "requires": [
         "canBePatient",
         {"or": [
@@ -2692,7 +2712,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2701,7 +2723,7 @@
     {
       "id": 91,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Zero (Zero Damage Boost Up)",
+      "name": "Get Hit By Zero (Zero Damage Boost Up)",
       "requires": [
         "canBePatient",
         {"or": [
@@ -2714,7 +2736,9 @@
         {"enemyDamage": {"enemy": "Zero", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
@@ -2731,7 +2755,7 @@
     {
       "id": 108,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Zero (Catatac Damage Boost Up)",
+      "name": "Get Hit By Zero (Catatac Damage Boost Up)",
       "requires": [
         "canBePatient",
         {"or": [
@@ -2745,7 +2769,9 @@
         {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zero"
+        }
       },
       "wallJumpAvoid": true,
       "flashSuitChecked": true,

--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -313,10 +313,12 @@
     {
       "id": 10,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit By Zebbo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -432,7 +434,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 2],
       "name": "Come in Spinning, Leave with Mockball (Space Jump)",
@@ -727,10 +729,12 @@
     {
       "id": 22,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit By Zebbo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -308,10 +308,12 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -438,7 +440,7 @@
         "canTrickyJump",
         {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}},
         {"or": [
-          {"and":[
+          {"and": [
             "canDash",
             "canTrickyDodgeEnemies"
           ]},
@@ -1321,12 +1323,14 @@
     {
       "id": 43,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [
         "canBePatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1618,9 +1622,7 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": [
-        "Damage boost off of a Waver to cross the gap onto the upper spikes."
-      ]
+      "note": ["Damage boost off of a Waver to cross the gap onto the upper spikes."]
     },
     {
       "link": [3, 1],

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -493,14 +493,15 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -525,7 +526,7 @@
     {
       "id": 9,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"noBlueSuit": {}},
@@ -533,7 +534,8 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -706,7 +708,7 @@
     {
       "id": 139,
       "link": [1, 2],
-      "name": "Moondance Clip, G-Mode Setup - Get Hit By Beetom",
+      "name": "Moondance Clip, Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"noBlueSuit": {}},
@@ -716,7 +718,8 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -788,14 +791,15 @@
     {
       "id": 15,
       "link": [1, 3],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -921,14 +925,15 @@
     {
       "id": 18,
       "link": [1, 4],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 5}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -3102,7 +3107,7 @@
     {
       "id": 90,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"obstaclesNotCleared": ["A"]},
         {"noBlueSuit": {}},
@@ -3121,7 +3126,8 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 9}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -480,6 +480,28 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 4],
+      "name": "Come In With Damage Boost",
+      "entranceCondition": {
+        "comeInWithDamageBoost": {}
+      },
+      "requires": [
+        "canDash",
+        "canUseIFrames",
+        "canTrickyJump"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Damage boost from the neighboring room, to land on the spikes with enough i-frames to run and jump across without taking a spike hit."
+      ],
+      "detailNote": [
+        "The damage boost can be buffered through the transition:",
+        "face away from the transition, and release all inputs while an enemy hits Samus and knocks her into the transition;",
+        "hold jump and back through the transition to buffer the damage boost."        
+      ]
+    },
+    {
       "id": 99,
       "link": [1, 4],
       "name": "Cross with Blue Suit",

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -353,10 +353,12 @@
     {
       "id": 10,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Mellow",
+      "name": "Get Hit By Mellow",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mellow"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -666,10 +668,12 @@
     {
       "id": 23,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Mellow",
+      "name": "Get Hit By Mellow",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mellow"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -389,13 +389,15 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Bomb the Blocks and Get Hit By Geemer",
+      "name": "Bomb the Blocks and Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
         "h_destroyBombWalls"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -767,12 +769,14 @@
     {
       "id": 16,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1234,12 +1238,14 @@
     {
       "id": 31,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1697,12 +1703,14 @@
     {
       "id": 45,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2039,7 +2047,7 @@
     {
       "id": 58,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
@@ -2048,7 +2056,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2922,7 +2932,7 @@
     {
       "id": 83,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
@@ -2931,7 +2941,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -3289,7 +3301,9 @@
         "canDownwardGModeSetup"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -3501,13 +3515,15 @@
     {
       "id": 104,
       "link": [8, 1],
-      "name": "G-Mode Setup - Power Bomb the Blocks from Below and Get Hit By Geemer",
+      "name": "Power Bomb the Blocks from Below and Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
         "h_usePowerBomb"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -3520,7 +3536,7 @@
     {
       "id": 105,
       "link": [8, 1],
-      "name": "G-Mode Setup - Speed Through the Blocks then Get Hit By Geemer",
+      "name": "Speed Through the Blocks then Get Hit By Geemer",
       "requires": [
         "h_ZebesIsAwake",
         {"or": [
@@ -3549,7 +3565,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/crateria/central/Pre-Map Flyway.json
+++ b/region/crateria/central/Pre-Map Flyway.json
@@ -230,10 +230,12 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Mellow",
+      "name": "Get Hit By Mellow",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mellow"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -462,10 +464,12 @@
     {
       "id": 21,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Mellow",
+      "name": "Get Hit By Mellow",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mellow"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -192,7 +192,7 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "G-Mode Setup - Frozen Sciser",
+      "name": "Get Hit by Thawing Sciser",
       "requires": [
         "Morph",
         "canCameraManip",
@@ -201,7 +201,9 @@
         "canBeVeryPatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -940,10 +942,12 @@
     {
       "id": 18,
       "link": [2, 2],
-      "name": "G-Mode Setup - Getting hit by Sciser",
+      "name": "Get Hit by Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -133,10 +133,12 @@
     {
       "id": 2,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit by Kihunter",
+      "name": "Get Hit by Kihunter",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Kihunter (green)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -557,10 +559,12 @@
     {
       "id": 18,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit by Kihunter",
+      "name": "Get Hit by Kihunter",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Kihunter (green)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -737,14 +741,16 @@
     {
       "id": 27,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit by Thawing Sciser",
+      "name": "Get Hit by Thawing Sciser",
       "requires": [
         "canWallIceClip",
         "canDownwardGModeSetup",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/crateria/east/Pancakes and Wavers Room.json
+++ b/region/crateria/east/Pancakes and Wavers Room.json
@@ -242,7 +242,7 @@
         "leaveWithMockball": {
           "remoteRunway": {
             "length": 5,
-            "openEnd": 1            
+            "openEnd": 1
           },
           "landingRunway": {
             "length": 8,
@@ -252,9 +252,7 @@
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": [
-        "Use the nearby island to gain run speed while the water is low."
-      ]
+      "note": ["Use the nearby island to gain run speed while the water is low."]
     },
     {
       "id": 9,
@@ -380,10 +378,12 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get hit by Waver",
+      "name": "Get Hit by Waver",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -939,7 +939,7 @@
         "leaveWithMockball": {
           "remoteRunway": {
             "length": 5,
-            "openEnd": 1            
+            "openEnd": 1
           },
           "landingRunway": {
             "length": 8,
@@ -949,9 +949,7 @@
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": [
-        "Use the nearby island to gain run speed while the water is low."
-      ]
+      "note": ["Use the nearby island to gain run speed while the water is low."]
     },
     {
       "id": 33,
@@ -1123,10 +1121,12 @@
     {
       "id": 39,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get hit by Waver",
+      "name": "Get Hit by Waver",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -1748,9 +1748,7 @@
         "Use the runway either on the left or right to gain a specific amount of dash speed ($2.0 or $2.1),",
         "to get a higher jump before doing a mid-air Spring Ball jump."
       ],
-      "detailNote": [
-        "It is not necessary to keep the dash speed for the Spring Ball jump."
-      ],
+      "detailNote": ["It is not necessary to keep the dash speed for the Spring Ball jump."],
       "devNote": [
         "This technically can be done without a tricky dash jump, using the full runway to the right, but it's not any easier."
       ]
@@ -2135,9 +2133,9 @@
     {
       "id": 74,
       "link": [6, 2],
-      "name": "G-Mode Setup Lure Zeb from Below (to Top Right Section - Top Right Door)",
+      "name": "Lure Zeb from Below (to Top Right Section - Top Right Door)",
       "requires": [
-        {"notable": "G-Mode Setup Lure Zeb from Below"},
+        {"notable": "Lure Zeb from Below, Get Hit"},
         "canComplexGMode",
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -2148,7 +2146,9 @@
         "canCameraManip"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -2166,9 +2166,9 @@
     {
       "id": 75,
       "link": [6, 3],
-      "name": "G-Mode Setup Lure Zeb from Below (to Top Right Section - Bottom Right Door)",
+      "name": "Lure Zeb from Below (to Top Right Section - Bottom Right Door)",
       "requires": [
-        {"notable": "G-Mode Setup Lure Zeb from Below"},
+        {"notable": "Lure Zeb from Below, Get Hit"},
         "canComplexGMode",
         "canTrickyUseFrozenEnemies",
         {"or": [
@@ -2179,7 +2179,9 @@
         "canCameraManip"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -2293,10 +2295,12 @@
     {
       "id": 79,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit by Zeb",
+      "name": "Get Hit by Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -3762,7 +3766,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "G-Mode Setup Lure Zeb from Below",
+      "name": "Lure Zeb from Below, Get Hit",
       "note": [
         "Start from the Middle Right Door next to the Zeb farm.",
         "While standing on the right of the Zeb farm, freeze the Zeb while it is still moving up and facing to the right.",

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -357,10 +357,12 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get hit by Zebbo",
+      "name": "Get Hit by Zebbo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1147,7 +1149,7 @@
     {
       "id": 69,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit By Zebbo",
       "requires": [
         {"or": [
           {"and": [
@@ -1164,7 +1166,9 @@
         "canTrickyGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -297,7 +297,7 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get hit by Waver",
+      "name": "Get Hit by Waver",
       "requires": [
         {"or": [
           "h_useMorphBombs",
@@ -306,7 +306,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -314,12 +316,14 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get hit by Waver, Using a Power Bomb",
+      "name": "Get Hit by Waver, Using a Power Bomb",
       "requires": [
         "h_usePowerBomb"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -335,7 +339,7 @@
     {
       "id": 8,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get hit by Waver, Break Blocks with Speed",
+      "name": "Get Hit by Waver, Break Blocks with Speed",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -348,7 +352,9 @@
         "h_blueJump"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -702,13 +708,15 @@
     {
       "id": 21,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get hit by Waver, Using Power Bombs",
+      "name": "Get Hit by Waver, Using Power Bombs",
       "requires": [
         "Morph",
         {"ammo": {"type": "PowerBomb", "count": 3}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1152,14 +1160,16 @@
     {
       "id": 37,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get hit by Waver, Using Power Bombs",
+      "name": "Get Hit by Waver, Using Power Bombs",
       "requires": [
         "Morph",
         {"ammo": {"type": "PowerBomb", "count": 3}},
         "canBePatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1230,7 +1240,7 @@
         "leaveWithMockball": {
           "remoteRunway": {
             "length": 7,
-            "openEnd": 1            
+            "openEnd": 1
           },
           "landingRunway": {
             "length": 5,
@@ -1355,7 +1365,7 @@
     {
       "id": 43,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get hit by Waver",
+      "name": "Get Hit by Waver",
       "requires": [
         {"or": [
           "h_useMorphBombs",
@@ -1364,7 +1374,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1372,12 +1384,14 @@
     {
       "id": 44,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get hit by Waver, Using a Power Bomb",
+      "name": "Get Hit by Waver, Using a Power Bomb",
       "requires": [
         "h_usePowerBomb"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1389,7 +1403,7 @@
     {
       "id": 45,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get hit by Waver, Break Blocks with Speed",
+      "name": "Get Hit by Waver, Break Blocks with Speed",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -1402,7 +1416,9 @@
         "h_blueJump"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -577,7 +577,7 @@
     {
       "id": 12,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"noBlueSuit": {}},
         "h_usePowerBomb",
@@ -590,7 +590,8 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -1277,7 +1278,7 @@
     {
       "id": 36,
       "link": [4, 2],
-      "name": "Tank the Damage (Get Hit by Each Pirate)",
+      "name": "Tank the Damage (Hit by Each Pirate)",
       "requires": [
         {"enemyDamage": {
           "enemy": "Green Space Pirate (standing)",
@@ -2024,7 +2025,7 @@
     {
       "id": 64,
       "link": [9, 2],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"noBlueSuit": {}},
         {"or": [
@@ -2034,7 +2035,8 @@
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 4}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -2093,7 +2095,7 @@
     {
       "id": 67,
       "link": [9, 3],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit by Beetom",
       "requires": [
         {"noBlueSuit": {}},
         {"or": [
@@ -2132,7 +2134,8 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -2197,7 +2200,7 @@
     {
       "id": 70,
       "link": [9, 4],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit by Beetom",
       "requires": [
         {"noBlueSuit": {}},
         {"or": [
@@ -2236,7 +2239,8 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -146,12 +146,14 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get hit by Geemer",
+      "name": "Get Hit by Geemer",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (grey)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -434,12 +436,14 @@
     {
       "id": 15,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get hit by Geemer",
+      "name": "Get Hit by Geemer",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (grey)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -184,13 +184,16 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get hit by Waver or Geemer",
+      "name": "Get Hit by Geemer",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "A Waver can also be used."
     },
     {
       "id": 5,
@@ -377,13 +380,16 @@
     {
       "id": 14,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit by Geemer or Waver",
+      "name": "Get Hit by Geemer",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (blue)"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "A Waver can also be used."
     },
     {
       "id": 15,

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -3499,12 +3499,14 @@
     {
       "id": 91,
       "link": [5, 2],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit by Viola",
       "requires": [
         {"heatFrames": 175}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -3536,12 +3538,14 @@
     {
       "id": 92,
       "link": [5, 3],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit by Viola",
       "requires": [
         {"heatFrames": 175}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},

--- a/region/lowernorfair/east/Lower Norfair Farming Room.json
+++ b/region/lowernorfair/east/Lower Norfair Farming Room.json
@@ -572,7 +572,7 @@
     {
       "id": 33,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit by Zebbo",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -584,7 +584,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -670,7 +672,7 @@
     {
       "id": 34,
       "link": [3, 1],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit by Zebbo",
       "requires": [
         {"heatFrames": 280},
         {"or": [
@@ -679,7 +681,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -503,12 +503,14 @@
     {
       "id": 86,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Dessgeega",
+      "name": "Get Hit by Dessgeega",
       "requires": [
         {"heatFrames": 145}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Dessgeega"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -2975,7 +2977,7 @@
     {
       "id": 93,
       "link": [9, 2],
-      "name": "G-Mode Setup - Get Hit By Multiviola",
+      "name": "Get Hit by Multiviola",
       "requires": [
         {"notable": "Multiviola Ice Clip"},
         "canBePatient",
@@ -3007,7 +3009,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -123,7 +123,7 @@
     {
       "id": 47,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Holtz",
+      "name": "Get Hit by Holtz",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -131,7 +131,9 @@
         {"heatFrames": 110}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Holtz"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1308,7 +1310,7 @@
     {
       "id": 48,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit by Zebbo",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1324,7 +1326,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},

--- a/region/lowernorfair/east/Red Kihunter Shaft.json
+++ b/region/lowernorfair/east/Red Kihunter Shaft.json
@@ -946,12 +946,14 @@
     {
       "id": 79,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Kihunter",
+      "name": "Get Hit by Kihunter",
       "requires": [
         {"heatFrames": 150}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Kihunter (red)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -153,14 +153,16 @@
     {
       "id": 31,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Ridley",
+      "name": "Get Hit by Ridley",
       "requires": [
         {"heatFrames": 500},
         {"not": "f_DefeatedRidley"},
         "canRiskPermanentLossOfAccess"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Ridley"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -684,7 +686,7 @@
     {
       "id": 32,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Ridley",
+      "name": "Get Hit by Ridley",
       "requires": [
         {"heatFrames": 900},
         {"or": [
@@ -704,7 +706,9 @@
         "canRiskPermanentLossOfAccess"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Ridley"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -591,7 +591,7 @@
     {
       "id": 43,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Holtz",
+      "name": "Get Hit by Holtz",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -599,7 +599,9 @@
         {"heatFrames": 440}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Holtz"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1466,7 +1468,7 @@
     {
       "id": 44,
       "link": [5, 2],
-      "name": "G-Mode Setup - Get Hit By Holtz",
+      "name": "Get Hit by Holtz",
       "requires": [
         {"or": [
           {"and": [
@@ -1493,7 +1495,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Holtz"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -405,7 +405,7 @@
     {
       "id": 26,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Ripper",
+      "name": "Get Hit by Ripper",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -413,7 +413,9 @@
         {"heatFrames": 95}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Ripper 2 (red)"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1451,7 +1453,7 @@
     {
       "id": 27,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Ripper",
+      "name": "Get Hit by Ripper",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1460,7 +1462,9 @@
         {"obstaclesCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Ripper 2 (red)"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -143,10 +143,12 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit by Puyo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -559,10 +561,12 @@
     {
       "id": 17,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit by Puyo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -258,7 +258,7 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Evir Projectile",
+      "name": "Get Hit by Evir Projectile",
       "requires": [
         "h_navigateUnderwater",
         {"or": [
@@ -267,7 +267,10 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Evir",
+          "attack": "particle"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -618,7 +621,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 2],
       "name": "Come in Spinning, Leave with Mockball (Space Jump)",
@@ -656,7 +659,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "id": 61,
       "link": [1, 2],
@@ -1705,7 +1708,7 @@
     {
       "id": 39,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Evir Projectile",
+      "name": "Get Hit by Evir Projectile",
       "requires": [
         "Gravity",
         "canComplexGMode",
@@ -1715,7 +1718,10 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Evir",
+          "attack": "particle"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1744,7 +1750,10 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Evir",
+          "attack": "particle"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/inner-green/Lonely Crab Room.json
+++ b/region/maridia/inner-green/Lonely Crab Room.json
@@ -579,10 +579,12 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit by Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1423,10 +1425,12 @@
     {
       "id": 30,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit by Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -369,10 +369,12 @@
     {
       "id": 11,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit by Puyo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -342,14 +342,29 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Shaktool or Yard",
-      "requires": [],
+      "name": "Get Hit by Yard (Snail)",
+      "requires": [
+        "f_ShaktoolDoneDigging"
+      ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": "If Shaktool is done digging, it is faster to use one of the snails from the right side of the room."
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Get Hit by Shaktool",
+      "requires": [],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Shaktool"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -1098,31 +1113,26 @@
       "blueSuitChecked": true
     },
     {
-      "id": 28,
-      "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Shaktool",
-      "requires": [
-        {"obstaclesCleared": ["A", "B"]}
-      ],
-      "exitCondition": {
-        "leaveWithGModeSetup": {}
-      },
-      "flashSuitChecked": true,
-      "blueSuitChecked": true
-    },
-    {
       "id": 29,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Yard (Snail)",
+      "name": "Get Hit By Yard (Snail)",
       "requires": [
-        "h_ShaktoolCameraFix"
+        {"or": [
+          "h_ShaktoolCameraFix",
+          {"obstaclesCleared": ["A", "B"]}
+        ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": "Shoot a Snail to make it chase Samus."
+      "note": [
+        "Shoot a Snail to make it chase Samus.",
+        "Shaktool could also be used, if he is done digging."
+      ]
     },
     {
       "id": 30,

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -331,7 +331,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 2],
       "name": "Come in Spinning, Leave with Mockball (Space Jump)",
@@ -368,7 +368,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "id": 59,
       "link": [1, 2],
@@ -1031,12 +1031,15 @@
     {
       "id": 29,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Evir Projectile",
+      "name": "Get Hit By Evir Projectile",
       "requires": [
         "Gravity"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Evir",
+          "attack": "particle"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1044,14 +1047,17 @@
     {
       "id": 30,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Evir Projectile Suitless",
+      "name": "Get Hit By Evir Projectile Suitless",
       "requires": [
         "canComplexGMode",
         "canSuitlessMaridia",
         "canTurnaroundSpinJump"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Evir",
+          "attack": "particle"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -282,7 +282,7 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Yard",
+      "name": "Get Hit By Yard",
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
@@ -290,7 +290,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1401,10 +1403,12 @@
     {
       "id": 29,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Yard",
+      "name": "Get Hit by Yard",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1970,7 +1974,7 @@
     {
       "id": 157,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit by Yard",
+      "name": "Get Hit by Yard",
       "requires": [
         "h_navigateUnderwater",
         {"noBlueSuit": {}},
@@ -1978,7 +1982,9 @@
         "canDownwardGModeSetup"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2024,7 +2030,7 @@
     {
       "id": 158,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit by Yard",
+      "name": "Get Hit by Yard",
       "requires": [
         "h_navigateUnderwater",
         {"noBlueSuit": {}},
@@ -2032,7 +2038,9 @@
         "canDownwardGModeSetup"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2436,10 +2444,12 @@
     {
       "id": 80,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Yard",
+      "name": "Get Hit By Yard",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -3015,13 +3025,15 @@
     {
       "id": 102,
       "link": [6, 6],
-      "name": "G-Mode Setup - Snail Platform",
+      "name": "Snail Platform",
       "requires": [
         "canUpwardGModeSetup",
         "h_navigateUnderwater"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -3411,7 +3423,7 @@
     {
       "id": 120,
       "link": [9, 1],
-      "name": "G-Mode Setup - Get Hit By Yard, from Above",
+      "name": "Get Hit By Yard, from Above",
       "requires": [
         {"or": [
           "h_useMorphBombs",
@@ -3422,7 +3434,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Yard"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -409,10 +409,12 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zoa",
+      "name": "Get Hit By Zoa",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zoa"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -493,10 +493,12 @@
     {
       "id": 13,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit By Puyo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -589,7 +591,7 @@
     {
       "id": 112,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit by Puyo",
+      "name": "Get Hit by Puyo",
       "requires": [
         "h_navigateUnderwater",
         {"noBlueSuit": {}},
@@ -601,7 +603,9 @@
         "canTrickyGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -694,7 +698,7 @@
     {
       "id": 113,
       "link": [1, 3],
-      "name": "G-Mode Setup - Get Hit by Puyo",
+      "name": "Get Hit by Puyo",
       "requires": [
         "h_navigateUnderwater",
         {"noBlueSuit": {}},
@@ -706,7 +710,9 @@
         "canTrickyGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2344,10 +2350,12 @@
     {
       "id": 72,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Zoa",
+      "name": "Get Hit By Zoa",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zoa"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -1218,7 +1218,7 @@
     {
       "id": 32,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Mochtroid",
+      "name": "Get Hit By Mochtroid",
       "requires": [
         "h_navigateUnderwater",
         {"or": [
@@ -1232,7 +1232,8 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Mochtroid",
           "knockback": false
         }
       },

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -266,10 +266,11 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Mochtroid",
+      "name": "Get Hit By Mochtroid",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Mochtroid",
           "knockback": false
         }
       },
@@ -1402,10 +1403,11 @@
     {
       "id": 39,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Mochtroid",
+      "name": "Get Hit By Mochtroid",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Mochtroid",
           "knockback": false
         }
       },
@@ -3507,10 +3509,11 @@
     {
       "id": 84,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Mochtroid",
+      "name": "Get Hit By Mochtroid",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Mochtroid",
           "knockback": false
         }
       },

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -452,10 +452,12 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1882,10 +1884,12 @@
     {
       "id": 52,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1895,7 +1899,10 @@
       "name": "Door X-Mode Setup - Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithXModeSetup": {"enemy": "Sciser","attack": "contact"}
+        "leaveWithDamage": {
+          "enemy": "Sciser",
+          "xMode": true
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2113,7 +2120,7 @@
     {
       "id": 60,
       "link": [3, 3],
-      "name": "G-Mode Setup - Frozen Sciser",
+      "name": "Get Hit by Thawing Sciser",
       "requires": [
         "canUpwardGModeSetup",
         "canTrickyUseFrozenEnemies",
@@ -2130,7 +2137,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -646,7 +646,7 @@
     {
       "id": 59,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Draygon",
+      "name": "Get Hit By Draygon",
       "requires": [
         {"not": "f_DefeatedDraygon"},
         "canRiskPermanentLossOfAccess",
@@ -663,7 +663,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Draygon"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -242,10 +242,11 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Mochtroid",
+      "name": "Get Hit By Mochtroid",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Mochtroid",
           "knockback": false
         }
       },
@@ -2311,10 +2312,11 @@
     {
       "id": 55,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Mochtroid",
+      "name": "Get Hit By Mochtroid",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Mochtroid",
           "knockback": false
         }
       },
@@ -3970,9 +3972,7 @@
         "One reliable method for using the Oum is to stand near the door, press against the Oum when it is rolling to the right and close to the door to get it to stop,",
         "wait a bit for it to start its attack animation, then jump up and onto it. Depending on the timinig, Samus may take a hit."
       ],
-      "detailNote": [
-        "Stuttering on the Oum is not helpful."
-      ]
+      "detailNote": ["Stuttering on the Oum is not helpful."]
     },
     {
       "link": [3, 3],
@@ -3997,9 +3997,7 @@
         "wait a bit for it to start its attack animation, then jump up and onto it.",
         "Land on the Oum at a precise timing to get the full runway plus get pushed back by its movement, giving an effective 5-tile runway."
       ],
-      "detailNote": [
-        "Stuttering on the Oum is not helpful."
-      ]
+      "detailNote": ["Stuttering on the Oum is not helpful."]
     },
     {
       "id": 110,
@@ -4786,10 +4784,11 @@
     {
       "id": 128,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Mochtroid",
+      "name": "Get Hit By Mochtroid",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Mochtroid",
           "knockback": false
         }
       },

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -185,10 +185,12 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zoa",
+      "name": "Get Hit By Zoa",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zoa"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -479,7 +481,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 2],
       "name": "Come in Spinning, Leave with Mockball (Space Jump)",
@@ -517,7 +519,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "id": 17,
       "link": [2, 1],
@@ -916,10 +918,12 @@
     {
       "id": 32,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Zoa",
+      "name": "Get Hit By Zoa",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zoa"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-yellow/Kassiuz Room.json
+++ b/region/maridia/inner-yellow/Kassiuz Room.json
@@ -203,10 +203,12 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit By Puyo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-yellow/Maridia Swiss Cheese Room.json
+++ b/region/maridia/inner-yellow/Maridia Swiss Cheese Room.json
@@ -256,12 +256,14 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Menu",
+      "name": "Get Hit By Menu",
       "requires": [
         "canManipulateMellas"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Menu"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -689,12 +691,14 @@
     {
       "id": 17,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Menu",
+      "name": "Get Hit By Menu",
       "requires": [
         {"obstaclesNotCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Menu"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1116,7 +1120,7 @@
       "name": "Base",
       "requires": [
         "Morph",
-        { "or":  [
+        {"or": [
           {"obstaclesCleared": ["A"]},
           {"enemyDamage": {"enemy": "Menu", "type": "contact", "hits": 1}},
           "canDodgeWhileShooting"

--- a/region/maridia/inner-yellow/Plasma Tutorial Room.json
+++ b/region/maridia/inner-yellow/Plasma Tutorial Room.json
@@ -172,13 +172,15 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit By Puyo",
       "requires": [
         "canBePatient",
         "canTrickyGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "unlocksDoors": [
         {
@@ -743,13 +745,15 @@
     {
       "id": 31,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit By Puyo",
       "requires": [
         "canBeVeryPatient",
         "canTrickyGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "unlocksDoors": [
         {

--- a/region/maridia/inner-yellow/Thread The Needle Room.json
+++ b/region/maridia/inner-yellow/Thread The Needle Room.json
@@ -561,10 +561,12 @@
     {
       "id": 21,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit By Puyo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1268,10 +1270,12 @@
     {
       "id": 51,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Puyo",
+      "name": "Get Hit By Puyo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Puyo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -362,10 +362,12 @@
     {
       "id": 9,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zeb",
+      "name": "Get Hit By Zeb",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zeb"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-yellow/Yoink Room.json
+++ b/region/maridia/inner-yellow/Yoink Room.json
@@ -228,10 +228,12 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zoa",
+      "name": "Get Hit By Zoa",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zoa"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -689,7 +691,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 3],
       "name": "Come in Jumping, Leave with Mockball (Space Jump)",
@@ -729,7 +731,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 3],
       "name": "Come in Spinning, Leave with Mockball (Space Jump)",
@@ -765,7 +767,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 3],
       "name": "Come in with Side Platform Jump, Leave with Mockball",
@@ -778,9 +780,7 @@
               "minTiles": 5.4375,
               "speedBooster": "no",
               "obstructions": [[1, 0]],
-              "note": [
-                "This applies to Warehouse Energy Tank Room and Warehouse Entrance."
-              ]
+              "note": ["This applies to Warehouse Energy Tank Room and Warehouse Entrance."]
             },
             {
               "minHeight": 2,
@@ -824,7 +824,7 @@
               "obstructions": [[3, 2]],
               "requires": [],
               "note": ["This applies to Metal Pirates Room."]
-            }            
+            }
           ]
         }
       },
@@ -938,7 +938,7 @@
     {
       "id": 85,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit by Zoa",
+      "name": "Get Hit by Zoa",
       "requires": [
         "h_navigateUnderwater",
         "canPlayInSand",
@@ -968,7 +968,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zoa"
+        }
       },
       "unlocksDoors": [
         {"nodeId": 1, "types": ["super"], "requires": ["canTrickyJump"]},
@@ -1503,10 +1505,12 @@
     {
       "id": 36,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zoa",
+      "name": "Get Hit By Zoa",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zoa"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -1366,10 +1366,12 @@
     {
       "id": 50,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit By Zebbo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/outer/Crab Gate Room.json
+++ b/region/maridia/outer/Crab Gate Room.json
@@ -510,10 +510,12 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1208,10 +1210,12 @@
     {
       "id": 34,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1221,7 +1225,10 @@
       "name": "Door X-Mode Setup - Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithXModeSetup": {"enemy": "Sciser","attack": "contact"}
+        "leaveWithDamage": {
+          "enemy": "Sciser",
+          "xMode": true
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -236,10 +236,12 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2147,10 +2149,12 @@
     {
       "id": 52,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -3260,10 +3264,12 @@
     {
       "id": 81,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -4615,10 +4621,12 @@
     {
       "id": 111,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -4628,7 +4636,10 @@
       "name": "Door X-Mode Setup - Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithXModeSetup": {"enemy": "Sciser","attack": "contact"}
+        "leaveWithDamage": {
+          "enemy": "Sciser",
+          "xMode": true
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -1566,10 +1566,12 @@
     {
       "id": 40,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -3183,10 +3185,12 @@
     {
       "id": 74,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -4329,10 +4333,12 @@
     {
       "id": 105,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -4342,7 +4348,10 @@
       "name": "Door X-Mode Setup - Get Hit By Sciser",
       "requires": [],
       "exitCondition": {
-        "leaveWithXModeSetup": {"enemy": "Sciser","attack": "contact"}
+        "leaveWithDamage": {
+          "enemy": "Sciser",
+          "xMode": true
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -4996,7 +5005,7 @@
     {
       "id": 114,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [
         "canComplexGMode",
         "h_EverestMorphTunnelExpanded",
@@ -5004,7 +5013,9 @@
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -482,7 +482,7 @@
     {
       "id": 10,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sciser - Long Lure",
+      "name": "Get Hit By Sciser - Long Lure",
       "requires": [
         "Gravity",
         "canBePatient",
@@ -501,7 +501,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -513,7 +515,7 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sciser - Very Long Lure",
+      "name": "Get Hit By Sciser - Very Long Lure",
       "requires": [
         "canBeVeryPatient",
         {"or": [
@@ -538,7 +540,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -746,8 +750,7 @@
       "link": [1, 4],
       "name": "X-Mode Traversal (Jesus Walk)",
       "entranceCondition": {
-        "comeInWithXMode": {
-        }
+        "comeInWithXMode": {}
       },
       "requires": [],
       "flashSuitChecked": true,
@@ -3427,7 +3430,7 @@
     {
       "id": 104,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Sciser - Lure From Bottom Right",
+      "name": "Get Hit By Sciser - Lure From Bottom Right",
       "requires": [
         {"or": [
           {"and": [
@@ -3446,7 +3449,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -4215,7 +4220,7 @@
     {
       "id": 128,
       "link": [5, 5],
-      "name": "G-Mode Setup - Frozen Sciser",
+      "name": "Get Hit by Thawing Sciser",
       "requires": [
         "canBePatient",
         {"or": [
@@ -4248,7 +4253,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -4536,12 +4543,14 @@
     {
       "id": 137,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit By Sciser",
+      "name": "Get Hit By Sciser",
       "requires": [
         "h_EverestMorphTunnelExpanded"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sciser"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/outer/Red Fish Room.json
+++ b/region/maridia/outer/Red Fish Room.json
@@ -147,10 +147,12 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Zebbo",
+      "name": "Get Hit By Zebbo",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Zebbo"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/norfair/crocomire/Cosine Room.json
+++ b/region/norfair/crocomire/Cosine Room.json
@@ -92,7 +92,7 @@
     {
       "id": 2,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         "Morph",
         {"or": [
@@ -102,7 +102,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -171,7 +171,7 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         "h_navigateUnderwater",
         {"or": [
@@ -182,7 +182,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -253,7 +255,7 @@
     {
       "id": 7,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         "h_navigateUnderwater",
         {"or": [
@@ -282,7 +284,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -295,7 +299,7 @@
     {
       "id": 55,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit By Gamet, Tricky Manipulation",
+      "name": "Get Hit By Gamet, Tricky Manipulation",
       "requires": [
         "h_navigateUnderwater",
         "canDash",
@@ -320,7 +324,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/norfair/crocomire/Indiana Jones Room.json
+++ b/region/norfair/crocomire/Indiana Jones Room.json
@@ -1548,7 +1548,7 @@
     {
       "id": 87,
       "link": [2, 2],
-      "name": "G-Mode Setup - Frozen Mella",
+      "name": "Frozen Mella",
       "requires": [
         "canManipulateMellas",
         "canUpwardGModeSetup",
@@ -1556,7 +1556,9 @@
         "canInsaneJump"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mella"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2112,7 +2114,7 @@
     {
       "id": 56,
       "link": [5, 1],
-      "name": "G-Mode Setup - Get Hit By Mella",
+      "name": "Get Hit By Mella",
       "requires": [
         "canManipulateMellas",
         "canCameraManip",
@@ -2141,7 +2143,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mella"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -248,14 +248,16 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         "canComplexGMode",
         "canTrickyUseFrozenEnemies",
         "SpaceJump"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -269,7 +271,7 @@
     {
       "id": 88,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Gamet, Tricky Manipulation",
+      "name": "Get Hit By Gamet, Tricky Manipulation",
       "requires": [
         "canTrickyGMode",
         "canTrickyUseFrozenEnemies",
@@ -286,7 +288,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": false,
@@ -1306,10 +1310,12 @@
     {
       "id": 28,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2209,7 +2215,7 @@
     {
       "id": 49,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         {"or": [
           "HiJump",
@@ -2232,7 +2238,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -382,14 +382,16 @@
     {
       "id": 48,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit by Thawing Viola",
+      "name": "Get Hit by Thawing Viola",
       "requires": [
         "canWallIceClip",
         "canDownwardGModeSetup",
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -474,7 +476,7 @@
     {
       "id": 11,
       "link": [3, 1],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"or": [
@@ -488,7 +490,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -775,12 +779,14 @@
     {
       "id": 21,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -961,7 +967,7 @@
     {
       "id": 28,
       "link": [3, 4],
-      "name": "G-Mode Setup - Frozen Viola",
+      "name": "Frozen Viola",
       "requires": [
         "canTrickyUseFrozenEnemies",
         {"ammo": {"type": "Super", "count": 1}},
@@ -974,7 +980,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -712,12 +712,14 @@
     {
       "id": 27,
       "link": [3, 2],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         {"heatFrames": 240}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -338,10 +338,12 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1514,10 +1516,12 @@
     {
       "id": 33,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2371,7 +2375,7 @@
     {
       "id": 62,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"or": [
           {"obstaclesCleared": ["A"]},
@@ -2379,7 +2383,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2392,12 +2398,14 @@
     {
       "id": 205,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2832,7 +2840,7 @@
     {
       "id": 76,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"or": [
           {"resetRoom": {"nodes": [4, 5]}},
@@ -2843,7 +2851,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -3582,10 +3592,12 @@
     {
       "id": 102,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -4506,10 +4518,12 @@
     {
       "id": 134,
       "link": [7, 7],
-      "name": "G-Mode Setup - Get Hit By Waver",
+      "name": "Get Hit By Waver",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Waver"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -234,7 +234,7 @@
     {
       "id": 58,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -248,7 +248,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -659,7 +661,7 @@
     {
       "id": 59,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -667,7 +669,9 @@
         {"heatFrames": 1180}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1293,7 +1297,7 @@
           {"and": [
             "canPreciseWallJump",
             {"heatFrames": 160},
-            {"shineChargeFrames": 160}            
+            {"shineChargeFrames": 160}
           ]}
         ]}
       ],

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -135,7 +135,7 @@
     {
       "id": 30,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -149,7 +149,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -607,7 +609,7 @@
     {
       "id": 31,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -621,7 +623,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -224,12 +224,13 @@
     {
       "id": 5,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         {"noBlueSuit": {}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -1052,12 +1053,13 @@
     {
       "id": 35,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Beetom",
+      "name": "Get Hit By Beetom",
       "requires": [
         "h_getBlueSpeedMaxRunway"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },
@@ -1073,7 +1075,7 @@
     {
       "id": 36,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Beetom (Speedless Speedway)",
+      "name": "Get Hit By Beetom (Speedless Speedway)",
       "requires": [
         {"notable": "Shot Block Overload (Speedless Speedway)"},
         "canComplexGMode",
@@ -1090,7 +1092,8 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Beetom",
           "knockback": false
         }
       },

--- a/region/norfair/east/Green Bubbles Tunnel.json
+++ b/region/norfair/east/Green Bubbles Tunnel.json
@@ -521,13 +521,15 @@
     {
       "id": 22,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geruta",
+      "name": "Get Hit By Geruta",
       "requires": [
         "canComplexGMode",
         {"heatFrames": 350}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -398,7 +398,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 4],
       "name": "Come in Spinning, Leave with Mockball (Space Jump)",
@@ -435,11 +435,11 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "id": 51,
       "link": [1, 4],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -448,7 +448,9 @@
         {"heatFrames": 780}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles"], "requires": []},
@@ -1088,13 +1090,15 @@
     {
       "id": 52,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 290}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1119,13 +1123,15 @@
     {
       "id": 53,
       "link": [3, 4],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 1430}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1525,7 +1531,7 @@
     {
       "id": 54,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1534,7 +1540,9 @@
         {"heatFrames": 780}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles"], "requires": []},
@@ -1595,13 +1603,15 @@
     {
       "id": 55,
       "link": [5, 1],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 2130}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1725,7 +1735,7 @@
     {
       "id": 56,
       "link": [5, 2],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         "Morph",
@@ -1736,7 +1746,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1806,13 +1818,15 @@
     {
       "id": 57,
       "link": [5, 3],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 290}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles"], "requires": []},
@@ -1836,7 +1850,7 @@
     {
       "id": 58,
       "link": [5, 4],
-      "name": "G-Mode Setup - Get Hit By Viola",
+      "name": "Get Hit By Viola",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 820},
@@ -1846,7 +1860,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Viola"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},

--- a/region/norfair/east/Lava Farm Tunnel.json
+++ b/region/norfair/east/Lava Farm Tunnel.json
@@ -1047,7 +1047,7 @@
     {
       "id": 29,
       "link": [3, 3],
-      "name": "G-Mode Setup - Frozen Gamets",
+      "name": "Frozen Gamets",
       "requires": [
         "h_heatProof",
         "canUpwardGModeSetup",
@@ -1058,7 +1058,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1225,12 +1227,14 @@
     {
       "id": 44,
       "link": [4, 1],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         {"heatFrames": 290}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1282,13 +1286,15 @@
     {
       "id": 45,
       "link": [4, 2],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         "canDash",
         {"heatFrames": 440}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "powerbomb"], "requires": ["never"]},

--- a/region/norfair/east/Magdollite Tunnel.json
+++ b/region/norfair/east/Magdollite Tunnel.json
@@ -108,7 +108,7 @@
     {
       "id": 26,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Multiviola",
+      "name": "Get Hit By Multiviola",
       "requires": [
         "canComplexGMode",
         {"heatFrames": 1770},
@@ -123,7 +123,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -389,7 +391,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "link": [1, 2],
       "name": "Come in Spinning, Leave with Mockball (Space Jump)",
@@ -431,7 +433,7 @@
         "FIXME: This is a specific length needed for the Ice Beam Gate Room mockball;",
         "when the schema allows it, represent the possible runways more generally."
       ]
-    },    
+    },
     {
       "id": 28,
       "link": [1, 2],
@@ -898,7 +900,7 @@
     {
       "id": 27,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Multiviola",
+      "name": "Get Hit By Multiviola",
       "requires": [
         {"heatFrames": 570},
         {"or": [
@@ -911,7 +913,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -318,7 +318,7 @@
     {
       "id": 42,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}},
         {"heatFrames": 210},
@@ -328,7 +328,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Purple Farming Room.json
+++ b/region/norfair/east/Purple Farming Room.json
@@ -195,12 +195,14 @@
     {
       "id": 6,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         {"heatFrames": 220}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -529,12 +529,14 @@
     {
       "id": 13,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geemer",
+      "name": "Get Hit By Geemer",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geemer (grey)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -300,7 +300,7 @@
     {
       "id": 28,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"or": [
           "canDash",
@@ -313,7 +313,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -566,7 +568,7 @@
     {
       "id": 29,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"or": [
           "canDash",
@@ -575,7 +577,9 @@
         {"heatFrames": 1390}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -915,7 +919,7 @@
     {
       "id": 30,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"or": [
           "canDash",
@@ -928,7 +932,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1282,7 +1288,7 @@
     {
       "id": 31,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"or": [
           "canDash",
@@ -1295,7 +1301,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -341,12 +341,14 @@
     {
       "id": 62,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Multiviola",
+      "name": "Get Hit By Multiviola",
       "requires": [
         {"heatFrames": 120}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -974,12 +976,14 @@
     {
       "id": 63,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Multiviola",
+      "name": "Get Hit By Multiviola",
       "requires": [
         {"heatFrames": 920}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2654,7 +2658,7 @@
     {
       "id": 64,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Multiviola",
+      "name": "Get Hit By Multiviola",
       "requires": [
         "canComplexGMode",
         {"or": [
@@ -2667,7 +2671,9 @@
         {"heatFrames": 950}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -201,7 +201,7 @@
     {
       "id": 29,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Geruta",
+      "name": "Get Hit By Geruta",
       "requires": [
         "canComplexGMode",
         {"heatFrames": 2100},
@@ -218,7 +218,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -520,7 +522,7 @@
     {
       "id": 30,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit By Geruta",
+      "name": "Get Hit By Geruta",
       "requires": [
         "canComplexGMode",
         {"heatFrames": 2200},
@@ -537,7 +539,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1127,7 +1131,7 @@
     {
       "id": 31,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Geruta",
+      "name": "Get Hit By Geruta",
       "requires": [
         "canDash",
         "h_SpeedBoosterHallNoRisingLava",
@@ -1139,7 +1143,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1255,7 +1261,7 @@
     {
       "id": 32,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geruta",
+      "name": "Get Hit By Geruta",
       "requires": [
         {"or": [
           "h_SpeedBoosterHallNoRisingLava",
@@ -1276,7 +1282,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -1224,7 +1224,7 @@
     {
       "id": 46,
       "link": [5, 1],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         "canComplexGMode",
         {"heatFrames": 480},
@@ -1245,7 +1245,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1301,13 +1303,15 @@
     {
       "id": 47,
       "link": [5, 2],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"heatFrames": 280}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1319,7 +1323,7 @@
     {
       "id": 48,
       "link": [5, 3],
-      "name": "G-Mode Setup - Get Hit By Gamet",
+      "name": "Get Hit By Gamet",
       "requires": [
         {"or": [
           "canWallJump",
@@ -1330,7 +1334,9 @@
         {"heatFrames": 390}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Gamet"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},

--- a/region/norfair/west/Business Center.json
+++ b/region/norfair/west/Business Center.json
@@ -232,12 +232,14 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1133,12 +1135,14 @@
     {
       "id": 32,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1992,12 +1996,14 @@
     {
       "id": 61,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2650,12 +2656,14 @@
     {
       "id": 81,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -3501,12 +3509,14 @@
     {
       "id": 110,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -4150,12 +4160,14 @@
     {
       "id": 131,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"ammo": {"type": "Super", "count": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -398,7 +398,7 @@
     {
       "id": 42,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Geruta, Heatproof, Morph",
+      "name": "Get Hit By Geruta, Heatproof, Morph",
       "requires": [
         "canComplexGMode",
         "h_heatProof",
@@ -457,7 +457,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "collectsItems": [3],
@@ -469,7 +471,7 @@
     {
       "id": 43,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Geruta, Heatproof, Morphless",
+      "name": "Get Hit By Geruta, Heatproof, Morphless",
       "requires": [
         "canComplexGMode",
         "h_heatProof",
@@ -519,7 +521,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "collectsItems": [3],
@@ -534,7 +538,7 @@
     {
       "id": 44,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Geruta, Heatproof, Frozen Geruta Step",
+      "name": "Get Hit By Geruta, Heatproof, Frozen Geruta Step",
       "requires": [
         {"noBlueSuit": {}},
         "canComplexGMode",
@@ -552,7 +556,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "collectsItems": [3],
@@ -834,7 +840,7 @@
     {
       "id": 65,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Geruta",
+      "name": "Get Hit By Geruta",
       "requires": [
         "canComplexGMode",
         "h_heatProof",
@@ -861,7 +867,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Geruta"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -455,7 +455,7 @@
     {
       "id": 72,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Multiviola, Kill Pirates",
+      "name": "Get Hit By Multiviola, Kill Pirates",
       "requires": [
         {"heatFrames": 600},
         {"or": [
@@ -498,7 +498,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -507,7 +509,7 @@
     {
       "id": 73,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Multiviola, Pirate Tank",
+      "name": "Get Hit By Multiviola, Pirate Tank",
       "requires": [
         "canDash",
         {"heatFrames": 720},
@@ -518,7 +520,9 @@
         }}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -530,14 +534,16 @@
     {
       "id": 74,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Multiviola, Dodge Pirates",
+      "name": "Get Hit By Multiviola, Dodge Pirates",
       "requires": [
         "canDash",
         {"heatFrames": 765},
         "canTrickyDodgeEnemies"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -875,7 +881,7 @@
     {
       "id": 75,
       "link": [2, 4],
-      "name": "G-Mode Setup - Get Hit By Multiviola, Complex Manipulation",
+      "name": "Get Hit By Multiviola, Complex Manipulation",
       "requires": [
         "canTrickyGMode",
         "h_heatProof",
@@ -884,7 +890,9 @@
         "h_getBlueSpeedMaxRunway"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Multiviola"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -219,7 +219,7 @@
     {
       "id": 42,
       "link": [1, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -227,7 +227,9 @@
         {"heatFrames": 405}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -655,7 +657,7 @@
     {
       "id": 43,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"heatFrames": 2070},
         {"or": [
@@ -675,7 +677,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -952,7 +956,7 @@
     {
       "id": 44,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -973,7 +977,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -239,10 +239,12 @@
     {
       "id": 3,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -846,10 +848,12 @@
     {
       "id": 22,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -619,7 +619,7 @@
     {
       "id": 13,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"obstaclesCleared": ["A"]},
         {"obstaclesCleared": ["B"]},
@@ -630,7 +630,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -661,13 +663,15 @@
     {
       "id": 19,
       "link": [2, 4],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         {"obstaclesCleared": ["A", "B"]},
         "Morph"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1114,14 +1118,19 @@
     {
       "id": 30,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Mella or Small Dessgeega",
+      "name": "Get Hit By Mella",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mella"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": "Either enemy type can be used, so it may be best to kill one and use the other."
+      "note": [
+        "Either enemy type can be used, so it may be best to kill one and use the other.",
+        "A small Dessgeega can also be used."
+      ]
     },
     {
       "id": 31,
@@ -1436,7 +1445,7 @@
         "Having Spazer or Wave equipped creates an issue for clearing the second shot block,",
         "in that the shot would collide with the shutter, but this can be avoided:",
         "If Spazer is equipped, the shot block can be destroyed by crouching and firing a hero shot.",
-        "If Wave is equipped, it can be cleared by walking forward and firing an angle-down shot before the shutter finishes closing."        
+        "If Wave is equipped, it can be cleared by walking forward and firing an angle-down shot before the shutter finishes closing."
       ]
     },
     {
@@ -1452,7 +1461,7 @@
         {"or": [
           {"and": [
             "h_preciseIceClip",
-            "canBeVeryPatient"            
+            "canBeVeryPatient"
           ]},
           {"and": [
             "h_highPixelIceClip",
@@ -1705,13 +1714,15 @@
     },
     {
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "requires": [
         "h_usePowerBomb",
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1720,10 +1731,8 @@
         "While the Sova is far enough away, lay a Power Bomb to break the bomb blocks without killing the Sova.",
         "Roll back through the morph tunnel to return to the door, and wait for the Sova."
       ],
-      "detailNote": [
-        "This can be done with a blue suit."
-      ]
-    },    
+      "detailNote": ["This can be done with a blue suit."]
+    },
     {
       "id": 92,
       "link": [4, 7],

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -317,7 +317,7 @@
     {
       "id": 48,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -326,7 +326,9 @@
         "canBePatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -336,7 +338,7 @@
     {
       "id": 49,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Sova, Two Supers",
+      "name": "Get Hit By Sova, Two Supers",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -345,7 +347,9 @@
         {"ammo": {"type": "Super", "count": 2}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "powerbomb"], "requires": []},
@@ -620,7 +624,7 @@
     {
       "id": 50,
       "link": [1, 3],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -628,7 +632,9 @@
         {"heatFrames": 1200}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -709,7 +715,7 @@
     {
       "id": 51,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -719,7 +725,9 @@
         "canBePatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -729,7 +737,7 @@
     {
       "id": 52,
       "link": [2, 1],
-      "name": "G-Mode Setup - Get Hit By Sova, Two Supers",
+      "name": "Get Hit By Sova, Two Supers",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -739,7 +747,9 @@
         {"ammo": {"type": "Super", "count": 2}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles"], "requires": []},
@@ -979,7 +989,7 @@
     {
       "id": 53,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1001,7 +1011,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1058,7 +1070,7 @@
     {
       "id": 54,
       "link": [2, 3],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1067,7 +1079,9 @@
         "Morph"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles", "super"], "requires": []},
@@ -1210,7 +1224,7 @@
     {
       "id": 55,
       "link": [3, 1],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1219,7 +1233,9 @@
         "canBePatient"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1229,7 +1245,7 @@
     {
       "id": 56,
       "link": [3, 1],
-      "name": "G-Mode Setup - Get Hit By Sova, Two Supers",
+      "name": "Get Hit By Sova, Two Supers",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1238,7 +1254,9 @@
         {"ammo": {"type": "Super", "count": 2}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [
         {"types": ["missiles"], "requires": []},
@@ -1620,7 +1638,7 @@
     {
       "id": 57,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Sova",
+      "name": "Get Hit By Sova",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1628,7 +1646,9 @@
         {"heatFrames": 1140}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Sova"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1999,12 +2019,8 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": [
-        "Press against both Funes on the way up to gain extra height."
-      ],
-      "devNote": [
-        "This is technically possible without a crouch jump but seems unreasonable."
-      ]
+      "note": ["Press against both Funes on the way up to gain extra height."],
+      "devNote": ["This is technically possible without a crouch jump but seems unreasonable."]
     },
     {
       "id": 37,

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -417,10 +417,12 @@
     {
       "id": 12,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2157,7 +2159,7 @@
     {
       "id": 46,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [
         {"or": [
           "canTrickyJump",
@@ -2171,7 +2173,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2183,14 +2187,15 @@
     {
       "id": 47,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Metroid",
+      "name": "Get Hit By Metroid",
       "requires": [
         {"obstaclesNotCleared": ["B"]},
         {"not": "f_KilledMetroidRoom1"},
         "canRiskPermanentLossOfAccess"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Metroid",
           "knockback": false
         }
       },

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -186,10 +186,12 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1423,7 +1425,7 @@
     {
       "id": 51,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [
         {"or": [
           "canMetroidAvoid",
@@ -1433,7 +1435,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1443,13 +1447,14 @@
     {
       "id": 52,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Metroid",
+      "name": "Get Hit By Metroid",
       "requires": [
         {"not": "f_KilledMetroidRoom2"},
         "canRiskPermanentLossOfAccess"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {
+        "leaveWithDamage": {
+          "enemy": "Metroid",
           "knockback": false
         }
       },

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -424,10 +424,12 @@
     {
       "id": 13,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1128,10 +1130,12 @@
     {
       "id": 47,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -146,10 +146,12 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -221,10 +221,12 @@
     {
       "id": 2,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -456,13 +458,17 @@
     {
       "id": 9,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Rinka or Turret Shot",
+      "name": "Get Hit By Turret Shot",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Mother Brain 1",
+          "attack": "turret"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "A Rinka can also be used."
     },
     {
       "id": 10,

--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -190,12 +190,14 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [
         "canComplexGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -644,10 +646,12 @@
     {
       "id": 25,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1244,7 +1248,7 @@
         {"shineChargeFrames": 115},
         {"or": [
           "canSpeedyJump",
-         {"shineChargeFrames": 15} 
+          {"shineChargeFrames": 15}
         ]},
         "HiJump",
         "canShinechargeMovementComplex"
@@ -1466,10 +1470,12 @@
     {
       "id": 57,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Rinka",
+      "name": "Get Hit By Rinka",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Rinka"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -212,14 +212,16 @@
     {
       "id": 24,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Space Pirate",
+      "name": "Get Hit By Space Pirate",
       "requires": [
         "canUpwardGModeSetup",
         "canTrickyUseFrozenEnemies",
         "canTrickyGMode"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Tourian Space Pirate (all)"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/tourian/main/Tourian Hopper Room.json
+++ b/region/tourian/main/Tourian Hopper Room.json
@@ -354,12 +354,14 @@
     {
       "id": 17,
       "link": [1, 2],
-      "name": "G-Mode Setup - Tank During Setup",
+      "name": "Get Hit by Blue Sidehopper (Tank Extra Hit)",
       "requires": [
         {"enemyDamage": {"enemy": "Blue Sidehopper", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Blue Sidehopper"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -376,7 +378,7 @@
     {
       "id": 18,
       "link": [1, 2],
-      "name": "G-Mode Setup - Prepared Dodge",
+      "name": "Get Hit by Blue Sidehopper (Prepared Dodge)",
       "entranceCondition": {
         "comeInNormally": {},
         "comesThroughToilet": "no"
@@ -395,7 +397,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Blue Sidehopper"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
@@ -1100,12 +1104,14 @@
     {
       "id": 30,
       "link": [2, 2],
-      "name": "G-Mode Setup",
+      "name": "Get Hit by Blue Sidehopper",
       "requires": [
         {"obstaclesNotCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Blue Sidehopper"
+        }
       },
       "unlocksDoors": [
         {"types": ["super"], "requires": []},

--- a/region/tourian/main/Tourian Hopper Room.json
+++ b/region/tourian/main/Tourian Hopper Room.json
@@ -559,6 +559,25 @@
     },
     {
       "link": [2, 1],
+      "name": "Come In With I-Frames",
+      "entranceCondition": {
+        "comeInWithIFrames": {
+          "iFramesNeeded": 52
+        }
+      },
+      "requires": [
+        "canDash",
+        "h_complexToCarryFlashSuit"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Use an enemy or other damage source in the previous room to obtain i-frames,",
+        "to be able to run through the Sidehoppers without taking a hit."
+      ]
+    },
+    {
+      "link": [2, 1],
       "name": "Come in Spinning, Squeeze Under Hoppers",
       "entranceCondition": {
         "comeInSpinning": {

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -719,13 +719,31 @@
     {
       "id": 21,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Covern, Atomic, or Kihunter",
+      "name": "Get Hit By Covern",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "If power is on, an Atomic (or Kihunter) can be used."
+    },
+    {
+      "link": [1, 1],
+      "name": "Get Hit By Atomic",
+      "requires": [
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "A Kihunter can also be used."
     },
     {
       "id": 22,
@@ -1319,7 +1337,7 @@
     {
       "id": 58,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit by Thawing Atomic",
+      "name": "Get Hit by Thawing Atomic",
       "requires": [
         "f_DefeatedPhantoon",
         "canDash",
@@ -1327,7 +1345,9 @@
         "canDownwardGModeSetup"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1755,13 +1775,31 @@
     {
       "id": 54,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Covern, Atomic, or Kihunter",
+      "name": "Get Hit By Covern",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
       },
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": "If power is on, an Atomic (or Kihunter) can be used."      
+    },
+    {
+      "link": [3, 3],
+      "name": "Get Hit By Atomic",
+      "requires": [
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "A Kihunter can also be used."
     },
     {
       "id": 55,

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -302,12 +302,14 @@
     {
       "id": 11,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Atomic",
+      "name": "Get Hit By Atomic",
       "requires": [
         "f_DefeatedPhantoon"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -716,14 +718,16 @@
     {
       "id": 24,
       "link": [2, 2],
-      "name": "G-Mode Setup - Frozen Atomic",
+      "name": "Frozen Atomic",
       "requires": [
         "canUpwardGModeSetup",
         "canTrickyUseFrozenEnemies",
         "f_DefeatedPhantoon"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -1481,7 +1485,7 @@
     {
       "id": 51,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Atomic, Lured from the Left",
+      "name": "Get Hit By Atomic, Lured from the Left",
       "requires": [
         "f_DefeatedPhantoon",
         {"or": [
@@ -1493,7 +1497,9 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -288,13 +288,15 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Phantoon",
+      "name": "Get Hit By Phantoon",
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Phantoon"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -281,12 +281,14 @@
     {
       "id": 7,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Bull",
+      "name": "Get Hit By Bull",
       "requires": [
         "f_DefeatedPhantoon"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Bull"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1506,12 +1508,14 @@
     {
       "id": 59,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Bull",
+      "name": "Get Hit By Bull",
       "requires": [
         "f_DefeatedPhantoon"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Bull"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -537,10 +537,27 @@
     {
       "id": 14,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Covern or Bull",
+      "name": "Get Hit By Covern",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "If power is on, a Bull can be used."
+    },
+    {
+      "link": [1, 1],
+      "name": "Get Hit By Bull",
+      "requires": [
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Bull"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -368,7 +368,7 @@
     {
       "id": 6,
       "link": [1, 1],
-      "name": "G-Mode Setup - Frozen Atomic",
+      "name": "Get Hit by Thawing Atomic",
       "requires": [
         "canUpwardGModeSetup",
         "canTrickyUseFrozenEnemies",
@@ -376,7 +376,9 @@
         {"enemyDamage": {"enemy": "Atomic", "type": "contact", "hits": 1}}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -536,10 +538,27 @@
     {
       "id": 11,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get Hit By Covern or Atomic",
+      "name": "Get Hit By Covern",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "If power is on, an Atomic can be used."
+    },
+    {
+      "link": [2, 2],
+      "name": "Get Hit By Atomic",
+      "requires": [
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -839,10 +858,27 @@
     {
       "id": 25,
       "link": [3, 3],
-      "name": "G-Mode Setup - Get Hit By Covern or Atomic",
+      "name": "Get Hit By Covern",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "If power is on, an Atomic can be used."
+    },
+    {
+      "link": [3, 3],
+      "name": "Get Hit By Atomic",
+      "requires": [
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1143,7 +1179,7 @@
     {
       "id": 108,
       "link": [3, 7],
-      "name": "G-Mode Setup - Get Hit by Thawing Atomic",
+      "name": "Get Hit by Thawing Atomic",
       "requires": [
         "f_DefeatedPhantoon",
         "canWallIceClip",
@@ -1151,7 +1187,9 @@
         "Morph"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
@@ -1876,10 +1914,27 @@
     {
       "id": 55,
       "link": [4, 4],
-      "name": "G-Mode Setup - Get Hit By Covern or Atomic",
+      "name": "Get Hit By Covern",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "If power is on, an Atomic can be used."      
+    },
+    {
+      "link": [4, 4],
+      "name": "Get Hit By Atomic",
+      "requires": [
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2246,10 +2301,27 @@
     {
       "id": 70,
       "link": [5, 5],
-      "name": "G-Mode Setup - Get Hit By Covern or Atomic",
+      "name": "Get Hit By Covern",
       "requires": [],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "If power is on, an Atomic can be used."      
+    },
+    {
+      "link": [5, 5],
+      "name": "Get Hit By Atomic",
+      "requires": [
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -2622,7 +2694,7 @@
     {
       "id": 84,
       "link": [6, 6],
-      "name": "G-Mode Setup - Get Hit By Covern or Atomic",
+      "name": "Get Hit By Covern",
       "requires": [
         {"or": [
           "h_bombThings",
@@ -2634,7 +2706,32 @@
         ]}
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "If power is on, an Atomic can be used as long as the bomb blocks can be broken."      
+    },
+    {
+      "link": [6, 6],
+      "name": "Get Hit By Atomic",
+      "requires": [
+        {"or": [
+          "h_bombThings",
+          {"obstaclesCleared": ["A"]},
+          {"and": [
+            {"not": "f_DefeatedPhantoon"},
+            "canRiskPermanentLossOfAccess"
+          ]}
+        ]},
+        "f_DefeatedPhantoon"
+      ],
+      "exitCondition": {
+        "leaveWithDamage": {
+          "enemy": "Atomic"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -163,13 +163,15 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Covern",
+      "name": "Get Hit By Covern",
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -168,13 +168,15 @@
     {
       "id": 4,
       "link": [1, 1],
-      "name": "G-Mode Setup - Get Hit By Covern",
+      "name": "Get Hit By Covern",
       "requires": [
         {"not": "f_DefeatedPhantoon"},
         "canRiskPermanentLossOfAccess"
       ],
       "exitCondition": {
-        "leaveWithGModeSetup": {}
+        "leaveWithDamage": {
+          "enemy": "Covern"
+        }
       },
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1242,7 +1242,7 @@
                 "knockback": {
                   "type": "boolean",
                   "default": true,
-                  "description": "If true, then Samus gets knockback frames through the transition."
+                  "description": "If true, then Samus gets knockback from the damage."
                 },
                 "iFramesRemaining": {
                   "type": "integer",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -580,6 +580,26 @@
                 }
               }
             },
+            "comeInWithIFrames": {
+              "type": "object",
+              "title": "Come in With I-Frames",
+              "description": "Represents that Samus must enter the room with a minimum number of i-frames remaining.",
+              "required": ["iFramesNeeded"],
+              "additionalProperties": false,
+              "properties": {
+                "iFramesNeeded": {
+                  "type": "integer",
+                  "description": "Minimum number of i-frames Samus must have when entering the room."
+                }
+              }
+            },
+            "comeInWithDamageBoost": {
+              "type": "object",
+              "title": "Come in With Damage Boost",
+              "description": "Represents that Samus must damage boost through the transition, starting from the doorway.",
+              "additionalProperties": false,
+              "properties": {}
+            },
             "comeInWithRMode": {
               "type": "object",
               "title": "Come in With R-Mode",
@@ -905,6 +925,8 @@
             {"required": ["comeInSpinning"]},
             {"required": ["comeInBlueSpinning"]},
             {"required": ["comeInWithStoredFallSpeed"]},
+            {"required": ["comeInWithIFrames"]},
+            {"required": ["comeInWithDamageBoost"]},
             {"required": ["comeInWithRMode"]},
             {"required": ["comeInWithGMode"]},
             {"required": ["comeInWithXMode"]},
@@ -1213,9 +1235,9 @@
                 },
                 "location": {
                   "type": "string",
-                  "enum": ["transition", "remote"],
+                  "enum": ["transition", "near", "remote"],
                   "default": "transition",
-                  "description": "Where the damage is taken: 'transition' if during the transition or on the frame that triggers the transition, 'remote' otherwise."
+                  "description": "Where the damage is taken: 'transition' if during the transition, 'near' if close enough to damage boost through the top of the doorway, or 'remote' otherwise."
                 },
                 "knockback": {
                   "type": "boolean",

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1196,38 +1196,66 @@
                 }
               }
             },
-            "leaveWithGModeSetup": {
+            "leaveWithDamage": {
               "type": "object",
-              "title": "Leave With G-Mode Setup",
-              "description": "Represents that Samus can leave through this door while taking damage through the transition, in a pose that would allow using X-Ray on the first frame after the transition. This is for setting up to enter R-mode or direct G-mode in the next room.",
-              "required": [],
-              "additionalProperties": false,
-              "properties": {
-                "knockback": {
-                  "type": "boolean",
-                  "default": true,
-                  "title": "Leaves With Knockback",
-                  "description": "If true, then Samus gets knockback frames through the transition."
-                }
-              }
-            },
-            "leaveWithXModeSetup": {
-              "type": "object",
-              "title": "Leave With X-Mode Setup",
-              "description": "Represents that Samus can leave through this door while taking damage during the transition, in a pose and at a height after the transition to be able to perform a single frame damage boost to land in the doorframe with X-Ray buffered to activate upon landing.",
-              "required": [],
+              "title": "Leave With Damage",
+              "description": "Represents that Samus can leave through this door while taking damage, either through the transition or shortly before. Depending on the properties, this can be used to provide i-frames, a damage boost, or G-mode, R-mode, or X-mode in the next room.",
+              "required": ["enemy"],
               "additionalProperties": false,
               "properties": {
                 "enemy": {
-                  "pattern": "^(.*)$",
-                  "title": "Name of enemy"
+                  "type": ["string", "null"],
+                  "description": "If null, then the damage must already be accounted for in strat requirements."
                 },
                 "attack": {
-                  "default": "contact",
-                  "pattern": "^(.*)$",
-                  "title": "Type of enemy damage."
+                  "type": "string",
+                  "default": "contact"
+                },
+                "location": {
+                  "type": "string",
+                  "enum": ["transition", "remote"],
+                  "default": "transition",
+                  "description": "Where the damage is taken: 'transition' if during the transition or on the frame that triggers the transition, 'remote' otherwise."
+                },
+                "knockback": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "If true, then Samus gets knockback frames through the transition."
+                },
+                "iFramesRemaining": {
+                  "type": "integer",
+                  "description": "Amount of i-frames remaining through the transition. If unspecified, it defaults to 95, unless 'knockback' is 'false', in which case it defaults to 0."
+                },
+                "xMode": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether this setup is suitable for setting up X-mode through the transition."
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "required": ["location"],
+                    "properties": {"location": {"const": "remote"}}
+                  },
+                  "then": {"required": ["iFramesRemaining"]}
+                },
+                {
+                  "if": {
+                    "required": ["knockback"],
+                    "properties": {"knockback": {"const": false}}
+                  },
+                  "then": {"not": {"required": ["iFramesRemaining"]}}
+                },
+                {
+                  "if": {
+                    "not": {"required": ["location"]}
+                  },
+                  "then": {
+                    "required": ["enemy"]
+                  }
+                }
+              ]
             },
             "leaveWithGMode": {
               "type": "object",

--- a/strats.md
+++ b/strats.md
@@ -90,8 +90,6 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveWithSpringBallBounce_: This indicates that it is possible to leave through this door with a spring ball bounce with a certain amount of momentum.
 - _leaveSpaceJumping_: This indicates that it is possible to Space Jump through the bottom of the doorway (through a horizontal transition) with a certain amount of momentum, and possibly with blue speed.
 - _leaveWithStoredFallSpeed_: This indicates that is is possible to walk through the door with the stored velocity to clip through floor tiles using a Moonfall.
-- _leaveWithGModeSetup_: This indicates that Samus can take enemy damage through the door transition, to set up R-mode or direct G-mode in the next room.
-- _leaveWithXModeSetup_: This indicates that Samus can take enemy damage through the door transition, to set up door transition X-Mode in the next room.
 - _leaveWithGMode_: This indicates that Samus can carry G-mode into the next room (where it will become indirect G-mode).
 - _leaveWithDoorFrameBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump.
 - _leaveWithPlatformBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping from a platform below, possibly with run speed.

--- a/strats.md
+++ b/strats.md
@@ -90,6 +90,7 @@ In all strats with an `exitCondition`, the `to` node of the strat must be a door
 - _leaveWithSpringBallBounce_: This indicates that it is possible to leave through this door with a spring ball bounce with a certain amount of momentum.
 - _leaveSpaceJumping_: This indicates that it is possible to Space Jump through the bottom of the doorway (through a horizontal transition) with a certain amount of momentum, and possibly with blue speed.
 - _leaveWithStoredFallSpeed_: This indicates that is is possible to walk through the door with the stored velocity to clip through floor tiles using a Moonfall.
+- _leaveWithDamage_: This indicates that Samus can leave through this door while taking enemy damage, providing i-frames, knockback, a damage boost, or a setup for R-mode, G-mode, or X-mode in the next room.
 - _leaveWithGMode_: This indicates that Samus can carry G-mode into the next room (where it will become indirect G-mode).
 - _leaveWithDoorFrameBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping in the door frame, e.g. using a wall-jump or Space Jump.
 - _leaveWithPlatformBelow_: This indicates that Samus can go up through this vertical door with momentum by jumping from a platform below, possibly with run speed.
@@ -403,58 +404,33 @@ A `leaveWithStoredFallSpeed` entrance condition must match with a `comeInWithSto
 }
 ```
 
-### Leave with G-Mode Setup
+### Leave with Damage
 
-A `leaveWithGModeSetup` exit condition represents that Samus can leave through this door while taking damage through the transition, in a pose that would allow using X-Ray on the first frame after the transition. This sets up the player to enter R-mode or direct G-mode in the next room. The only known way to achieve this is to use an enemy that can follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions, and environmental damage such as heat, lava, acid do not work as these are not active during the transition. Also note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not work. The enemy damage through the transition should _not_ be included in the `requires`, as the type/amount of enemy damage is irrelevant since Samus' energy will always reach zero here in order to trigger reserves.
+A `leaveWithDamage` exit condition represents that Samus can leave through this door while taking damage, either during the door transition or shortly before it. Depending on its properties, the damage can provide i-frames, knockback, a damage boost, or a setup for R-mode, direct G-mode, or X-mode in the next room.
 
-A `leaveWithGModeSetup` object contains the following property:
-- _knockback_: If true, then Samus gets knockback frames through the transition. This makes it possible for Samus to retain mobility in the next room if reserve energy is at most 4. Most enemies provide knockback, so this property is true by default if unspecified. Certain enemies such as Beetoms, Metroids, and Mochtroids do not provide knockback, so this property should be set to false for strats that use these enemies for the transition damage.
+A `leaveWithDamage` object has the following properties:
+- _enemy_: The name of the enemy dealing the damage. If null, the damage must already be accounted for in the strat's `requires`; otherwise the damage is required implicitly as part of the exit condition.
+- _attack_: The name of the enemy attack dealing the damage. This defaults to `"contact"`.
+- _location_: Where the damage is taken: `"transition"` if it can occur during the door transition, `"near"` if it can be close enough to damage boost through the top of the doorway, or `"remote"` if it must be done further away. This defaults to `"transition"`.
+- _knockback_: Whether Samus receives knockback frames that continue through the transition. This defaults to true. Certain enemies such as Beetoms, Metroids, and Mochtroids do not provide knockback, so this should be false when using their contact damage.
+- _iFramesRemaining_: The number of i-frames remaining through the transition. This defaults to 95, except when `knockback` is false, in which case it defaults to 0. It must be specified when `location` is `"remote"`, and it must not be specified when `knockback` is false.
+- _xMode_: Whether the damage setup is suitable for entering X-mode. This defaults to false.
 
-A `leaveWithGModeSetup` comes with implicit requirements, which are described in detail under the entrance conditions `comeInWithRMode` and `comeInWithGMode`. The implicit requirements depend on the specifics of the entrance condition in the next room, but they always include at least the following:
-- The `XRayScope` item requirement.
-- A requirement `{"or": ["canBlueSuitGModeSetup", {"noBlueSuit": {}}]}`.
-- A requirement to have at least 1 reserve energy.
-- A requirement to damage down to 0 energy, triggering reserves.
+A `leaveWithDamage` exit condition must pair with a `comeInWithIFrames`, `comeInWithDamageBoost`, `comeInWithGMode`, `comeInWithRMode`, or `comeInWithXMode` entrance condition. It comes with various implicit requirements, described in detail under the corresponding entrance conditions below.
 
 #### Example
 ```json
 {
-  "name": "Leave With G-Mode Setup",
+  "name": "Get Hit By Geemer",
   "requires": [],
   "exitCondition": {
-    "leaveWithGModeSetup": {}
+    "leaveWithDamage": {
+      "enemy": "Geemer (blue)"
+    }
   }
 }
 ```
 
-### Leave with X-Mode Setup
-
-A `leaveWithXModeSetup_` exit condition represents that Samus can leave through this door while taking damage through the transition, in a pose and at a height after the transition to be able to perform a single frame damage boost to land in the doorframe with X-Ray buffered to activate upon landing. This sets up the player to enter X-Mode in the next room. The only known way to achieve this is to use an enemy that can follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions, and environmental damage such as heat, lava, acid do not work as these are not active during the transition. Also note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not work. A reserve tank is not required if Samus has sufficient health to tank the enemy damage. However, an auto reserve trigger can also be used if the amount of reserve energy is set to 1 before taking damage.
-
-Only water to water transitions are known to be possible.
-
-A `leaveWithXModeSetup_` object has two properites:
-- _enemy: The name of the enemy used to damage Samus during the door transition
-- _attack: The type of damage received from the enemy. This is normally "contact".
-
-A `leaveWithXModeSetup_` comes with implicit requirements, which are described in detail under the entrance condition `comeInWithXMode`.
-
-- The `canDoorTransitionXMode` tech requirement.
-- The `XRayScope` item requirement.
-- The requirements `{"and": [{"noFlashSuit": {}}, {"noBlueSuit": {}}]}`.
-- A requirement `{"disableEquipment": "Gravity"}`.
-- A requirement to take damage from the enemy. If Samus can only survive by using a reserve trigger, this includes a requirement to drain reserve energy to 1 first.
-
-#### Example
-```json
-{
-  "name": "Leave With X-Mode Setup - Get Hit By Sciser",
-  "requires": []
-  "exitCondition": {
-    "leaveWithXModeSetup": {"enemy": "Sciser", "attack": "contact"}
-  }
-}
-```
 
 ### Leave with G-Mode
 
@@ -694,6 +670,8 @@ In all strats with an `entranceCondition`, the `from` node of the strat must be 
 - _comeInSpinning_: This indicates that Samus come in with a spin jump through the doorway with speed in a certain range.
 - _comeInBlueSpinning_: This indicates that Samus come in with a spin jump through the doorway while having blue speed.
 - _comeInWithStoredFallSpeed_: This indicates that Samus must enter the room with fall speed stored, and is able to clip through a floor with a Moonfall.
+- _comeInWithIFrames_: This indicates that Samus must enter the room with a minimum number of i-frames, without assuming a specific movement state.
+- _comeInWithDamageBoost_: This indicates that Samus must damage boost through the transition, starting from the doorway.
 - _comeInWithRMode_: This indicates that Samus must obtain R-mode while coming through this door.
 - _comeInWithGMode_: This indicates that Samus must have or obtain G-mode (direct or indirect) while coming through this door. 
 - _comeInWithXMode_: This indicates that Samus must obtain X-mode while coming through this door.
@@ -1398,13 +1376,58 @@ A `comeInWithStoredFallSpeed` entrance condition must match with a `leaveWithSto
   "requires": []
 }
 ```
-### Come In With R-Mode
+### Come In With I-Frames
+
+A `comeInWithIFrames` entrance condition indicates that Samus must enter the room with i-frames but does not assume a specific movement state. It has one required property:
+- _iFramesNeeded_: The minimum number of i-frames needed when entering the room.
+
+It must match with a `leaveWithDamage` exit condition whose `iFramesRemaining` value (accounting for its default if applicable), is at least `iFramesNeeded`.
+
+It has the following implicit requirements:
+- The tech requirement "canUseIFrames".
+- A requirement to take damage from the enemy. It is assumed that Samus must survive the enemy damage using regular energy only, not a pause abuse or auto reserve trigger.
+
+#### Example
+```json
+{
+  "name": "Come In With I-Frames",
+  "requires": [],
+  "entranceCondition": {
+    "comeInWithIFrames": {
+      "iFramesNeeded": 30
+    }
+  }
+}
+```
+
+### Come In With Damage Boost
+
+A `comeInWithDamageBoost` entrance condition indicates that Samus must damage boost through the transition, starting from the doorway. A damage boost from further away would not satisfy this entrance condition. It has no properties.
+
+It must match with a `leaveWithDamage` exit condition whose `location` is `"transition"` or `"near"` and whose `knockback` is true or omitted (not false).
+
+It has the following implicit requirements:
+- The tech requirement "canHorizontalDamageBoost".
+- A requirement to take damage from the enemy. It is assumed that Samus must survive the enemy damage using regular energy only, not a pause abuse or auto reserve trigger.
+
+#### Example
+```json
+{
+  "name": "Come In With Damage Boost",
+  "requires": [],
+  "entranceCondition": {
+    "comeInWithDamageBoost": {}
+  }
+}
+```
+
+### Come In With R-Mode- A requirement to take damage from the enemy.
 
 A `comeInWithRMode` entrance condition indicates that Samus must obtain R-mode while coming through this door.
 
 A `comeInWithRMode` object does not have any properties.
 
-A `comeInWithRMode` entrance condition must match with a `leaveWithGModeSetup` entrance condition on the other side of the door. It comes with the following implicit requirements:
+A `comeInWithRMode` entrance condition must match with a `leaveWithDamage` exit condition on the other side of the door, with `location` set to `"transition"` or omitted. It comes with the following implicit requirements:
 - The tech requirement `canRMode`.
 - The `XRayScope` item requirement.
 - A requirement `{"or": ["canBlueSuitGModeSetup", {"noBlueSuit": {}}]}`.
@@ -1445,10 +1468,10 @@ A `comeInWithGMode` object has the following properties:
 * _mobility_: Takes one of three possible values, "mobile", "immobile", or "any", indicating whether or not Samus is
 required to be mobile (or immobile) after entering the room. The default value is "any". When entering with indirect G-mode, Samus is always mobile. With direct G-mode, Samus can be mobile if she takes knockback through the door transition and the reserve energy is low enough (<= 4 energy) so that knockback frames do not expire until after reserves finish filling.
 
-A `comeInWithGMode` entrance condition must match with either a `leaveWithGModeSetup` or `leaveWithGMode` entrance condition on the other side of the door:
-- If `mode` is "direct", then it can only match with a `leaveWithGModeSetup`. If `mode` is "indirect", then it can only match with a `leaveWithGMode`.
+A `comeInWithGMode` entrance condition must match with either a `leaveWithDamage` or `leaveWithGMode` exit condition on the other side of the door:
+- If `mode` is "direct", then it can only match with a `leaveWithDamage` having `location` set to `"transition"` or omitted. If `mode` is "indirect", then it can only match with a `leaveWithGMode`.
 
-When matching with a `leaveWithGModeSetup`, a `comeInWithGMode` has implicit requirements:
+When matching with a `leaveWithDamage`, a `comeInWithGMode` has implicit requirements:
 - The tech requirement `canGMode`.
 - The requirement `h_heatedGMode` if either the previous room or current room is heated.
 - The `XRayScope` item requirement.
@@ -1456,9 +1479,9 @@ When matching with a `leaveWithGModeSetup`, a `comeInWithGMode` has implicit req
 - A requirement to have at least 1 reserve energy.
 - A requirement to damage down to 0 energy, triggering reserves (causing the reserve energy to become zero and the regular energy to become what the reserve energy was).
 - The requirement `{"or": ["Morph", "canArtificialMorph"]}`, if the `morphed` property of `comeInWithGMode` is true.
-- The Toilet must not come between the room with the `leaveWithGModeSetup` and the `comeInWithGMode`, because obtaining direct G-mode in the Toilet is not possible, due to Samus not having an ability to use X-Ray while entering the room.
+- The Toilet must not come between the room with the `leaveWithDamage` and the `comeInWithGMode`, because obtaining direct G-mode in the Toilet is not possible, due to Samus not having an ability to use X-Ray while entering the room.
 - Requirements for regaining mobility (there may be multiple options here, and they should be treated either as separate strats or the requirements should be joined as though with an `or`):
-  - G-mode mobile: Samus uses the knockback from the previous room to retain mobility. Here the `knockback` property of the `leaveWithGModeSetup` must be true, and reserve energy is assumed to have been drained to at most 4 before doing the strat.
+  - G-mode mobile: Samus uses the knockback from the previous room to retain mobility. Here the `knockback` property of the `leaveWithDamage` must be true or omitted, and reserve energy is assumed to have been drained to at most 4 before doing the strat.
   - G-mode immobile: Samus uses knockback from a hit in the current room to regain mobility. The possibility of doing this is indicated by the presence of a strat with a `gModeRegainMobility` property with `from` and `to` node matching entrance/door node of the current strat (the `from` node of the strat with `comeInWithGMode`). Any requirements of the `gModeRegainMobility` strat should be included as requirements to execute the current strat; it is important that these requirements be applied *after* the requirement to damage down to 0 energy and trigger reserves. If there are multiple such `gModeRegainMobility` strats, then these should be treated as multiple options.
 
 When matching with a `leaveWithGMode`, a `comeInWithGMode` has an implicit requirement in one scenario:
@@ -1484,11 +1507,11 @@ A `comeInWithXMode` entrance condition indicates that Samus must obtain X-mode w
 
 A `comeInWithXMode` object does not have any properties.
 
-A `comeInWithXMode` entrance condition must match with  a `leaveWithXModeSetup` entrance condition on the other side of the door:
+A `comeInWithXMode` entrance condition must match with a `leaveWithDamage` exit condition having `xMode` set to true on the other side of the door.
 
 Only water to water transitions are known to be possible.
 
-When matching with a `leaveWithXModeSetup`, a `comeInWithXMode` has implicit requirements:
+When matching with a `leaveWithDamage`, a `comeInWithXMode` has implicit requirements:
 - The tech requirement `canDoorTransitionXMode`.
 - The `XRayScope` item requirement.
 - The requirements `{"and": [{"noFlashSuit": {}}, {"noBlueSuit": {}}]}`.

--- a/strats.md
+++ b/strats.md
@@ -412,7 +412,7 @@ A `leaveWithDamage` object has the following properties:
 - _enemy_: The name of the enemy dealing the damage. If null, the damage must already be accounted for in the strat's `requires`; otherwise the damage is required implicitly as part of the exit condition.
 - _attack_: The name of the enemy attack dealing the damage. This defaults to `"contact"`.
 - _location_: Where the damage is taken: `"transition"` if it can occur during the door transition, `"near"` if it can be close enough to damage boost through the top of the doorway, or `"remote"` if it must be done further away. This defaults to `"transition"`.
-- _knockback_: Whether Samus receives knockback frames that continue through the transition. This defaults to true. Certain enemies such as Beetoms, Metroids, and Mochtroids do not provide knockback, so this should be false when using their contact damage.
+- _knockback_: Whether Samus receives knockback from the damage, regardless of whether those knockback frames continue through the transition. This defaults to true. Certain enemies such as Beetoms, Metroids, and Mochtroids do not provide knockback, so this should be false when they are used.
 - _iFramesRemaining_: The number of i-frames remaining through the transition. This defaults to 95, except when `knockback` is false, in which case it defaults to 0. It must be specified when `location` is `"remote"`, and it must not be specified when `knockback` is false.
 - _xMode_: Whether the damage setup is suitable for entering X-mode. This defaults to false.
 

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -157,7 +157,7 @@ def process_keyvalue(k, v, metadata):
         "position",  # validated by schema
         "environment",  # validated by schema
         "bypassesDoorShell",  # validated by schema
-        "attack", # FIXME: to be validated
+        "attack", # validated explicitly
     ]
 
     # Keys that need validation but share a name with a filtered key
@@ -1034,6 +1034,7 @@ for r,d,f in os.walk(os.path.join(".","region")):
                     strat_id_set = set()
                     used_notable_name_set = set()
                     link_strat_names = set()
+                    room_enemy_names = {enemy["enemyName"] for enemy in room.get("enemies", [])}
                     for strat in room["strats"]:
                         if "link" not in strat:
                             # Errors are already generated above in this case.
@@ -1196,6 +1197,15 @@ for r,d,f in os.walk(os.path.join(".","region")):
                                 msg = f"🔴ERROR: Strat has exitCondition but To Node is not door or exit:{stratRef}"
                                 messages["reds"].append(msg)
                                 messages["counts"]["reds"] += 1
+                            leave_with_damage = strat["exitCondition"].get("leaveWithDamage", {})
+                            enemy_name = leave_with_damage.get("enemy")
+                            if enemy_name is not None:
+                                if enemy_name not in room_enemy_names:
+                                    strat_err_fn(f"leaveWithDamage references enemy '{enemy_name}' not present in room")
+                                enemy_id = keywords["enemies"]["enemyByName"].get(enemy_name)
+                                attack_name = leave_with_damage.get("attack", "contact")
+                                if enemy_id in enemies and attack_name not in {attack["name"] for attack in enemies[enemy_id]["attacks"]}:
+                                    strat_err_fn(f"leaveWithDamage enemy '{enemy_name}' doesn't have attack '{attack_name}'")
                             if "leaveShinecharged" in strat["exitCondition"]:
                                 if not covers_shinecharge_frames({"and": strat["requires"]}):
                                     msg = f"🔴ERROR: Strat has leavesShinecharged exitCondition without `shineChargeFrames` covering all cases:{stratRef}"

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -75,7 +75,8 @@ strat_name_exit_conditions = [
     ("Leave With Stored Fall Speed", "leaveWithStoredFallSpeed"),
     ("Leave With Moondance", "leaveWithStoredFallSpeed"),
     ("Leave With Extended Moondance", "leaveWithStoredFallSpeed"),
-    ("G-Mode Setup", "leaveWithGModeSetup"),
+    ("Leave With Damage", "leaveWithDamage"),
+    ("Get Hit by", "leaveWithDamage"),
     ("Carry G-Mode", "leaveWithGMode"),
     ("Leave With Door Frame Below", "leaveWithDoorFrameBelow"),
     ("Leave With Platform Below", "leaveWithPlatformBelow"),
@@ -139,7 +140,7 @@ def process_keyvalue(k, v, metadata):
         "comeInRunning",  # validated by schema
         "comeInJumping",    # validated by schema,
         "comeInWithGMode",    # validated by schema,
-        "leaveWithGModeSetup", # validated by schema
+        "leaveWithDamage", # validated by schema and explicitly below
         "gModeRegainMobility",    # validated by schema
         "leaveWithSpark", # validated by schema
         "speedBooster", # validated by schema


### PR DESCRIPTION
- Introduces a `leaveWithDamage` exit condition which replaces `leaveWithGModeSetup` and `leaveWithXModeSetup`, extending them to be usable for more purposes. I think of `leaveWithDamage` as similar now to `leaveWithRunway` in how the same exit condition can represent multiple possible actions in the exiting room, depending on what is needed in the next room.
- Adds corresponding new entrance conditions `comeInWithIFrames` and `comeInWithDamageBoost`, with applications in Tourian Hopper Room and Climb Supers respectively.
- I would recommend reviewing this commit-by-commit. The bulk of the changes come from an LLM-assisted migration of the G-mode setup strats, which in the new schema needs to specify the enemy name (and attack, if not "contact"). This is supported by a test which checks that the enemy/attack name is one that exists in the `enemies` list in the room. The only cases which needed some special handling were ones where originally there were multiple possible enemies that could be used; these needed to either be split into separate strats (e.g. where the available enemy depends on game state, in Wrecked Ship with power on/off), or just pick the enemy with lowest damage and mention the other in a note.
- Adding more `leaveWithDamage` strats will be done in another pass (maybe a stacked PR on top of this one), to avoid making this PR any more complicated.
- Although the schema would now allow them to be consolidated, I kept the X-mode setup strats separate for now; it's possible we may want to add notes there about subpixel normalizations, but if that ends up instead going into the tech or entrance strat then we can consolidate the setup strats later.